### PR TITLE
feat: delete stale cache and dictionary entries on quick output deletion

### DIFF
--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -9,6 +9,9 @@ const MONITOR_WINDOW_SECS: u64 = 60;
 const POLL_INTERVAL_SECS: u64 = 2;
 const BASELINE_CAPTURE_DELAY_MS: u64 = 250;
 const BASELINE_RETRY_DELAY_MS: u64 = 500;
+const REJECTION_WINDOW_SECS: u64 = 8;
+const REJECTION_POLL_MS: u64 = 500;
+const CACHE_REJECTION_WINDOW_SECS: u64 = 10;
 const PENDING_RETENTION_DAYS: i64 = 2;
 const PROMOTION_THRESHOLD: i64 = 2;
 const STABLE_TEXT_OBSERVATIONS_REQUIRED: usize = 2;
@@ -461,9 +464,29 @@ fn current_anchored_span<'a>(
     Some(&current[anchor.start..new_end])
 }
 
+fn find_last_anchor(haystack: &str, needle: &str) -> Option<TextAnchor> {
+    if needle.trim().is_empty() {
+        return None;
+    }
+    let start = haystack.rfind(needle)?;
+    Some(TextAnchor {
+        start,
+        end: start + needle.len(),
+    })
+}
+
 fn capture_baseline_text(injected_text: &str) -> Option<String> {
     let current_text = read_focused_text()?;
     if find_unique_anchor(&current_text, injected_text).is_some() {
+        Some(current_text)
+    } else {
+        None
+    }
+}
+
+fn capture_baseline_text_any(injected_text: &str) -> Option<String> {
+    let current_text = read_focused_text()?;
+    if current_text.contains(injected_text) {
         Some(current_text)
     } else {
         None
@@ -938,6 +961,222 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
             }
         }
         let _ = db::log_auto_learn_event(&db, "monitor", "timeout", &app_context, "", "", 0.0);
+    });
+}
+
+pub fn start_rejection_monitor(
+    injected_text: String,
+    applied_entry_ids: Vec<i64>,
+    db: DbHandle,
+    app: AppHandle,
+) {
+    if applied_entry_ids.is_empty() {
+        return;
+    }
+    let (key_hash, _) = pair_hash(&injected_text, "rejection");
+    let key = format!("rejection:{key_hash}");
+    let inserted = match active_monitors().lock() {
+        Ok(mut active) => active.insert(key.clone()),
+        Err(_) => false,
+    };
+    if !inserted {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        let _guard = MonitorKeyGuard::new(key);
+
+        tokio::time::sleep(std::time::Duration::from_millis(BASELINE_CAPTURE_DELAY_MS)).await;
+        let mut baseline = tokio::task::spawn_blocking({
+            let text = injected_text.clone();
+            move || capture_baseline_text_any(&text)
+        })
+        .await
+        .ok()
+        .flatten();
+
+        if baseline.is_none() {
+            tokio::time::sleep(std::time::Duration::from_millis(BASELINE_RETRY_DELAY_MS)).await;
+            baseline = tokio::task::spawn_blocking({
+                let text = injected_text.clone();
+                move || capture_baseline_text_any(&text)
+            })
+            .await
+            .ok()
+            .flatten();
+        }
+
+        let Some(baseline_text) = baseline else {
+            // Text not found at capture time — either UIAutomation is unavailable,
+            // or the user deleted the output before the 250ms baseline window.
+            // Distinguish: if the field is readable, the text is already gone → reject.
+            let field_readable =
+                tokio::task::spawn_blocking(|| read_focused_text().is_some())
+                    .await
+                    .unwrap_or(false);
+            if field_readable {
+                log::info!(
+                    "rejection-monitor: text absent at baseline, removing {} auto-learned dict entries",
+                    applied_entry_ids.len()
+                );
+                if let Err(e) = db::delete_auto_learned_entries_by_ids(&db, &applied_entry_ids) {
+                    log::warn!("rejection-monitor: delete failed: {e}");
+                } else {
+                    app.emit("open-flow:dictionary-entry-rejected", applied_entry_ids.len()).ok();
+                }
+            } else {
+                log::debug!("rejection-monitor: anchor miss (UIAutomation unavailable)");
+            }
+            return;
+        };
+        let Some(anchor) = find_last_anchor(&baseline_text, &injected_text) else {
+            log::debug!("rejection-monitor: anchor not found");
+            return;
+        };
+
+        let rejection_threshold = injected_text.len() / 10;
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(REJECTION_WINDOW_SECS);
+
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(REJECTION_POLL_MS)).await;
+
+            let current = match tokio::task::spawn_blocking(read_focused_text).await {
+                Ok(Some(t)) => t,
+                _ => continue,
+            };
+
+            let rejected = match current_anchored_span(&baseline_text, &current, anchor) {
+                Some(span) => span.len() <= rejection_threshold,
+                // Anchor tracking lost (edit too complex for prefix/suffix heuristic).
+                // Reject if the injected text is completely absent AND the document
+                // shrank — confirming deletion rather than a stale baseline.
+                None => {
+                    !current.contains(injected_text.as_str())
+                        && current.len() < baseline_text.len()
+                }
+            };
+
+            if rejected {
+                log::info!(
+                    "rejection-monitor: deletion detected, removing {} auto-learned dict entries",
+                    applied_entry_ids.len()
+                );
+                if let Err(e) = db::delete_auto_learned_entries_by_ids(&db, &applied_entry_ids) {
+                    log::warn!("rejection-monitor: delete failed: {e}");
+                } else {
+                    app.emit("open-flow:dictionary-entry-rejected", applied_entry_ids.len()).ok();
+                }
+                return;
+            }
+        }
+        log::debug!("rejection-monitor: window expired, no rejection detected");
+    });
+}
+
+pub fn start_cache_rejection_monitor(
+    injected_text: String,
+    cache_key: String,
+    db: DbHandle,
+    app: AppHandle,
+) {
+    let (key_hash, _) = pair_hash(&injected_text, "cache_rejection");
+    let key = format!("cache_rejection:{key_hash}");
+    let inserted = match active_monitors().lock() {
+        Ok(mut active) => active.insert(key.clone()),
+        Err(_) => false,
+    };
+    if !inserted {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        let _guard = MonitorKeyGuard::new(key);
+
+        tokio::time::sleep(std::time::Duration::from_millis(BASELINE_CAPTURE_DELAY_MS)).await;
+        let mut baseline = tokio::task::spawn_blocking({
+            let text = injected_text.clone();
+            move || capture_baseline_text_any(&text)
+        })
+        .await
+        .ok()
+        .flatten();
+
+        if baseline.is_none() {
+            tokio::time::sleep(std::time::Duration::from_millis(BASELINE_RETRY_DELAY_MS)).await;
+            baseline = tokio::task::spawn_blocking({
+                let text = injected_text.clone();
+                move || capture_baseline_text_any(&text)
+            })
+            .await
+            .ok()
+            .flatten();
+        }
+
+        let Some(baseline_text) = baseline else {
+            // Text not found at capture time — either UIAutomation is unavailable,
+            // or the user deleted the output before the 250ms baseline window.
+            // Distinguish: if the field is readable, the text is already gone → reject.
+            let field_readable =
+                tokio::task::spawn_blocking(|| read_focused_text().is_some())
+                    .await
+                    .unwrap_or(false);
+            if field_readable {
+                log::info!("cache-rejection-monitor: text absent at baseline, invalidating cache entry");
+                if let Err(e) = db::cleanup_cache_delete_by_key(&db, &cache_key) {
+                    log::warn!("cache-rejection-monitor: delete failed: {e}");
+                } else {
+                    app.emit("open-flow:cleanup-cache-invalidated", ()).ok();
+                }
+            } else {
+                log::debug!("cache-rejection-monitor: anchor miss (UIAutomation unavailable)");
+            }
+            return;
+        };
+        let Some(anchor) = find_last_anchor(&baseline_text, &injected_text) else {
+            log::debug!("cache-rejection-monitor: anchor not found");
+            return;
+        };
+
+        let rejection_threshold = injected_text.len() / 10;
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(CACHE_REJECTION_WINDOW_SECS);
+
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(REJECTION_POLL_MS)).await;
+
+            let current = match tokio::task::spawn_blocking(read_focused_text).await {
+                Ok(Some(t)) => t,
+                _ => continue,
+            };
+
+            let rejected = match current_anchored_span(&baseline_text, &current, anchor) {
+                Some(span) => span.len() <= rejection_threshold,
+                None => {
+                    !current.contains(injected_text.as_str())
+                        && current.len() < baseline_text.len()
+                }
+            };
+
+            if rejected {
+                log::info!("cache-rejection-monitor: deletion detected, invalidating cache entry");
+                if let Err(e) = db::cleanup_cache_delete_by_key(&db, &cache_key) {
+                    log::warn!("cache-rejection-monitor: delete failed: {e}");
+                } else {
+                    app.emit("open-flow:cleanup-cache-invalidated", ()).ok();
+                }
+                return;
+            }
+        }
+        log::debug!("cache-rejection-monitor: window expired, no rejection detected");
     });
 }
 

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -972,17 +972,56 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
     });
 }
 
