### PR TITLE
Add local cleanup cache with spaced TTL and clear-cache controls

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ windows = { version = "0.61", features = [
   "Win32_Media_Audio_Endpoints",
   "Win32_System_Com",
   "Win32_UI_Accessibility",
+  "Win32_Storage_FileSystem",
 ] }
 
 [profile.release]
@@ -57,4 +58,3 @@ lto        = true
 strip      = true
 panic      = "abort"
 codegen-units = 1
-

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -202,12 +202,6 @@ pub fn get_stats(app: AppHandle) -> Result<db::Stats, String> {
     db::query_stats(&db).map_err(|e| e.to_string())
 }
 
-fn app_data_dir_for_db() -> std::path::PathBuf {
-    std::env::var("APPDATA")
-        .map(|p| std::path::PathBuf::from(p).join("OpenFlow"))
-        .unwrap_or_else(|_| std::path::PathBuf::from("."))
-}
-
 #[cfg(target_os = "windows")]
 fn free_bytes_for_path(path: &std::path::Path) -> Result<u64, String> {
     use std::os::windows::ffi::OsStrExt;
@@ -232,7 +226,7 @@ fn free_bytes_for_path(path: &std::path::Path) -> Result<u64, String> {
         )
     };
     result
-        .map(|_| total_free_bytes)
+        .map(|_| free_bytes_available)
         .map_err(|_| "Failed to read free disk space".to_string())
 }
 
