### PR TITLE
chore: upgrade Google provider to gemini-3.5-flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 - Github Repo: https://github.com/MONKE2525E/Open-Flow
 - Use the Mono font very sparingly only use it when its in technical items like file names folder names, code, etc...
 - docs/ROADMAP.md keeps recorded bugs and long term goals far future plans are not to be acted on unless the user requests so.
-- currently working towards OpenFlow 0.10.0.
+- currently working towards OpenFlow 0.11.0.
 - Always add yourself as a co-author  in all commits you make e.g @Claude, @Codex, etc
 
 
@@ -177,7 +177,7 @@ WAL mode is enabled. Migrations use `execute_batch` wrapped in explicit `BEGIN/C
 |---|---|---|
 | Groq | `whisper-large-v3-turbo` | `llama-3.3-70b-versatile` |
 | OpenAI | `gpt-4o-transcribe` | `gpt-4o-mini` |
-| Google | `gemini-2.5-flash` (inline audio) | `gemini-2.5-flash` |
+| Google | `gemini-3.5-flash` (inline audio) | `gemini-3.5-flash` |
 
 Groq is the recommended default — free tier, fast LPU inference. Google uses base64-encoded audio in the request body; Groq/OpenAI use multipart form upload. The cleanup API wraps transcription text in `<raw_dictation>` XML delimiters before sending. Google cleanup sets `thinking_budget: 0` to disable deep thinking.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open Flow is provider-agnostic — pick whichever service you trust, use the che
 | :--- | :--- | :--- | :--- | :--- |
 | **Groq** | `whisper-large-v3-turbo`| `llama-3.3-70b-versatile` | ~1.0s | Free tier available ⭐ |
 | **OpenAI** | `gpt-4o-transcribe` | `gpt-4o-mini` | ~1.0s | ~$0.01–0.03 per request |
-| **Google** | `gemini-2.5-flash` | `gemini-2.5-flash` | ~3-5s | Free tier (limited quota) |
+| **Google** | `gemini-3.5-flash` | `gemini-3.5-flash` | ~3-5s | Free tier (limited quota) |
 
 **Security:** API keys are stored locally using OS-level encryption (`tauri-plugin-store`). They're never written to the database, synced to the cloud, or logged anywhere.
 

--- a/src-tauri/src/api/cleanup.rs
+++ b/src-tauri/src/api/cleanup.rs
@@ -221,7 +221,7 @@ async fn google_cleanup(text: &str, api_key: &str, prompt: &str) -> Result<Strin
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={api_key}"
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key={api_key}"
     );
 
     let request_started = std::time::Instant::now();

--- a/src-tauri/src/api/transcription.rs
+++ b/src-tauri/src/api/transcription.rs
@@ -137,7 +137,7 @@ async fn transcribe_gemini(wav: Bytes, api_key: &str, language: &str) -> Result<
         "Transcribe this audio exactly as spoken in {language_label}. \
          Return only the spoken words, no commentary, no formatting, no explanation."
     );
-    transcribe_gemini_with_prompt(wav, api_key, &prompt, false).await
+    transcribe_gemini_with_prompt(wav, api_key, &prompt, true).await
 }
 
 async fn transcribe_gemini_with_prompt(
@@ -180,7 +180,7 @@ async fn transcribe_gemini_with_prompt(
     };
 
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={api_key}"
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key={api_key}"
     );
 
     let request_started = std::time::Instant::now();

--- a/src/lib/components/settings/ApiKeysSection.svelte
+++ b/src/lib/components/settings/ApiKeysSection.svelte
@@ -6,7 +6,7 @@
   const keyProviders: { id: 'groq' | 'openai' | 'google'; label: string; ph: string; models: string }[] = [
     { id: 'groq',   label: 'Groq',   ph: 'gsk_…',  models: 'whisper-large-v3-turbo · llama-3.3-70b' },
     { id: 'openai', label: 'OpenAI', ph: 'sk-…',   models: 'gpt-4o-transcribe · gpt-4o-mini' },
-    { id: 'google', label: 'Google', ph: 'AIza…',  models: 'Chirp 3 · gemini-2.5-flash' },
+    { id: 'google', label: 'Google', ph: 'AIza…',  models: 'Chirp 3 · gemini-3.5-flash' },
   ];
 
   let keyStatus = $state({ groq: false, openai: false, google: false });

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -7,13 +7,13 @@
   const transcriptionModels = [
     { id: 'groq/whisper-large-v3-turbo', provider: 'Groq',   name: 'whisper-large-v3-turbo', note: '~0.5s · free tier · recommended', recommended: true },
     { id: 'openai/gpt-4o-transcribe',    provider: 'OpenAI', name: 'gpt-4o-transcribe',       note: '~1s · best accuracy for accents & noise', recommended: false },
-    { id: 'google/gemini-2.5-flash',     provider: 'Google', name: 'gemini-2.5-flash',        note: '~3s · slow for transcription, not recommended', recommended: false },
+    { id: 'google/gemini-3.5-flash',     provider: 'Google', name: 'gemini-3.5-flash',        note: '~3s · slow for transcription, not recommended', recommended: false },
   ];
 
   const cleanupModels = [
     { id: 'groq/llama-3.3-70b-versatile', provider: 'Groq',   name: 'llama-3.3-70b-versatile', note: '~0.3s · free tier · recommended', recommended: true },
     { id: 'openai/gpt-4o-mini',           provider: 'OpenAI', name: 'gpt-4o-mini',              note: '~0.5s · best cost/quality balance', recommended: false },
-    { id: 'google/gemini-2.5-flash',      provider: 'Google', name: 'gemini-2.5-flash',          note: '~1s · fused with transcription when both Google', recommended: false },
+    { id: 'google/gemini-3.5-flash',      provider: 'Google', name: 'gemini-3.5-flash',          note: '~1s · fused with transcription when both Google', recommended: false },
   ];
 
   let transcriptionModel = $state('groq/whisper-large-v3-turbo');

--- a/tests/smoke/playwright-test-state.cjs
+++ b/tests/smoke/playwright-test-state.cjs
@@ -38,12 +38,12 @@ async function closeSettings(page) {
     const expectedTranscription = [
       'whisper-large-v3-turbo',
       'gpt-4o-transcribe',
-      'gemini-2.5-flash',
+      'gemini-3.5-flash',
     ];
     const expectedCleanup = [
       'llama-3.3-70b-versatile',
       'gpt-4o-mini',
-      'gemini-2.5-flash',
+      'gemini-3.5-flash',
     ];
 
     for (const name of expectedTranscription) {


### PR DESCRIPTION
# Summary

Upgrades the Google provider from `gemini-2.5-flash` to `gemini-3.5-flash` across the full stack — API endpoints, UI model selectors, API key card, smoke test assertions, and docs. Also fixes a latent bug where `disable_thinking` was `false` on the plain transcription path, allowing thinking tokens to be billed unnecessarily.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [x] Build or release change

## Testing

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [x] `npm run test:smoke:state` — smoke test model assertions updated to `gemini-3.5-flash`
- [ ] Playwright or manual UI verification, if applicable

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

No behavioral changes to clipboard, hotkey, or database. The only runtime change is the API endpoint URL for Google calls — requests now hit `gemini-3.5-flash` instead of `gemini-2.5-flash`. Thinking is now explicitly disabled (`thinking_budget: 0`) on both the transcription and cleanup paths; previously the plain transcription path left this unset.

## UI Evidence

Not applicable — no visual changes. Model names update in Settings → Models and Settings → API Keys to reflect `gemini-3.5-flash`.

## Reviewer Notes

The smoke test file (`tests/smoke/playwright-test-state.cjs`) was updated to assert `gemini-3.5-flash` instead of `gemini-2.5-flash`. This is an intentional model rename, not a workaround — the frozen-contract rule applies to structural test contracts, not model name literals that must track the live API.