### PR TITLE
Onboarding: restore appearance mode selection and enforce no-scroll setup

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { currentPage, settingsOpen, accentColor, appearanceMode, setupComplete } from './lib/stores';
+  import { currentPage, settingsOpen, appearanceMode, setupComplete } from './lib/stores';
   import TitleBar from './lib/components/layout/TitleBar.svelte';
   import Sidebar from './lib/components/layout/Sidebar.svelte';
   import Home from './lib/views/Home.svelte';
@@ -16,21 +16,6 @@
 
   type EffectiveTheme = 'light' | 'dark';
 
-  const accentMap: Record<EffectiveTheme, Record<string, [string, string, string]>> = {
-    light: {
-      terracotta: ['oklch(0.62 0.14 40)',  'oklch(0.94 0.03 40)',   'oklch(0.42 0.12 40)'],
-      moss:       ['oklch(0.55 0.1 145)',  'oklch(0.94 0.03 145)',  'oklch(0.4 0.1 145)' ],
-      slate:      ['oklch(0.45 0.04 250)', 'oklch(0.94 0.015 250)', 'oklch(0.35 0.05 250)'],
-      ink:        ['oklch(0.18 0.01 60)',  'oklch(0.92 0.005 70)',  'oklch(0.18 0.01 60)' ],
-    },
-    dark: {
-      terracotta: ['oklch(0.70 0.13 42)',  '#3a241d',              '#f0a987'],
-      moss:       ['oklch(0.72 0.10 145)', '#1f3022',              '#a7d99f'],
-      slate:      ['oklch(0.72 0.04 250)', '#202532',              '#b7c4e3'],
-      ink:        ['oklch(0.82 0.01 70)',  '#2a241d',              '#f2e6d5'],
-    },
-  };
-
   function systemTheme(): EffectiveTheme {
     return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
@@ -42,17 +27,10 @@
   function applyTheme() {
     const theme = effectiveTheme($appearanceMode);
     document.documentElement.dataset.theme = theme;
-
-    const accents = accentMap[theme];
-    const [a, b, c] = accents[$accentColor] ?? accents.terracotta;
-    document.documentElement.style.setProperty('--accent', a);
-    document.documentElement.style.setProperty('--accent-soft', b);
-    document.documentElement.style.setProperty('--accent-ink', c);
   }
 
   $effect(() => {
     $appearanceMode;
-    $accentColor;
     if (typeof document !== 'undefined') applyTheme();
   });
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -4,7 +4,6 @@ import { invoke } from '@tauri-apps/api/core';
 export const currentPage = writable<'home' | 'dictionary' | 'snippets' | 'style'>('home');
 export const settingsOpen = writable(false);
 export const devModeEnabled = writable(false);
-export const accentColor = writable<'terracotta' | 'moss' | 'slate' | 'ink'>('terracotta');
 export const appearanceMode = writable<'system' | 'light' | 'dark'>('system');
 export const pillState = writable<'idle' | 'recording' | 'processing' | 'handsfree'>('idle');
 

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -490,7 +490,10 @@
             <button
               class="appearance-mode-card"
               class:selected={selectedAppearance === mode.id}
-              onclick={() => { selectedAppearance = mode.id; }}
+              onclick={() => {
+                selectedAppearance = mode.id;
+                appearanceMode.set(mode.id);
+              }}
             >
               <div class="appearance-mode-title-row">
                 <span class="appearance-mode-name">{mode.name}</span>
@@ -703,7 +706,7 @@
           </div>
           <div class="summary-item">
             <span class="summary-label">Theme</span>
-            <span class="summary-val">{appearanceModes.find((mode) => mode.id === selectedAppearance)?.name}</span>
+            <span class="summary-val">{appearanceModes.find((mode) => mode.id === selectedAppearance)?.name ?? 'System'}</span>
           </div>
         </div>
         <button class="btn-primary btn-lg" onclick={finish}>Start dictating</button>

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core';
   import { onMount } from 'svelte';
-  import { setupComplete } from '../stores';
-  import { animateWidth } from '../motion';
-  import { saveSetting, type CleanupIntensity, type ToneId } from '../settings';
+  import { appearanceMode, setupComplete } from '../stores';
+  import { saveSetting, type AppearanceMode, type CleanupIntensity, type ToneId } from '../settings';
   import {
     getTranscriptionLanguageLabel,
     transcriptionLanguages,
@@ -15,6 +14,18 @@
     try {
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
       win = getCurrentWindow();
+    } catch {}
+    try {
+      const [savedAppearance, savedLanguage] = await Promise.all([
+        invoke<AppearanceMode | null>('get_setting', { key: 'appearance_mode' }),
+        invoke<TranscriptionLanguageCode | null>('get_setting', { key: 'transcription_language' }),
+      ]);
+      if (savedAppearance === 'system' || savedAppearance === 'light' || savedAppearance === 'dark') {
+        selectedAppearance = savedAppearance;
+      }
+      if (savedLanguage && transcriptionLanguages.some((option) => option.code === savedLanguage)) {
+        selectedLanguage = savedLanguage;
+      }
     } catch {}
     setTimeout(() => { introReady = true; }, 60);
   });
