### PR TITLE
Harden automatic dictionary reliability and observability

### DIFF
--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1,4 +1,6 @@
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::sync::{Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use crate::data::db;
@@ -15,11 +17,26 @@ const MIN_CANDIDATE_NORM_LEN: usize = 2;
 const MAX_SPAN_GROWTH_WORDS: usize = 5;
 const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
 const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
+const MIN_CANDIDATE_CONFIDENCE: f64 = 0.45;
+const PAIR_COOLDOWN_MINUTES: i64 = 0;
+
+static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn active_monitors() -> &'static Mutex<HashSet<String>> {
+    ACTIVE_MONITORS.get_or_init(|| Mutex::new(HashSet::new()))
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WordToken {
     raw: String,
     norm: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct CandidateCorrection {
+    mistake: String,
+    correction: String,
+    confidence: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -210,11 +227,14 @@ fn is_common_word(word: &str) -> bool {
             | "our"
             | "out"
             | "so"
+            | "ship"
+            | "shop"
             | "that"
             | "the"
             | "them"
             | "then"
             | "there"
+            | "their"
             | "they"
             | "this"
             | "to"
@@ -270,6 +290,44 @@ fn is_candidate_correction(original: &WordToken, corrected: &WordToken) -> bool 
         || ((original_distinct || corrected_distinct)
             && original.norm.len().max(corrected.norm.len()) >= 4
             && edit_distance(&original.norm, &corrected.norm) <= 3)
+}
+
+fn pair_hash(left: &str, right: &str) -> (String, String) {
+    fn hash_str(value: &str) -> String {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        value.to_lowercase().hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
+    (hash_str(left), hash_str(right))
+}
+
+fn monitor_key(injected_text: &str, app_context: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    injected_text.to_lowercase().hash(&mut hasher);
+    app_context.hash(&mut hasher);
+    format!("{}:{:016x}", app_context, hasher.finish())
+}
+
+fn candidate_confidence(
+    original: &WordToken,
+    corrected: &WordToken,
+    changed_ops: usize,
+    replacements_len: usize,
+) -> f64 {
+    let distance = edit_distance(&original.norm, &corrected.norm) as f64;
+    let max_len = original.norm.len().max(corrected.norm.len()).max(1) as f64;
+    let ratio_score = 1.0 - (distance / max_len).min(1.0);
+
+    let mut score = ratio_score * 0.55;
+    if has_distinctive_features(&original.raw) || has_distinctive_features(&corrected.raw) {
+        score += 0.25;
+    }
+    if is_common_word(&original.norm) && is_common_word(&corrected.norm) {
+        score -= 0.2;
+    }
+    score -= (changed_ops.saturating_sub(1) as f64) * 0.07;
+    score -= (replacements_len.saturating_sub(1) as f64) * 0.08;
+    score.clamp(0.0, 1.0)
 }
 
 fn is_plain_suffix_completion(original: &str, corrected: &str) -> bool {
@@ -452,7 +510,7 @@ fn align_word_ops(
     ops
 }
 
-fn detect_span_corrections(original_span: &str, current_span: &str) -> Vec<(String, String)> {
+fn detect_span_corrections(original_span: &str, current_span: &str) -> Vec<CandidateCorrection> {
     let original = tokenize_words(original_span);
     let current = tokenize_words(current_span);
 
@@ -489,13 +547,18 @@ fn detect_span_corrections(original_span: &str, current_span: &str) -> Vec<(Stri
         return vec![];
     }
 
+    let replacements_len = replacements.len();
     replacements
         .into_iter()
         .filter_map(|(old_idx, new_idx)| {
             let old = &original[old_idx];
             let new = &current[new_idx];
             if is_candidate_correction(old, new) {
-                Some((old.raw.clone(), new.raw.clone()))
+                Some(CandidateCorrection {
+                    mistake: old.raw.clone(),
+                    correction: new.raw.clone(),
+                    confidence: candidate_confidence(old, new, changed_ops, replacements_len),
+                })
             } else {
                 log::debug!("auto-learn: rejected low-confidence candidate");
                 None
@@ -504,11 +567,11 @@ fn detect_span_corrections(original_span: &str, current_span: &str) -> Vec<(Stri
         .collect()
 }
 
-pub fn detect_corrections_from_anchored_text(
+fn detect_corrections_from_anchored_text(
     injected_text: &str,
     baseline_full_text: &str,
     current_full_text: &str,
-) -> Vec<(String, String)> {
+) -> Vec<CandidateCorrection> {
     let Some(anchor) = find_unique_anchor(baseline_full_text, injected_text) else {
         log::debug!("auto-learn: injected text was not uniquely anchored");
         return vec![];
@@ -526,22 +589,74 @@ pub fn detect_corrections_from_anchored_text(
 #[cfg(test)]
 fn diff_words(original: &str, current: &str) -> Vec<(String, String)> {
     detect_span_corrections(original, current)
+        .into_iter()
+        .map(|c| (c.mistake, c.correction))
+        .collect()
 }
 
 fn record_candidate(
     db: &DbHandle,
     recorded_this_session: &mut HashSet<(String, String)>,
+    app_context: &str,
     mistake: String,
     correction: String,
+    confidence: f64,
 ) -> bool {
     let key = (mistake.clone(), correction.clone());
     if recorded_this_session.contains(&key) {
+        let _ = db::log_auto_learn_event(
+            db,
+            "candidate",
+            "duplicate_in_session",
+            app_context,
+            "",
+            "",
+            confidence,
+        );
         return false;
     }
     recorded_this_session.insert(key);
+    let (mistake_hash, correction_hash) = pair_hash(&mistake, &correction);
+
+    if confidence < MIN_CANDIDATE_CONFIDENCE {
+        let _ = db::log_auto_learn_event(
+            db,
+            "candidate",
+            "low_confidence",
+            app_context,
+            &mistake_hash,
+            &correction_hash,
+            confidence,
+        );
+        return false;
+    }
+
+    if !db::upsert_auto_learn_candidate(db, &mistake, &correction, confidence, PAIR_COOLDOWN_MINUTES)
+        .unwrap_or(false)
+    {
+        let _ = db::log_auto_learn_event(
+            db,
+            "candidate",
+            "cooldown_skip",
+            app_context,
+            &mistake_hash,
+            &correction_hash,
+            confidence,
+        );
+        return false;
+    }
 
     if let Err(e) = db::insert_pending_correction(db, &mistake, &correction) {
         log::warn!("auto-learn pending insert failed: {e}");
+        let _ = db::log_auto_learn_event(
+            db,
+            "candidate",
+            "pending_insert_failed",
+            app_context,
+            &mistake_hash,
+            &correction_hash,
+            confidence,
+        );
         return false;
     }
 
@@ -550,19 +665,66 @@ fn record_candidate(
             .unwrap_or(0);
 
     if count < PROMOTION_THRESHOLD {
+        let _ = db::log_auto_learn_event(
+            db,
+            "candidate",
+            "below_threshold",
+            app_context,
+            &mistake_hash,
+            &correction_hash,
+            confidence,
+        );
         return false;
     }
 
-    match db::insert_dictionary_entry_auto_learned(db, &correction, Some(&mistake)) {
-        Ok(true) => true,
+    let tier = if confidence >= 0.85 {
+        "high"
+    } else if confidence >= 0.72 {
+        "medium"
+    } else {
+        "low"
+    };
+
+    match db::insert_dictionary_entry_auto_learned(db, &correction, Some(&mistake), tier) {
+        Ok(true) => {
+            let _ = db::mark_auto_learn_candidate_promoted(db, &mistake, &correction);
+            let _ = db::log_auto_learn_event(
+                db,
+                "promotion",
+                "promoted",
+                app_context,
+                &mistake_hash,
+                &correction_hash,
+                confidence,
+            );
+            true
+        }
         Ok(false) => {
             log::debug!(
                 "auto-learn: promotion skipped because dictionary entry is manual or mismatched"
+            );
+            let _ = db::log_auto_learn_event(
+                db,
+                "promotion",
+                "promotion_skipped",
+                app_context,
+                &mistake_hash,
+                &correction_hash,
+                confidence,
             );
             false
         }
         Err(e) => {
             log::warn!("auto-learn dictionary promotion failed: {e}");
+            let _ = db::log_auto_learn_event(
+                db,
+                "promotion",
+                "promotion_failed",
+                app_context,
+                &mistake_hash,
+                &correction_hash,
+                confidence,
+            );
             false
         }
     }
@@ -648,10 +810,45 @@ pub fn read_focused_text() -> Option<String> {
     None
 }
 
-pub fn start_monitor(injected_text: String, db: DbHandle, app: AppHandle) {
+pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, app: AppHandle) {
     if injected_text.split_whitespace().count() < 2 {
+        let _ = db::log_auto_learn_event(
+            &db,
+            "monitor",
+            "too_short",
+            &app_context,
+            "",
+            "",
+            0.0,
+        );
         return;
     }
+    let key = monitor_key(&injected_text, &app_context);
+    let inserted = match active_monitors().lock() {
+        Ok(mut active) => active.insert(key.clone()),
+        Err(_) => false,
+    };
+    if !inserted {
+        let _ = db::log_auto_learn_event(
+            &db,
+            "monitor",
+            "duplicate_skip",
+            &app_context,
+            "",
+            "",
+            0.0,
+        );
+        return;
+    }
+    let _ = db::log_auto_learn_event(
+        &db,
+        "monitor",
+        "started",
+        &app_context,
+        "",
+        "",
+        0.0,
+    );
 
     tauri::async_runtime::spawn(async move {
         if let Err(e) = db::prune_pending_corrections(&db, PENDING_RETENTION_DAYS) {
@@ -680,8 +877,21 @@ pub fn start_monitor(injected_text: String, db: DbHandle, app: AppHandle) {
 
         let Some(baseline_text) = baseline_text else {
             log::debug!("auto-learn: could not anchor injected text in focused control");
+            let _ = db::log_auto_learn_event(
+                &db,
+                "anchor",
+                "anchor_miss",
+                &app_context,
+                "",
+                "",
+                0.0,
+            );
+            if let Ok(mut active) = active_monitors().lock() {
+                active.remove(&key);
+            }
             return;
         };
+        let _ = db::log_auto_learn_event(&db, "anchor", "anchor_ok", &app_context, "", "", 0.0);
 
         let mut stable_text_gate = StableTextGate::default();
         let deadline =
@@ -704,21 +914,36 @@ pub fn start_monitor(injected_text: String, db: DbHandle, app: AppHandle) {
             let Some(stable_text) = stable_text_gate.observe(current_text) else {
                 continue;
             };
+            let _ = db::log_auto_learn_event(
+                &db,
+                "stable_text",
+                "stable_pass",
+                &app_context,
+                "",
+                "",
+                0.0,
+            );
 
             let diffs =
                 detect_corrections_from_anchored_text(&injected_text, &baseline_text, stable_text);
 
-            for (mistake, correction) in diffs {
+            for candidate in diffs {
                 if record_candidate(
                     &db,
                     &mut recorded_this_session,
-                    mistake,
-                    correction,
+                    &app_context,
+                    candidate.mistake,
+                    candidate.correction,
+                    candidate.confidence,
                 ) {
                     log::info!("auto-learn: promoted candidate pair");
                     app.emit("open-flow:dictionary-updated", ()).ok();
                 }
             }
+        }
+        let _ = db::log_auto_learn_event(&db, "monitor", "timeout", &app_context, "", "", 0.0);
+        if let Ok(mut active) = active_monitors().lock() {
+            active.remove(&key);
         }
     });
 }
@@ -743,10 +968,11 @@ mod tests {
         let baseline = "Before this. Ask me about Koobernetes today After this.";
         let current = "Before this. Ask me about Kubernetes today After this.";
 
-        assert_eq!(
-            detect_corrections_from_anchored_text(injected, baseline, current),
-            vec![("Koobernetes".to_string(), "Kubernetes".to_string())]
-        );
+        let diffs = detect_corrections_from_anchored_text(injected, baseline, current);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].mistake, "Koobernetes");
+        assert_eq!(diffs[0].correction, "Kubernetes");
+        assert!(diffs[0].confidence > 0.0);
     }
 
     #[test]
@@ -835,14 +1061,18 @@ mod tests {
         assert!(!record_candidate(
             &db,
             &mut recorded,
+            "test-app",
             "Koobernetes".to_string(),
-            "Kubernetes".to_string()
+            "Kubernetes".to_string(),
+            0.9,
         ));
         assert!(!record_candidate(
             &db,
             &mut recorded,
+            "test-app",
             "Koobernetes".to_string(),
-            "Kubernetes".to_string()
+            "Kubernetes".to_string(),
+            0.9,
         ));
 
         let count = db::count_pending_corrections_recent(
@@ -865,8 +1095,10 @@ mod tests {
                 record_candidate(
                     &db,
                     &mut recorded,
+                    "test-app",
                     "Koobernetes".to_string(),
-                    "Kubernetes".to_string()
+                    "Kubernetes".to_string(),
+                    0.9,
                 ),
                 expected
             );
@@ -886,7 +1118,14 @@ mod tests {
         for expected in [false, true] {
             let mut recorded = HashSet::new();
             assert_eq!(
-                record_candidate(&db, &mut recorded, "rock".to_string(), "qroq".to_string()),
+                record_candidate(
+                    &db,
+                    &mut recorded,
+                    "test-app",
+                    "rock".to_string(),
+                    "qroq".to_string(),
+                    0.9,
+                ),
                 expected
             );
         }
@@ -939,7 +1178,14 @@ mod tests {
                 for expected_promoted in [false, true] {
                     let mut recorded = HashSet::new();
                     assert_eq!(
-                        record_candidate(&db, &mut recorded, mistake.clone(), correction.clone()),
+                        record_candidate(
+                            &db,
+                            &mut recorded,
+                            "test-app",
+                            mistake.clone(),
+                            correction.clone(),
+                            0.9,
+                        ),
                         expected_promoted,
                         "case {} promotion threshold",
                         case.name

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
 use std::sync::{Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
@@ -24,6 +23,24 @@ static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 fn active_monitors() -> &'static Mutex<HashSet<String>> {
     ACTIVE_MONITORS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+struct MonitorKeyGuard {
+    key: String,
+}
+
+impl MonitorKeyGuard {
+    fn new(key: String) -> Self {
+        Self { key }
+    }
+}
+
+impl Drop for MonitorKeyGuard {
+    fn drop(&mut self) {
+        if let Ok(mut active) = active_monitors().lock() {
+            active.remove(&self.key);
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -293,19 +310,24 @@ fn is_candidate_correction(original: &WordToken, corrected: &WordToken) -> bool 
 }
 
 fn pair_hash(left: &str, right: &str) -> (String, String) {
+    // FNV-1a 64-bit with a fixed offset/prime gives stable hashes across
+    // app versions and process runs. This is telemetry bucketing, not crypto.
     fn hash_str(value: &str) -> String {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        value.to_lowercase().hash(&mut hasher);
-        format!("{:016x}", hasher.finish())
+        const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+        const FNV_PRIME: u64 = 0x100000001b3;
+        let mut hash = FNV_OFFSET_BASIS;
+        for b in value.to_lowercase().as_bytes() {
+            hash ^= u64::from(*b);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        format!("{hash:016x}")
     }
     (hash_str(left), hash_str(right))
 }
 
 fn monitor_key(injected_text: &str, app_context: &str) -> String {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    injected_text.to_lowercase().hash(&mut hasher);
-    app_context.hash(&mut hasher);
-    format!("{}:{:016x}", app_context, hasher.finish())
+    let (lhs, rhs) = pair_hash(injected_text, app_context);
+    format!("{rhs}:{lhs}")
 }
 
 fn candidate_confidence(
@@ -851,6 +873,7 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
     );
 
     tauri::async_runtime::spawn(async move {
+        let _monitor_guard = MonitorKeyGuard::new(key);
         if let Err(e) = db::prune_pending_corrections(&db, PENDING_RETENTION_DAYS) {
             log::warn!("auto-learn prune failed: {e}");
         }
@@ -886,9 +909,6 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
                 "",
                 0.0,
             );
-            if let Ok(mut active) = active_monitors().lock() {
-                active.remove(&key);
-            }
             return;
         };
         let _ = db::log_auto_learn_event(&db, "anchor", "anchor_ok", &app_context, "", "", 0.0);
@@ -942,9 +962,6 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
             }
         }
         let _ = db::log_auto_learn_event(&db, "monitor", "timeout", &app_context, "", "", 0.0);
-        if let Ok(mut active) = active_monitors().lock() {
-            active.remove(&key);
-        }
     });
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -420,6 +420,21 @@ pub fn remove_dictionary_entry(app: AppHandle, id: i64) -> Result<(), String> {
     db::delete_dictionary_entry(&db, id).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub fn get_auto_learn_status_summary(app: AppHandle) -> Result<db::AutoLearnStatusSummary, String> {
+    let db = app.state::<DbHandle>();
+    db::get_auto_learn_status_summary(&db).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_recent_auto_learn_activity(
+    app: AppHandle,
+    limit: Option<i64>,
+) -> Result<Vec<db::AutoLearnEvent>, String> {
+    let db = app.state::<DbHandle>();
+    db::get_recent_auto_learn_activity(&db, limit.unwrap_or(20)).map_err(|e| e.to_string())
+}
+
 // ---------- hotkey ----------
 
 #[tauri::command]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -10,6 +10,27 @@ fn lock_conn(db: &Db) -> Result<MutexGuard<'_, Connection>> {
         .map_err(|_| anyhow::anyhow!("Database lock was poisoned"))
 }
 
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&pragma)?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn ensure_table_column(conn: &Connection, table: &str, column: &str, def_sql: &str) -> Result<()> {
+    if table_has_column(conn, table, column)? {
+        return Ok(());
+    }
+    conn.execute_batch(def_sql)?;
+    Ok(())
+}
+
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS transcriptions (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -168,44 +189,22 @@ pub fn open(path: &str) -> Result<Db> {
         }
     }
     if user_version < 4 {
-        let res = conn.execute_batch(
-            "BEGIN;
-             ALTER TABLE dictionary ADD COLUMN confidence_tier TEXT NOT NULL DEFAULT 'low';
-             ALTER TABLE dictionary ADD COLUMN last_seen_at DATETIME;
-             CREATE TABLE IF NOT EXISTS auto_learn_events (
-               id             INTEGER PRIMARY KEY AUTOINCREMENT,
-               event_type     TEXT    NOT NULL,
-               reason_code    TEXT    NOT NULL DEFAULT '',
-               app_context    TEXT    NOT NULL DEFAULT '',
-               mistake_hash   TEXT    NOT NULL DEFAULT '',
-               correction_hash TEXT   NOT NULL DEFAULT '',
-               confidence     REAL    NOT NULL DEFAULT 0.0,
-               created_at     DATETIME NOT NULL DEFAULT (datetime('now'))
-             );
-             CREATE INDEX IF NOT EXISTS idx_auto_learn_events_event_type
-               ON auto_learn_events(event_type, created_at);
-             CREATE TABLE IF NOT EXISTS auto_learn_candidates (
-               id                 INTEGER PRIMARY KEY AUTOINCREMENT,
-               wrong_word         TEXT    NOT NULL,
-               correct_word       TEXT    NOT NULL,
-               confidence_sum     REAL    NOT NULL DEFAULT 0.0,
-               confidence_avg     REAL    NOT NULL DEFAULT 0.0,
-               seen_count         INTEGER NOT NULL DEFAULT 0,
-               last_seen_at       DATETIME NOT NULL DEFAULT (datetime('now')),
-               cooldown_until     DATETIME,
-               promoted_at        DATETIME,
-               UNIQUE(wrong_word, correct_word)
-             );
-             CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
-               ON auto_learn_candidates(last_seen_at);
-             PRAGMA user_version = 4;
-             COMMIT;",
-        );
-        if res.is_err() {
-            let _ = conn.execute_batch("ROLLBACK;");
-            let res_retry = conn.execute_batch(
-                "BEGIN;
-                 CREATE TABLE IF NOT EXISTS auto_learn_events (
+        conn.execute_batch("BEGIN;")?;
+        if let Err(err) = (|| -> Result<()> {
+            ensure_table_column(
+                &conn,
+                "dictionary",
+                "confidence_tier",
+                "ALTER TABLE dictionary ADD COLUMN confidence_tier TEXT NOT NULL DEFAULT 'low';",
+            )?;
+            ensure_table_column(
+                &conn,
+                "dictionary",
+                "last_seen_at",
+                "ALTER TABLE dictionary ADD COLUMN last_seen_at DATETIME;",
+            )?;
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS auto_learn_events (
                    id             INTEGER PRIMARY KEY AUTOINCREMENT,
                    event_type     TEXT    NOT NULL,
                    reason_code    TEXT    NOT NULL DEFAULT '',
@@ -231,14 +230,14 @@ pub fn open(path: &str) -> Result<Db> {
                  );
                  CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
                    ON auto_learn_candidates(last_seen_at);
-                 PRAGMA user_version = 4;
-                 COMMIT;",
-            );
-            if let Err(err) = res_retry {
-                let _ = conn.execute_batch("ROLLBACK;");
-                return Err(err.into());
-            }
+                 PRAGMA user_version = 4;",
+            )?;
+            Ok(())
+        })() {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err);
         }
+        conn.execute_batch("COMMIT;")?;
     }
 
     Ok(Arc::new(Mutex::new(conn)))

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS dictionary (
   mistake          TEXT,
   auto_learned     INTEGER NOT NULL DEFAULT 0,
   correction_count INTEGER NOT NULL DEFAULT 0,
+  confidence_tier  TEXT    NOT NULL DEFAULT 'low',
+  last_seen_at     DATETIME,
   created_at       DATETIME NOT NULL DEFAULT (datetime('now'))
 );
 CREATE TABLE IF NOT EXISTS snippets (
@@ -44,6 +46,32 @@ CREATE TABLE IF NOT EXISTS pending_corrections (
 );
 CREATE INDEX IF NOT EXISTS idx_pending_words
   ON pending_corrections(wrong_word, correct_word);
+CREATE TABLE IF NOT EXISTS auto_learn_events (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_type     TEXT    NOT NULL,
+  reason_code    TEXT    NOT NULL DEFAULT '',
+  app_context    TEXT    NOT NULL DEFAULT '',
+  mistake_hash   TEXT    NOT NULL DEFAULT '',
+  correction_hash TEXT   NOT NULL DEFAULT '',
+  confidence     REAL    NOT NULL DEFAULT 0.0,
+  created_at     DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_auto_learn_events_event_type
+  ON auto_learn_events(event_type, created_at);
+CREATE TABLE IF NOT EXISTS auto_learn_candidates (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  wrong_word         TEXT    NOT NULL,
+  correct_word       TEXT    NOT NULL,
+  confidence_sum     REAL    NOT NULL DEFAULT 0.0,
+  confidence_avg     REAL    NOT NULL DEFAULT 0.0,
+  seen_count         INTEGER NOT NULL DEFAULT 0,
+  last_seen_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+  cooldown_until     DATETIME,
+  promoted_at        DATETIME,
+  UNIQUE(wrong_word, correct_word)
+);
+CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
+  ON auto_learn_candidates(last_seen_at);
 CREATE TABLE IF NOT EXISTS cleanup_cache (
   key         TEXT PRIMARY KEY,
   clean_text  TEXT NOT NULL,
@@ -137,6 +165,79 @@ pub fn open(path: &str) -> Result<Db> {
         if let Err(err) = res {
             let _ = conn.execute_batch("ROLLBACK;");
             return Err(err.into());
+        }
+    }
+    if user_version < 4 {
+        let res = conn.execute_batch(
+            "BEGIN;
+             ALTER TABLE dictionary ADD COLUMN confidence_tier TEXT NOT NULL DEFAULT 'low';
+             ALTER TABLE dictionary ADD COLUMN last_seen_at DATETIME;
+             CREATE TABLE IF NOT EXISTS auto_learn_events (
+               id             INTEGER PRIMARY KEY AUTOINCREMENT,
+               event_type     TEXT    NOT NULL,
+               reason_code    TEXT    NOT NULL DEFAULT '',
+               app_context    TEXT    NOT NULL DEFAULT '',
+               mistake_hash   TEXT    NOT NULL DEFAULT '',
+               correction_hash TEXT   NOT NULL DEFAULT '',
+               confidence     REAL    NOT NULL DEFAULT 0.0,
+               created_at     DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE INDEX IF NOT EXISTS idx_auto_learn_events_event_type
+               ON auto_learn_events(event_type, created_at);
+             CREATE TABLE IF NOT EXISTS auto_learn_candidates (
+               id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+               wrong_word         TEXT    NOT NULL,
+               correct_word       TEXT    NOT NULL,
+               confidence_sum     REAL    NOT NULL DEFAULT 0.0,
+               confidence_avg     REAL    NOT NULL DEFAULT 0.0,
+               seen_count         INTEGER NOT NULL DEFAULT 0,
+               last_seen_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+               cooldown_until     DATETIME,
+               promoted_at        DATETIME,
+               UNIQUE(wrong_word, correct_word)
+             );
+             CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
+               ON auto_learn_candidates(last_seen_at);
+             PRAGMA user_version = 4;
+             COMMIT;",
+        );
+        if res.is_err() {
+            let _ = conn.execute_batch("ROLLBACK;");
+            let res_retry = conn.execute_batch(
+                "BEGIN;
+                 CREATE TABLE IF NOT EXISTS auto_learn_events (
+                   id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                   event_type     TEXT    NOT NULL,
+                   reason_code    TEXT    NOT NULL DEFAULT '',
+                   app_context    TEXT    NOT NULL DEFAULT '',
+                   mistake_hash   TEXT    NOT NULL DEFAULT '',
+                   correction_hash TEXT   NOT NULL DEFAULT '',
+                   confidence     REAL    NOT NULL DEFAULT 0.0,
+                   created_at     DATETIME NOT NULL DEFAULT (datetime('now'))
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_auto_learn_events_event_type
+                   ON auto_learn_events(event_type, created_at);
+                 CREATE TABLE IF NOT EXISTS auto_learn_candidates (
+                   id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                   wrong_word         TEXT    NOT NULL,
+                   correct_word       TEXT    NOT NULL,
+                   confidence_sum     REAL    NOT NULL DEFAULT 0.0,
+                   confidence_avg     REAL    NOT NULL DEFAULT 0.0,
+                   seen_count         INTEGER NOT NULL DEFAULT 0,
+                   last_seen_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+                   cooldown_until     DATETIME,
+                   promoted_at        DATETIME,
+                   UNIQUE(wrong_word, correct_word)
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
+                   ON auto_learn_candidates(last_seen_at);
+                 PRAGMA user_version = 4;
+                 COMMIT;",
+            );
+            if let Err(err) = res_retry {
+                let _ = conn.execute_batch("ROLLBACK;");
+                return Err(err.into());
+            }
         }
     }
 
@@ -267,13 +368,37 @@ pub struct DictionaryEntry {
     pub mistake: Option<String>,
     pub auto_learned: bool,
     pub correction_count: i64,
+    pub confidence_tier: String,
+    pub last_seen_at: Option<String>,
     pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AutoLearnEvent {
+    pub id: i64,
+    pub event_type: String,
+    pub reason_code: String,
+    pub app_context: String,
+    pub mistake_hash: String,
+    pub correction_hash: String,
+    pub confidence: f64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AutoLearnStatusSummary {
+    pub monitors_started: i64,
+    pub anchor_misses: i64,
+    pub low_confidence_rejections: i64,
+    pub promotions: i64,
+    pub duplicate_monitor_skips: i64,
+    pub timeout_finishes: i64,
 }
 
 pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
     let conn = lock_conn(db)?;
     let mut stmt = conn.prepare(
-        "SELECT id, term, mistake, auto_learned, correction_count, created_at \
+        "SELECT id, term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at, created_at \
          FROM dictionary ORDER BY created_at DESC",
     )?;
     let rows = stmt
@@ -284,7 +409,9 @@ pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
                 mistake: r.get(2)?,
                 auto_learned: r.get::<_, i64>(3)? != 0,
                 correction_count: r.get(4)?,
-                created_at: r.get(5)?,
+                confidence_tier: r.get(5)?,
+                last_seen_at: r.get(6)?,
+                created_at: r.get(7)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -294,7 +421,7 @@ pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
 pub fn insert_dictionary_entry(db: &Db, term: &str, mistake: Option<&str>) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
-        "INSERT INTO dictionary (term, mistake) VALUES (?1, ?2)",
+        "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
         params![term, mistake],
     )?;
     Ok(())
@@ -304,18 +431,142 @@ pub fn insert_dictionary_entry_auto_learned(
     db: &Db,
     term: &str,
     mistake: Option<&str>,
+    confidence_tier: &str,
 ) -> Result<bool> {
     let conn = lock_conn(db)?;
     let changed = conn.execute(
         "INSERT INTO dictionary (term, mistake, auto_learned, correction_count) \
          VALUES (?1, ?2, 1, 1) \
          ON CONFLICT(term) DO UPDATE SET \
-           correction_count = correction_count + 1 \
+           correction_count = correction_count + 1, \
+           confidence_tier = ?3, \
+           last_seen_at = datetime('now') \
          WHERE dictionary.auto_learned = 1 \
            AND COALESCE(dictionary.mistake, '') = COALESCE(excluded.mistake, '')",
-        params![term, mistake],
+        params![term, mistake, confidence_tier],
     )?;
     Ok(changed > 0)
+}
+
+pub fn log_auto_learn_event(
+    db: &Db,
+    event_type: &str,
+    reason_code: &str,
+    app_context: &str,
+    mistake_hash: &str,
+    correction_hash: &str,
+    confidence: f64,
+) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO auto_learn_events
+         (event_type, reason_code, app_context, mistake_hash, correction_hash, confidence)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![event_type, reason_code, app_context, mistake_hash, correction_hash, confidence],
+    )?;
+    Ok(())
+}
+
+pub fn upsert_auto_learn_candidate(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    confidence: f64,
+    cooldown_minutes: i64,
+) -> Result<bool> {
+    let conn = lock_conn(db)?;
+    let blocked: i64 = conn.query_row(
+        "SELECT COUNT(*)
+         FROM auto_learn_candidates
+         WHERE wrong_word = ?1
+           AND correct_word = ?2
+           AND cooldown_until IS NOT NULL
+           AND cooldown_until > datetime('now')",
+        params![wrong, correct],
+        |r| r.get(0),
+    )?;
+    if blocked > 0 {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT INTO auto_learn_candidates
+         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at, cooldown_until)
+         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'), datetime('now', ?4))
+         ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
+           confidence_sum = auto_learn_candidates.confidence_sum + excluded.confidence_sum,
+           seen_count = auto_learn_candidates.seen_count + 1,
+           confidence_avg = (auto_learn_candidates.confidence_sum + excluded.confidence_sum) / (auto_learn_candidates.seen_count + 1),
+           last_seen_at = datetime('now'),
+           cooldown_until = datetime('now', ?4)",
+        params![wrong, correct, confidence, format!("+{} minutes", cooldown_minutes.max(0))],
+    )?;
+    Ok(true)
+}
+
+pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "UPDATE auto_learn_candidates
+         SET promoted_at = datetime('now')
+         WHERE wrong_word = ?1 AND correct_word = ?2",
+        params![wrong, correct],
+    )?;
+    Ok(())
+}
+
+pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> {
+    let conn = lock_conn(db)?;
+    let count_by = |event_type: &str, reason_code: &str| -> Result<i64> {
+        conn.query_row(
+            "SELECT COUNT(*) FROM auto_learn_events WHERE event_type = ?1 AND reason_code = ?2",
+            params![event_type, reason_code],
+            |r| r.get(0),
+        )
+        .map_err(Into::into)
+    };
+    let monitors_started: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM auto_learn_events WHERE event_type = 'monitor'",
+        [],
+        |r| r.get(0),
+    )?;
+    let promotions: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM auto_learn_events WHERE event_type = 'promotion' AND reason_code = 'promoted'",
+        [],
+        |r| r.get(0),
+    )?;
+    Ok(AutoLearnStatusSummary {
+        monitors_started,
+        anchor_misses: count_by("anchor", "anchor_miss")?,
+        low_confidence_rejections: count_by("candidate", "low_confidence")?,
+        promotions,
+        duplicate_monitor_skips: count_by("monitor", "duplicate_skip")?,
+        timeout_finishes: count_by("monitor", "timeout")?,
+    })
+}
+
+pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLearnEvent>> {
+    let conn = lock_conn(db)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, event_type, reason_code, app_context, mistake_hash, correction_hash, confidence, created_at
+         FROM auto_learn_events
+         ORDER BY created_at DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit.max(1)], |r| {
+            Ok(AutoLearnEvent {
+                id: r.get(0)?,
+                event_type: r.get(1)?,
+                reason_code: r.get(2)?,
+                app_context: r.get(3)?,
+                mistake_hash: r.get(4)?,
+                correction_hash: r.get(5)?,
+                confidence: r.get(6)?,
+                created_at: r.get(7)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
 }
 
 pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<()> {
@@ -517,7 +768,12 @@ mod tests {
         let db = test_db();
 
         insert_dictionary_entry(&db, "Kubernetes", Some("manual typo")).expect("manual insert");
-        let promoted = insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"))
+        let promoted = insert_dictionary_entry_auto_learned(
+            &db,
+            "Kubernetes",
+            Some("Koobernetes"),
+            "high",
+        )
             .expect("auto insert");
 
         assert!(!promoted);
@@ -534,15 +790,20 @@ mod tests {
         let db = test_db();
 
         assert!(
-            insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"))
+            insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"), "high")
                 .expect("first insert")
         );
         assert!(
-            insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"))
+            insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"), "high")
                 .expect("same pair")
         );
         assert!(
-            !insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Kubernetties"))
+            !insert_dictionary_entry_auto_learned(
+                &db,
+                "Kubernetes",
+                Some("Kubernetties"),
+                "low",
+            )
                 .expect("different pair")
         );
 

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -78,35 +78,42 @@ fn format_dictionary_entry(entry: &db::DictionaryEntry) -> String {
 }
 
 pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> String {
-    let replaceable: Vec<(&str, &str)> = entries
+    let mut replaceable: Vec<(&str, &str)> = entries
         .iter()
         .filter_map(|e| e.mistake.as_deref().map(|m| (m, e.term.as_str())))
         .collect();
+    replaceable.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
 
     if replaceable.is_empty() {
         return text.to_string();
+    }
+
+    fn is_word_byte(ch: u8) -> bool {
+        ch.is_ascii_alphanumeric() || matches!(ch, b'\'' | b'-' | b'_')
     }
 
     let mut result = text.to_string();
     let mut haystack = result.to_lowercase();
     for (mistake, term) in &replaceable {
         let needle = mistake.to_lowercase();
-        if needle.is_empty() {
+        if needle.is_empty() || !needle.is_ascii() {
             continue;
         }
         let mut positions = Vec::new();
         let mut from = 0usize;
         while let Some(p) = haystack[from..].find(&needle) {
             let abs = from + p;
-            positions.push(abs);
+            let start_ok = abs == 0 || !is_word_byte(haystack.as_bytes()[abs - 1]);
+            let end = abs + needle.len();
+            let end_ok = end >= haystack.len() || !is_word_byte(haystack.as_bytes()[end]);
+            if start_ok && end_ok {
+                positions.push(abs);
+            }
             from = abs + needle.len();
         }
         if positions.is_empty() {
             continue;
         }
-        // Use the lowercase needle length because result indices were found in
-        // the lowercase haystack. Using the original mistake length can panic
-        // when lowercase expansion changes UTF-8 byte length.
         for pos in positions.into_iter().rev() {
             result.replace_range(pos..pos + needle.len(), term);
         }
@@ -117,7 +124,7 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::build_relevant_dictionary_prompt_from;
+    use super::{apply_substitutions_from, build_relevant_dictionary_prompt_from};
     use crate::data::db::DictionaryEntry;
 
     fn entry(id: i64, term: &str, mistake: Option<&str>) -> DictionaryEntry {
@@ -127,6 +134,8 @@ mod tests {
             mistake: mistake.map(str::to_string),
             auto_learned: false,
             correction_count: 0,
+            confidence_tier: "manual".to_string(),
+            last_seen_at: None,
             created_at: "now".to_string(),
         }
     }
@@ -158,5 +167,12 @@ mod tests {
 
         assert!(prompt.contains("RecentTerm"));
         assert!(prompt.contains("AnotherTerm"));
+    }
+
+    #[test]
+    fn substitutions_respect_word_boundaries() {
+        let entries = vec![entry(1, "Kubernetes", Some("kube"))];
+        let out = apply_substitutions_from("kube kubelet", &entries);
+        assert_eq!(out, "Kubernetes kubelet");
     }
 }

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -88,36 +88,59 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
         return text.to_string();
     }
 
-    fn is_word_byte(ch: u8) -> bool {
-        ch.is_ascii_alphanumeric() || matches!(ch, b'\'' | b'-' | b'_')
+    fn is_word_char(ch: char) -> bool {
+        ch.is_alphanumeric() || matches!(ch, '\'' | '-' | '_')
+    }
+
+    fn is_boundary(haystack: &str, start: usize, end: usize) -> bool {
+        let left_ok = haystack[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !is_word_char(ch));
+        let right_ok = haystack[end..]
+            .chars()
+            .next()
+            .is_none_or(|ch| !is_word_char(ch));
+        left_ok && right_ok
     }
 
     let mut result = text.to_string();
-    let mut haystack = result.to_lowercase();
     for (mistake, term) in &replaceable {
-        let needle = mistake.to_lowercase();
-        if needle.is_empty() || !needle.is_ascii() {
+        if mistake.is_empty() {
             continue;
         }
         let mut positions = Vec::new();
-        let mut from = 0usize;
-        while let Some(p) = haystack[from..].find(&needle) {
-            let abs = from + p;
-            let start_ok = abs == 0 || !is_word_byte(haystack.as_bytes()[abs - 1]);
-            let end = abs + needle.len();
-            let end_ok = end >= haystack.len() || !is_word_byte(haystack.as_bytes()[end]);
-            if start_ok && end_ok {
-                positions.push(abs);
+        if mistake.is_ascii() {
+            let mut i = 0usize;
+            while i + mistake.len() <= result.len() {
+                if !result.is_char_boundary(i) {
+                    i += 1;
+                    continue;
+                }
+                let end = i + mistake.len();
+                if !result.is_char_boundary(end) {
+                    i += 1;
+                    continue;
+                }
+                if result[i..end].eq_ignore_ascii_case(mistake) && is_boundary(&result, i, end) {
+                    positions.push(i);
+                }
+                i += 1;
             }
-            from = abs + needle.len();
+        } else {
+            for (start, matched) in result.match_indices(mistake) {
+                let end = start + matched.len();
+                if is_boundary(&result, start, end) {
+                    positions.push(start);
+                }
+            }
         }
         if positions.is_empty() {
             continue;
         }
         for pos in positions.into_iter().rev() {
-            result.replace_range(pos..pos + needle.len(), term);
+            result.replace_range(pos..pos + mistake.len(), term);
         }
-        haystack = result.to_lowercase();
     }
     result
 }
@@ -174,5 +197,12 @@ mod tests {
         let entries = vec![entry(1, "Kubernetes", Some("kube"))];
         let out = apply_substitutions_from("kube kubelet", &entries);
         assert_eq!(out, "Kubernetes kubelet");
+    }
+
+    #[test]
+    fn substitutions_support_non_ascii_terms() {
+        let entries = vec![entry(1, "cliche", Some("cliché"))];
+        let out = apply_substitutions_from("Use cliché in this line.", &entries);
+        assert_eq!(out, "Use cliche in this line.");
     }
 }

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -82,7 +82,7 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
         .iter()
         .filter_map(|e| e.mistake.as_deref().map(|m| (m, e.term.as_str())))
         .collect();
-    replaceable.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
+    replaceable.sort_by_key(|(mistake, _)| std::cmp::Reverse(mistake.len()));
 
     if replaceable.is_empty() {
         return text.to_string();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -160,6 +160,8 @@ fn main() {
             commands::create_dictionary_entry,
             commands::edit_dictionary_entry,
             commands::remove_dictionary_entry,
+            commands::get_auto_learn_status_summary,
+            commands::get_recent_auto_learn_activity,
             commands::check_for_update,
             commands::install_update,
             commands::check_connectivity,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -417,7 +417,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
     app.emit("open-flow:transcribed", &injected_text).ok();
 
     if cfg.auto_learn_enabled {
-        auto_learn::start_monitor(injected_text, db.inner().clone(), app.clone());
+        auto_learn::start_monitor(injected_text, process_name, db.inner().clone(), app.clone());
     }
 }
 

--- a/src-tauri/testdata/auto_learn_cases.json
+++ b/src-tauri/testdata/auto_learn_cases.json
@@ -68,5 +68,26 @@
     "corrected": "rewrite this whole sentence into something else",
     "expect": [],
     "promotes_after_two_sessions": false
+  },
+  {
+    "name": "near homophone should not promote",
+    "original": "their deployment passed",
+    "corrected": "there deployment passed",
+    "expect": [],
+    "promotes_after_two_sessions": false
+  },
+  {
+    "name": "ambiguous short common swap rejected",
+    "original": "we can ship this now",
+    "corrected": "we can shop this now",
+    "expect": [],
+    "promotes_after_two_sessions": false
+  },
+  {
+    "name": "brand typo with numbers promotes",
+    "original": "please open vsc0de now",
+    "corrected": "please open vscode now",
+    "expect": [["vsc0de", "vscode"]],
+    "promotes_after_two_sessions": true
   }
 ]

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -15,14 +15,25 @@
   let cleanupCacheSpaceConstrained = $state(false);
   let cleanupCacheFreeBytes = $state(0);
   let clearingCleanupCache = $state(false);
+  let autoLearnSummary = $state({
+    monitors_started: 0,
+    anchor_misses: 0,
+    low_confidence_rejections: 0,
+    promotions: 0,
+    duplicate_monitor_skips: 0,
+    timeout_finishes: 0,
+  });
+  let recentAutoLearn = $state<Array<{ id: number; event_type: string; reason_code: string; created_at: string }>>([]);
 
   async function loadSettings() {
     try {
-      const [retention, hint, learn, cacheStatus] = await Promise.all([
+      const [retention, hint, learn, cacheStatus, summary, recent] = await Promise.all([
         invoke<string | null>('get_setting', { key: 'history_retention' }),
         invoke<boolean | null>('get_setting', { key: 'app_context_hint' }),
         invoke<boolean | null>('get_setting', { key: 'auto_learn_enabled' }),
         invoke<{ entry_count: number; is_space_constrained: boolean; free_bytes: number }>('get_cleanup_cache_status'),
+        invoke<typeof autoLearnSummary>('get_auto_learn_status_summary'),
+        invoke<typeof recentAutoLearn>('get_recent_auto_learn_activity', { limit: 5 }),
       ]);
       if (retention) historyRetention = retention;
       appContextHint = hint ?? false;
@@ -30,6 +41,8 @@
       cleanupCacheEntries = cacheStatus.entry_count ?? 0;
       cleanupCacheSpaceConstrained = cacheStatus.is_space_constrained ?? false;
       cleanupCacheFreeBytes = cacheStatus.free_bytes ?? 0;
+      autoLearnSummary = summary ?? autoLearnSummary;
+      recentAutoLearn = recent ?? [];
     } catch (err) {
       console.error('PrivacySection load failed:', err);
     }
@@ -139,6 +152,19 @@
     <div class="desc">Add confirmed corrections to dictionary automatically</div>
   </div>
   <Toggle checked={autoLearn} onchange={handleAutoLearn} />
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Auto-learn activity</div>
+    <div class="desc">
+      Promoted: {autoLearnSummary.promotions} | Low-confidence blocked: {autoLearnSummary.low_confidence_rejections} | Anchor misses: {autoLearnSummary.anchor_misses}
+    </div>
+    {#if recentAutoLearn.length > 0}
+      <div class="desc" style="margin-top:4px;">
+        Latest: {recentAutoLearn[0].event_type} ({recentAutoLearn[0].reason_code})
+      </div>
+    {/if}
+  </div>
 </div>
 <div class="setting-row">
   <div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -45,6 +45,8 @@ export interface DictionaryEntry {
   mistake: string | null; // optional: what the transcription typically writes instead
   auto_learned: boolean;
   correction_count: number;
+  confidence_tier?: 'manual' | 'low' | 'medium' | 'high';
+  last_seen_at?: string | null;
   created_at: string;
 }
 

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -23,6 +23,14 @@
     } catch { return iso.slice(0, 10); }
   }
 
+  function confidenceLabel(tier?: string | null): string {
+    if (tier === 'high') return 'High confidence';
+    if (tier === 'medium') return 'Medium confidence';
+    if (tier === 'low') return 'Low confidence';
+    if (tier === 'manual') return 'Manual';
+    return 'Unknown confidence';
+  }
+
   let search        = $state('');
   let sort          = $state<SortKey>('newest');
   let selected      = $state<DictionaryEntry | null>(null);
@@ -264,6 +272,9 @@
                   {#if e.correction_count > 0}
                     <span>{e.correction_count} {e.correction_count === 1 ? 'correction' : 'corrections'}</span>
                   {/if}
+                  {#if e.auto_learned}
+                    <span>{confidenceLabel(e.confidence_tier)}</span>
+                  {/if}
                   <span>{fmtDate(e.created_at)}</span>
                 </div>
               </div>
@@ -297,6 +308,10 @@
                   </svg>
                   Auto-learned
                 </div>
+                <div class="insp-often">
+                  <span class="insp-often-label">Confidence:</span>
+                  <span class="insp-often-text">{confidenceLabel(selected.confidence_tier)}</span>
+                </div>
               {/if}
 
               <div class="insp-divider"></div>
@@ -312,6 +327,12 @@
                   <span class="insp-stat-label">Added</span>
                   <span class="insp-stat-date">{fmtDate(selected.created_at)}</span>
                 </div>
+                {#if selected.last_seen_at}
+                  <div class="insp-stat-row">
+                    <span class="insp-stat-label">Last seen</span>
+                    <span class="insp-stat-date">{fmtDate(selected.last_seen_at)}</span>
+                  </div>
+                {/if}
               </div>
 
               <div class="insp-actions">


### PR DESCRIPTION
# Summary

Hardens automatic dictionary reliability with precision-first auto-learn safeguards, observability, and safer substitution behavior. Adds telemetry/candidate persistence, confidence gating, duplicate-monitor suppression, boundary-aware dictionary replacement, and UI visibility for auto-learn confidence/activity.

## Type of Change

- [x] Bug fix
- [x] Feature
- [x] UI change
- [x] Refactor
- [ ] Documentation
- [x] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Notes:

- `cargo test --manifest-path src-tauri/Cargo.toml` passed (26/26).
- `npm run check` passed with 0 errors/warnings.
- Playwright dictionary smoke script was attempted but requires a running dev server at `http://localhost:5173`; run failed with `ERR_CONNECTION_REFUSED` in this session.

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

- Added local-only auto-learn telemetry and candidate stats tables. Event data stores reason codes, app context label, hashed pair identifiers, and confidence only; raw document text is not persisted.
- Database schema updated to include dictionary confidence metadata and auto-learn diagnostics/candidate tables.
- No API provider key handling was changed.

## UI Evidence

Not applicable.

## Reviewer Notes

- Cooldown infrastructure is implemented but configured to `0` minutes to preserve existing two-session promotion behavior while still enabling future tuning.
- Confidence threshold is set conservatively (`0.45`) to avoid breaking existing correction promotions; threshold can be tightened after telemetry review.
- Substitution logic now enforces ASCII word boundaries to avoid partial-token replacements (for example, replacing `kube` inside `kubelet`).
