### PR TITLE
Polish scrollbars to match design system

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -269,21 +269,17 @@
     min-width: 0;
   }
 
-  .content::-webkit-scrollbar {
-    width: 10px;
-  }
-
-  .content::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
+  .content::-webkit-scrollbar { width: 10px; }
+  .content::-webkit-scrollbar-track { background: transparent; }
   .content::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
+    background: transparent;
     border: 3px solid var(--paper);
     border-radius: 999px;
   }
-
-  .content::-webkit-scrollbar-thumb:hover {
+  .content:hover::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
+  }
+  .content:hover::-webkit-scrollbar-thumb:hover {
     background: color-mix(in srgb, var(--ink-faint) 62%, transparent);
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -112,7 +112,7 @@
   <TitleBar />
   <div class="body">
     <Sidebar />
-    <div class="content">
+    <div class="content scroll-styled">
       {#key $currentPage}
         <div class="page-wrapper" in:fly={{ y: 8, duration: 400, delay: 150, easing: expoOut }} out:fly={{ y: -8, duration: 150, easing: expoOut }}>
           {#if $currentPage === 'home'}
@@ -269,19 +269,7 @@
     min-width: 0;
   }
 
-  .content::-webkit-scrollbar { width: 10px; }
-  .content::-webkit-scrollbar-track { background: transparent; }
-  .content::-webkit-scrollbar-thumb {
-    background: transparent;
-    border: 3px solid var(--paper);
-    border-radius: 999px;
-  }
-  .content:hover::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
-  }
-  .content:hover::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--ink-faint) 62%, transparent);
-  }
+  .content::-webkit-scrollbar-thumb { border: 3px solid var(--paper); }
 
   .page-wrapper {
     grid-area: 1 / 1;

--- a/src/app.css
+++ b/src/app.css
@@ -3,3 +3,18 @@
 body {
   font-feature-settings: 'ss01', 'cv11';
 }
+
+/* Hover-reveal floating-pill scrollbar — add this class to any overflow container.
+   Override the thumb border-color locally to match the element's own background. */
+.scroll-styled::-webkit-scrollbar { width: 10px; }
+.scroll-styled::-webkit-scrollbar-track { background: transparent; }
+.scroll-styled::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+}
+.scroll-styled:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
+}
+.scroll-styled:hover::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--ink-faint) 62%, transparent);
+}

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -197,6 +197,21 @@
     inset: 0;
     padding: 26px 30px;
     overflow-y: auto;
+    scrollbar-gutter: stable;
+  }
+
+  .panel::-webkit-scrollbar { width: 10px; }
+  .panel::-webkit-scrollbar-track { background: transparent; }
+  .panel::-webkit-scrollbar-thumb {
+    background: transparent;
+    border: 3px solid var(--bg-elev);
+    border-radius: 999px;
+  }
+  .panel:hover::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--ink-faint) 45%, transparent);
+  }
+  .panel:hover::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--ink-faint) 65%, transparent);
   }
 
   /* Shared styles for all section components — scoped to .settings-body */

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -94,7 +94,7 @@
       <div class="settings-body">
         {#key section}
           <div
-            class="panel"
+            class="panel scroll-styled"
             in:fly={{ y: animDir === 'up' ? 20 : -20, duration: 350, delay: 150, easing: expoOut }}
             out:fly={{ y: animDir === 'up' ? -20 : 20, duration: 150, easing: expoOut }}
           >
@@ -200,19 +200,7 @@
     scrollbar-gutter: stable;
   }
 
-  .panel::-webkit-scrollbar { width: 10px; }
-  .panel::-webkit-scrollbar-track { background: transparent; }
-  .panel::-webkit-scrollbar-thumb {
-    background: transparent;
-    border: 3px solid var(--bg-elev);
-    border-radius: 999px;
-  }
-  .panel:hover::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--ink-faint) 45%, transparent);
-  }
-  .panel:hover::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--ink-faint) 65%, transparent);
-  }
+  .panel::-webkit-scrollbar-thumb { border: 3px solid var(--bg-elev); }
 
   /* Shared styles for all section components — scoped to .settings-body */
   .settings-body :global(.settings-h) {


### PR DESCRIPTION
# Summary

Replace the raw Windows scrollbar in the settings panel with a styled floating-pill thumb, and make the main content scrollbar hover-reveal across all pages.

- **Settings panel** (`Settings.svelte`): adds `::-webkit-scrollbar` rules using `--bg-elev` as the border colour (matches the modal background) and `scrollbar-gutter: stable` to prevent layout shift. Thumb is hidden until you hover over the panel.
- **Main content area** (`App.svelte`): converts the always-visible thumb to hover-reveal — thumb is transparent at rest, fades in on `.content:hover`. Consistent with the settings panel behaviour.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Smoke tests assert CSS class contracts only — none of the changed selectors (`::-webkit-scrollbar-*`, `scrollbar-gutter`) are tested by them. Changes are pure CSS with no behaviour impact.

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes: None. CSS-only change.

## UI Evidence

Before: default Windows scrollbar visible at all times in the settings panel.  
After: thin floating-pill scrollbar, hidden at rest, appears on hover — consistent across settings panel and all main content pages.

## Reviewer Notes

The border-colour trick (`border: 3px solid var(--bg-elev)` on the thumb) is what makes the visible portion appear narrow without needing a narrower `scrollbar-width`. This is the same pattern already used on `.content` in `App.svelte` — just extended to the settings panel with the correct background token.