@@ -36,7 +47,8 @@
   let quickPrefs = { cleanup: true, noise: true, caps: true, autoLearn: false, autostart: false, muteAudio: false, apiFallback: false };
   let quickSettingsReady = false;
   let selectedLanguage = 'en' as TranscriptionLanguageCode;
-  let languageDropdownOpen = false;
+  const onboardingLanguageSet = new Set<TranscriptionLanguageCode>(['en', 'es', 'fr', 'de', 'pt', 'zh']);
+  const onboardingLanguages = transcriptionLanguages.filter((option) => onboardingLanguageSet.has(option.code));
 
   // ── Provider ─────────────────────────────────────────────────────────────────
   let selectedProvider: 'groq' | 'openai' | 'google' = 'groq';
@@ -107,77 +119,17 @@
     { id: 'very_casual', name: 'Very Casual', desc: 'All lowercase, almost no punctuation. Like a quick text typed without thinking.' },
   ];
 
-  // ── App mappings ──────────────────────────────────────────────────────────────
-  interface InstalledApp { name: string; exe: string; }
-  interface AppMapping { exe: string; profile: string; name: string; }
-
-  let installedApps: InstalledApp[] = [];
-  let mappings: AppMapping[] = [];
-  let appSearch = '';
-  let appsLoaded = false;
-  let openDropdownExe = '';   // which app's profile dropdown is open
-
-  const profileOptions = [
-    { id: 'casual',      label: 'Casual'      },
-    { id: 'formal',      label: 'Formal'      },
-    { id: 'very_casual', label: 'Very Casual' },
+  // ── Appearance ──────────────────────────────────────────────────────────────
+  let selectedAppearance: AppearanceMode = 'system';
+  const appearanceModes: { id: AppearanceMode; name: string; desc: string }[] = [
+    { id: 'system', name: 'System', desc: 'Match your Windows theme automatically.' },
+    { id: 'dark', name: 'Dark', desc: 'Lower glare for night work and dark desktops.' },
+    { id: 'light', name: 'Light', desc: 'Brighter surfaces with higher daylight contrast.' },
   ];
-
-  function toggleProfileDropdown(exe: string, e: MouseEvent) {
-    e.stopPropagation();
-    openDropdownExe = openDropdownExe === exe ? '' : exe;
-  }
-
-  function pickProfile(exe: string, profile: string) {
-    updateMappingProfile(exe, profile);
-    openDropdownExe = '';
-  }
-
-  function closeDropdowns() {
-    openDropdownExe = '';
-    languageDropdownOpen = false;
-  }
-
-  function toggleLanguageDropdown(e: MouseEvent) {
-    e.stopPropagation();
-    languageDropdownOpen = !languageDropdownOpen;
-  }
 
   function pickLanguage(code: TranscriptionLanguageCode) {
     selectedLanguage = code;
-    languageDropdownOpen = false;
   }
-
-  $: filteredApps = appSearch
-    ? installedApps.filter(a =>
-        a.name.toLowerCase().includes(appSearch.toLowerCase()) ||
-        a.exe.toLowerCase().includes(appSearch.toLowerCase())
-      ).slice(0, 50)
-    : installedApps.slice(0, 50);
-
-  $: mappingExes = new Set(mappings.map(m => m.exe));
-
-  function toggleMapping(app: InstalledApp) {
-    if (mappingExes.has(app.exe)) {
-      mappings = mappings.filter(m => m.exe !== app.exe);
-    } else {
-      mappings = [...mappings, { exe: app.exe, profile: 'casual', name: app.name }];
-    }
-  }
-
-  function updateMappingProfile(exe: string, profile: string) {
-    mappings = mappings.map(m => m.exe === exe ? { ...m, profile } : m);
-  }
-
-  async function loadInstalledApps() {
-    if (appsLoaded) return;
-    try {
-      installedApps = await invoke<InstalledApp[]>('get_installed_apps');
-      appsLoaded = true;
-    } catch {}
-  }
-
-  $: if (step === 5) loadInstalledApps();
 
   // ── Navigation ────────────────────────────────────────────────────────────────
   async function goNext() {
@@ -244,9 +196,7 @@
       await saveSetting('transcription_provider', selectedProvider);
       await saveSetting('transcription_language', selectedLanguage);
       await saveSetting('cleanup_provider', selectedProvider);
-      if (mappings.length > 0) {
-        await invoke('save_app_mappings', { mappings });
-      }
+      await saveSetting('appearance_mode', selectedAppearance);
       await saveSetting('cleanup_enabled', quickPrefs.cleanup);
       await saveSetting('noise_reduction', quickPrefs.noise);
       await saveSetting('contextual_caps_enabled', quickPrefs.caps);
@@ -256,6 +206,7 @@
       if (quickPrefs.autostart) await invoke('set_autostart', { enabled: true });
       await saveSetting('setup_complete', true);
     } catch {}
+    appearanceMode.set(selectedAppearance);
     setupComplete.set(true);
   }
 
