### PR TITLE
fix: snippet UI polish — scrollbar, modal height cap, inspector truncation

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -21,9 +21,12 @@ body {
   background: transparent;
 }
 
+/* Pill-within-track: shared border gutter and clip for both thumb classes. */
 .scrollbar-standard::-webkit-scrollbar-thumb,
 .scroll-styled::-webkit-scrollbar-thumb {
   border-radius: 999px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }
 
 .scrollbar-standard {
@@ -35,11 +38,9 @@ body {
   scrollbar-color: color-mix(in srgb, var(--ink-faint) 62%, transparent) transparent;
 }
 
-/* Border gutter gives the thumb a pill-within-track appearance in WebView2. */
 .scrollbar-standard::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
-  border: 3px solid var(--scroll-thumb-border, transparent);
-  background-clip: padding-box;
+  border-color: var(--scroll-thumb-border, transparent);
 }
 
 .scrollbar-standard::-webkit-scrollbar-thumb:hover {
@@ -55,7 +56,7 @@ body {
 
 .scroll-styled::-webkit-scrollbar-thumb {
   background: transparent;
-  border: 3px solid var(--scroll-thumb-border);
+  border-color: var(--scroll-thumb-border);
 }
 
 .scroll-thumb-elev {

--- a/src/app.css
+++ b/src/app.css
@@ -35,12 +35,17 @@ body {
   scrollbar-color: color-mix(in srgb, var(--ink-faint) 62%, transparent) transparent;
 }
 
+/* Border gutter gives the thumb a pill-within-track appearance in WebView2. */
 .scrollbar-standard::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }
 
 .scrollbar-standard::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--ink-faint) 62%, transparent);
+  border: 3px solid transparent;
+  background-clip: padding-box;
 }
 
 /* Hover-reveal floating-pill scrollbar; add this class to any overflow container.

--- a/src/app.css
+++ b/src/app.css
@@ -44,8 +44,6 @@ body {
 
 .scrollbar-standard::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--ink-faint) 62%, transparent);
-  border: 3px solid transparent;
-  background-clip: padding-box;
 }
 
 /* Hover-reveal floating-pill scrollbar; add this class to any overflow container.

--- a/src/app.css
+++ b/src/app.css
@@ -38,7 +38,7 @@ body {
 /* Border gutter gives the thumb a pill-within-track appearance in WebView2. */
 .scrollbar-standard::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--ink-faint) 42%, transparent);
-  border: 3px solid transparent;
+  border: 3px solid var(--scroll-thumb-border, transparent);
   background-clip: padding-box;
 }
 

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -306,7 +306,7 @@
               </div>
               <div class="insp-expansion">
                 {selected.expansion.length > 200
-                  ? selected.expansion.slice(0, 200).trimEnd() + '…'
+                  ? [...selected.expansion].slice(0, 200).join('').trimEnd() + '…'
                   : selected.expansion}
               </div>
 

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -45,6 +45,14 @@
 
   const TRIGGER_LIMIT = 300;
 
+  const inspExpansion = $derived.by(() => {
+    if (!selected) return '';
+    const chars = [...selected.expansion.slice(0, 401)];
+    return chars.length > 200
+      ? chars.slice(0, 200).join('').trimEnd() + '…'
+      : selected.expansion;
+  });
+
   const filtered = $derived.by(() => {
     const q = search.toLowerCase();
     let list = q
@@ -304,11 +312,7 @@
                 <polyline points="2,9 5.5,13.5 9,9"/>
               </svg>
               </div>
-              <div class="insp-expansion">
-                {selected.expansion.length > 200
-                  ? [...selected.expansion.slice(0, 400)].slice(0, 200).join('').trimEnd() + '…'
-                  : selected.expansion}
-              </div>
+              <div class="insp-expansion">{inspExpansion}</div>
 
               {#if selected.instructions}
                 <div class="insp-instructions" in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.base), easing: expoOut }}>
@@ -390,7 +394,7 @@
       </button>
     </div>
 
-    <div class="modal-body">
+    <div class="modal-body scrollbar-standard">
       <label class="field-label" for="trigger-input">
         Trigger
         <span class="char-count" class:over={draftTrigger.length > TRIGGER_LIMIT}>{draftTrigger.length}/{TRIGGER_LIMIT}</span>

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -306,7 +306,7 @@
               </div>
               <div class="insp-expansion">
                 {selected.expansion.length > 200
-                  ? [...selected.expansion].slice(0, 200).join('').trimEnd() + '…'
+                  ? [...selected.expansion.slice(0, 400)].slice(0, 200).join('').trimEnd() + '…'
                   : selected.expansion}
               </div>
 

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -304,7 +304,11 @@
                 <polyline points="2,9 5.5,13.5 9,9"/>
               </svg>
               </div>
-              <div class="insp-expansion">{selected.expansion}</div>
+              <div class="insp-expansion">
+                {selected.expansion.length > 200
+                  ? selected.expansion.slice(0, 200).trimEnd() + '…'
+                  : selected.expansion}
+              </div>
 
               {#if selected.instructions}
                 <div class="insp-instructions" in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.base), easing: expoOut }}>
@@ -884,8 +888,11 @@
     border: 1px solid var(--line);
     border-radius: var(--r-lg);
     width: min(500px, calc(100vw - 40px));
+    max-height: calc(100dvh - 80px);
     box-shadow: var(--shadow-elev);
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
 
   .modal-header {
@@ -894,6 +901,7 @@
     justify-content: space-between;
     padding: 16px 20px 14px;
     border-bottom: 1px solid var(--line-soft);
+    flex-shrink: 0;
   }
 
   .modal-title {
@@ -911,6 +919,9 @@
     flex-direction: column;
     gap: 4px;
     --field-input-max-height: 220px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
   }
 
   .modal-footer {
@@ -919,6 +930,7 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
+    flex-shrink: 0;
   }
 
   .footer-actions {


### PR DESCRIPTION
# Summary

Three UX fixes in the Snippets view:

1. **Scrollbar styling** — the expansion textarea was showing the native OS scrollbar when content exceeded the `max-height: 220px` cap. Fixed by adding `border: 3px solid transparent` + `background-clip: padding-box` to `.scrollbar-standard::-webkit-scrollbar-thumb`, the same pill-within-track trick used by `.scroll-styled`. The custom rounded thumb now renders correctly in WebView2.

2. **Modal footer always visible** — the modal had no height constraint, so at small window sizes the Save/Cancel buttons disappeared below the viewport. Added `max-height: calc(100dvh - 80px)` + flex column to `.modal-card`, and `overflow-y: auto; flex: 1; min-height: 0` to `.modal-body`. Header and footer stay pinned; only the form body scrolls.

3. **Inspector expansion truncation** — the right-side inspector was rendering the full multi-line expansion with `white-space: pre-wrap` and no limit, forcing page-level scrolling. The displayed text is now capped at 200 characters with a `…`. Full content remains available via the Edit modal.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [x] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Manual verification steps:
- Open Snippets → New snippet → paste a multi-paragraph expansion → confirm scrollbar appears as a thin rounded pill
- Resize the app window to ~600px tall → open Edit on a long snippet → confirm Save/Cancel always visible
- Select a snippet with expansion > 200 chars → confirm inspector shows truncated text with `…`

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes: None. CSS and template-only changes.

## UI Evidence

Not included — manual verification described in Testing section above.

## Reviewer Notes

The `min-height: 0` on `.modal-body` is load-bearing for the flex shrink to work — without it the body ignores the `max-height` constraint on the card and still overflows.