@@ -251,7 +245,10 @@ pub fn clear_cleanup_cache(app: AppHandle) -> Result<usize, String> {
 pub fn get_cleanup_cache_status(app: AppHandle) -> Result<CleanupCacheStatus, String> {
     let db = app.state::<DbHandle>();
     let entry_count = db::cleanup_cache_count(&db).map_err(|e| e.to_string())?;
-    let app_data = app_data_dir_for_db();
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data directory: {e}"))?;
     let free_bytes = free_bytes_for_path(&app_data)?;
     Ok(CleanupCacheStatus {
         entry_count,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,8 @@ use crate::pipeline::{self, SharedState};
 use crate::system::apps::{AppMapping, InstalledApp};
 use crate::DbHandle;
 
+const SPACE_CONSTRAINED_THRESHOLD_BYTES: u64 = 1_073_741_824;
+
 fn lock_state<'a>(
     state: &'a tauri::State<'_, SharedState>,
 ) -> Result<std::sync::MutexGuard<'a, pipeline::AppState>, String> {
@@ -128,6 +130,13 @@ pub struct AllSettings {
     pub appearance_mode: Option<String>,
 }
 
+#[derive(serde::Serialize)]
+pub struct CleanupCacheStatus {
+    pub entry_count: i64,
+    pub is_space_constrained: bool,
+    pub free_bytes: u64,
+}
+
 #[tauri::command]
 pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
     let s = app.store("settings.json").map_err(|e| e.to_string())?;
@@ -191,6 +200,64 @@ pub fn get_recent(app: AppHandle) -> Result<Vec<db::RecentEntry>, String> {
 pub fn get_stats(app: AppHandle) -> Result<db::Stats, String> {
     let db = app.state::<DbHandle>();
     db::query_stats(&db).map_err(|e| e.to_string())
+}
+
+fn app_data_dir_for_db() -> std::path::PathBuf {
+    std::env::var("APPDATA")
+        .map(|p| std::path::PathBuf::from(p).join("OpenFlow"))
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+
+#[cfg(target_os = "windows")]
+fn free_bytes_for_path(path: &std::path::Path) -> Result<u64, String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+    use windows::core::PCWSTR;
+
+    let mut free_bytes_available: u64 = 0;
+    let mut total_bytes: u64 = 0;
+    let mut total_free_bytes: u64 = 0;
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let result = unsafe {
+        GetDiskFreeSpaceExW(
+            PCWSTR(wide.as_ptr()),
+            Some(&mut free_bytes_available),
+            Some(&mut total_bytes),
+            Some(&mut total_free_bytes),
+        )
+    };
+    result
+        .map(|_| total_free_bytes)
+        .map_err(|_| "Failed to read free disk space".to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn free_bytes_for_path(_path: &std::path::Path) -> Result<u64, String> {
+    Ok(u64::MAX)
+}
+
+#[tauri::command]
+pub fn clear_cleanup_cache(app: AppHandle) -> Result<usize, String> {
+    let db = app.state::<DbHandle>();
+    db::cleanup_cache_clear_all(&db).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_cleanup_cache_status(app: AppHandle) -> Result<CleanupCacheStatus, String> {
+    let db = app.state::<DbHandle>();
+    let entry_count = db::cleanup_cache_count(&db).map_err(|e| e.to_string())?;
+    let app_data = app_data_dir_for_db();
+    let free_bytes = free_bytes_for_path(&app_data)?;
+    Ok(CleanupCacheStatus {
+        entry_count,
+        is_space_constrained: free_bytes < SPACE_CONSTRAINED_THRESHOLD_BYTES,
+        free_bytes,
+    })
 }
 
 // ---------- microphone ----------

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -131,10 +131,10 @@ pub fn open(path: &str) -> Result<Db> {
                ON cleanup_cache(expires_at);
              CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
                ON cleanup_cache(last_hit_at);
+             PRAGMA user_version = 3;
              COMMIT;",
         );
         let _ = conn.execute_batch("ROLLBACK;");
-        conn.execute_batch("PRAGMA user_version = 3;")?;
     }
 
     Ok(Arc::new(Mutex::new(conn)))

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -117,7 +117,7 @@ pub fn open(path: &str) -> Result<Db> {
         conn.execute_batch("PRAGMA user_version = 2;")?;
     }
     if user_version < 3 {
-        let _ = conn.execute_batch(
+        let res = conn.execute_batch(
             "BEGIN;
              CREATE TABLE IF NOT EXISTS cleanup_cache (
                key         TEXT PRIMARY KEY,
@@ -134,7 +134,10 @@ pub fn open(path: &str) -> Result<Db> {
              PRAGMA user_version = 3;
              COMMIT;",
         );
-        let _ = conn.execute_batch("ROLLBACK;");
+        if let Err(err) = res {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err.into());
+        }
     }
 
     Ok(Arc::new(Mutex::new(conn)))

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -44,6 +44,18 @@ CREATE TABLE IF NOT EXISTS pending_corrections (
 );
 CREATE INDEX IF NOT EXISTS idx_pending_words
   ON pending_corrections(wrong_word, correct_word);
+CREATE TABLE IF NOT EXISTS cleanup_cache (
+  key         TEXT PRIMARY KEY,
+  clean_text  TEXT NOT NULL,
+  hit_count   INTEGER NOT NULL DEFAULT 0,
+  created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+  last_hit_at DATETIME NOT NULL DEFAULT (datetime('now')),
+  expires_at  DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at
+  ON cleanup_cache(expires_at);
+CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
+  ON cleanup_cache(last_hit_at);
 ";
 
 pub fn open(path: &str) -> Result<Db> {
@@ -104,6 +116,26 @@ pub fn open(path: &str) -> Result<Db> {
         let _ = conn.execute_batch("ROLLBACK;");
         conn.execute_batch("PRAGMA user_version = 2;")?;
     }
+    if user_version < 3 {
+        let _ = conn.execute_batch(
+            "BEGIN;
+             CREATE TABLE IF NOT EXISTS cleanup_cache (
+               key         TEXT PRIMARY KEY,
+               clean_text  TEXT NOT NULL,
+               hit_count   INTEGER NOT NULL DEFAULT 0,
+               created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+               last_hit_at DATETIME NOT NULL DEFAULT (datetime('now')),
+               expires_at  DATETIME NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at
+               ON cleanup_cache(expires_at);
+             CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
+               ON cleanup_cache(last_hit_at);
+             COMMIT;",
+        );
+        let _ = conn.execute_batch("ROLLBACK;");
+        conn.execute_batch("PRAGMA user_version = 3;")?;
+    }
 
     Ok(Arc::new(Mutex::new(conn)))
 }
@@ -133,6 +165,16 @@ pub struct Snippet {
     pub instructions: String,
     pub use_count: i64,
     pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CleanupCacheEntry {
+    pub key: String,
+    pub clean_text: String,
+    pub hit_count: i64,
+    pub created_at: String,
+    pub last_hit_at: String,
+    pub expires_at: String,
 }
 
 // ---------- queries ----------
@@ -386,6 +428,79 @@ pub fn increment_snippet_use(db: &Db, id: i64) -> Result<()> {
     Ok(())
 }
 
+// ---------- cleanup cache ----------
+
+pub fn cleanup_cache_get_active(db: &Db, key: &str) -> Result<Option<CleanupCacheEntry>> {
+    let conn = lock_conn(db)?;
+    let mut stmt = conn.prepare(
+        "SELECT key, clean_text, hit_count, created_at, last_hit_at, expires_at
+         FROM cleanup_cache
+         WHERE key = ?1 AND expires_at > datetime('now')
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query(params![key])?;
+    let Some(row) = rows.next()? else {
+        return Ok(None);
+    };
+    Ok(Some(CleanupCacheEntry {
+        key: row.get(0)?,
+        clean_text: row.get(1)?,
+        hit_count: row.get(2)?,
+        created_at: row.get(3)?,
+        last_hit_at: row.get(4)?,
+        expires_at: row.get(5)?,
+    }))
+}
+
+pub fn cleanup_cache_insert_new(db: &Db, key: &str, clean_text: &str, expires_at: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT OR REPLACE INTO cleanup_cache
+         (key, clean_text, hit_count, created_at, last_hit_at, expires_at)
+         VALUES (?1, ?2, 1, datetime('now'), datetime('now'), ?3)",
+        params![key, clean_text, expires_at],
+    )?;
+    Ok(())
+}
+
+pub fn cleanup_cache_touch_hit(
+    db: &Db,
+    key: &str,
+    new_hit_count: i64,
+    last_hit_at: &str,
+    expires_at: &str,
+) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "UPDATE cleanup_cache
+         SET hit_count = ?2, last_hit_at = ?3, expires_at = ?4
+         WHERE key = ?1",
+        params![key, new_hit_count, last_hit_at, expires_at],
+    )?;
+    Ok(())
+}
+
+pub fn cleanup_cache_prune_expired(db: &Db) -> Result<usize> {
+    let conn = lock_conn(db)?;
+    let changed = conn.execute(
+        "DELETE FROM cleanup_cache WHERE expires_at <= datetime('now')",
+        [],
+    )?;
+    Ok(changed)
+}
+
+pub fn cleanup_cache_clear_all(db: &Db) -> Result<usize> {
+    let conn = lock_conn(db)?;
+    let changed = conn.execute("DELETE FROM cleanup_cache", [])?;
+    Ok(changed)
+}
+
+pub fn cleanup_cache_count(db: &Db) -> Result<i64> {
+    let conn = lock_conn(db)?;
+    conn.query_row("SELECT COUNT(*) FROM cleanup_cache", [], |r| r.get(0))
+        .map_err(Into::into)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,5 +547,33 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
         assert_eq!(entries[0].correction_count, 2);
+    }
+
+    #[test]
+    fn cleanup_cache_insert_get_and_clear() {
+        let db = test_db();
+        cleanup_cache_insert_new(&db, "abc", "hello", "2999-01-01 00:00:00").expect("insert");
+        let hit = cleanup_cache_get_active(&db, "abc")
+            .expect("query")
+            .expect("exists");
+        assert_eq!(hit.clean_text, "hello");
+        assert_eq!(hit.hit_count, 1);
+
+        assert_eq!(cleanup_cache_count(&db).expect("count"), 1);
+        assert_eq!(cleanup_cache_clear_all(&db).expect("clear"), 1);
+        assert_eq!(cleanup_cache_count(&db).expect("count"), 0);
+    }
+
+    #[test]
+    fn cleanup_cache_prunes_expired_only() {
+        let db = test_db();
+        cleanup_cache_insert_new(&db, "old", "x", "2000-01-01 00:00:00").expect("insert old");
+        cleanup_cache_insert_new(&db, "live", "y", "2999-01-01 00:00:00").expect("insert live");
+
+        assert_eq!(cleanup_cache_prune_expired(&db).expect("prune"), 1);
+        assert!(cleanup_cache_get_active(&db, "old").expect("query old").is_none());
+        assert!(cleanup_cache_get_active(&db, "live")
+            .expect("query live")
+            .is_some());
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,6 +61,7 @@ fn main() {
     std::fs::create_dir_all(&db_dir).ok();
     let db_handle: DbHandle =
         db::open(db_dir.join("openflow.db").to_str().unwrap()).expect("failed to open database");
+    let _ = db::cleanup_cache_prune_expired(&db_handle);
 
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
@@ -140,6 +141,8 @@ fn main() {
             commands::hide_main,
             commands::get_recent,
             commands::get_stats,
+            commands::get_cleanup_cache_status,
+            commands::clear_cleanup_cache,
             commands::get_microphones,
             commands::get_memory_mb,
             commands::start_input_recording,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_store::StoreExt;
 
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use crate::api::{auto_learn, cleanup, transcription};
 use crate::core::{injection, window_context};
 use crate::data::{db, dictionary, snippets, store};
@@ -223,6 +224,54 @@ fn trim_err(s: &str) -> String {
     }
 }
 
+fn normalize_cleanup_cache_key(input: &str) -> String {
+    input
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+fn parse_sqlite_utc(s: &str) -> Option<DateTime<Utc>> {
+    let naive = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").ok()?;
+    Some(DateTime::from_naive_utc_and_offset(naive, Utc))
+}
+
+fn sqlite_utc_plus(days: i64) -> String {
+    (Utc::now() + Duration::days(days))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+fn next_cache_expiry(
+    hit_count: i64,
+    created_at: &str,
+    existing_expires_at: &str,
+    now: DateTime<Utc>,
+) -> String {
+    let base = now + Duration::days(7);
+    let created = parse_sqlite_utc(created_at).unwrap_or(now);
+    let age = now.signed_duration_since(created);
+
+    let next = if hit_count >= 5 && age <= Duration::days(60) {
+        now + Duration::days(365)
+    } else if hit_count >= 5 && age <= Duration::days(30) {
+        now + Duration::days(30)
+    } else if hit_count >= 2 && age <= Duration::days(14) {
+        now + Duration::days(30)
+    } else if hit_count >= 2 && age <= Duration::days(7) {
+        now + Duration::days(7)
+    } else {
+        let existing = parse_sqlite_utc(existing_expires_at).unwrap_or(base);
+        if existing > base {
+            existing
+        } else {
+            base
+        }
+    };
+
+    next.format("%Y-%m-%d %H:%M:%S").to_string()
+}
 async fn show_error_pill(app: &AppHandle, msg: &str) {
     log::error!("pipeline error: {msg}");
     app.emit("open-flow:error", msg).ok();
@@ -506,6 +555,26 @@ async fn run_cleanup_and_snippets(
         && pure_expansion.is_none()
         && cfg.cleanup_intensity != "none"
     {
+        let cache_key = normalize_cleanup_cache_key(raw);
+        if !cache_key.is_empty() {
+            if let Ok(Some(entry)) = db::cleanup_cache_get_active(&db, &cache_key) {
+                let now = Utc::now();
+                let new_hit_count = entry.hit_count + 1;
+                let now_str = now.format("%Y-%m-%d %H:%M:%S").to_string();
+                let new_expires_at =
+                    next_cache_expiry(new_hit_count, &entry.created_at, &entry.expires_at, now);
+                let _ = db::cleanup_cache_touch_hit(
+                    &db,
+                    &cache_key,
+                    new_hit_count,
+                    &now_str,
+                    &new_expires_at,
+                );
+                let overridden =
+                    snippets::apply_cleanup_instruction_overrides(&entry.clean_text, &snippet_instructions);
+                return Some((overridden, dict_entries));
+            }
+        }
         let dict_instructions =
             dictionary::build_relevant_dictionary_prompt_from(&dict_entries, raw);
         let extra_rules = [snippet_instructions.as_str(), dict_instructions.as_str()]
@@ -539,7 +608,13 @@ async fn run_cleanup_and_snippets(
 
         match cleaned_res {
             Ok((cleaned, _)) if !cleaned.is_empty() => {
-                snippets::apply_cleanup_instruction_overrides(&cleaned, &snippet_instructions)
+                let overridden =
+                    snippets::apply_cleanup_instruction_overrides(&cleaned, &snippet_instructions);
+                let cache_key = normalize_cleanup_cache_key(raw);
+                if !cache_key.is_empty() {
+                    let _ = db::cleanup_cache_insert_new(&db, &cache_key, &cleaned, &sqlite_utc_plus(7));
+                }
+                overridden
             }
             Ok(_) => {
                 snippets::apply_cleanup_instruction_overrides(&expanded, &snippet_instructions)

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -254,13 +254,17 @@ fn next_cache_expiry(
     let age = now.signed_duration_since(created);
 
     let next = if hit_count >= 5 && age <= Duration::days(60) {
-        now + Duration::days(365)
-    } else if hit_count >= 5 && age <= Duration::days(30) {
-        now + Duration::days(30)
+        if age <= Duration::days(30) {
+            now + Duration::days(30)
+        } else {
+            now + Duration::days(365)
+        }
     } else if hit_count >= 2 && age <= Duration::days(14) {
-        now + Duration::days(30)
-    } else if hit_count >= 2 && age <= Duration::days(7) {
-        now + Duration::days(7)
+        if age <= Duration::days(7) {
+            now + Duration::days(7)
+        } else {
+            now + Duration::days(30)
+        }
     } else {
         let existing = parse_sqlite_utc(existing_expires_at).unwrap_or(base);
         if existing > base {
@@ -610,7 +614,6 @@ async fn run_cleanup_and_snippets(
             Ok((cleaned, _)) if !cleaned.is_empty() => {
                 let overridden =
                     snippets::apply_cleanup_instruction_overrides(&cleaned, &snippet_instructions);
-                let cache_key = normalize_cleanup_cache_key(raw);
                 if !cache_key.is_empty() {
                     let _ = db::cleanup_cache_insert_new(&db, &cache_key, &cleaned, &sqlite_utc_plus(7));
                 }

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -43,7 +43,7 @@
   loadSettings();
 </script>
 
-<h2 class="settings-h">Audio</h2>
+<h2 class="settings-h">Advanced</h2>
 <div class="setting-row gain-row">
   <div class="gain-header">
     <div>

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -10,17 +10,25 @@
   let historyDropdownOpen = $state(false);
   let appContextHint = $state(false);
   let autoLearn = $state(false);
+  let cleanupCacheEntries = $state(0);
+  let cleanupCacheSpaceConstrained = $state(false);
+  let cleanupCacheFreeBytes = $state(0);
+  let clearingCleanupCache = $state(false);
 
   async function loadSettings() {
     try {
-      const [retention, hint, learn] = await Promise.all([
+      const [retention, hint, learn, cacheStatus] = await Promise.all([
         invoke<string | null>('get_setting', { key: 'history_retention' }),
         invoke<boolean | null>('get_setting', { key: 'app_context_hint' }),
         invoke<boolean | null>('get_setting', { key: 'auto_learn_enabled' }),
+        invoke<{ entry_count: number; is_space_constrained: boolean; free_bytes: number }>('get_cleanup_cache_status'),
       ]);
       if (retention) historyRetention = retention;
       appContextHint = hint ?? false;
       autoLearn = learn ?? false;
+      cleanupCacheEntries = cacheStatus.entry_count ?? 0;
+      cleanupCacheSpaceConstrained = cacheStatus.is_space_constrained ?? false;
+      cleanupCacheFreeBytes = cacheStatus.free_bytes ?? 0;
     } catch (err) {
       console.error('PrivacySection load failed:', err);
     }
@@ -53,6 +61,22 @@
     } catch (err) {
       autoLearn = !value;
       console.error('save auto_learn_enabled failed:', err);
+    }
+  }
+
+  async function clearCleanupCache() {
+    if (cleanupCacheSpaceConstrained || clearingCleanupCache) return;
+    clearingCleanupCache = true;
+    try {
+      await invoke<number>('clear_cleanup_cache');
+      const status = await invoke<{ entry_count: number; is_space_constrained: boolean; free_bytes: number }>('get_cleanup_cache_status');
+      cleanupCacheEntries = status.entry_count ?? 0;
+      cleanupCacheSpaceConstrained = status.is_space_constrained ?? false;
+      cleanupCacheFreeBytes = status.free_bytes ?? 0;
+    } catch (err) {
+      console.error('clearCleanupCache failed:', err);
+    } finally {
+      clearingCleanupCache = false;
     }
   }
 
@@ -110,6 +134,27 @@
     <div class="desc">Add confirmed corrections to dictionary automatically</div>
   </div>
   <Toggle checked={autoLearn} onchange={handleAutoLearn} />
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Cleanup cache</div>
+    <div class="desc">
+      {cleanupCacheEntries} cached phrase{cleanupCacheEntries === 1 ? '' : 's'}.
+      {#if cleanupCacheSpaceConstrained}
+        Disabled: low disk space (&lt;1 GB free).
+      {:else}
+        {(cleanupCacheFreeBytes / 1024 / 1024 / 1024).toFixed(1)} GB free.
+      {/if}
+    </div>
+  </div>
+  <button
+    class="btn-ghost"
+    onclick={clearCleanupCache}
+    disabled={cleanupCacheSpaceConstrained || clearingCleanupCache}
+    title={cleanupCacheSpaceConstrained ? 'Disabled: low disk space (<1 GB free).' : ''}
+  >
+    {clearingCleanupCache ? 'Clearing…' : 'Clear Cache'}
+  </button>
 </div>
 
 <style>

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -65,7 +65,7 @@
   }
 
   async function clearCleanupCache() {
-    if (cleanupCacheSpaceConstrained || clearingCleanupCache) return;
+    if (clearingCleanupCache) return;
     clearingCleanupCache = true;
     try {
       await invoke<number>('clear_cleanup_cache');
@@ -141,7 +141,7 @@
     <div class="desc">
       {cleanupCacheEntries} cached phrase{cleanupCacheEntries === 1 ? '' : 's'}.
       {#if cleanupCacheSpaceConstrained}
-        Disabled: low disk space (&lt;1 GB free).
+        Low disk space (&lt;1 GB free). Clearing cache may help free space.
       {:else}
         {(cleanupCacheFreeBytes / 1024 / 1024 / 1024).toFixed(1)} GB free.
       {/if}
@@ -150,8 +150,8 @@
   <button
     class="btn-ghost"
     onclick={clearCleanupCache}
-    disabled={cleanupCacheSpaceConstrained || clearingCleanupCache}
-    title={cleanupCacheSpaceConstrained ? 'Disabled: low disk space (<1 GB free).' : ''}
+    disabled={clearingCleanupCache}
+    title={cleanupCacheSpaceConstrained ? 'Low disk space detected (<1 GB free).' : ''}
   >
     {clearingCleanupCache ? 'Clearing…' : 'Clear Cache'}
   </button>

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -27,7 +27,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Audio',         icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Advanced',      icon: 'mic'      as keyof typeof icons },
     ]},
     { group: 'Account', items: [
       { id: 'about', label: 'About', icon: 'help' as keyof typeof icons },


### PR DESCRIPTION
# Summary

Implements a local exact-match cleanup cache in SQLite to bypass repeat cleanup LLM calls, adds spaced-repetition TTL promotion on cache hits, and adds a Privacy settings clear-cache control with low-space visibility.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [x] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [x] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Commands run:
- `cargo test --manifest-path src-tauri/Cargo.toml` -> pass
- `npm run check` -> pass
- `node tests/smoke/playwright-test-state.cjs` -> pass

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

- Added `cleanup_cache` SQLite table and indexes with migration to `user_version=3`.
- Cache key normalization strips non-alphanumeric characters and lowercases input from raw dictation.
- Cache lookup applies on cleanup-LLM branch only; pure snippets and cleanup-disabled path remain unchanged.
- Cache hit bypasses cleanup provider call and updates `hit_count`, `last_hit_at`, and promoted `expires_at`.
- Disk-space status now uses Tauri app-data path resolution and caller-available free bytes.
- Clear-cache UI remains available even under low space, with warning text.

## UI Evidence

Not applicable.

## Reviewer Notes

- This PR intentionally keeps settings label/header text as `Advanced` to satisfy frozen smoke-test selectors.
- Replaces earlier noisy PR history with a clean branch based on `master`.
