### PR TITLE
Fix settings audio tab label

### DIFF
--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -43,7 +43,7 @@
   loadSettings();
 </script>
 
-<h2 class="settings-h">Advanced</h2>
+<h2 class="settings-h">Audio</h2>
 <div class="setting-row gain-row">
   <div class="gain-header">
     <div>

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -27,7 +27,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Advanced',      icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Audio',         icon: 'mic'      as keyof typeof icons },
     ]},
     { group: 'Account', items: [
       { id: 'about', label: 'About', icon: 'help' as keyof typeof icons },


### PR DESCRIPTION
# Summary

Fixes a settings UI labeling mismatch where the audio settings tab and panel header were shown as "Advanced". Both now display "Audio" for consistency and clarity.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [x] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

`npm run check` passed with 0 errors and 0 warnings.

Playwright smoke script `node tests/smoke/playwright-test-ui.cjs` was attempted, but could not reach `http://localhost:1420/` in this environment (`ERR_CONNECTION_REFUSED`), so full UI smoke verification could not be completed here.

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

None. No backend or security-sensitive behavior changed.

## UI Evidence

Not applicable.

## Reviewer Notes

Repo had unrelated local modifications in release artifacts and Cargo metadata before this change. This PR intentionally scopes to two frontend label updates only.
