### PR TITLE
Fix profanity handling precedence across cleanup intensity and tone

### DIFF
--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -112,10 +112,21 @@ fn role_line(intensity: &str) -> &'static str {
     }
 }
 
-fn intensity_rules(intensity: &str, tier: PromptTier, has_overrides: bool) -> String {
+fn intensity_rules(
+    intensity: &str,
+    tier: PromptTier,
+    has_overrides: bool,
+    profile: &str,
+) -> String {
     let base = match (intensity, tier) {
         ("none", _) => {
-            "CLEANUP: Return input unchanged, character-for-character.".to_string()
+            if profile == "formal" {
+                "CLEANUP: Keep wording and structure unchanged by default. \
+                You may only change wording where needed to apply FORMAL profanity policy replacements."
+                    .to_string()
+            } else {
+                "CLEANUP: Return input unchanged, character-for-character.".to_string()
+            }
         }
         ("light", PromptTier::Short) => {
             "CLEANUP: Remove filler words (um, uh, like, you know) and immediate repeats only.".to_string()
@@ -223,7 +234,7 @@ fn get_system_prompt(
     has_numeric_content: bool,
 ) -> String {
     let context = context_section(app_context, tier);
-    let cleanup = intensity_rules(intensity, tier, has_snippet_overrides);
+    let cleanup = intensity_rules(intensity, tier, has_snippet_overrides, profile);
     let tone = tone_rules(profile);
     let profanity = profanity_policy(profile, intensity);
     let number_style = if tier == PromptTier::Short && !has_numeric_content {
@@ -371,5 +382,13 @@ mod tests {
         assert!(prompt.contains(
             "PROFANITY PRECEDENCE: If profanity instructions conflict, FORMAL tone rules override intensity baseline rules."
         ));
+    }
+
+    #[test]
+    fn formal_with_none_intensity_allows_only_profanity_rewording_changes() {
+        let input = "holy shit this is wild".to_string();
+        let prompt = get_system_prompt_with_extras("formal", "none", "", None, &input);
+        assert!(prompt.contains("You may only change wording where needed to apply FORMAL profanity policy replacements."));
+        assert!(!prompt.contains("Return input unchanged, character-for-character."));
     }
 }

--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -380,7 +380,7 @@ mod tests {
         assert!(prompt.contains(
             "This overrides intensity profanity defaults."
         ));
-        assert!(!prompt.contains("PROFANITY BASELINE (DIRECT)"));
+        assert!(!prompt.contains("Keep profanity as spoken."));
     }
 
     #[test]

--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -355,7 +355,7 @@ mod tests {
         let prompt = get_system_prompt_with_extras("formal", "medium", "", None, &input);
         assert!(prompt.contains("PROFANITY (FORMAL): Soften most profanity to professional wording, preserving meaning and emphasis."));
         assert!(prompt.contains("No asterisk censorship."));
-        assert!(!prompt.contains("PROFANITY BASELINE"));
+        assert!(!prompt.contains("Keep profanity as spoken."));
     }
 
     #[test]

--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -164,6 +164,32 @@ fn tone_rules(profile: &str) -> &'static str {
     }
 }
 
+fn profanity_policy(profile: &str, intensity: &str) -> String {
+    let intensity_line = match intensity {
+        "none" => "PROFANITY BASELINE (VERBATIM): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
+        "light" => "PROFANITY BASELINE (LIGHT): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
+        "high" => "PROFANITY BASELINE (DIRECT): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
+        _ => "PROFANITY BASELINE (MEDIUM): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
+    };
+
+    let tone_line = match profile {
+        "formal" => {
+            "TONE PROFANITY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis. Do not use asterisk-style censorship."
+        }
+        "very_casual" => {
+            "TONE PROFANITY (VERY CASUAL): Retain swear words and natural intensity from the speaker."
+        }
+        _ => "TONE PROFANITY (CASUAL): Retain swear words and natural intensity from the speaker.",
+    };
+
+    format!(
+        "{intensity_line}\n\
+        {tone_line}\n\
+        PROFANITY PRECEDENCE: If profanity instructions conflict, FORMAL tone rules override intensity baseline rules.\n\
+        EXAMPLE: Keep \"holy shit\" as profanity by default; do not auto-sanitize it to \"holy moly\" unless FORMAL tone is active."
+    )
+}
+
 fn context_section(app_context: Option<&str>, tier: PromptTier) -> String {
     let Some(ctx) = app_context else {
         return String::new();
@@ -199,6 +225,7 @@ fn get_system_prompt(
     let context = context_section(app_context, tier);
     let cleanup = intensity_rules(intensity, tier, has_snippet_overrides);
     let tone = tone_rules(profile);
+    let profanity = profanity_policy(profile, intensity);
     let number_style = if tier == PromptTier::Short && !has_numeric_content {
         String::new()
     } else {
@@ -224,6 +251,7 @@ fn get_system_prompt(
         {context}\
         {cleanup}\n\
         {tone}\n\
+        {profanity}\n\
         \n\
         {number_style}\
         FORMATTING COMMANDS: If speech includes literal commands like 'new paragraph', 'new line', \
@@ -300,5 +328,48 @@ mod tests {
         assert!(prompt.contains("1. MUST no period"));
         assert!(prompt.contains("2. MUST all caps"));
         assert!(!prompt.contains("=================================================="));
+    }
+
+    #[test]
+    fn non_formal_intensities_keep_profanity() {
+        let input = "holy shit this is wild".to_string();
+        for intensity in ["none", "light", "medium", "high"] {
+            let prompt = get_system_prompt_with_extras("casual", intensity, "", None, &input);
+            assert!(prompt.contains("PROFANITY BASELINE"));
+            assert!(prompt.contains("Preserve profanity exactly as spoken by default"));
+            assert!(prompt.contains("Do not sanitize, euphemize, or censor it."));
+        }
+    }
+
+    #[test]
+    fn formal_tone_filters_most_profanity_with_mild_rewording() {
+        let input = "holy shit this is wild".to_string();
+        let prompt = get_system_prompt_with_extras("formal", "medium", "", None, &input);
+        assert!(prompt.contains("TONE PROFANITY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis."));
+        assert!(prompt.contains("Do not use asterisk-style censorship."));
+    }
+
+    #[test]
+    fn casual_and_very_casual_retain_swear_words() {
+        let input = "holy shit this is wild".to_string();
+        let casual_prompt = get_system_prompt_with_extras("casual", "medium", "", None, &input);
+        let very_casual_prompt =
+            get_system_prompt_with_extras("very_casual", "medium", "", None, &input);
+
+        assert!(casual_prompt.contains(
+            "TONE PROFANITY (CASUAL): Retain swear words and natural intensity from the speaker."
+        ));
+        assert!(very_casual_prompt.contains(
+            "TONE PROFANITY (VERY CASUAL): Retain swear words and natural intensity from the speaker."
+        ));
+    }
+
+    #[test]
+    fn formal_profanity_rule_overrides_intensity_rule() {
+        let input = "holy shit this is wild".to_string();
+        let prompt = get_system_prompt_with_extras("formal", "none", "", None, &input);
+        assert!(prompt.contains(
+            "PROFANITY PRECEDENCE: If profanity instructions conflict, FORMAL tone rules override intensity baseline rules."
+        ));
     }
 }

--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -176,6 +176,12 @@ fn tone_rules(profile: &str) -> &'static str {
 }
 
 fn profanity_policy(profile: &str, intensity: &str) -> String {
+    if profile == "formal" {
+        return "PROFANITY POLICY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis. Do not use asterisk-style censorship.\n\
+        PROFANITY CONFLICT RULE: For FORMAL tone, ignore profanity-retention defaults tied to cleanup intensity."
+            .to_string();
+    }
+
     let intensity_line = match intensity {
         "none" => "PROFANITY BASELINE (VERBATIM): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
         "light" => "PROFANITY BASELINE (LIGHT): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
@@ -184,9 +190,6 @@ fn profanity_policy(profile: &str, intensity: &str) -> String {
     };
 
     let tone_line = match profile {
-        "formal" => {
-            "TONE PROFANITY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis. Do not use asterisk-style censorship."
-        }
         "very_casual" => {
             "TONE PROFANITY (VERY CASUAL): Retain swear words and natural intensity from the speaker."
         }
@@ -195,9 +198,7 @@ fn profanity_policy(profile: &str, intensity: &str) -> String {
 
     format!(
         "{intensity_line}\n\
-        {tone_line}\n\
-        PROFANITY PRECEDENCE: If profanity instructions conflict, FORMAL tone rules override intensity baseline rules.\n\
-        EXAMPLE: Keep \"holy shit\" as profanity by default; do not auto-sanitize it to \"holy moly\" unless FORMAL tone is active."
+        {tone_line}"
     )
 }
 
@@ -356,8 +357,9 @@ mod tests {
     fn formal_tone_filters_most_profanity_with_mild_rewording() {
         let input = "holy shit this is wild".to_string();
         let prompt = get_system_prompt_with_extras("formal", "medium", "", None, &input);
-        assert!(prompt.contains("TONE PROFANITY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis."));
+        assert!(prompt.contains("PROFANITY POLICY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis."));
         assert!(prompt.contains("Do not use asterisk-style censorship."));
+        assert!(!prompt.contains("PROFANITY BASELINE"));
     }
 
     #[test]
@@ -376,12 +378,13 @@ mod tests {
     }
 
     #[test]
-    fn formal_profanity_rule_overrides_intensity_rule() {
+    fn formal_profanity_rules_are_conflict_free_with_direct_intensity() {
         let input = "holy shit this is wild".to_string();
-        let prompt = get_system_prompt_with_extras("formal", "none", "", None, &input);
+        let prompt = get_system_prompt_with_extras("formal", "high", "", None, &input);
         assert!(prompt.contains(
-            "PROFANITY PRECEDENCE: If profanity instructions conflict, FORMAL tone rules override intensity baseline rules."
+            "PROFANITY CONFLICT RULE: For FORMAL tone, ignore profanity-retention defaults tied to cleanup intensity."
         ));
+        assert!(!prompt.contains("PROFANITY BASELINE (DIRECT)"));
     }
 
     #[test]

--- a/src-tauri/src/api/prompts.rs
+++ b/src-tauri/src/api/prompts.rs
@@ -177,29 +177,25 @@ fn tone_rules(profile: &str) -> &'static str {
 
 fn profanity_policy(profile: &str, intensity: &str) -> String {
     if profile == "formal" {
-        return "PROFANITY POLICY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis. Do not use asterisk-style censorship.\n\
-        PROFANITY CONFLICT RULE: For FORMAL tone, ignore profanity-retention defaults tied to cleanup intensity."
+        return "PROFANITY (FORMAL): Soften most profanity to professional wording, preserving meaning and emphasis. No asterisk censorship. This overrides intensity profanity defaults."
             .to_string();
     }
 
-    let intensity_line = match intensity {
-        "none" => "PROFANITY BASELINE (VERBATIM): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
-        "light" => "PROFANITY BASELINE (LIGHT): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
-        "high" => "PROFANITY BASELINE (DIRECT): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
-        _ => "PROFANITY BASELINE (MEDIUM): Preserve profanity exactly as spoken by default. Do not sanitize, euphemize, or censor it.",
+    let intensity_label = match intensity {
+        "none" => "VERBATIM",
+        "light" => "LIGHT",
+        "high" => "DIRECT",
+        _ => "MEDIUM",
     };
 
     let tone_line = match profile {
         "very_casual" => {
-            "TONE PROFANITY (VERY CASUAL): Retain swear words and natural intensity from the speaker."
+            "PROFANITY TONE (VERY CASUAL): Keep swear words and speaker intensity."
         }
-        _ => "TONE PROFANITY (CASUAL): Retain swear words and natural intensity from the speaker.",
+        _ => "PROFANITY TONE (CASUAL): Keep swear words and speaker intensity.",
     };
 
-    format!(
-        "{intensity_line}\n\
-        {tone_line}"
-    )
+    format!("PROFANITY ({intensity_label}): Keep profanity as spoken. Do not sanitize or euphemize.\n{tone_line}")
 }
 
 fn context_section(app_context: Option<&str>, tier: PromptTier) -> String {
@@ -347,9 +343,9 @@ mod tests {
         let input = "holy shit this is wild".to_string();
         for intensity in ["none", "light", "medium", "high"] {
             let prompt = get_system_prompt_with_extras("casual", intensity, "", None, &input);
-            assert!(prompt.contains("PROFANITY BASELINE"));
-            assert!(prompt.contains("Preserve profanity exactly as spoken by default"));
-            assert!(prompt.contains("Do not sanitize, euphemize, or censor it."));
+            assert!(prompt.contains("PROFANITY ("));
+            assert!(prompt.contains("Keep profanity as spoken."));
+            assert!(prompt.contains("Do not sanitize or euphemize."));
         }
     }
 
@@ -357,8 +353,8 @@ mod tests {
     fn formal_tone_filters_most_profanity_with_mild_rewording() {
         let input = "holy shit this is wild".to_string();
         let prompt = get_system_prompt_with_extras("formal", "medium", "", None, &input);
-        assert!(prompt.contains("PROFANITY POLICY (FORMAL): Replace most profanity with milder professional wording while preserving meaning and emphasis."));
-        assert!(prompt.contains("Do not use asterisk-style censorship."));
+        assert!(prompt.contains("PROFANITY (FORMAL): Soften most profanity to professional wording, preserving meaning and emphasis."));
+        assert!(prompt.contains("No asterisk censorship."));
         assert!(!prompt.contains("PROFANITY BASELINE"));
     }
 
@@ -370,10 +366,10 @@ mod tests {
             get_system_prompt_with_extras("very_casual", "medium", "", None, &input);
 
         assert!(casual_prompt.contains(
-            "TONE PROFANITY (CASUAL): Retain swear words and natural intensity from the speaker."
+            "PROFANITY TONE (CASUAL): Keep swear words and speaker intensity."
         ));
         assert!(very_casual_prompt.contains(
-            "TONE PROFANITY (VERY CASUAL): Retain swear words and natural intensity from the speaker."
+            "PROFANITY TONE (VERY CASUAL): Keep swear words and speaker intensity."
         ));
     }
 
@@ -382,7 +378,7 @@ mod tests {
         let input = "holy shit this is wild".to_string();
         let prompt = get_system_prompt_with_extras("formal", "high", "", None, &input);
         assert!(prompt.contains(
-            "PROFANITY CONFLICT RULE: For FORMAL tone, ignore profanity-retention defaults tied to cleanup intensity."
+            "This overrides intensity profanity defaults."
         ));
         assert!(!prompt.contains("PROFANITY BASELINE (DIRECT)"));
     }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1068,11 +1068,13 @@ async fn run_cleanup_and_snippets(
     );
 
     let c_key = cfg.key_for(&cfg.cleanup_provider).to_owned();
-    let final_text = if cfg.cleanup_enabled
-        && !c_key.is_empty()
-        && pure_expansion.is_none()
-        && cfg.cleanup_intensity != "none"
-    {
+    let final_text = if should_run_cleanup_llm(
+        cfg.cleanup_enabled,
+        !c_key.is_empty(),
+        pure_expansion.is_none(),
+        &cfg.cleanup_intensity,
+        profile,
+    ) {
         let (cache_tokens, cache_separators) = tokenize_cache_key_parts(raw);
         let allow_cache = should_use_cleanup_cache_tokens(&cache_tokens);
         let cache_key = if allow_cache {
@@ -1197,6 +1199,19 @@ async fn run_cleanup_and_snippets(
     Some((final_text, dict_entries))
 }
 
+fn should_run_cleanup_llm(
+    cleanup_enabled: bool,
+    has_cleanup_key: bool,
+    no_pure_expansion: bool,
+    cleanup_intensity: &str,
+    profile: &str,
+) -> bool {
+    cleanup_enabled
+        && has_cleanup_key
+        && no_pure_expansion
+        && (cleanup_intensity != "none" || profile == "formal")
+}
+
 use std::future::Future;
 use std::pin::Pin;
 
@@ -1255,7 +1270,7 @@ where
 mod tests {
     use super::{
         normalize_cleanup_cache_key, normalize_transcription_math_artifacts,
-        should_use_cleanup_cache,
+        should_run_cleanup_llm, should_use_cleanup_cache,
     };
 
     #[test]
@@ -1398,5 +1413,15 @@ mod tests {
             "one hundred hundred hundred hundred hundred hundred hundred hundred hundred hundred",
         );
         assert!(key.starts_with("num"));
+    }
+
+    #[test]
+    fn cleanup_llm_runs_for_formal_even_when_none_intensity() {
+        assert!(should_run_cleanup_llm(true, true, true, "none", "formal"));
+    }
+
+    #[test]
+    fn cleanup_llm_skips_for_non_formal_when_none_intensity() {
+        assert!(!should_run_cleanup_llm(true, true, true, "none", "casual"));
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1078,7 +1078,8 @@ async fn run_cleanup_and_snippets(
         let (cache_tokens, cache_separators) = tokenize_cache_key_parts(raw);
         let allow_cache = should_use_cleanup_cache_tokens(&cache_tokens);
         let cache_key = if allow_cache {
-            normalize_cleanup_cache_key_parts(&cache_tokens, &cache_separators)
+            let base_cache_key = normalize_cleanup_cache_key_parts(&cache_tokens, &cache_separators);
+            style_scoped_cleanup_cache_key(&base_cache_key, profile, &cfg.cleanup_intensity)
         } else {
             String::new()
         };
@@ -1212,6 +1213,13 @@ fn should_run_cleanup_llm(
         && (cleanup_intensity != "none" || profile == "formal")
 }
 
+fn style_scoped_cleanup_cache_key(base_key: &str, profile: &str, cleanup_intensity: &str) -> String {
+    if base_key.is_empty() {
+        return String::new();
+    }
+    format!("{base_key}|profile:{profile}|intensity:{cleanup_intensity}")
+}
+
 use std::future::Future;
 use std::pin::Pin;
 
@@ -1270,7 +1278,7 @@ where
 mod tests {
     use super::{
         normalize_cleanup_cache_key, normalize_transcription_math_artifacts,
-        should_run_cleanup_llm, should_use_cleanup_cache,
+        should_run_cleanup_llm, should_use_cleanup_cache, style_scoped_cleanup_cache_key,
     };
 
     #[test]
@@ -1423,5 +1431,19 @@ mod tests {
     #[test]
     fn cleanup_llm_skips_for_non_formal_when_none_intensity() {
         assert!(!should_run_cleanup_llm(true, true, true, "none", "casual"));
+    }
+
+    #[test]
+    fn style_scoped_cache_key_changes_with_profile_and_intensity() {
+        let casual_medium = style_scoped_cleanup_cache_key("abc123", "casual", "medium");
+        let formal_medium = style_scoped_cleanup_cache_key("abc123", "formal", "medium");
+        let casual_high = style_scoped_cleanup_cache_key("abc123", "casual", "high");
+        assert_ne!(casual_medium, formal_medium);
+        assert_ne!(casual_medium, casual_high);
+    }
+
+    #[test]
+    fn style_scoped_cache_key_preserves_empty_base_key() {
+        assert_eq!(style_scoped_cleanup_cache_key("", "casual", "medium"), "");
     }
 }


### PR DESCRIPTION
# Summary

Implemented prompt-level profanity policy so cleanup intensities keep swearing by default while `Formal` tone filters most profanity via mild rewording. Added explicit precedence (`Formal` tone overrides intensity baseline on conflict) and new prompt tests to lock behavior.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [x] Test-only change
- [ ] Build or release change

## Testing

<!-- List exact commands run and their result. If not run, explain why. -->

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Commands run:
- `cargo test --manifest-path src-tauri/Cargo.toml api::prompts::tests -- --nocapture` (pass: 11 passed, 0 failed)
- `node tests/smoke/playwright-test-pipeline.cjs` (pass: 9 passed, 0 failed, 0 skipped)

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

Prompt behavior only in `src-tauri/src/api/prompts.rs`; no storage schema, key handling, clipboard, hotkey, or database behavior changed.

## UI Evidence

Not applicable.

## Reviewer Notes

This PR is intentionally scoped to prompt contract and tests:
- Adds `profanity_policy(profile, intensity)`.
- Keeps internal intensity IDs unchanged (`none/light/medium/high`).
- Keeps tone IDs unchanged (`casual/formal/very_casual`).
- Preserves existing snippet override flow and technical-token preservation rules.