-pub fn start_rejection_monitor(
+#[derive(Debug)]
+enum RejectionTarget {
+    DictEntries { ids: Vec<i64> },
+    CacheKey { key: String },
+}
+
+impl RejectionTarget {
+    fn monitor_key_prefix(&self) -> &'static str {
+        match self {
+            RejectionTarget::DictEntries { .. } => "rejection",
+            RejectionTarget::CacheKey { .. } => "cache_rejection",
+        }
+    }
+
+    fn window_secs(&self) -> u64 {
+        match self {
+            RejectionTarget::DictEntries { .. } => REJECTION_WINDOW_SECS,
+            RejectionTarget::CacheKey { .. } => CACHE_REJECTION_WINDOW_SECS,
+        }
+    }
+}
+
+fn apply_rejection(target: &RejectionTarget, db: &DbHandle, app: &AppHandle, prefix: &str) {
+    match target {
+        RejectionTarget::DictEntries { ids } => {
+            if let Err(e) = db::delete_auto_learned_entries_by_ids(db, ids) {
+                log::warn!("{prefix}: delete failed: {e}");
+            } else {
+                app.emit("open-flow:dictionary-entry-rejected", ids.len()).ok();
+            }
+        }
+        RejectionTarget::CacheKey { key } => {
+            if let Err(e) = db::cleanup_cache_delete_by_key(db, key) {
+                log::warn!("{prefix}: delete failed: {e}");
+            } else {
+                app.emit("open-flow:cleanup-cache-invalidated", ()).ok();
+            }
+        }
+    }
+}
+
+fn run_rejection_monitor(
     injected_text: String,
-    applied_entry_ids: Vec<i64>,
+    target: RejectionTarget,
     db: DbHandle,
     app: AppHandle,
 ) {
-    if applied_entry_ids.is_empty() {
-        return;
-    }
-    let (key_hash, _) = pair_hash(&injected_text, "rejection");
-    let key = format!("rejection:{key_hash}");
+    let prefix = target.monitor_key_prefix();
+    let (key_hash, _) = pair_hash(&injected_text, prefix);
+    let key = format!("{prefix}:{key_hash}");
     let inserted = match active_monitors().lock() {
         Ok(mut active) => active.insert(key.clone()),
         Err(_) => false,
@@ -993,6 +1032,7 @@ pub fn start_rejection_monitor(
 
     tauri::async_runtime::spawn(async move {
         let _guard = MonitorKeyGuard::new(key);
+        let prefix = target.monitor_key_prefix();
 
         tokio::time::sleep(std::time::Duration::from_millis(BASELINE_CAPTURE_DELAY_MS)).await;
         let mut baseline = tokio::task::spawn_blocking({
@@ -1018,33 +1058,25 @@ pub fn start_rejection_monitor(
             // Text not found at capture time — either UIAutomation is unavailable,
             // or the user deleted the output before the 250ms baseline window.
             // Distinguish: if the field is readable, the text is already gone → reject.
-            let field_readable =
-                tokio::task::spawn_blocking(|| read_focused_text().is_some())
-                    .await
-                    .unwrap_or(false);
+            let field_readable = tokio::task::spawn_blocking(|| read_focused_text().is_some())
+                .await
+                .unwrap_or(false);
             if field_readable {
-                log::info!(
-                    "rejection-monitor: text absent at baseline, removing {} auto-learned dict entries",
-                    applied_entry_ids.len()
-                );
-                if let Err(e) = db::delete_auto_learned_entries_by_ids(&db, &applied_entry_ids) {
-                    log::warn!("rejection-monitor: delete failed: {e}");
-                } else {
-                    app.emit("open-flow:dictionary-entry-rejected", applied_entry_ids.len()).ok();
-                }
+                log::info!("{prefix}: text absent at baseline, firing rejection");
+                apply_rejection(&target, &db, &app, prefix);
             } else {
-                log::debug!("rejection-monitor: anchor miss (UIAutomation unavailable)");
+                log::debug!("{prefix}: anchor miss (UIAutomation unavailable)");
             }
             return;
         };
         let Some(anchor) = find_last_anchor(&baseline_text, &injected_text) else {
-            log::debug!("rejection-monitor: anchor not found");
+            log::debug!("{prefix}: anchor not found");
             return;
         };
 
         let rejection_threshold = injected_text.len() / 10;
         let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_secs(REJECTION_WINDOW_SECS);
+            tokio::time::Instant::now() + std::time::Duration::from_secs(target.window_secs());
 
         loop {
             if tokio::time::Instant::now() >= deadline {
@@ -1070,20 +1102,30 @@ pub fn start_rejection_monitor(
             };
 
             if rejected {
-                log::info!(
-                    "rejection-monitor: deletion detected, removing {} auto-learned dict entries",
-                    applied_entry_ids.len()
-                );
-                if let Err(e) = db::delete_auto_learned_entries_by_ids(&db, &applied_entry_ids) {
-                    log::warn!("rejection-monitor: delete failed: {e}");
-                } else {
-                    app.emit("open-flow:dictionary-entry-rejected", applied_entry_ids.len()).ok();
-                }
+                log::info!("{prefix}: deletion detected, firing rejection");
+                apply_rejection(&target, &db, &app, prefix);
                 return;
             }
         }
-        log::debug!("rejection-monitor: window expired, no rejection detected");
+        log::debug!("{prefix}: window expired, no rejection detected");
     });
+}
+
+pub fn start_rejection_monitor(
+    injected_text: String,
+    applied_entry_ids: Vec<i64>,
+    db: DbHandle,
+    app: AppHandle,
+) {
+    if applied_entry_ids.is_empty() {
+        return;
+    }
+    run_rejection_monitor(
+        injected_text,
+        RejectionTarget::DictEntries { ids: applied_entry_ids },
+        db,
+        app,
+    );
 }
 
 pub fn start_cache_rejection_monitor(
@@ -1092,100 +1134,12 @@ pub fn start_cache_rejection_monitor(
     db: DbHandle,
     app: AppHandle,
 ) {
-    let (key_hash, _) = pair_hash(&injected_text, "cache_rejection");
-    let key = format!("cache_rejection:{key_hash}");
-    let inserted = match active_monitors().lock() {
-        Ok(mut active) => active.insert(key.clone()),
-        Err(_) => false,
-    };
-    if !inserted {
-        return;
-    }
-
-    tauri::async_runtime::spawn(async move {
-        let _guard = MonitorKeyGuard::new(key);
-
-        tokio::time::sleep(std::time::Duration::from_millis(BASELINE_CAPTURE_DELAY_MS)).await;
-        let mut baseline = tokio::task::spawn_blocking({
-            let text = injected_text.clone();
-            move || capture_baseline_text_any(&text)
-        })
-        .await
-        .ok()
-        .flatten();
-
-        if baseline.is_none() {
-            tokio::time::sleep(std::time::Duration::from_millis(BASELINE_RETRY_DELAY_MS)).await;
-            baseline = tokio::task::spawn_blocking({
-                let text = injected_text.clone();
-                move || capture_baseline_text_any(&text)
-            })
-            .await
-            .ok()
-            .flatten();
-        }
-
-        let Some(baseline_text) = baseline else {
-            // Text not found at capture time — either UIAutomation is unavailable,
-            // or the user deleted the output before the 250ms baseline window.
-            // Distinguish: if the field is readable, the text is already gone → reject.
-            let field_readable =
-                tokio::task::spawn_blocking(|| read_focused_text().is_some())
-                    .await
-                    .unwrap_or(false);
-            if field_readable {
-                log::info!("cache-rejection-monitor: text absent at baseline, invalidating cache entry");
-                if let Err(e) = db::cleanup_cache_delete_by_key(&db, &cache_key) {
-                    log::warn!("cache-rejection-monitor: delete failed: {e}");
-                } else {
-                    app.emit("open-flow:cleanup-cache-invalidated", ()).ok();
-                }
-            } else {
-                log::debug!("cache-rejection-monitor: anchor miss (UIAutomation unavailable)");
-            }
-            return;
-        };
-        let Some(anchor) = find_last_anchor(&baseline_text, &injected_text) else {
-            log::debug!("cache-rejection-monitor: anchor not found");
-            return;
-        };
-
-        let rejection_threshold = injected_text.len() / 10;
-        let deadline = tokio::time::Instant::now()
-            + std::time::Duration::from_secs(CACHE_REJECTION_WINDOW_SECS);
-
-        loop {
-            if tokio::time::Instant::now() >= deadline {
-                break;
-            }
-
-            tokio::time::sleep(std::time::Duration::from_millis(REJECTION_POLL_MS)).await;
-
-            let current = match tokio::task::spawn_blocking(read_focused_text).await {
-                Ok(Some(t)) => t,
-                _ => continue,
-            };
-
-            let rejected = match current_anchored_span(&baseline_text, &current, anchor) {
-                Some(span) => span.len() <= rejection_threshold,
-                None => {
-                    !current.contains(injected_text.as_str())
-                        && current.len() < baseline_text.len()
-                }
-            };
-
-            if rejected {
-                log::info!("cache-rejection-monitor: deletion detected, invalidating cache entry");
-                if let Err(e) = db::cleanup_cache_delete_by_key(&db, &cache_key) {
-                    log::warn!("cache-rejection-monitor: delete failed: {e}");
-                } else {
-                    app.emit("open-flow:cleanup-cache-invalidated", ()).ok();
-                }
-                return;
-            }
-        }
-        log::debug!("cache-rejection-monitor: window expired, no rejection detected");
-    });
+    run_rejection_monitor(
+        injected_text,
+        RejectionTarget::CacheKey { key: cache_key },
+        db,
+        app,
+    );
 }
 
 #[cfg(test)]

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -828,6 +828,12 @@ pub fn read_focused_text() -> Option<String> {
             CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER).ok()?;
         let element = automation.GetFocusedElement().ok()?;
 
+        // Track whether any pattern was readable (even if the field is empty).
+        // Only return None when UIAutomation cannot read the element at all —
+        // an accessible-but-empty field must return Some("") so callers can
+        // distinguish "field cleared" from "UIAutomation unavailable".
+        let mut accessible_empty: Option<String> = None;
+
         if let Ok(pattern) =
             element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
         {
@@ -836,6 +842,7 @@ pub fn read_focused_text() -> Option<String> {
                 if !s.is_empty() {
                     return Some(s);
                 }
+                accessible_empty = Some(s);
             }
         }
 
@@ -848,11 +855,12 @@ pub fn read_focused_text() -> Option<String> {
                     if !s.is_empty() {
                         return Some(s);
                     }
+                    accessible_empty = Some(s);
                 }
             }
         }
 
-        None
+        accessible_empty
     }
 }
 

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1013,9 +1013,21 @@ fn apply_rejection(target: &RejectionTarget, db: &DbHandle, app: &AppHandle, pre
     }
 }
 
+#[cfg(windows)]
+fn is_target_window_focused(target_hwnd: usize) -> bool {
+    use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+    unsafe { GetForegroundWindow().0 as usize == target_hwnd }
+}
+
+#[cfg(not(windows))]
+fn is_target_window_focused(_target_hwnd: usize) -> bool {
+    true
+}
+
 fn run_rejection_monitor(
     injected_text: String,
     target: RejectionTarget,
+    target_hwnd: usize,
     db: DbHandle,
     app: AppHandle,
 ) {
@@ -1057,15 +1069,18 @@ fn run_rejection_monitor(
         let Some(baseline_text) = baseline else {
             // Text not found at capture time — either UIAutomation is unavailable,
             // or the user deleted the output before the 250ms baseline window.
-            // Distinguish: if the field is readable, the text is already gone → reject.
-            let field_readable = tokio::task::spawn_blocking(|| read_focused_text().is_some())
-                .await
-                .unwrap_or(false);
-            if field_readable {
+            // Only fire if the original window is still focused; a window switch
+            // in that 750ms window would cause a false positive otherwise.
+            let should_fire = tokio::task::spawn_blocking(move || {
+                read_focused_text().is_some() && is_target_window_focused(target_hwnd)
+            })
+            .await
+            .unwrap_or(false);
+            if should_fire {
                 log::info!("{prefix}: text absent at baseline, firing rejection");
                 apply_rejection(&target, &db, &app, prefix);
             } else {
-                log::debug!("{prefix}: anchor miss (UIAutomation unavailable)");
+                log::debug!("{prefix}: anchor miss or window switched, skipping");
             }
             return;
         };
@@ -1102,9 +1117,19 @@ fn run_rejection_monitor(
             };
 
             if rejected {
-                log::info!("{prefix}: deletion detected, firing rejection");
-                apply_rejection(&target, &db, &app, prefix);
-                return;
+                // Guard against false positives from window switches: only fire
+                // if the original injection window is still in the foreground.
+                let still_focused = tokio::task::spawn_blocking(move || {
+                    is_target_window_focused(target_hwnd)
+                })
+                .await
+                .unwrap_or(false);
+                if still_focused {
+                    log::info!("{prefix}: deletion detected, firing rejection");
+                    apply_rejection(&target, &db, &app, prefix);
+                    return;
+                }
+                log::debug!("{prefix}: rejection signal but window switched, ignoring");
             }
         }
         log::debug!("{prefix}: window expired, no rejection detected");
@@ -1114,6 +1139,7 @@ fn run_rejection_monitor(
 pub fn start_rejection_monitor(
     injected_text: String,
     applied_entry_ids: Vec<i64>,
+    target_hwnd: usize,
     db: DbHandle,
     app: AppHandle,
 ) {
@@ -1123,6 +1149,7 @@ pub fn start_rejection_monitor(
     run_rejection_monitor(
         injected_text,
         RejectionTarget::DictEntries { ids: applied_entry_ids },
+        target_hwnd,
         db,
         app,
     );
@@ -1131,12 +1158,14 @@ pub fn start_rejection_monitor(
 pub fn start_cache_rejection_monitor(
     injected_text: String,
     cache_key: String,
+    target_hwnd: usize,
     db: DbHandle,
     app: AppHandle,
 ) {
     run_rejection_monitor(
         injected_text,
         RejectionTarget::CacheKey { key: cache_key },
+        target_hwnd,
         db,
         app,
     );

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1074,7 +1074,7 @@ fn run_rejection_monitor(
             return;
         };
 
-        let rejection_threshold = injected_text.len() / 10;
+        let rejection_threshold = injected_text.chars().count() / 10;
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(target.window_secs());
 
@@ -1091,7 +1091,7 @@ fn run_rejection_monitor(
             };
 
             let rejected = match current_anchored_span(&baseline_text, &current, anchor) {
-                Some(span) => span.len() <= rejection_threshold,
+                Some(span) => span.chars().count() <= rejection_threshold,
                 // Anchor tracking lost (edit too complex for prefix/suffix heuristic).
                 // Reject if the injected text is completely absent AND the document
                 // shrank — confirming deletion rather than a stale baseline.

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -626,6 +626,38 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
     Ok(())
 }
 
+pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let conn = lock_conn(db)?;
+    for &id in ids {
+        let mut stmt = conn.prepare(
+            "SELECT term, mistake FROM dictionary WHERE id = ?1 AND auto_learned = 1 AND mistake IS NOT NULL",
+        )?;
+        let pairs: Vec<(String, String)> = stmt
+            .query_map(params![id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        conn.execute(
+            "DELETE FROM dictionary WHERE id = ?1 AND auto_learned = 1",
+            params![id],
+        )?;
+
+        for (term, mistake) in pairs {
+            conn.execute(
+                "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
+                params![mistake, term],
+            )?;
+            conn.execute(
+                "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
+                params![mistake, term],
+            )?;
+        }
+    }
+    Ok(())
+}
+
 // ---------- snippets ----------
 
 pub fn insert_snippet(db: &Db, trigger: &str, expansion: &str, instructions: &str) -> Result<()> {
@@ -766,6 +798,12 @@ pub fn cleanup_cache_count(db: &Db) -> Result<i64> {
         .map_err(Into::into)
 }
 
+pub fn cleanup_cache_delete_by_key(db: &Db, key: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute("DELETE FROM cleanup_cache WHERE key = ?1", params![key])?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -852,5 +890,145 @@ mod tests {
         assert!(cleanup_cache_get_active(&db, "live")
             .expect("query live")
             .is_some());
+    }
+
+    #[test]
+    fn cache_rejection_delete_removes_entry() {
+        let db = test_db();
+        cleanup_cache_insert_new(&db, "key1", "bad answer", "2999-01-01 00:00:00").expect("insert");
+
+        // Verify it's cached.
+        assert!(cleanup_cache_get_active(&db, "key1").expect("get").is_some());
+
+        // Simulate rejection monitor firing.
+        cleanup_cache_delete_by_key(&db, "key1").expect("delete");
+
+        // Entry must be gone — next dictation will hit the LLM.
+        assert!(cleanup_cache_get_active(&db, "key1").expect("get after").is_none());
+        assert_eq!(cleanup_cache_count(&db).expect("count"), 0);
+    }
+
+    #[test]
+    fn cache_rejection_leaves_other_keys_intact() {
+        let db = test_db();
+        cleanup_cache_insert_new(&db, "target", "bad", "2999-01-01 00:00:00").expect("target");
+        cleanup_cache_insert_new(&db, "bystander", "good", "2999-01-01 00:00:00")
+            .expect("bystander");
+
+        cleanup_cache_delete_by_key(&db, "target").expect("delete");
+
+        assert!(cleanup_cache_get_active(&db, "target").expect("target").is_none());
+        assert!(
+            cleanup_cache_get_active(&db, "bystander")
+                .expect("bystander")
+                .is_some(),
+            "unrelated entry must survive"
+        );
+    }
+
+    #[test]
+    fn cache_rejection_after_hit_removes_entry() {
+        let db = test_db();
+        cleanup_cache_insert_new(&db, "k", "stale text", "2999-01-01 00:00:00").expect("insert");
+
+        // Simulate a cache hit (the phrase was served from cache once).
+        cleanup_cache_touch_hit(&db, "k", 2, "2026-01-01 00:00:00", "2999-01-01 00:00:00")
+            .expect("touch");
+
+        let hit = cleanup_cache_get_active(&db, "k").expect("get").expect("exists");
+        assert_eq!(hit.hit_count, 2);
+
+        // User deletes output → rejection monitor fires.
+        cleanup_cache_delete_by_key(&db, "k").expect("delete");
+
+        assert!(cleanup_cache_get_active(&db, "k").expect("get after").is_none());
+    }
+
+    #[test]
+    fn dict_rejection_only_removes_auto_learned_entries() {
+        let db = test_db();
+
+        // Manual entry — must survive rejection.
+        insert_dictionary_entry(&db, "groq", Some("grog")).expect("manual");
+        let manual_id = query_dictionary(&db)
+            .expect("query")
+            .into_iter()
+            .find(|e| e.term == "groq")
+            .expect("find")
+            .id;
+
+        // Auto-learned entry — must be removed.
+        insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "high").expect("auto");
+        let auto_id = query_dictionary(&db)
+            .expect("query")
+            .into_iter()
+            .find(|e| e.term == "Tauri")
+            .expect("find")
+            .id;
+
+        delete_auto_learned_entries_by_ids(&db, &[manual_id, auto_id]).expect("reject");
+
+        let remaining: Vec<_> = query_dictionary(&db).expect("query after");
+        assert_eq!(remaining.len(), 1, "only manual entry survives");
+        assert_eq!(remaining[0].term, "groq");
+    }
+
+    #[test]
+    fn dict_rejection_cleans_up_pending_corrections() {
+        let db = test_db();
+
+        insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "low").expect("insert");
+        let id = query_dictionary(&db)
+            .expect("query")
+            .into_iter()
+            .next()
+            .expect("entry")
+            .id;
+
+        // Simulate pending correction records that led to the promotion.
+        insert_pending_correction(&db, "Tari", "Tauri").expect("pending 1");
+        insert_pending_correction(&db, "Tari", "Tauri").expect("pending 2");
+        assert_eq!(
+            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count"),
+            2
+        );
+
+        // Rejection monitor fires.
+        delete_auto_learned_entries_by_ids(&db, &[id]).expect("reject");
+
+        // Dictionary entry gone.
+        assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
+        // Pending corrections also purged — prevents immediate re-promotion.
+        assert_eq!(
+            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
+            0
+        );
+    }
+
+    #[test]
+    fn cache_rejection_full_lifecycle() {
+        // End-to-end: insert → hit (cache serves stale) → reject → miss (LLM runs again).
+        let db = test_db();
+        let key = "chromium-is-a-web-browser-base";
+        let bad_answer = "bad cached answer";
+
+        // First dictation: LLM runs, result cached.
+        cleanup_cache_insert_new(&db, key, bad_answer, "2999-01-01 00:00:00").expect("insert");
+        assert_eq!(cleanup_cache_count(&db).expect("count"), 1);
+
+        // Second dictation: cache hit, stale answer served.
+        let entry = cleanup_cache_get_active(&db, key).expect("get").expect("hit");
+        assert_eq!(entry.clean_text, bad_answer);
+        cleanup_cache_touch_hit(&db, key, 2, "2026-01-01 00:00:00", "2999-01-01 00:00:00")
+            .expect("touch");
+
+        // User deletes output within 10s → monitor fires.
+        cleanup_cache_delete_by_key(&db, key).expect("delete");
+
+        // Third dictation: cache miss, LLM runs again with fresh context.
+        assert!(
+            cleanup_cache_get_active(&db, key).expect("get after").is_none(),
+            "cache must be empty after rejection so next dictation hits the LLM"
+        );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -626,6 +626,9 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
     Ok(())
 }
 
+// Conservative batch size well below SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999).
+const SQL_BATCH_SIZE: usize = 500;
+
 pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     if ids.is_empty() {
         return Ok(());
@@ -633,33 +636,36 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
     {
-        let placeholders = vec!["?"; ids.len()].join(", ");
-
-        let select_sql = format!(
-            "SELECT term, mistake FROM dictionary \
-             WHERE id IN ({placeholders}) AND auto_learned = 1 AND mistake IS NOT NULL"
-        );
-        let pairs: Vec<(String, String)> = tx
-            .prepare(&select_sql)?
-            .query_map(rusqlite::params_from_iter(ids.iter()), |r| {
-                Ok((r.get(0)?, r.get(1)?))
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-
-        let delete_dict_sql = format!(
-            "DELETE FROM dictionary WHERE id IN ({placeholders}) AND auto_learned = 1"
-        );
-        tx.execute(&delete_dict_sql, rusqlite::params_from_iter(ids.iter()))?;
-
         let mut del_pending_stmt = tx.prepare(
             "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
         let mut del_candidate_stmt = tx.prepare(
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
-        for (term, mistake) in pairs {
-            del_pending_stmt.execute(params![mistake, term])?;
-            del_candidate_stmt.execute(params![mistake, term])?;
+
+        for chunk in ids.chunks(SQL_BATCH_SIZE) {
+            let placeholders = vec!["?"; chunk.len()].join(", ");
+
+            let select_sql = format!(
+                "SELECT term, mistake FROM dictionary \
+                 WHERE id IN ({placeholders}) AND auto_learned = 1 AND mistake IS NOT NULL"
+            );
+            let pairs: Vec<(String, String)> = tx
+                .prepare(&select_sql)?
+                .query_map(rusqlite::params_from_iter(chunk.iter()), |r| {
+                    Ok((r.get(0)?, r.get(1)?))
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+
+            let delete_dict_sql = format!(
+                "DELETE FROM dictionary WHERE id IN ({placeholders}) AND auto_learned = 1"
+            );
+            tx.execute(&delete_dict_sql, rusqlite::params_from_iter(chunk.iter()))?;
+
+            for (term, mistake) in pairs {
+                del_pending_stmt.execute(params![mistake, term])?;
+                del_candidate_stmt.execute(params![mistake, term])?;
+            }
         }
     }
     tx.commit()?;

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -633,29 +633,33 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
     {
-        let mut select_stmt = tx.prepare(
-            "SELECT term, mistake FROM dictionary WHERE id = ?1 AND auto_learned = 1 AND mistake IS NOT NULL",
-        )?;
-        let mut del_dict_stmt =
-            tx.prepare("DELETE FROM dictionary WHERE id = ?1 AND auto_learned = 1")?;
+        let placeholders = vec!["?"; ids.len()].join(", ");
+
+        let select_sql = format!(
+            "SELECT term, mistake FROM dictionary \
+             WHERE id IN ({placeholders}) AND auto_learned = 1 AND mistake IS NOT NULL"
+        );
+        let pairs: Vec<(String, String)> = tx
+            .prepare(&select_sql)?
+            .query_map(rusqlite::params_from_iter(ids.iter()), |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        let delete_dict_sql = format!(
+            "DELETE FROM dictionary WHERE id IN ({placeholders}) AND auto_learned = 1"
+        );
+        tx.execute(&delete_dict_sql, rusqlite::params_from_iter(ids.iter()))?;
+
         let mut del_pending_stmt = tx.prepare(
             "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
         let mut del_candidate_stmt = tx.prepare(
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
-
-        for &id in ids {
-            let pairs: Vec<(String, String)> = select_stmt
-                .query_map(params![id], |r| Ok((r.get(0)?, r.get(1)?)))?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-
-            del_dict_stmt.execute(params![id])?;
-
-            for (term, mistake) in pairs {
-                del_pending_stmt.execute(params![mistake, term])?;
-                del_candidate_stmt.execute(params![mistake, term])?;
-            }
+        for (term, mistake) in pairs {
+            del_pending_stmt.execute(params![mistake, term])?;
+            del_candidate_stmt.execute(params![mistake, term])?;
         }
     }
     tx.commit()?;
@@ -1034,5 +1038,20 @@ mod tests {
             cleanup_cache_get_active(&db, key).expect("get after").is_none(),
             "cache must be empty after rejection so next dictation hits the LLM"
         );
+    }
+
+    #[test]
+    fn dict_rejection_bulk_removes_multiple_entries() {
+        let db = test_db();
+        insert_dictionary_entry_auto_learned(&db, "groq", Some("grog"), "high").expect("1");
+        insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "high").expect("2");
+        let ids: Vec<i64> = query_dictionary(&db)
+            .expect("query")
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        assert_eq!(ids.len(), 2);
+        delete_auto_learned_entries_by_ids(&db, &ids).expect("bulk delete");
+        assert_eq!(query_dictionary(&db).expect("after").len(), 0);
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -630,31 +630,35 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     if ids.is_empty() {
         return Ok(());
     }
-    let conn = lock_conn(db)?;
-    for &id in ids {
-        let mut stmt = conn.prepare(
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    {
+        let mut select_stmt = tx.prepare(
             "SELECT term, mistake FROM dictionary WHERE id = ?1 AND auto_learned = 1 AND mistake IS NOT NULL",
         )?;
-        let pairs: Vec<(String, String)> = stmt
-            .query_map(params![id], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-
-        conn.execute(
-            "DELETE FROM dictionary WHERE id = ?1 AND auto_learned = 1",
-            params![id],
+        let mut del_dict_stmt =
+            tx.prepare("DELETE FROM dictionary WHERE id = ?1 AND auto_learned = 1")?;
+        let mut del_pending_stmt = tx.prepare(
+            "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
+        )?;
+        let mut del_candidate_stmt = tx.prepare(
+            "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
 
-        for (term, mistake) in pairs {
-            conn.execute(
-                "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
-                params![mistake, term],
-            )?;
-            conn.execute(
-                "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
-                params![mistake, term],
-            )?;
+        for &id in ids {
+            let pairs: Vec<(String, String)> = select_stmt
+                .query_map(params![id], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+
+            del_dict_stmt.execute(params![id])?;
+
+            for (term, mistake) in pairs {
+                del_pending_stmt.execute(params![mistake, term])?;
+                del_candidate_stmt.execute(params![mistake, term])?;
+            }
         }
     }
+    tx.commit()?;
     Ok(())
 }
 

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -172,15 +172,15 @@ fn format_dictionary_entry(entry: &db::DictionaryEntry) -> String {
     }
 }
 
-pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> String {
-    let mut replaceable: Vec<(&str, &str)> = entries
+pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> (String, Vec<i64>) {
+    let mut replaceable: Vec<(i64, &str, &str)> = entries
         .iter()
-        .filter_map(|e| e.mistake.as_deref().map(|m| (m, e.term.as_str())))
+        .filter_map(|e| e.mistake.as_deref().map(|m| (e.id, m, e.term.as_str())))
         .collect();
-    replaceable.sort_by_key(|(mistake, _)| std::cmp::Reverse(mistake.len()));
+    replaceable.sort_by_key(|(_, mistake, _)| std::cmp::Reverse(mistake.len()));
 
     if replaceable.is_empty() {
-        return text.to_string();
+        return (text.to_string(), Vec::new());
     }
 
     fn is_word_char(ch: char) -> bool {
@@ -200,7 +200,8 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
     }
 
     let mut result = text.to_string();
-    for (mistake, term) in &replaceable {
+    let mut applied_ids: Vec<i64> = Vec::new();
+    for (id, mistake, term) in &replaceable {
         if mistake.is_empty() {
             continue;
         }
@@ -223,7 +224,7 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
                 i += 1;
             }
         } else {
-            for (start, matched) in result.match_indices(mistake) {
+            for (start, matched) in result.match_indices(*mistake) {
                 let end = start + matched.len();
                 if is_boundary(&result, start, end) {
                     positions.push(start);
@@ -233,11 +234,12 @@ pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> 
         if positions.is_empty() {
             continue;
         }
+        applied_ids.push(*id);
         for pos in positions.into_iter().rev() {
             result.replace_range(pos..pos + mistake.len(), term);
         }
     }
-    result
+    (result, applied_ids)
 }
 
 #[cfg(test)]
@@ -300,14 +302,16 @@ mod tests {
     #[test]
     fn substitutions_respect_word_boundaries() {
         let entries = vec![entry(1, "Kubernetes", Some("kube"))];
-        let out = apply_substitutions_from("kube kubelet", &entries);
+        let (out, applied) = apply_substitutions_from("kube kubelet", &entries);
         assert_eq!(out, "Kubernetes kubelet");
+        assert_eq!(applied, vec![1]);
     }
 
     #[test]
     fn substitutions_support_non_ascii_terms() {
         let entries = vec![entry(1, "cliche", Some("cliché"))];
-        let out = apply_substitutions_from("Use cliché in this line.", &entries);
+        let (out, applied) = apply_substitutions_from("Use cliché in this line.", &entries);
         assert_eq!(out, "Use cliche in this line.");
+        assert_eq!(applied, vec![1]);
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -909,6 +909,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
         auto_learn::start_cache_rejection_monitor(
             injected_text.clone(),
             cleanup_cache_key,
+            target_hwnd,
             db.inner().clone(),
             app.clone(),
         );
@@ -924,6 +925,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
             auto_learn::start_rejection_monitor(
                 injected_text.clone(),
                 applied_dict_ids,
+                target_hwnd,
                 db.inner().clone(),
                 app.clone(),
             );

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -831,7 +831,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
         stage_transcribe.elapsed().as_millis()
     );
     let stage_cleanup = std::time::Instant::now();
-    let Some((final_text, dict_entries)) =
+    let Some((final_text, dict_entries, cleanup_cache_key)) =
         run_cleanup_and_snippets(&app, &raw, &cfg, &profile, app_context.as_deref()).await
     else {
         return;
@@ -865,8 +865,8 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
 
     let dict_stage = std::time::Instant::now();
     let final_before_dict = final_text.clone();
-    let final_text = dictionary::apply_substitutions_from(&final_text, &dict_entries);
-    let dict_changed = final_text != final_before_dict;
+    let (final_text, applied_dict_ids) = dictionary::apply_substitutions_from(&final_text, &dict_entries);
+    let dict_changed = !applied_dict_ids.is_empty();
     log::debug!(
         "pipeline: dictionary apply changed={} before_chars={} after_chars={} stage_ms={}",
         dict_changed,
@@ -904,8 +904,30 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
         started_at.elapsed().as_millis()
     );
 
+    if !cleanup_cache_key.is_empty() {
+        log::debug!("pipeline: cache rejection monitor starting key_len={}", cleanup_cache_key.len());
+        auto_learn::start_cache_rejection_monitor(
+            injected_text.clone(),
+            cleanup_cache_key,
+            db.inner().clone(),
+            app.clone(),
+        );
+    }
+
     if cfg.auto_learn_enabled {
         log::debug!("pipeline: auto_learn monitor starting");
+        if !applied_dict_ids.is_empty() {
+            log::debug!(
+                "pipeline: rejection monitor starting applied_dict_ids={}",
+                applied_dict_ids.len()
+            );
+            auto_learn::start_rejection_monitor(
+                injected_text.clone(),
+                applied_dict_ids,
+                db.inner().clone(),
+                app.clone(),
+            );
+        }
         auto_learn::start_monitor(injected_text, process_name, db.inner().clone(), app.clone());
     }
 }
@@ -1040,7 +1062,7 @@ async fn run_cleanup_and_snippets(
     cfg: &store::PipelineConfig,
     profile: &str,
     app_context: Option<&str>,
-) -> Option<(String, Vec<db::DictionaryEntry>)> {
+) -> Option<(String, Vec<db::DictionaryEntry>, String)> {
     let db = app.state::<DbHandle>();
     let mut db_snippets = db::query_snippets(&db).unwrap_or_default();
     let dict_entries = db::query_dictionary(&db).unwrap_or_default();
@@ -1086,6 +1108,7 @@ async fn run_cleanup_and_snippets(
     );
 
     let c_key = cfg.key_for(&cfg.cleanup_provider).to_owned();
+    let mut used_cache_key = String::new();
     let final_text = if should_run_cleanup_llm(
         cfg.cleanup_enabled,
         !c_key.is_empty(),
@@ -1102,6 +1125,7 @@ async fn run_cleanup_and_snippets(
             String::new()
         };
         if !cache_key.is_empty() {
+            used_cache_key = cache_key.clone();
             if let Ok(Some(entry)) = db::cleanup_cache_get_active(&db, &cache_key) {
                 log::debug!(
                     "pipeline: cleanup cache hit key_len={} hit_count={}",
@@ -1129,7 +1153,7 @@ async fn run_cleanup_and_snippets(
                     &entry.clean_text,
                     &snippet_instructions,
                 );
-                return Some((overridden, dict_entries));
+                return Some((overridden, dict_entries, cache_key));
             }
         }
         log::debug!(
@@ -1215,7 +1239,7 @@ async fn run_cleanup_and_snippets(
         snippets::apply_cleanup_instruction_overrides(&expanded, &snippet_instructions)
     };
 
-    Some((final_text, dict_entries))
+    Some((final_text, dict_entries, used_cache_key))
 }
 
 fn should_run_cleanup_llm(


### PR DESCRIPTION
# Summary

This PR adds a negative feedback loop for the cleanup LLM cache and auto-learned dictionary: if the user deletes dictated output within a short window after injection, the cached entry is automatically removed so the next dictation of the same phrase hits the LLM fresh instead of serving the stale answer.

- When injected output is deleted within **10 seconds**, the cleanup cache entry for that phrase is invalidated
- When output containing an **auto-learned dictionary substitution** is deleted within **8 seconds**, that dictionary entry is removed along with its pending corrections (prevents re-promotion)
- Manually created dictionary entries are never auto-removed
- Math-like phrases already excluded from caching are unaffected

Detection uses Windows UIAutomation to anchor the injected text span and poll for deletion. Three scenarios handled: normal span shrinkage, complex edits detected via text-presence check, and fast deletions (< 250ms) caught by a field-readability check at baseline capture time.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

The rejection monitors use Windows UIAutomation (read-only) to observe the focused text control after injection — same mechanism as the existing auto-learn monitor. No clipboard, hotkey, or provider behavior is changed. The only new database writes are deletions (`cleanup_cache`, `dictionary`, `pending_corrections`, `auto_learn_candidates`).

## UI Evidence

Not applicable — no UI changes. Feature is silent/background; observable via verbose dev logs (`cache-rejection-monitor: deletion detected` / `cache-rejection-monitor: window expired`).

## Reviewer Notes

Six new unit tests added in `db.rs` covering the full rejection lifecycle (insert → cache hit → reject → miss). The `apply_substitutions_from()` signature in `dictionary.rs` changed from `-> String` to `-> (String, Vec<i64>)` to surface which entries fired; all callers updated.