### PR TITLE
feat: hidden dev mode with verbose real-time debugging logs

### DIFF
--- a/src-tauri/src/api/cleanup.rs
+++ b/src-tauri/src/api/cleanup.rs
@@ -21,6 +21,26 @@ pub async fn cleanup(
 ) -> Result<String> {
     let prompt =
         get_system_prompt_with_extras(profile, intensity, snippet_instructions, app_context);
+    log::debug!(
+        "cleanup: start provider={:?} profile={} intensity={} input_chars={} prompt_chars={} snippet_rule_lines={} app_context={}",
+        provider,
+        profile,
+        intensity,
+        text.chars().count(),
+        prompt.chars().count(),
+        snippet_instructions.lines().filter(|l| !l.trim().is_empty()).count(),
+        app_context.is_some()
+    );
+    if crate::system::logger::is_verbose() {
+        log::debug!("cleanup: input_full=\"{}\"", text);
+        log::debug!("cleanup: prompt_full=\"{}\"", prompt);
+        if !snippet_instructions.is_empty() {
+            log::debug!("cleanup: snippet_rules_full=\"{}\"", snippet_instructions);
+        }
+        if let Some(ctx) = app_context {
+            log::debug!("cleanup: app_context_full=\"{}\"", ctx);
+        }
+    }
     match provider {
         CleanupProvider::Groq => {
             openai_compat(
@@ -98,12 +118,31 @@ async fn openai_compat(
         temperature: 0.0,
     };
 
+    log::debug!(
+        "cleanup: openai_compat request model={} url={} input_chars={} prompt_chars={}",
+        model,
+        url,
+        text.chars().count(),
+        prompt.chars().count()
+    );
+    let request_started = std::time::Instant::now();
     let resp = super::client::get()
         .post(url)
         .bearer_auth(api_key)
         .json(&body)
         .send()
         .await?;
+    let request_id = resp
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    log::debug!(
+        "cleanup: openai_compat response status={} request_id={} latency_ms={}",
+        resp.status(),
+        request_id,
+        request_started.elapsed().as_millis()
+    );
 
     if resp.status().as_u16() == 429 {
         return Err(crate::api::quota_bail(model));
@@ -111,10 +150,16 @@ async fn openai_compat(
     let resp = resp.error_for_status().context("Cleanup API error")?;
 
     let data: ChatResp = resp.json().await?;
-    data.choices
+    let output = data
+        .choices
         .first()
         .map(|c| c.message.content.trim().to_owned())
-        .ok_or_else(|| anyhow::anyhow!("No choices in OpenAI response"))
+        .ok_or_else(|| anyhow::anyhow!("No choices in OpenAI response"))?;
+    log::debug!("cleanup: openai_compat parsed chars={}", output.chars().count());
+    if crate::system::logger::is_verbose() {
+        log::debug!("cleanup: openai_compat output_full=\"{}\"", output);
+    }
+    Ok(output)
 }
 
 async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<String> {
@@ -151,6 +196,11 @@ async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<Strin
         text: String,
     }
 
+    log::debug!(
+        "cleanup: google request input_chars={} prompt_chars={}",
+        text.chars().count(),
+        prompt.chars().count()
+    );
     let req = Req {
         contents: vec![GContent {
             parts: vec![GPart {
@@ -171,7 +221,19 @@ async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<Strin
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={api_key}"
     );
 
+    let request_started = std::time::Instant::now();
     let resp = super::client::get().post(&url).json(&req).send().await?;
+    let request_id = resp
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    log::debug!(
+        "cleanup: google response status={} request_id={} latency_ms={}",
+        resp.status(),
+        request_id,
+        request_started.elapsed().as_millis()
+    );
 
     if resp.status().as_u16() == 429 {
         return Err(crate::api::quota_bail("Google"));
@@ -181,7 +243,7 @@ async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<Strin
         .context("Google Cleanup API error")?;
 
     let data: GeminiResp = resp.json().await?;
-    data.candidates
+    let output = data.candidates
         .unwrap_or_default()
         .into_iter()
         .next()
@@ -189,5 +251,10 @@ async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<Strin
         .and_then(|c| c.parts.into_iter().next())
         .and_then(|p| p.text)
         .map(|t| t.trim().to_owned())
-        .ok_or_else(|| anyhow::anyhow!("No candidates or parts in Google response"))
+        .ok_or_else(|| anyhow::anyhow!("No candidates or parts in Google response"))?;
+    log::debug!("cleanup: google parsed chars={}", output.chars().count());
+    if crate::system::logger::is_verbose() {
+        log::debug!("cleanup: google output_full=\"{}\"", output);
+    }
+    Ok(output)
 }

--- a/src-tauri/src/api/transcription.rs
+++ b/src-tauri/src/api/transcription.rs
@@ -37,6 +37,12 @@ pub async fn transcribe(
     api_key: &str,
     language: &str,
 ) -> Result<String> {
+    log::debug!(
+        "transcription: start provider={:?} language={} wav_bytes={}",
+        provider,
+        language,
+        wav.len()
+    );
     match provider {
         Provider::Groq => {
             transcribe_whisper(
@@ -76,6 +82,13 @@ async fn transcribe_whisper(
         text: String,
     }
 
+    log::debug!(
+        "transcription: whisper request model={} url={} language={} wav_bytes={}",
+        model,
+        url,
+        language,
+        wav.len()
+    );
     let part =
         multipart::Part::stream_with_length(reqwest::Body::from(wav.clone()), wav.len() as u64)
             .file_name("audio.wav")
@@ -86,12 +99,24 @@ async fn transcribe_whisper(
         .text("response_format", "json")
         .text("language", language.to_owned());
 
+    let request_started = std::time::Instant::now();
     let resp = super::client::get()
         .post(url)
         .bearer_auth(api_key)
         .multipart(form)
         .send()
         .await?;
+    let request_id = resp
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    log::debug!(
+        "transcription: whisper response status={} request_id={} latency_ms={}",
+        resp.status(),
+        request_id,
+        request_started.elapsed().as_millis()
+    );
 
     if resp.status().as_u16() == 429 {
         return Err(crate::api::quota_bail(model));
@@ -99,6 +124,7 @@ async fn transcribe_whisper(
     let resp = resp.error_for_status().context("Transcription API error")?;
 
     let body: WhisperResponse = resp.json().await?;
+    log::debug!("transcription: whisper parsed chars={}", body.text.trim().chars().count());
     Ok(body.text.trim().to_owned())
 }
 
@@ -117,6 +143,12 @@ async fn transcribe_gemini_with_prompt(
     prompt: &str,
     disable_thinking: bool,
 ) -> Result<String> {
+    log::debug!(
+        "transcription: gemini request disable_thinking={} wav_bytes={} prompt_chars={}",
+        disable_thinking,
+        wav.len(),
+        prompt.chars().count()
+    );
     let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wav);
 
     let body = super::gemini_types::GeminiTranscribeReq {
@@ -148,9 +180,21 @@ async fn transcribe_gemini_with_prompt(
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={api_key}"
     );
 
+    let request_started = std::time::Instant::now();
     let resp = super::client::get().post(&url).json(&body).send().await?;
 
     let status = resp.status();
+    let request_id = resp
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    log::debug!(
+        "transcription: gemini response status={} request_id={} latency_ms={}",
+        status,
+        request_id,
+        request_started.elapsed().as_millis()
+    );
     if status.as_u16() == 429 {
         return Err(crate::api::quota_bail("Google"));
     }
@@ -188,6 +232,7 @@ async fn transcribe_gemini_with_prompt(
         .unwrap_or("")
         .trim()
         .to_owned();
+    log::debug!("transcription: gemini parsed chars={}", text.chars().count());
 
     Ok(text)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -615,3 +615,20 @@ pub async fn check_connectivity() -> bool {
     };
     client.head("https://www.google.com").send().await.is_ok()
 }
+
+// ---------- developer logs ----------
+
+#[tauri::command]
+pub fn get_recent_logs(limit: Option<usize>) -> Vec<String> {
+    crate::system::logger::recent(limit)
+}
+
+#[tauri::command]
+pub fn download_logs(app: AppHandle) -> Result<String, String> {
+    crate::system::logger::export_to_downloads(&app)
+}
+
+#[tauri::command]
+pub fn set_dev_logging_enabled(enabled: bool) {
+    crate::system::logger::set_verbose(enabled);
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -75,6 +75,7 @@ fn main() {
         .manage(shared.clone())
         .manage(db_handle.clone())
         .setup(move |app| {
+            crate::system::logger::init(app.handle())?;
             let first_launch = if let Ok(store) =
                 tauri_plugin_store::StoreExt::store(app.handle(), "settings.json")
             {
@@ -165,6 +166,9 @@ fn main() {
             commands::check_for_update,
             commands::install_update,
             commands::check_connectivity,
+            commands::get_recent_logs,
+            commands::download_logs,
+            commands::set_dev_logging_enabled,
         ])
         .run(tauri::generate_context!())
         .expect("error running Open Flow");

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -224,6 +224,16 @@ fn trim_err(s: &str) -> String {
     }
 }
 
+fn preview_text(s: &str, limit: usize) -> String {
+    let compact = s.replace(['\n', '\r'], " ");
+    let compact = compact.trim();
+    if compact.chars().count() > limit {
+        format!("{}...", compact.chars().take(limit).collect::<String>())
+    } else {
+        compact.to_string()
+    }
+}
+
 fn normalize_cleanup_cache_key(input: &str) -> String {
     input
         .chars()
@@ -359,6 +369,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
 }
 
 pub async fn run_pipeline(app: AppHandle, state: SharedState) {
+    let started_at = std::time::Instant::now();
     let Some((session, target_hwnd)) = take_pipeline_session(&state) else {
         log::debug!("pipeline: no session — recording never started or was already consumed");
         return;
@@ -369,25 +380,73 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
     let process_name = window_context::get_active_process_name()
         .unwrap_or_else(|| "unknown".into())
         .to_lowercase();
+    log::info!("pipeline: start process={process_name} target_hwnd={target_hwnd}");
 
     std::thread::spawn(crate::system::volume::unmute);
     show_pill(&app, "processing");
 
+    let stage_audio = std::time::Instant::now();
     let Some((wav, duration_ms)) = stop_and_validate_audio(&app, session).await else {
         return;
     };
+    log::debug!(
+        "pipeline: audio accepted duration_ms={duration_ms} wav_bytes={} stage_ms={}",
+        wav.len(),
+        stage_audio.elapsed().as_millis()
+    );
+    let stage_config = std::time::Instant::now();
     let Some((cfg, profile, app_context)) = open_config_and_context(&app, &process_name).await
     else {
         return;
     };
+    log::debug!(
+        "pipeline: config t_provider={} c_provider={} cleanup_enabled={} intensity={} fallback={} app_context_hint={} profile={}",
+        cfg.transcription_provider,
+        cfg.cleanup_provider,
+        cfg.cleanup_enabled,
+        cfg.cleanup_intensity,
+        cfg.api_fallback_enabled,
+        cfg.app_context_hint,
+        profile
+    );
+    log::debug!(
+        "pipeline: context resolved app_context={} stage_ms={}",
+        app_context.as_deref().unwrap_or("none"),
+        stage_config.elapsed().as_millis()
+    );
+    let stage_transcribe = std::time::Instant::now();
     let Some((raw, api_used)) = run_transcription(&app, &wav, &cfg).await else {
         return;
     };
+    log::debug!(
+        "pipeline: transcription ok provider={} raw_chars={} raw_preview=\"{}\"",
+        api_used,
+        raw.chars().count(),
+        preview_text(&raw, 140)
+    );
+    if crate::system::logger::is_verbose() {
+        log::debug!("pipeline: transcription raw_full=\"{}\"", raw);
+    }
+    log::debug!(
+        "pipeline: transcription stage_ms={}",
+        stage_transcribe.elapsed().as_millis()
+    );
+    let stage_cleanup = std::time::Instant::now();
     let Some((final_text, dict_entries)) =
         run_cleanup_and_snippets(&app, &raw, &cfg, &profile, app_context.as_deref()).await
     else {
         return;
     };
+    log::debug!(
+        "pipeline: cleanup/snippets ok final_chars={} final_preview=\"{}\" dict_entries={}",
+        final_text.chars().count(),
+        preview_text(&final_text, 140),
+        dict_entries.len()
+    );
+    if crate::system::logger::is_verbose() {
+        log::debug!("pipeline: final_text_full=\"{}\"", final_text);
+    }
+    log::debug!("pipeline: cleanup stage_ms={}", stage_cleanup.elapsed().as_millis());
 
     let db = app.state::<DbHandle>();
     let words = final_text.split_whitespace().count() as i64;
@@ -402,9 +461,24 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
         return;
     }
 
+    let dict_stage = std::time::Instant::now();
+    let final_before_dict = final_text.clone();
     let final_text = dictionary::apply_substitutions_from(&final_text, &dict_entries);
+    let dict_changed = final_text != final_before_dict;
+    log::debug!(
+        "pipeline: dictionary apply changed={} before_chars={} after_chars={} stage_ms={}",
+        dict_changed,
+        final_before_dict.chars().count(),
+        final_text.chars().count(),
+        dict_stage.elapsed().as_millis()
+    );
+    if dict_changed && crate::system::logger::is_verbose() {
+        log::debug!("pipeline: dictionary before_full=\"{}\"", final_before_dict);
+        log::debug!("pipeline: dictionary after_full=\"{}\"", final_text);
+    }
 
     hide_pill(&app);
+    let inject_stage = std::time::Instant::now();
     let injected_text =
         match injection::inject_text(&final_text, target_hwnd, cfg.contextual_caps_enabled).await {
             Ok(text) => text,
@@ -414,9 +488,22 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
                 final_text.clone()
             }
         };
+    log::debug!(
+        "pipeline: injection done contextual_caps={} output_chars={} stage_ms={}",
+        cfg.contextual_caps_enabled,
+        injected_text.chars().count(),
+        inject_stage.elapsed().as_millis()
+    );
     app.emit("open-flow:transcribed", &injected_text).ok();
+    log::info!(
+        "pipeline: completed words={} duration_ms={} elapsed_ms={}",
+        words,
+        duration_ms,
+        started_at.elapsed().as_millis()
+    );
 
     if cfg.auto_learn_enabled {
+        log::debug!("pipeline: auto_learn monitor starting");
         auto_learn::start_monitor(injected_text, process_name, db.inner().clone(), app.clone());
     }
 }
@@ -497,6 +584,12 @@ async fn run_transcription(
     cfg: &store::PipelineConfig,
 ) -> Option<(String, String)> {
     let wav = wav.clone();
+    log::debug!(
+        "pipeline: transcription stage start provider={} language={} bytes={}",
+        cfg.transcription_provider,
+        cfg.transcription_language,
+        wav.len()
+    );
     match try_providers(&[&cfg.transcription_provider], cfg, |provider_id, key| {
         let w = wav.clone();
         let provider = transcription_provider_from_str(provider_id);
@@ -506,6 +599,11 @@ async fn run_transcription(
     .await
     {
         Ok((raw, t_provider)) if !raw.is_empty() => {
+            log::debug!(
+                "pipeline: transcription provider success={} chars={}",
+                t_provider,
+                raw.chars().count()
+            );
             Some((raw, format!("{t_provider}/transcription")))
         }
         Ok(_) => {
@@ -517,6 +615,7 @@ async fn run_transcription(
             None
         }
         Err(Some(e)) => {
+            log::error!("pipeline: transcription failed error={}", trim_err(&e.to_string()));
             show_error_pill(app, &trim_err(&e.to_string())).await;
             None
         }
@@ -540,8 +639,25 @@ async fn run_cleanup_and_snippets(
     let db = app.state::<DbHandle>();
     let mut db_snippets = db::query_snippets(&db).unwrap_or_default();
     let dict_entries = db::query_dictionary(&db).unwrap_or_default();
+    log::debug!(
+        "pipeline: cleanup inputs snippets={} dict_entries={}",
+        db_snippets.len(),
+        dict_entries.len()
+    );
 
     let snippet_instructions = snippets::collect_snippet_instructions_from(raw, &db_snippets);
+    log::debug!(
+        "pipeline: cleanup stage start raw_chars={} snippet_override_lines={} cleanup_enabled={}",
+        raw.chars().count(),
+        snippet_instructions.lines().filter(|l| !l.trim().is_empty()).count(),
+        cfg.cleanup_enabled
+    );
+    if crate::system::logger::is_verbose() {
+        log::debug!("pipeline: cleanup raw_full=\"{}\"", raw);
+        if !snippet_instructions.is_empty() {
+            log::debug!("pipeline: cleanup snippet_instructions_full=\"{}\"", snippet_instructions);
+        }
+    }
 
     // Fast path: entire transcription was a single snippet trigger — skip the LLM.
     let pure_expansion = if snippet_instructions.is_empty() {
@@ -552,6 +668,11 @@ async fn run_cleanup_and_snippets(
     let expanded = pure_expansion
         .clone()
         .unwrap_or_else(|| snippets::expand_snippets_from(raw, &mut db_snippets, &db));
+    log::debug!(
+        "pipeline: snippets expanded pure_fast_path={} expanded_chars={}",
+        pure_expansion.is_some(),
+        expanded.chars().count()
+    );
 
     let c_key = cfg.key_for(&cfg.cleanup_provider).to_owned();
     let final_text = if cfg.cleanup_enabled
@@ -562,6 +683,11 @@ async fn run_cleanup_and_snippets(
         let cache_key = normalize_cleanup_cache_key(raw);
         if !cache_key.is_empty() {
             if let Ok(Some(entry)) = db::cleanup_cache_get_active(&db, &cache_key) {
+                log::debug!(
+                    "pipeline: cleanup cache hit key_len={} hit_count={}",
+                    cache_key.len(),
+                    entry.hit_count
+                );
                 let now = Utc::now();
                 let new_hit_count = entry.hit_count + 1;
                 let now_str = now.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -574,11 +700,17 @@ async fn run_cleanup_and_snippets(
                     &now_str,
                     &new_expires_at,
                 );
+                log::debug!(
+                    "pipeline: cleanup cache touch hit_count={} expires_at={}",
+                    new_hit_count,
+                    new_expires_at
+                );
                 let overridden =
                     snippets::apply_cleanup_instruction_overrides(&entry.clean_text, &snippet_instructions);
                 return Some((overridden, dict_entries));
             }
         }
+        log::debug!("pipeline: cleanup cache miss key_len={}", cache_key.len());
         let dict_instructions =
             dictionary::build_relevant_dictionary_prompt_from(&dict_entries, raw);
         let extra_rules = [snippet_instructions.as_str(), dict_instructions.as_str()]
@@ -587,6 +719,11 @@ async fn run_cleanup_and_snippets(
             .copied()
             .collect::<Vec<_>>()
             .join("\n\n");
+        log::debug!(
+            "pipeline: cleanup extra_rules chars={} lines={}",
+            extra_rules.chars().count(),
+            extra_rules.lines().filter(|l| !l.trim().is_empty()).count()
+        );
 
         let cleaned_res = try_providers(&[&cfg.cleanup_provider], cfg, |provider_id, key| {
             let cp = cleanup_provider_from_str(provider_id);
@@ -612,10 +749,15 @@ async fn run_cleanup_and_snippets(
 
         match cleaned_res {
             Ok((cleaned, _)) if !cleaned.is_empty() => {
+                log::debug!("pipeline: cleanup provider success cleaned_chars={}", cleaned.chars().count());
                 let overridden =
                     snippets::apply_cleanup_instruction_overrides(&cleaned, &snippet_instructions);
                 if !cache_key.is_empty() {
-                    let _ = db::cleanup_cache_insert_new(&db, &cache_key, &cleaned, &sqlite_utc_plus(7));
+                    let expires = sqlite_utc_plus(7);
+                    match db::cleanup_cache_insert_new(&db, &cache_key, &cleaned, &expires) {
+                        Ok(_) => log::debug!("pipeline: cleanup cache insert ok expires_at={expires}"),
+                        Err(err) => log::warn!("pipeline: cleanup cache insert failed: {err}"),
+                    }
                 }
                 overridden
             }
@@ -623,6 +765,7 @@ async fn run_cleanup_and_snippets(
                 snippets::apply_cleanup_instruction_overrides(&expanded, &snippet_instructions)
             }
             Err(Some(e)) => {
+                log::error!("pipeline: cleanup failed error={}", trim_err(&e.to_string()));
                 show_error_pill(
                     app,
                     &format!("Cleanup failed: {}", trim_err(&e.to_string())),
@@ -662,14 +805,26 @@ where
     }
 
     let mut last_err = None;
-    for provider_id in to_try {
+    log::debug!("pipeline: provider chain={}", to_try.join("->"));
+    for (idx, provider_id) in to_try.iter().enumerate() {
+        let provider_id = *provider_id;
+        log::debug!(
+            "pipeline: provider attempt {}/{} id={}",
+            idx + 1,
+            to_try.len(),
+            provider_id
+        );
         let key = cfg.key_for(provider_id).to_owned();
         if key.is_empty() {
+            log::debug!("pipeline: provider {} skipped (missing key)", provider_id);
             continue;
         }
 
         match call(provider_id, key).await {
-            Ok(result) => return Ok((result, provider_id.to_string())),
+            Ok(result) => {
+                log::debug!("pipeline: provider {} succeeded", provider_id);
+                return Ok((result, provider_id.to_string()));
+            }
             Err(e) => {
                 if cfg.api_fallback_enabled && crate::api::is_retryable_provider_error(&e) {
                     log::warn!("retryable provider error on {provider_id}, trying fallback: {e}");

--- a/src-tauri/src/system/logger.rs
+++ b/src-tauri/src/system/logger.rs
@@ -1,0 +1,177 @@
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Local;
+use log::{LevelFilter, Log, Metadata, Record};
+use tauri::{AppHandle, Emitter, Manager};
+
+const MAX_LOG_LINES: usize = 1000;
+const LOG_EVENT: &str = "open-flow:log";
+
+static LOG_BUFFER: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+static LOGGER: SessionLogger = SessionLogger;
+static VERBOSE_MODE: AtomicBool = AtomicBool::new(false);
+
+pub fn init(app: &AppHandle) -> tauri::Result<()> {
+    let _ = LOG_BUFFER.set(Mutex::new(VecDeque::with_capacity(MAX_LOG_LINES)));
+    let _ = APP_HANDLE.set(app.clone());
+
+    if log::set_logger(&LOGGER).is_ok() {
+        log::set_max_level(LevelFilter::Debug);
+        log::info!("session logger initialized");
+    }
+    Ok(())
+}
+
+pub fn recent(limit: Option<usize>) -> Vec<String> {
+    let Some(buffer) = LOG_BUFFER.get() else {
+        return vec![];
+    };
+    let Ok(guard) = buffer.lock() else {
+        return vec![];
+    };
+
+    let requested = limit.unwrap_or(200).max(1);
+    let count = requested.min(guard.len());
+    guard
+        .iter()
+        .rev()
+        .take(count)
+        .cloned()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+pub fn snapshot() -> Vec<String> {
+    recent(Some(MAX_LOG_LINES))
+}
+
+pub fn set_verbose(enabled: bool) {
+    VERBOSE_MODE.store(enabled, Ordering::Relaxed);
+    log::info!("dev verbose logging {}", if enabled { "enabled" } else { "disabled" });
+}
+
+pub fn is_verbose() -> bool {
+    VERBOSE_MODE.load(Ordering::Relaxed)
+}
+
+pub fn export_to_downloads(app: &AppHandle) -> Result<String, String> {
+    let downloads = app
+        .path()
+        .download_dir()
+        .map_err(|e| format!("Failed to resolve Downloads directory: {e}"))?;
+    std::fs::create_dir_all(&downloads).map_err(|e| format!("Failed to create Downloads path: {e}"))?;
+
+    let ts = Local::now().format("%Y%m%d-%H%M%S");
+    let file_name = format!("open-flow-logs-{ts}.txt");
+    let path: PathBuf = downloads.join(file_name);
+    let payload = snapshot().join("\n");
+    std::fs::write(&path, payload).map_err(|e| format!("Failed to write logs file: {e}"))?;
+    Ok(path.display().to_string())
+}
+
+fn redact_message(input: &str) -> String {
+    let mut out = input.to_string();
+    out = redact_after_token_ci(&out, "authorization:");
+    out = redact_after_token_ci(&out, "bearer ");
+    out = redact_after_token_ci(&out, "api_key=");
+    out = redact_after_token_ci(&out, "x-api-key:");
+    out = redact_json_key_ci(&out, "api_key");
+    out = redact_json_key_ci(&out, "authorization");
+    out
+}
+
+fn redact_after_token_ci(input: &str, token: &str) -> String {
+    let mut cursor = 0usize;
+    let mut remaining = input.to_string();
+    let token_l = token.to_ascii_lowercase();
+
+    loop {
+        let lower = remaining.to_ascii_lowercase();
+        let Some(found_rel) = lower[cursor..].find(&token_l) else {
+            break;
+        };
+        let idx = cursor + found_rel + token.len();
+        let end_rel = remaining[idx..]
+            .find(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == '"')
+            .unwrap_or(remaining.len() - idx);
+        let end = idx + end_rel;
+        remaining.replace_range(idx..end, "[REDACTED]");
+        cursor = idx + "[REDACTED]".len();
+    }
+    remaining
+}
+
+fn redact_json_key_ci(input: &str, key: &str) -> String {
+    let pattern = format!("\"{}\":", key.to_ascii_lowercase());
+    let mut cursor = 0usize;
+    let mut remaining = input.to_string();
+
+    loop {
+        let lower = remaining.to_ascii_lowercase();
+        let Some(found_rel) = lower[cursor..].find(&pattern) else {
+            break;
+        };
+        let start = cursor + found_rel + pattern.len();
+        let mut value_start = start;
+        while value_start < remaining.len() && remaining.as_bytes()[value_start].is_ascii_whitespace() {
+            value_start += 1;
+        }
+        if value_start < remaining.len() && remaining.as_bytes()[value_start] == b'"' {
+            let content_start = value_start + 1;
+            if let Some(next_quote_rel) = remaining[content_start..].find('"') {
+                let content_end = content_start + next_quote_rel;
+                remaining.replace_range(content_start..content_end, "[REDACTED]");
+                cursor = content_start + "[REDACTED]".len();
+                continue;
+            }
+        }
+        cursor = value_start;
+    }
+    remaining
+}
+
+struct SessionLogger;
+
+impl Log for SessionLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let msg = record.args().to_string();
+        if !is_verbose() && msg.starts_with("starting new connection:") {
+            return;
+        }
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        let line = format!(
+            "[{}] {:<5} {}",
+            timestamp,
+            record.level(),
+            redact_message(&msg)
+        );
+
+        if let Some(buffer) = LOG_BUFFER.get() {
+            if let Ok(mut guard) = buffer.lock() {
+                guard.push_back(line.clone());
+                if guard.len() > MAX_LOG_LINES {
+                    let _ = guard.pop_front();
+                }
+            }
+        }
+
+        if let Some(app) = APP_HANDLE.get() {
+            let _ = app.emit(LOG_EVENT, line);
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/src-tauri/src/system/logger.rs
+++ b/src-tauri/src/system/logger.rs
@@ -38,12 +38,8 @@ pub fn recent(limit: Option<usize>) -> Vec<String> {
     let count = requested.min(guard.len());
     guard
         .iter()
-        .rev()
-        .take(count)
+        .skip(guard.len().saturating_sub(count))
         .cloned()
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
         .collect()
 }
 
@@ -89,14 +85,12 @@ fn redact_message(input: &str) -> String {
 fn redact_after_token_ci(input: &str, token: &str) -> String {
     let mut cursor = 0usize;
     let mut remaining = input.to_string();
-    let token_l = token.to_ascii_lowercase();
 
     loop {
-        let lower = remaining.to_ascii_lowercase();
-        let Some(found_rel) = lower[cursor..].find(&token_l) else {
+        let Some(found_idx) = find_ascii_case_insensitive_from(&remaining, token, cursor) else {
             break;
         };
-        let idx = cursor + found_rel + token.len();
+        let idx = found_idx + token.len();
         let end_rel = remaining[idx..]
             .find(|ch: char| ch.is_whitespace() || ch == ',' || ch == ';' || ch == '"')
             .unwrap_or(remaining.len() - idx);
@@ -108,24 +102,22 @@ fn redact_after_token_ci(input: &str, token: &str) -> String {
 }
 
 fn redact_json_key_ci(input: &str, key: &str) -> String {
-    let pattern = format!("\"{}\":", key.to_ascii_lowercase());
+    let pattern = format!("\"{}\":", key);
     let mut cursor = 0usize;
     let mut remaining = input.to_string();
 
     loop {
-        let lower = remaining.to_ascii_lowercase();
-        let Some(found_rel) = lower[cursor..].find(&pattern) else {
+        let Some(found_idx) = find_ascii_case_insensitive_from(&remaining, &pattern, cursor) else {
             break;
         };
-        let start = cursor + found_rel + pattern.len();
+        let start = found_idx + pattern.len();
         let mut value_start = start;
         while value_start < remaining.len() && remaining.as_bytes()[value_start].is_ascii_whitespace() {
             value_start += 1;
         }
         if value_start < remaining.len() && remaining.as_bytes()[value_start] == b'"' {
             let content_start = value_start + 1;
-            if let Some(next_quote_rel) = remaining[content_start..].find('"') {
-                let content_end = content_start + next_quote_rel;
+            if let Some(content_end) = find_json_string_end(&remaining, content_start) {
                 remaining.replace_range(content_start..content_end, "[REDACTED]");
                 cursor = content_start + "[REDACTED]".len();
                 continue;
@@ -134,6 +126,58 @@ fn redact_json_key_ci(input: &str, key: &str) -> String {
         cursor = value_start;
     }
     remaining
+}
+
+fn find_ascii_case_insensitive_from(haystack: &str, needle: &str, start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.len() > h.len().saturating_sub(start) {
+        return None;
+    }
+
+    for i in start..=h.len() - n.len() {
+        if !haystack.is_char_boundary(i) {
+            continue;
+        }
+        let mut matches = true;
+        for j in 0..n.len() {
+            if !h[i + j].eq_ignore_ascii_case(&n[j]) {
+                matches = false;
+                break;
+            }
+        }
+        if matches {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn find_json_string_end(input: &str, content_start: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut i = content_start;
+    let mut escaped = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+        if b == b'\\' {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
 }
 
 struct SessionLogger;
@@ -147,8 +191,17 @@ impl Log for SessionLogger {
         if !self.enabled(record.metadata()) {
             return;
         }
+        let verbose = is_verbose();
+        if !verbose
+            && record.level() <= log::Level::Debug
+            && !record.target().starts_with("open_flow")
+            && !record.target().starts_with("open-flow")
+            && !record.target().starts_with("src_tauri")
+        {
+            return;
+        }
         let msg = record.args().to_string();
-        if !is_verbose() && msg.starts_with("starting new connection:") {
+        if !verbose && msg.starts_with("starting new connection:") {
             return;
         }
         let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
@@ -174,4 +227,40 @@ impl Log for SessionLogger {
     }
 
     fn flush(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_json_string_end, recent, redact_json_key_ci, LOG_BUFFER};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    #[test]
+    fn redacts_json_value_with_escaped_quote() {
+        let input = r#"{"api_key":"abc\"def","other":"ok"}"#;
+        let out = redact_json_key_ci(input, "api_key");
+        assert!(out.contains(r#""api_key":"[REDACTED]""#));
+        assert!(!out.contains(r#"abc\"def"#));
+    }
+
+    #[test]
+    fn json_string_end_handles_escape_sequences() {
+        let s = r#""abc\"def""#;
+        let end = find_json_string_end(s, 1).expect("expected end quote");
+        assert_eq!(&s[end..=end], "\"");
+    }
+
+    #[test]
+    fn recent_returns_tail_in_order() {
+        let _ = LOG_BUFFER.set(Mutex::new(VecDeque::new()));
+        let buf = LOG_BUFFER.get().expect("buffer");
+        let mut guard = buf.lock().expect("lock");
+        guard.clear();
+        guard.push_back("a".into());
+        guard.push_back("b".into());
+        guard.push_back("c".into());
+        drop(guard);
+
+        assert_eq!(recent(Some(2)), vec!["b".to_string(), "c".to_string()]);
+    }
 }

--- a/src-tauri/src/system/mod.rs
+++ b/src-tauri/src/system/mod.rs
@@ -1,3 +1,4 @@
 pub mod apps;
+pub mod logger;
 pub mod memory;
 pub mod volume;

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core';
-  import { updateInfo, type UpdateInfo } from '../../stores';
+  import { devModeEnabled, updateInfo, type UpdateInfo } from '../../stores';
   import { saveSetting } from '../../settings';
 
   let { appVersion }: { appVersion: string } = $props();
@@ -8,6 +8,9 @@
   type UpdateCheckState = 'idle' | 'checking' | 'up-to-date' | 'available';
   let updateCheckState: UpdateCheckState = $state('idle');
   let installingFromAbout = $state(false);
+  let versionTapCount = $state(0);
+  let versionTapTimer: ReturnType<typeof setTimeout> | null = null;
+  let devModeHintVisible = $state(false);
 
   $effect(() => {
     if ($updateInfo) updateCheckState = 'available';
@@ -49,13 +52,40 @@
       installingFromAbout = false;
     }
   }
+
+  function handleVersionTap() {
+    if ($devModeEnabled) return;
+    versionTapCount += 1;
+    if (versionTapTimer) clearTimeout(versionTapTimer);
+    versionTapTimer = setTimeout(() => {
+      versionTapCount = 0;
+    }, 2600);
+    if (versionTapCount >= 10) {
+      devModeEnabled.set(true);
+      invoke('set_dev_logging_enabled', { enabled: true }).catch(() => {});
+      versionTapCount = 0;
+      if (versionTapTimer) {
+        clearTimeout(versionTapTimer);
+        versionTapTimer = null;
+      }
+      devModeHintVisible = true;
+      setTimeout(() => {
+        devModeHintVisible = false;
+      }, 1800);
+    }
+  }
 </script>
 
 <h2 class="settings-h">About</h2>
 <div class="setting-row">
   <div><div class="label">Version</div></div>
-  <span class="desc">v{appVersion}</span>
+  <button class="version-tap desc" onclick={handleVersionTap}>v{appVersion}</button>
 </div>
+{#if devModeHintVisible}
+  <div class="dev-hint-row">
+    <span class="desc dev-hint">Developer mode enabled for this session.</span>
+  </div>
+{/if}
 <div class="setting-row">
   <div><div class="label">License</div></div>
   <span class="desc">MIT</span>
@@ -96,6 +126,18 @@
 
 <style>
   .update-controls { flex-shrink: 0; }
+  .version-tap {
+    border: none;
+    background: transparent;
+    padding: 0;
+  }
+  .dev-hint-row {
+    margin-top: -4px;
+    margin-bottom: 8px;
+  }
+  .dev-hint {
+    color: var(--ink-faint);
+  }
   .update-ok { color: var(--success); }
   .update-available { color: var(--accent); }
 

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import { onMount } from 'svelte';
+
+  let logs = $state<string[]>([]);
+  let autoScroll = $state(true);
+  let exportMessage = $state('');
+  let exporting = $state(false);
+  let logViewport: HTMLDivElement | null = null;
+  let verboseEnabled = $state(true);
+
+  async function loadRecentLogs() {
+    try {
+      logs = await invoke<string[]>('get_recent_logs', { limit: 300 });
+      queueMicrotask(scrollToBottom);
+    } catch (err) {
+      console.error('Failed to load logs:', err);
+    }
+  }
+
+  function scrollToBottom() {
+    if (!autoScroll || !logViewport) return;
+    logViewport.scrollTop = logViewport.scrollHeight;
+  }
+
+  async function downloadLogs() {
+    if (exporting) return;
+    exporting = true;
+    exportMessage = '';
+    try {
+      const path = await invoke<string>('download_logs');
+      exportMessage = `Saved: ${path}`;
+    } catch (err) {
+      exportMessage = 'Failed to save logs.';
+      console.error('downloadLogs failed:', err);
+    } finally {
+      exporting = false;
+    }
+  }
+
+  async function toggleVerbose() {
+    verboseEnabled = !verboseEnabled;
+    try {
+      await invoke('set_dev_logging_enabled', { enabled: verboseEnabled });
+    } catch (err) {
+      verboseEnabled = !verboseEnabled;
+      console.error('set_dev_logging_enabled failed:', err);
+    }
+  }
+
+  onMount(() => {
+    let active = true;
+    let unlisten: (() => void) | null = null;
+
+    loadRecentLogs();
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen<string>('open-flow:log', (ev) => {
+          if (!active) return;
+          logs = [...logs.slice(-499), ev.payload];
+          queueMicrotask(scrollToBottom);
+        });
+      } catch (err) {
+        console.error('Failed to listen for log events:', err);
+      }
+    })();
+
+    return () => {
+      active = false;
+      if (unlisten) unlisten();
+    };
+  });
+</script>
+
+<h2 class="settings-h">Developer</h2>
+<p class="panel-note">Session log stream from backend runtime. Dev mode resets after app restart.</p>
+<div class="setting-row">
+  <div>
+    <div class="label">Real-time Logs</div>
+    <div class="desc">{logs.length} lines loaded</div>
+  </div>
+  <div class="actions">
+    <button class="btn-ghost" onclick={toggleVerbose}>
+      {verboseEnabled ? 'Verbose: On' : 'Verbose: Off'}
+    </button>
+    <button class="btn-ghost" onclick={() => (autoScroll = !autoScroll)}>
+      {autoScroll ? 'Pause Auto-scroll' : 'Resume Auto-scroll'}
+    </button>
+  </div>
+</div>
+<div class="logs-panel scroll-styled" bind:this={logViewport}>
+  {#if logs.length === 0}
+    <div class="logs-empty">No logs yet.</div>
+  {:else}
+    {#each logs as line}
+      <div class="log-line">{line}</div>
+    {/each}
+  {/if}
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Download Logs</div>
+    <div class="desc">Writes current session logs to your Downloads folder.</div>
+    {#if exportMessage}
+      <div class="desc export-status">{exportMessage}</div>
+    {/if}
+  </div>
+  <button class="btn-ghost" onclick={downloadLogs} disabled={exporting}>
+    {exporting ? 'Saving...' : 'Download Logs'}
+  </button>
+</div>
+
+<style>
+  .logs-panel {
+    height: 280px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--paper);
+    padding: 8px 10px;
+    overflow: auto;
+    margin-top: 12px;
+    margin-bottom: 12px;
+  }
+  .log-line {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--ink-soft);
+    line-height: 1.45;
+    padding: 2px 0;
+    border-bottom: 1px solid var(--line-soft);
+    word-break: break-word;
+  }
+  .log-line:last-child {
+    border-bottom: none;
+  }
+  .logs-empty {
+    font-size: 12px;
+    color: var(--ink-mute);
+    padding: 8px 2px;
+  }
+  .export-status {
+    margin-top: 6px;
+    color: var(--ink-faint);
+  }
+  .actions {
+    display: flex;
+    gap: 8px;
+  }
+</style>

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -13,7 +13,7 @@ export const MOTION_PX = {
 } as const;
 
 export const NAV_ORDER = ['home', 'dictionary', 'snippets', 'style'] as const;
-export const SETTINGS_SECTION_ORDER = ['general', 'apps', 'keys', 'models', 'privacy', 'advanced', 'about'] as const;
+export const SETTINGS_SECTION_ORDER = ['general', 'apps', 'keys', 'models', 'privacy', 'advanced', 'about', 'developer'] as const;
 export const STYLE_TAB_ORDER = ['cleanup', 'personal', 'apps'] as const;
 
 export function directionFromOrder(current: string, next: string, order: readonly string[]): 1 | -1 {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 
 export const currentPage = writable<'home' | 'dictionary' | 'snippets' | 'style'>('home');
 export const settingsOpen = writable(false);
+export const devModeEnabled = writable(false);
 export const accentColor = writable<'terracotta' | 'moss' | 'slate' | 'ink'>('terracotta');
 export const appearanceMode = writable<'system' | 'light' | 'dark'>('system');
 export const pillState = writable<'idle' | 'recording' | 'processing' | 'handsfree'>('idle');

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { settingsOpen } from '../stores';
+  import { devModeEnabled, settingsOpen } from '../stores';
   import { icons } from '../icons';
   import { onDestroy, onMount } from 'svelte';
   import { fly, fade } from 'svelte/transition';
@@ -14,6 +14,7 @@
   import PrivacySection from '../components/settings/PrivacySection.svelte';
   import AudioSection from '../components/settings/AudioSection.svelte';
   import AboutSection from '../components/settings/AboutSection.svelte';
+  import DeveloperSection from '../components/settings/DeveloperSection.svelte';
 
   let section = $state('general');
   let animDir: 1 | -1 = $state(1);
@@ -21,19 +22,20 @@
 
   const sectionOrder = SETTINGS_SECTION_ORDER;
 
-  const navSections = [
+  const navSections = $derived([
     { group: 'Settings', items: [
       { id: 'general',  label: 'General',      icon: 'sliders'  as keyof typeof icons },
       { id: 'apps',     label: 'App Mappings', icon: 'apps'     as keyof typeof icons },
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Advanced',      icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Advanced',     icon: 'mic'      as keyof typeof icons },
+      ...($devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
     { group: 'Account', items: [
       { id: 'about', label: 'About', icon: 'help' as keyof typeof icons },
     ]},
-  ];
+  ]);
 
   onMount(async () => {
     appVersion = await getVersion();
@@ -46,6 +48,12 @@
     animDir = directionFromOrder(section, id, sectionOrder);
     section = id;
   }
+
+  $effect(() => {
+    if (!$devModeEnabled && section === 'developer') {
+      section = 'about';
+    }
+  });
 </script>
 
 {#if $settingsOpen}
@@ -111,6 +119,8 @@
               <AudioSection />
             {:else if section === 'about'}
               <AboutSection {appVersion} />
+            {:else if section === 'developer' && $devModeEnabled}
+              <DeveloperSection />
             {/if}
           </div>
         {/key}

--- a/tests/smoke/_tauri-mock.cjs
+++ b/tests/smoke/_tauri-mock.cjs
@@ -136,6 +136,9 @@ function tauriMock() {
       case 'get_snippets':       return [];
       case 'get_memory_mb':      return 75;   // number required — tweened(0) crashes on null
       case 'check_for_update':   return null;
+      case 'get_recent_logs':    return ['[2026-05-17 10:00:00.000] INFO  smoke logger'];
+      case 'download_logs':      return 'C:\\Users\\test\\Downloads\\open-flow-logs-20260517-100000.txt';
+      case 'set_dev_logging_enabled': return null;
       default:                   return null;
     }
   }

--- a/tests/smoke/playwright-test-devmode.cjs
+++ b/tests/smoke/playwright-test-devmode.cjs
@@ -1,0 +1,53 @@
+const { chromium } = require('playwright');
+const { tauriMock } = require('./_tauri-mock.cjs');
+
+const TARGET_URL = 'http://localhost:1420';
+const TIMEOUT = 8_000;
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const errors = [];
+
+  await page.addInitScript(tauriMock);
+
+  page.on('pageerror', err => errors.push(`Page exception: ${err.message}`));
+  page.on('console', msg => {
+    if (msg.type() === 'error') errors.push(`Console error: ${msg.text()}`);
+  });
+
+  try {
+    await page.goto(TARGET_URL, { waitUntil: 'networkidle', timeout: TIMEOUT });
+
+    await page.locator('.nav-item:has-text("Settings")').click();
+    await page.locator('.settings-modal').waitFor({ state: 'visible', timeout: TIMEOUT });
+
+    const devTabBefore = page.locator('.settings-nav-item:has-text("Developer")');
+    if (await devTabBefore.count() > 0) {
+      errors.push('Developer tab should not be visible before unlock.');
+    }
+
+    await page.locator('.settings-nav-item:has-text("About")').click();
+    const versionBtn = page.locator('.version-tap');
+    await versionBtn.waitFor({ state: 'visible', timeout: TIMEOUT });
+    for (let i = 0; i < 10; i++) {
+      await versionBtn.click();
+    }
+
+    await page.locator('.settings-nav-item:has-text("Developer")').waitFor({ state: 'visible', timeout: TIMEOUT });
+    await page.locator('.settings-nav-item:has-text("Developer")').click();
+    await page.locator('h2.settings-h:has-text("Developer")').waitFor({ state: 'visible', timeout: TIMEOUT });
+
+    if (errors.length > 0) {
+      console.error('\nFAIL - errors:');
+      errors.forEach(e => console.error('  ' + e));
+      process.exit(1);
+    }
+    console.log('PASS - dev mode unlock smoke test passed.');
+  } catch (err) {
+    console.error('FAIL - test threw:', err.message);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
# Summary

Adds a hidden session-only Developer Mode (10 taps on About version) and a Developer Settings hub for real-time backend logs, downloadable session logs, and deep verbose telemetry for debugging integration failures.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [x] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Commands run and results:
- `npm run check` (pass)
- `cargo check --manifest-path src-tauri/Cargo.toml` (pass)
- `node tests/smoke/playwright-test-devmode.cjs` (pass)

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

- Added session logger ring buffer and log export command.
- Added verbose dev logging toggle gated behind hidden dev mode unlock.
- Verbose mode logs full dictation/prompt/output for debugging while preserving credential/token redaction.
- Default non-verbose mode suppresses noisy connection-level lines.

## UI Evidence

Not applicable.

## Reviewer Notes

- Start review in `src-tauri/src/system/logger.rs` and `src-tauri/src/pipeline.rs` for logging scope and verbosity gating.
- `set_dev_logging_enabled` is session-only and intentionally not persisted.
- Developer section is hidden unless unlocked via About version tap sequence.