@@ -272,8 +223,6 @@
   let checkAnimating = false;
   $: if (step === 7) { setTimeout(() => { checkAnimating = true; }, 200); }
 </script>
-
-<svelte:window onclick={closeDropdowns} />
 
 <!-- Full-screen overlay -->
 <div class="setup-overlay">
@@ -528,74 +477,36 @@
         </div>
       </div>
 
-    <!-- ── Step 5: App Mappings ───────────────────────────── -->
+    <!-- ── Step 5: Appearance ───────────────────────────── -->
     {:else if step === 5}
-      <div class="step">
+      <div class="step appearance-step">
         <div class="step-header">
-          <h2>Map apps to styles <span class="optional-badge">Optional</span></h2>
-          <p class="step-sub">Select apps that should use a different tone or cleanup level. You can add more anytime from the Style page.</p>
+          <h2>Choose your appearance</h2>
+          <p class="step-sub">Choose your default theme mode. You can change this later in Settings.</p>
         </div>
 
-        <div class="app-search-wrap">
-          <svg class="search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <input class="app-search" type="text" bind:value={appSearch} placeholder="Search installed apps…" />
-        </div>
-
-        {#if !appsLoaded}
-          <p class="apps-loading">Loading installed apps…</p>
-        {:else if filteredApps.length === 0}
-          <p class="apps-loading">No apps found.</p>
-        {:else}
-          <div class="apps-list scroll-styled">
-            {#each filteredApps as app}
-              {@const mapped = mappings.find(m => m.exe === app.exe)}
-              <div class="app-row" class:mapped={!!mapped}>
-                <button class="app-toggle" onclick={() => toggleMapping(app)}>
-                  <div class="app-toggle-check" class:checked={!!mapped}>
-                    {#if mapped}
-                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-                    {/if}
-                  </div>
-                  <span class="app-name">{app.name}</span>
-                  <span class="app-exe">{app.exe}</span>
-                </button>
-                {#if mapped}
-                  <div class="profile-drop-wrap">
-                    <button
-                      class="profile-drop-btn"
-                      use:animateWidth={{ text: profileOptions.find(o => o.id === mapped.profile)?.label ?? 'Casual' }}
-                      onclick={(e) => toggleProfileDropdown(app.exe, e)}
-                    >
-                      {profileOptions.find(o => o.id === mapped.profile)?.label ?? 'Casual'}
-                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
-                    </button>
-                    {#if openDropdownExe === app.exe}
-                      <div class="profile-drop-list scroll-styled">
-                        {#each profileOptions as opt}
-                          <button
-                            class="profile-drop-item"
-                            class:active={mapped.profile === opt.id}
-                            onclick={() => pickProfile(app.exe, opt.id)}
-                          >{opt.label}</button>
-                        {/each}
-                      </div>
-                    {/if}
-                  </div>
-                {/if}
+        <div class="appearance-mode-grid">
+          {#each appearanceModes as mode}
+            <button
+              class="appearance-mode-card"
+              class:selected={selectedAppearance === mode.id}
+              onclick={() => { selectedAppearance = mode.id; }}
+            >
+              <div class="appearance-mode-title-row">
+                <span class="appearance-mode-name">{mode.name}</span>
+                <span class="appearance-mode-radio" class:checked={selectedAppearance === mode.id}></span>
               </div>
-            {/each}
-          </div>
-        {/if}
+              <p class="appearance-mode-desc">{mode.desc}</p>
+            </button>
+          {/each}
+        </div>
 
         <div class="step-footer">
-          <button class="btn-skip" onclick={skip}>I'll set this up later</button>
-          <button class="btn-primary" onclick={goNext}>
-            {mappings.length > 0 ? `Save ${mappings.length} mapping${mappings.length !== 1 ? 's' : ''} & Next` : 'Next'}
-          </button>
+          <button class="btn-skip" onclick={skip}>Skip for now</button>
+          <button class="btn-primary" onclick={goNext}>Next</button>
         </div>
       </div>
 
-    <!-- ── Step 6: Quick Settings ──────────────────────────── -->
     {:else if step === 6}
       <div class="step qs-step">
         <div class="step-header">
@@ -722,30 +633,19 @@
                 <p class="qs-card-sub">Language expected in your dictation</p>
               </div>
             </div>
-            <div class="setup-language-wrap">
-              <button class="setup-language-btn" onclick={toggleLanguageDropdown}>
-                <span>{getTranscriptionLanguageLabel(selectedLanguage)}</span>
-                <span class="setup-language-code">{selectedLanguage}</span>
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="m6 9 6 6 6-6"/>
-                </svg>
-              </button>
-              {#if languageDropdownOpen}
-                <div class="setup-language-menu scroll-styled" role="presentation" onclick={(e) => e.stopPropagation()}>
-                  {#each transcriptionLanguages as language}
-                    <button
-                      class="setup-language-item"
-                      class:active={selectedLanguage === language.code}
-                      onclick={() => pickLanguage(language.code)}
-                    >
-                      <span>{language.label}</span>
-                      <span>{language.code}</span>
-                    </button>
-                  {/each}
-                </div>
-              {/if}
+            <div class="setup-language-chip-grid">
+              {#each onboardingLanguages as language}
+                <button
+                  class="setup-language-chip"
+                  class:active={selectedLanguage === language.code}
+                  onclick={() => pickLanguage(language.code)}
+                >
+                  <span>{language.label}</span>
+                  <span>{language.code}</span>
+                </button>
+              {/each}
             </div>
-            <p class="setup-language-note">This guides transcription only. It does not translate the app.</p>
+            <p class="setup-language-note">More languages are available in Settings > General.</p>
           </div>
         </div>
 
@@ -801,12 +701,10 @@
             <span class="summary-label">Language</span>
             <span class="summary-val">{getTranscriptionLanguageLabel(selectedLanguage)}</span>
           </div>
-          {#if mappings.length > 0}
-            <div class="summary-item">
-              <span class="summary-label">App mappings</span>
-              <span class="summary-val">{mappings.length} app{mappings.length !== 1 ? 's' : ''}</span>
-            </div>
-          {/if}
+          <div class="summary-item">
+            <span class="summary-label">Theme</span>
+            <span class="summary-val">{appearanceModes.find((mode) => mode.id === selectedAppearance)?.name}</span>
+          </div>
         </div>
         <button class="btn-primary btn-lg" onclick={finish}>Start dictating</button>
         <p class="done-note">Everything can be changed in Settings or the Style page.</p>
@@ -1461,166 +1359,81 @@
 
   .tone-check.visible { opacity: 1; transform: scale(1); }
 
-  /* ── App mappings ──────────────────────────────────────────────────── */
-  .optional-badge {
-    font-family: var(--sans);
-    font-size: 11px;
-    font-weight: 500;
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    border-radius: 20px;
-    padding: 1px 9px;
-    color: var(--ink-faint);
-    vertical-align: middle;
-    margin-left: 8px;
+  /* ── Appearance ──────────────────────────────────────────────────── */
+  .appearance-step {
+    max-width: 640px;
+    gap: 16px;
   }
 
-  .app-search-wrap {
-    display: flex;
-    align-items: center;
+  .appearance-mode-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
+  }
+
+  .appearance-mode-card {
     background: var(--bg-elev);
-    border: 1.5px solid var(--line-strong);
-    border-radius: var(--r-sm);
-    padding: 8px 12px;
-    transition: border-color 0.15s;
-  }
-
-  .app-search-wrap:focus-within { border-color: var(--accent); }
-
-  .search-icon { color: var(--ink-faint); flex-shrink: 0; }
-
-  .app-search {
-    flex: 1;
-    border: none;
-    background: transparent;
-    font-family: var(--sans);
-    font-size: 13px;
-    color: var(--ink);
-    outline: none;
-  }
-
-  .app-search::placeholder { color: var(--ink-faint); }
-
-  .apps-loading {
-    font-size: 12.5px;
-    color: var(--ink-faint);
-    text-align: center;
-    margin: 8px 0;
-  }
-
-  .apps-list {
-    max-height: 220px;
-    overflow-y: auto;
-    border: 1px solid var(--line);
+    border: 1.5px solid var(--line);
     border-radius: var(--r-md);
-    background: var(--bg-elev);
-  }
-
-  .app-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 0 12px 0 0;
-    border-bottom: 1px solid var(--line-soft);
-    transition: background 0.12s;
-  }
-
-  .app-row:last-child { border-bottom: none; }
-  .app-row.mapped { background: var(--accent-soft); }
-
-  .app-toggle {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    background: transparent;
-    border: none;
-    cursor: pointer;
+    padding: 12px;
     text-align: left;
+    cursor: pointer;
+    display: grid;
+    gap: 6px;
+    transition: border-color 0.15s, background 0.15s;
   }
 
-  .app-toggle-check {
-    width: 16px;
-    height: 16px;
-    border-radius: 4px;
-    border: 1.5px solid var(--line-strong);
-    flex-shrink: 0;
+  .appearance-mode-card:hover { border-color: var(--line-strong); }
+  .appearance-mode-card.selected {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .appearance-mode-title-row {
     display: flex;
     align-items: center;
-    justify-content: center;
-    transition: background 0.12s, border-color 0.12s;
-    color: var(--on-accent);
+    justify-content: space-between;
+    gap: 8px;
   }
 
-  .app-toggle-check.checked {
-    background: var(--accent);
-    border-color: var(--accent);
+  .appearance-mode-name {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ink-strong);
   }
 
-  .app-name { font-size: 13px; color: var(--ink-soft); flex: 1; }
-  .app-exe { font-size: 11px; color: var(--ink-faint); font-family: var(--mono); }
+  .appearance-mode-desc {
+    margin: 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    line-height: 1.35;
+  }
 
-  .profile-drop-wrap {
+  .appearance-mode-radio {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid var(--line-strong);
     position: relative;
     flex-shrink: 0;
   }
 
-  .profile-drop-btn {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    background: transparent;
-    border: 1px solid var(--line-strong);
-    border-radius: 6px;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    font-weight: 500;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .profile-drop-btn:hover { background: var(--paper); }
-
-  .profile-drop-list {
+  .appearance-mode-radio.checked { border-color: var(--accent); }
+  .appearance-mode-radio.checked::after {
+    content: '';
     position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    box-shadow: var(--shadow-popover);
-    min-width: 130px;
-    max-height: 200px;
-    overflow-y: auto;
-    z-index: 10;
+    inset: 2px;
+    border-radius: 50%;
+    background: var(--accent);
   }
 
-  .profile-drop-item {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 8px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--line);
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  @media (max-width: 960px) {
+    .appearance-mode-grid {
+      grid-template-columns: 1fr;
+    }
   }
-
-  .profile-drop-item:last-child { border-bottom: none; }
-  .profile-drop-item:hover { background: var(--paper); }
-  .profile-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
-
-  /* ── Done step ─────────────────────────────────────────────────────── */
+  /* Done step */
   .done-step {
     align-items: center;
     text-align: center;
@@ -1807,80 +1620,40 @@
   .qs-toggle.on { background: var(--accent); }
   .qs-toggle.on::after { left: 16px; }
 
-  .setup-language-wrap {
-    position: relative;
-  }
-
-  .setup-language-btn {
-    width: 100%;
-    display: flex;
-    align-items: center;
+  .setup-language-chip-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 8px;
-    background: var(--paper);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    padding: 10px 12px;
-    color: var(--ink-strong);
-    font-family: var(--sans);
-    font-size: 13px;
-    cursor: pointer;
   }
 
-  .setup-language-btn span:first-child {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: left;
-  }
-
-  .setup-language-code {
-    color: var(--ink-faint);
-    font-family: var(--mono);
-    font-size: 10.5px;
-    text-transform: uppercase;
-  }
-
-  .setup-language-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    z-index: 20;
+  .setup-language-chip {
     width: 100%;
-    min-width: 220px;
-    max-height: 220px;
-    overflow-y: auto;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    box-shadow: var(--shadow-popover);
-  }
-
-  .setup-language-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
-    width: 100%;
-    padding: 8px 10px;
-    background: transparent;
-    border: 0;
-    border-bottom: 1px solid var(--line);
+    gap: 10px;
+    border: 1px solid var(--line-strong);
+    background: var(--paper);
+    border-radius: 8px;
+    padding: 7px 9px;
     color: var(--ink-strong);
-    cursor: pointer;
     font-family: var(--sans);
     font-size: 12px;
     text-align: left;
   }
 
-  .setup-language-item:last-child { border-bottom: 0; }
-  .setup-language-item:hover { background: var(--paper); }
-  .setup-language-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
-  .setup-language-item span:last-child {
+  .setup-language-chip span:last-child {
     color: var(--ink-faint);
     font-family: var(--mono);
     font-size: 10.5px;
     text-transform: uppercase;
+  }
+
+  .setup-language-chip.active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--ink);
+    font-weight: 500;
   }
 
   .setup-language-note {

--- a/src/theme.css
+++ b/src/theme.css
@@ -41,6 +41,7 @@
   --line-soft: #efeae3;
   --line-strong: var(--arm-300);
 
+  /* Light defaults; dark overrides below in :root[data-theme="dark"]. */
   --accent: var(--jap-400);
   --accent-ink: var(--jap-700);
   --accent-soft: var(--jap-100);
@@ -146,12 +147,4 @@
   --pill-bg: #0d0a08;
   --pill-fg: #ffffff;
   --pill-bar: #ffffff;
-}
-
-:root[data-theme="light"] {
-  color-scheme: light;
-  --accent: var(--jap-400);
-  --accent-soft: var(--jap-100);
-  --accent-ink: var(--jap-700);
-  --on-accent: #ffffff;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -147,3 +147,11 @@
   --pill-fg: #ffffff;
   --pill-bar: #ffffff;
 }
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --accent: var(--jap-400);
+  --accent-soft: var(--jap-100);
+  --accent-ink: var(--jap-700);
+  --on-accent: #ffffff;
+}

--- a/tests/manual/setup-layout-bounds.js
+++ b/tests/manual/setup-layout-bounds.js
@@ -1,48 +1,122 @@
 import { chromium } from 'playwright';
 
+const TARGET_URL = 'http://localhost:1420';
+const VIEWPORTS = [
+  { width: 1100, height: 720, label: '1100x720' },
+  { width: 900, height: 600, label: '900x600' },
+];
+
+async function readLayoutState(page) {
+  return await page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const overlay = document.querySelector('.setup-overlay');
+    const wrap = document.querySelector('.step-wrap');
+    const step = document.querySelector('.step');
+    const footer = document.querySelector('.step-footer');
+    const heading = document.querySelector('.step-header h2, .done-title, .brand-name');
+
+    const rect = (el) => el ? el.getBoundingClientRect() : null;
+    const stepRect = rect(step);
+    const wrapRect = rect(wrap);
+    const footerRect = rect(footer);
+
+    const pageScroll =
+      html.scrollHeight !== html.clientHeight ||
+      body.scrollHeight !== body.clientHeight;
+
+    const inBounds = !!(
+      stepRect &&
+      wrapRect &&
+      stepRect.top >= wrapRect.top &&
+      stepRect.bottom <= wrapRect.bottom
+    );
+
+    const scrollableVisibleContainers = Array.from(
+      overlay?.querySelectorAll('*') ?? []
+    )
+      .filter((el) => {
+        const style = getComputedStyle(el);
+        const hasScrollableOverflow = style.overflowY === 'auto' || style.overflowY === 'scroll';
+        const visible = el.getClientRects().length > 0;
+        return hasScrollableOverflow && visible && el.scrollHeight > el.clientHeight;
+      })
+      .map((el) => ({
+        className: el.className,
+        overflowY: getComputedStyle(el).overflowY,
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+      }));
+
+    return {
+      title: heading?.textContent?.trim() ?? 'unknown',
+      pageScroll,
+      inBounds,
+      footerBottom: footerRect?.bottom ?? null,
+      wrapBottom: wrapRect?.bottom ?? null,
+      scrollableVisibleContainers,
+    };
+  });
+}
+
+async function verifyViewport(browser, viewport) {
+  const page = await browser.newPage({ viewport: { width: viewport.width, height: viewport.height } });
+  const failures = [];
+
+  await page.goto(TARGET_URL, { waitUntil: 'networkidle', timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  for (let stepIndex = 0; stepIndex <= 8; stepIndex++) {
+    const state = await readLayoutState(page);
+    console.log(`[${viewport.label}] Step ${stepIndex}: ${state.title}`);
+
+    if (state.pageScroll) {
+      failures.push(`[${viewport.label}] "${state.title}" has page scroll (html/body mismatch).`);
+    }
+    if (!state.inBounds) {
+      failures.push(`[${viewport.label}] "${state.title}" content exceeds step container bounds.`);
+    }
+    if (state.scrollableVisibleContainers.length > 0) {
+      failures.push(
+        `[${viewport.label}] "${state.title}" has internal scrollable container(s): ${JSON.stringify(state.scrollableVisibleContainers)}`
+      );
+    }
+    if (state.footerBottom !== null && state.wrapBottom !== null && state.footerBottom > state.wrapBottom) {
+      failures.push(`[${viewport.label}] "${state.title}" footer extends below visible area.`);
+    }
+
+    const finalButton = page.locator('.step-wrap.visible .btn-primary:has-text("Start dictating")');
+    if (await finalButton.count()) break;
+
+    const nextButton = page.locator('.step-wrap.visible .btn-primary').first();
+    if (!(await nextButton.count())) break;
+    await nextButton.click();
+    await page.waitForTimeout(420);
+  }
+
+  await page.close();
+  return failures;
+}
+
 (async () => {
+  const browser = await chromium.launch({ headless: true });
+  const allFailures = [];
+
   try {
-    const browser = await chromium.launch({ headless: true });
-    const page = await browser.newPage();
-    
-    await page.setViewportSize({ width: 900, height: 600 }); // min window size
-    
-    console.log(`Navigating to http://localhost:1420...`);
-    await page.goto('http://localhost:1420');
-    
-    await page.waitForTimeout(1000);
-    
-    for (let i = 0; i < 6; i++) {
-      try {
-        const btn = await page.locator('.step-wrap.visible .btn-primary').first();
-        await btn.waitFor({ state: 'visible', timeout: 5000 });
-        await btn.click();
-        await page.waitForTimeout(600);
-      } catch (e) {
-        console.log('Error clicking next:', e.message);
-      }
+    for (const viewport of VIEWPORTS) {
+      const failures = await verifyViewport(browser, viewport);
+      allFailures.push(...failures);
     }
-    
-    await page.waitForTimeout(1000);
-    
-    // Check if step 6 is visible
-    const setupOverlay = await page.locator('.setup-overlay').boundingBox();
-    const qsCardsBox = await page.locator('.qs-cards').boundingBox();
-    
-    console.log('Setup Overlay Box:', setupOverlay);
-    console.log('QS Cards Box:', qsCardsBox);
-    
-    if (qsCardsBox.y + qsCardsBox.height > setupOverlay.y + setupOverlay.height) {
-      console.log('FAILED: Content goes off the page.');
-      process.exit(1);
-    } else {
-      console.log('SUCCESS: Content fits cleanly within the page.');
-    }
-    
+  } finally {
     await browser.close();
-    process.exit(0);
-  } catch (e) {
-    console.error(e);
+  }
+
+  if (allFailures.length > 0) {
+    console.error('FAILED: setup onboarding layout checks');
+    allFailures.forEach((f) => console.error(`  - ${f}`));
     process.exit(1);
   }
+
+  console.log('PASS: setup onboarding has no scroll and stays in bounds at 1100x720 and 900x600');
+  process.exit(0);
 })();

--- a/tests/smoke/playwright-test-appearance.cjs
+++ b/tests/smoke/playwright-test-appearance.cjs
@@ -1,4 +1,4 @@
-// Smoke test: appearance mode persistence and theme application.
+// Smoke test: appearance mode persistence and live theme application.
 const { chromium } = require('playwright');
 const { tauriMock } = require('./_tauri-mock.cjs');
 
@@ -54,6 +54,9 @@ const TIMEOUT = 8_000;
       await btn.click();
       await page.locator('html[data-theme="dark"]').waitFor({ state: 'attached', timeout: 3_000 });
     }
+
+    await page.reload({ waitUntil: 'networkidle', timeout: TIMEOUT });
+    await page.locator('html[data-theme="dark"]').waitFor({ state: 'attached', timeout: 3_000 });
 
     if (errors.length > 0) {
       console.error('\nFAIL - errors:');


### PR DESCRIPTION
# Summary

- Replace onboarding Step 5 with an interactive appearance mode selector (`System`, `Dark`, `Light`) and persist the selected mode on finish.
- Keep onboarding no-scroll by removing the heavy app-mappings step from setup and using compact spoken-language chips with a Settings handoff note.
- Simplify runtime theme handling to appearance mode only and update onboarding validation tests for layout bounds and appearance persistence.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [x] UI change
- [x] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm run test:rust`
- [x] `npm run test:smoke`
- [x] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Additional verification run:
- `node tests/smoke/playwright-test-appearance.cjs`
- `node tests/manual/setup-layout-bounds.js`

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

- Onboarding now saves `appearance_mode` explicitly during setup completion.
- Hotkey behavior remains in Settings only.
- No provider key handling changes were introduced.

## UI Evidence

- Not applicable (no screenshots attached in this PR).

## Reviewer Notes

- Focus review on `src/lib/views/Setup.svelte` step sequencing, appearance option persistence, and no-scroll behavior at `1100x720` and `900x600`.
