### PR TITLE
feat: auto-spacing and contextual capitalisation improvements

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -42,6 +42,7 @@ fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), String> 
         | store::API_FALLBACK_ENABLED
         | store::AUTO_LEARN_ENABLED
         | store::CONTEXTUAL_CAPS
+        | store::AUTO_SPACING
         | store::SETUP_COMPLETE
         | store::FORCE_SETUP_ON_LAUNCH
         | "autostart_enabled" => value.is_boolean(),
@@ -124,6 +125,7 @@ pub struct AllSettings {
     pub api_fallback_enabled: Option<bool>,
     pub auto_learn_enabled: Option<bool>,
     pub contextual_caps_enabled: Option<bool>,
+    pub auto_spacing_enabled: Option<bool>,
     pub mic_gain: Option<f64>,
     pub history_retention: Option<String>,
     pub microphone_device: Option<String>,
@@ -156,6 +158,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         api_fallback_enabled: bool_val(store::API_FALLBACK_ENABLED),
         auto_learn_enabled: bool_val(store::AUTO_LEARN_ENABLED),
         contextual_caps_enabled: bool_val(store::CONTEXTUAL_CAPS),
+        auto_spacing_enabled: bool_val(store::AUTO_SPACING),
         mic_gain: f64_val(store::MIC_GAIN),
         history_retention: str_val("history_retention"),
         microphone_device: str_val(store::MICROPHONE_DEVICE),

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -317,15 +317,16 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         if !is_injected && is_down && !is_key1 && !is_key2 {
             if !MODIFIER_VKS.contains(&vk) {
                 if vk == VK_BACK {
-                    // Ctrl+Backspace deletes a whole word — we can't know how many
-                    // characters were removed, so reset entirely. Plain Backspace
-                    // pops just the last character to keep context accurate.
-                    if unsafe { modifier_held(VK_CTRL) } {
+                    // Ctrl+Backspace (word delete) or Alt+Backspace (undo) can remove
+                    // an unknown number of characters, so reset history entirely.
+                    // Plain Backspace pops just one character to keep context accurate.
+                    if unsafe { modifier_held(VK_CTRL) || modifier_held(0x12) } { // 0x12 is VK_MENU (Alt)
                         crate::core::injection::reset_injection_history();
                     } else {
                         crate::core::injection::backspace_injection_history();
                     }
                 } else {
+
                     // Any other key (Enter, character, arrow, Delete, etc.): the
                     // cursor context is unknown — treat the next injection as fresh.
                     crate::core::injection::reset_injection_history();

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -300,20 +300,22 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         // context tracking that drives auto-spacing and contextual capitalisation.
         let is_injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
         if !is_injected && is_down && !is_key1 && !is_key2 {
+            const VK_BACK: u32 = 0x08;
+            const VK_CONTROL: u32 = 0x11;
             const MODIFIER_VKS: &[u32] = &[
-                16, 17, 18,           // generic Shift / Ctrl / Alt
-                160, 161,             // LShift, RShift
-                162, 163,             // LCtrl, RCtrl
-                164, 165,             // LAlt, RAlt
-                91, 92,               // LWin, RWin
-                20, 144, 145,         // CapsLock, NumLock, ScrollLock
+                0x10, 0x11, 0x12,     // VK_SHIFT, VK_CONTROL, VK_MENU
+                0xA0, 0xA1,           // VK_LSHIFT, VK_RSHIFT
+                0xA2, 0xA3,           // VK_LCONTROL, VK_RCONTROL
+                0xA4, 0xA5,           // VK_LMENU, VK_RMENU
+                0x5B, 0x5C,           // VK_LWIN, VK_RWIN
+                0x14, 0x90, 0x91,     // VK_CAPITAL, VK_NUMLOCK, VK_SCROLL
             ];
             if !MODIFIER_VKS.contains(&vk) {
-                if vk == 8 {
+                if vk == VK_BACK {
                     // Ctrl+Backspace deletes a whole word — we can't know how many
                     // characters were removed, so reset entirely. Plain Backspace
                     // pops just the last character to keep context accurate.
-                    if unsafe { modifier_held(17) } {
+                    if unsafe { modifier_held(VK_CONTROL) } {
                         crate::core::injection::reset_injection_history();
                     } else {
                         crate::core::injection::backspace_injection_history();

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -310,9 +310,14 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             ];
             if !MODIFIER_VKS.contains(&vk) {
                 if vk == 8 {
-                    // Backspace: pop the last character off the tracked text so the
-                    // next injection still knows what's before the cursor.
-                    crate::core::injection::backspace_injection_history();
+                    // Ctrl+Backspace deletes a whole word — we can't know how many
+                    // characters were removed, so reset entirely. Plain Backspace
+                    // pops just the last character to keep context accurate.
+                    if unsafe { modifier_held(17) } {
+                        crate::core::injection::reset_injection_history();
+                    } else {
+                        crate::core::injection::backspace_injection_history();
+                    }
                 } else {
                     // Any other key (Enter, character, arrow, Delete, etc.): the
                     // cursor context is unknown — treat the next injection as fresh.

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 const VK_BACK: u32 = 0x08;    // Backspace
 const VK_CTRL: u32 = 0x11;    // VK_CONTROL (generic, used with modifier_held)
+const VK_ALT: u32 = 0x12;     // VK_MENU (generic, used with modifier_held)
 
 // Side-specific modifier VK codes that should never trigger a history update.
 // Generic codes (0x10/0x11/0x12) are omitted: the !is_injected guard already
@@ -317,16 +318,15 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         if !is_injected && is_down && !is_key1 && !is_key2 {
             if !MODIFIER_VKS.contains(&vk) {
                 if vk == VK_BACK {
-                    // Ctrl+Backspace (word delete) or Alt+Backspace (undo) can remove
-                    // an unknown number of characters, so reset history entirely.
-                    // Plain Backspace pops just one character to keep context accurate.
-                    if unsafe { modifier_held(VK_CTRL) || modifier_held(0x12) } { // 0x12 is VK_MENU (Alt)
+                    // Ctrl+Backspace and Alt+Backspace both delete a whole word —
+                    // unknown char count, so reset entirely. Plain Backspace pops
+                    // just the last character to keep context accurate.
+                    if unsafe { modifier_held(VK_CTRL) || modifier_held(VK_ALT) } {
                         crate::core::injection::reset_injection_history();
                     } else {
                         crate::core::injection::backspace_injection_history();
                     }
                 } else {
-
                     // Any other key (Enter, character, arrow, Delete, etc.): the
                     // cursor context is unknown — treat the next injection as fresh.
                     crate::core::injection::reset_injection_history();

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -1,4 +1,19 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+
+const VK_BACK: u32 = 0x08;    // Backspace
+const VK_CTRL: u32 = 0x11;    // VK_CONTROL (generic, used with modifier_held)
+
+// Side-specific modifier VK codes that should never trigger a history update.
+// Generic codes (0x10/0x11/0x12) are omitted: the !is_injected guard already
+// filters all synthetic input where those codes appear, so only side-specific
+// codes reach this path from real physical key presses.
+static MODIFIER_VKS: &[u32] = &[
+    0xA0, 0xA1,       // VK_LSHIFT, VK_RSHIFT
+    0xA2, 0xA3,       // VK_LCONTROL, VK_RCONTROL
+    0xA4, 0xA5,       // VK_LMENU, VK_RMENU
+    0x5B, 0x5C,       // VK_LWIN, VK_RWIN
+    0x14, 0x90, 0x91, // VK_CAPITAL, VK_NUMLOCK, VK_SCROLL
+];
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::SystemInformation::GetTickCount64;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
@@ -300,22 +315,12 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         // context tracking that drives auto-spacing and contextual capitalisation.
         let is_injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
         if !is_injected && is_down && !is_key1 && !is_key2 {
-            const VK_BACK: u32 = 0x08;
-            const VK_CONTROL: u32 = 0x11;
-            const MODIFIER_VKS: &[u32] = &[
-                0x10, 0x11, 0x12,     // VK_SHIFT, VK_CONTROL, VK_MENU
-                0xA0, 0xA1,           // VK_LSHIFT, VK_RSHIFT
-                0xA2, 0xA3,           // VK_LCONTROL, VK_RCONTROL
-                0xA4, 0xA5,           // VK_LMENU, VK_RMENU
-                0x5B, 0x5C,           // VK_LWIN, VK_RWIN
-                0x14, 0x90, 0x91,     // VK_CAPITAL, VK_NUMLOCK, VK_SCROLL
-            ];
             if !MODIFIER_VKS.contains(&vk) {
                 if vk == VK_BACK {
                     // Ctrl+Backspace deletes a whole word — we can't know how many
                     // characters were removed, so reset entirely. Plain Backspace
                     // pops just the last character to keep context accurate.
-                    if unsafe { modifier_held(VK_CONTROL) } {
+                    if unsafe { modifier_held(VK_CTRL) } {
                         crate::core::injection::reset_injection_history();
                     } else {
                         crate::core::injection::backspace_injection_history();

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -7,7 +7,8 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, GetMessageW, SetWindowsHookExW, TranslateMessage, HC_ACTION,
-    KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+    KBDLLHOOKSTRUCT, LLKHF_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
+    WM_SYSKEYUP,
 };
 
 // Returns true if the given specific-side VK (or its mirror) is currently held.
@@ -289,6 +290,33 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 let is_menu_trigger = k1 == 164 || k1 == 165 || k1 == 18 || k1 == 91 || k1 == 92;
                 if is_menu_trigger {
                     return LRESULT(1);
+                }
+            }
+        }
+
+        // Update injection history for real user keystrokes only.
+        // Synthetic events (LLKHF_INJECTED) are skipped — this prevents our own
+        // Ctrl+V paste and any app-generated keyboard events from corrupting the
+        // context tracking that drives auto-spacing and contextual capitalisation.
+        let is_injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
+        if !is_injected && is_down && !is_key1 && !is_key2 {
+            const MODIFIER_VKS: &[u32] = &[
+                16, 17, 18,           // generic Shift / Ctrl / Alt
+                160, 161,             // LShift, RShift
+                162, 163,             // LCtrl, RCtrl
+                164, 165,             // LAlt, RAlt
+                91, 92,               // LWin, RWin
+                20, 144, 145,         // CapsLock, NumLock, ScrollLock
+            ];
+            if !MODIFIER_VKS.contains(&vk) {
+                if vk == 8 {
+                    // Backspace: pop the last character off the tracked text so the
+                    // next injection still knows what's before the cursor.
+                    crate::core::injection::backspace_injection_history();
+                } else {
+                    // Any other key (Enter, character, arrow, Delete, etc.): the
+                    // cursor context is unknown — treat the next injection as fresh.
+                    crate::core::injection::reset_injection_history();
                 }
             }
         }

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -315,7 +315,7 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         // Ctrl+V paste and any app-generated keyboard events from corrupting the
         // context tracking that drives auto-spacing and contextual capitalisation.
         let is_injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
-        if !is_injected && is_down && !is_key1 && !is_key2 {
+if !is_injected && is_down {
             if !MODIFIER_VKS.contains(&vk) {
                 if vk == VK_BACK {
                     // Ctrl+Backspace and Alt+Backspace both delete a whole word —

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -143,16 +143,22 @@ pub async fn inject_text(
             // resets this whenever the user edits text, so by the time we reach
             // here the history reflects the actual state of the cursor context.
             let peeked: Option<char> = if contextual_caps || auto_spacing {
-                let guard = last_injection()
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("injection history mutex poisoned"))?;
-                (*guard)
-                    .as_ref()
-                    .filter(|(hwnd, _, instant)| {
-                        *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
-                    })
-                    .and_then(|(_, text, _)| text.chars().next_back())
-                // guard dropped here — Mutex not held across any await
+            let peeked: Option<char> = if contextual_caps || auto_spacing {
+                match last_injection().lock() {
+                    Ok(guard) => (*guard)
+                        .as_ref()
+                        .filter(|(hwnd, _, instant)| {
+                            *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
+                        })
+                        .and_then(|(_, text, _)| text.chars().next_back()),
+                    Err(_) => {
+                        log::error!("injection history mutex poisoned");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
             } else {
                 None
             };

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -241,13 +241,13 @@ pub async fn inject_text(
 
             // Record the full injected text so the keyboard hook can pop characters
             // off it on Backspace, keeping the context accurate after editing.
-            if target_hwnd != 0 && !text_to_inject.is_empty() {
+            if target_hwnd != 0 && !adjusted.is_empty() {
                 if let Ok(mut guard) = last_injection().lock() {
-                    *guard = Some((target_hwnd, text_to_inject.to_string(), Instant::now()));
+                    *guard = Some((target_hwnd, adjusted.clone(), Instant::now()));
                 }
             }
 
-            Ok(text_to_inject.to_string())
+            Ok(adjusted)
         }
     }
 

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -146,7 +146,7 @@ pub async fn inject_text(
                     Some((hwnd, ref text, ref instant))
                         if hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE =>
                     {
-                        text.chars().last()
+                        text.chars().next_back()
                     }
                     _ => None,
                 }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -176,7 +176,7 @@ pub async fn inject_text(
             if auto_spacing {
                 if let Some(c) = peeked {
                     if !c.is_whitespace() && !adjusted.starts_with(char::is_whitespace) {
-                        adjusted.insert(0, ' ');
+                        adjusted = format!(" {adjusted}");
                     }
                 }
             }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -139,7 +139,9 @@ pub async fn inject_text(
             // resets this whenever the user edits text, so by the time we reach
             // here the history reflects the actual state of the cursor context.
             let peeked: Option<char> = if contextual_caps || auto_spacing {
-                let guard = last_injection().lock().unwrap();
+                let guard = last_injection()
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("injection history mutex poisoned"))?;
                 match *guard {
                     Some((hwnd, ref text, ref instant))
                         if hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE =>
@@ -173,8 +175,8 @@ pub async fn inject_text(
 
             if auto_spacing {
                 if let Some(c) = peeked {
-                    if !c.is_whitespace() {
-                        adjusted = format!(" {adjusted}");
+                    if !c.is_whitespace() && !adjusted.starts_with(char::is_whitespace) {
+                        adjusted.insert(0, ' ');
                     }
                 }
             }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -1,3 +1,43 @@
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+// How long a previous injection stays relevant for spacing and capitalisation decisions.
+// The keyboard hook resets this early whenever the user types, so the timeout is mainly
+// a safety net for inactivity (e.g. the user idle for a minute then dictates again).
+const INJECTION_STALE: Duration = Duration::from_secs(60);
+
+static LAST_INJECTION: OnceLock<Mutex<Option<(usize, String, Instant)>>> = OnceLock::new();
+
+fn last_injection() -> &'static Mutex<Option<(usize, String, Instant)>> {
+    LAST_INJECTION.get_or_init(|| Mutex::new(None))
+}
+
+/// Full reset — called on Enter, character keys, arrows, etc. The cursor context
+/// is unknown after such input, so the next injection starts fresh.
+pub fn reset_injection_history() {
+    if let Ok(mut guard) = last_injection().lock() {
+        *guard = None;
+    }
+}
+
+/// Called on Backspace. Pops the last character off the tracked text so the
+/// next injection still knows what's immediately before the cursor after the
+/// deletion. Clears the record entirely once the tracked text empties.
+pub fn backspace_injection_history() {
+    if let Ok(mut guard) = last_injection().lock() {
+        let empty = if let Some((_, ref mut text, ref mut time)) = *guard {
+            text.pop();
+            *time = Instant::now();
+            text.is_empty()
+        } else {
+            false
+        };
+        if empty {
+            *guard = None;
+        }
+    }
+}
+
 #[cfg(target_os = "windows")]
 unsafe fn read_clipboard_unicode() -> Option<Vec<u16>> {
     use windows::Win32::System::DataExchange::{
@@ -57,13 +97,14 @@ pub async fn inject_text(
     text: &str,
     target_hwnd: usize,
     contextual_caps: bool,
+    auto_spacing: bool,
 ) -> anyhow::Result<String> {
     #[cfg(target_os = "windows")]
     {
         use windows::Win32::Foundation::HWND;
         use windows::Win32::UI::Input::KeyboardAndMouse::{
             SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-            KEYEVENTF_KEYUP, VK_C, VK_CONTROL, VK_LEFT, VK_LMENU, VK_RIGHT, VK_SHIFT, VK_V,
+            KEYEVENTF_KEYUP, VK_CONTROL, VK_LMENU, VK_V,
         };
         use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 
@@ -94,49 +135,29 @@ pub async fn inject_text(
                 },
             };
 
-            // Look-back: peek at the character immediately before the cursor.
-            // If it's a non-sentence-ending character, the injection is mid-sentence
-            // and the first character should be lowercase.
-            let adjusted: String = if contextual_caps {
-                // Shift+Left selects one character to the left.
-                let sel = [
-                    ki(VK_SHIFT, 0),
-                    ki(VK_LEFT, 0),
-                    ki(VK_LEFT, KEYEVENTF_KEYUP.0),
-                    ki(VK_SHIFT, KEYEVENTF_KEYUP.0),
-                ];
-                SendInput(&sel, std::mem::size_of::<INPUT>() as i32);
-
-                // Ctrl+C copies the selection.
-                let copy = [
-                    ki(VK_CONTROL, 0),
-                    ki(VK_C, 0),
-                    ki(VK_C, KEYEVENTF_KEYUP.0),
-                    ki(VK_CONTROL, KEYEVENTF_KEYUP.0),
-                ];
-                SendInput(&copy, std::mem::size_of::<INPUT>() as i32);
-                tokio::time::sleep(tokio::time::Duration::from_millis(60)).await;
-
-                // Read the peeked character from the clipboard.
-                let peeked: Option<char> = read_clipboard_unicode().and_then(|v| {
-                    if v.is_empty() || v[0] == 0 {
-                        None
-                    } else {
-                        char::from_u32(v[0] as u32)
+            // Look up what we last injected into this window. The keyboard hook
+            // resets this whenever the user edits text, so by the time we reach
+            // here the history reflects the actual state of the cursor context.
+            let peeked: Option<char> = if contextual_caps || auto_spacing {
+                let guard = last_injection().lock().unwrap();
+                match *guard {
+                    Some((hwnd, ref text, ref instant))
+                        if hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE =>
+                    {
+                        text.chars().last()
                     }
-                });
+                    _ => None,
+                }
+                // guard dropped here — Mutex not held across any await
+            } else {
+                None
+            };
 
-                // Right arrow collapses the selection and restores the cursor position.
-                let desel = [ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)];
-                SendInput(&desel, std::mem::size_of::<INPUT>() as i32);
-
-                // Lowercase the first character of the injection when the cursor is
-                // mid-sentence (preceded by anything other than a sentence-ending mark).
-                let sentence_enders: &[char] = &['.', '!', '?', '\n', '\r'];
+            let sentence_enders: &[char] = &['.', '!', '?', '\n', '\r'];
+            let mut adjusted = if contextual_caps {
                 let should_lower = peeked
                     .map(|c| !sentence_enders.contains(&c))
                     .unwrap_or(false);
-
                 if should_lower {
                     let mut chars = text.chars();
                     match chars.next() {
@@ -149,6 +170,14 @@ pub async fn inject_text(
             } else {
                 text.to_owned()
             };
+
+            if auto_spacing {
+                if let Some(c) = peeked {
+                    if !c.is_whitespace() {
+                        adjusted = format!(" {adjusted}");
+                    }
+                }
+            }
 
             let text_to_inject = adjusted.as_str();
 
@@ -206,6 +235,14 @@ pub async fn inject_text(
             // Restore clipboard
             if let Some(saved_wide) = saved {
                 let _ = write_clipboard_unicode(&saved_wide);
+            }
+
+            // Record the full injected text so the keyboard hook can pop characters
+            // off it on Backspace, keeping the context accurate after editing.
+            if target_hwnd != 0 && !text_to_inject.is_empty() {
+                if let Ok(mut guard) = last_injection().lock() {
+                    *guard = Some((target_hwnd, text_to_inject.to_string(), Instant::now()));
+                }
             }
 
             Ok(text_to_inject.to_string())

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -142,14 +142,12 @@ pub async fn inject_text(
                 let guard = last_injection()
                     .lock()
                     .map_err(|_| anyhow::anyhow!("injection history mutex poisoned"))?;
-                match *guard {
-                    Some((hwnd, ref text, ref instant))
-                        if hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE =>
-                    {
-                        text.chars().next_back()
-                    }
-                    _ => None,
-                }
+                (*guard)
+                    .as_ref()
+                    .filter(|(hwnd, _, instant)| {
+                        *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
+                    })
+                    .and_then(|(_, text, _)| text.chars().next_back())
                 // guard dropped here — Mutex not held across any await
             } else {
                 None

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -143,7 +143,6 @@ pub async fn inject_text(
             // resets this whenever the user edits text, so by the time we reach
             // here the history reflects the actual state of the cursor context.
             let peeked: Option<char> = if contextual_caps || auto_spacing {
-            let peeked: Option<char> = if contextual_caps || auto_spacing {
                 match last_injection().lock() {
                     Ok(guard) => (*guard)
                         .as_ref()
@@ -156,9 +155,7 @@ pub async fn inject_text(
                         None
                     }
                 }
-            } else {
-                None
-            };
+                // guard dropped here — Mutex not held across any await
             } else {
                 None
             };

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -6,6 +6,10 @@ use std::time::{Duration, Instant};
 // a safety net for inactivity (e.g. the user idle for a minute then dictates again).
 const INJECTION_STALE: Duration = Duration::from_secs(60);
 
+// Maximum bytes stored for backspace-tracking. Covers any practical editing sequence
+// while keeping the per-injection allocation bounded.
+const HISTORY_TAIL: usize = 512;
+
 static LAST_INJECTION: OnceLock<Mutex<Option<(usize, String, Instant)>>> = OnceLock::new();
 
 fn last_injection() -> &'static Mutex<Option<(usize, String, Instant)>> {
@@ -237,11 +241,21 @@ pub async fn inject_text(
                 let _ = write_clipboard_unicode(&saved_wide);
             }
 
-            // Record the full injected text so the keyboard hook can pop characters
-            // off it on Backspace, keeping the context accurate after editing.
+            // Record a tail of the injected text so the keyboard hook can pop
+            // characters off it on Backspace, keeping the context accurate after
+            // editing. Only the last HISTORY_TAIL bytes are kept to bound memory use.
             if target_hwnd != 0 && !adjusted.is_empty() {
                 if let Ok(mut guard) = last_injection().lock() {
-                    *guard = Some((target_hwnd, adjusted.clone(), Instant::now()));
+                    let tail = if adjusted.len() > HISTORY_TAIL {
+                        let mut start = adjusted.len() - HISTORY_TAIL;
+                        while !adjusted.is_char_boundary(start) {
+                            start += 1;
+                        }
+                        adjusted[start..].to_owned()
+                    } else {
+                        adjusted.clone()
+                    };
+                    *guard = Some((target_hwnd, tail, Instant::now()));
                 }
             }
 

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -23,6 +23,7 @@ pub const APP_CONTEXT_HINT: &str = "app_context_hint";
 pub const API_FALLBACK_ENABLED: &str = "api_fallback_enabled";
 pub const AUTO_LEARN_ENABLED: &str = "auto_learn_enabled";
 pub const CONTEXTUAL_CAPS: &str = "contextual_caps_enabled";
+pub const AUTO_SPACING: &str = "auto_spacing_enabled";
 pub const APPEARANCE_MODE: &str = "appearance_mode";
 pub const FORCE_SETUP_ON_LAUNCH: &str = "force_setup_on_launch";
 
@@ -43,6 +44,7 @@ pub struct PipelineConfig {
     pub api_fallback_enabled: bool,
     pub auto_learn_enabled: bool,
     pub contextual_caps_enabled: bool,
+    pub auto_spacing_enabled: bool,
 }
 
 pub const TRANSCRIPTION_LANGUAGE_OPTIONS: &[(&str, &str)] = &[
@@ -179,6 +181,10 @@ pub fn load_pipeline_config(store: &tauri_plugin_store::Store<tauri::Wry>) -> Pi
             .unwrap_or(false),
         contextual_caps_enabled: store
             .get(CONTEXTUAL_CAPS)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        auto_spacing_enabled: store
+            .get(AUTO_SPACING)
             .and_then(|v| v.as_bool())
             .unwrap_or(true),
     }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -882,7 +882,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
     hide_pill(&app);
     let inject_stage = std::time::Instant::now();
     let injected_text =
-        match injection::inject_text(&final_text, target_hwnd, cfg.contextual_caps_enabled).await {
+        match injection::inject_text(&final_text, target_hwnd, cfg.contextual_caps_enabled, cfg.auto_spacing_enabled).await {
             Ok(text) => text,
             Err(e) => {
                 log::error!("inject: {e}");
@@ -891,8 +891,9 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
             }
         };
     log::debug!(
-        "pipeline: injection done contextual_caps={} output_chars={} stage_ms={}",
+        "pipeline: injection done contextual_caps={} auto_spacing={} output_chars={} stage_ms={}",
         cfg.contextual_caps_enabled,
+        cfg.auto_spacing_enabled,
         injected_text.chars().count(),
         inject_stage.elapsed().as_millis()
     );

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -20,6 +20,7 @@
   let autostart = $state(false);
   let cleanup = $state(true);
   let contextualCaps = $state(true);
+  let autoSpacing = $state(true);
   let hotkey = $state(['ControlLeft', 'MetaLeft']);
   let recordingHotkey = $state(false);
   let capturedKeys = $state<string[]>([]);
@@ -88,6 +89,7 @@
       invoke<TranscriptionLanguageCode | null>('get_setting', { key: 'transcription_language' }),
       invoke<boolean | null>('get_setting', { key: 'cleanup_enabled' }),
       invoke<boolean | null>('get_setting', { key: 'contextual_caps_enabled' }),
+      invoke<boolean | null>('get_setting', { key: 'auto_spacing_enabled' }),
     ]);
 
     const val = <T>(i: number, fallback: T): T =>
@@ -97,6 +99,7 @@
     autostart = val<boolean | null>(1, null) ?? false;
     cleanup = val<boolean | null>(5, null) ?? true;
     contextualCaps = val<boolean | null>(6, null) ?? true;
+    autoSpacing = val<boolean | null>(7, null) ?? true;
 
     const hk = val<string[] | null>(2, null);
     if (hk && hk.length === 2) hotkey = hk;
@@ -174,6 +177,16 @@
     } catch (err) {
       contextualCaps = !value;
       console.error('save contextual_caps_enabled failed:', err);
+    }
+  }
+
+  async function handleAutoSpacing(value: boolean) {
+    autoSpacing = value;
+    try {
+      await saveSetting('auto_spacing_enabled', value);
+    } catch (err) {
+      autoSpacing = !value;
+      console.error('save auto_spacing_enabled failed:', err);
     }
   }
 
@@ -368,6 +381,10 @@
 <div class="setting-row">
   <div><div class="label">Contextual capitalization</div><div class="desc">Lowercases the first word when injecting mid-sentence</div></div>
   <Toggle checked={contextualCaps} onchange={handleContextualCaps} />
+</div>
+<div class="setting-row">
+  <div><div class="label">Automatic spacing</div><div class="desc">Adds a space before injected text when the cursor is after existing text</div></div>
+  <Toggle checked={autoSpacing} onchange={handleAutoSpacing} />
 </div>
 
 <style>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,6 +33,7 @@ type SettingsValueMap = {
   api_fallback_enabled: boolean;
   auto_learn_enabled: boolean;
   contextual_caps_enabled: boolean;
+  auto_spacing_enabled: boolean;
   history_retention: HistoryRetention;
   microphone_device: string | null;
   update_dismissed_version: string | null;


### PR DESCRIPTION
# Summary

Adds automatic spacing between consecutive dictation sessions and improves contextual capitalisation reliability. Previously, continuing dictation in the same text field required manually adding a space, and mid-sentence capitalisation detection was broken by unreliable UIA/clipboard-peek mechanisms. This replaces all of that with a lightweight injection history tracker that lives entirely within Open Flow's own process.

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

**Hotkey hook change:** The `WH_KEYBOARD_LL` hook in `hotkey.rs` now updates injection history on real user keypresses. Backspace pops the last character from the tracked string; any other non-modifier key resets it. Synthetic key events (flagged `LLKHF_INJECTED`) are explicitly skipped so our own `Ctrl+V` paste and any app-generated keyboard events cannot corrupt the tracker.

**Clipboard behaviour:** Unchanged. The previous clipboard-peek (Shift+Left → Ctrl+C → compare) and all UIA pattern attempts are removed entirely. Clipboard save/restore around the paste is unaffected.

**New setting:** `auto_spacing_enabled` (default `true`) added to `store.rs`, `settings.ts`, and `GeneralSection.svelte`. Stored via `tauri-plugin-store`; never touches SQLite.

## UI Evidence

Not applicable — no visual UI changes beyond the new toggle in General settings.

## Reviewer Notes

The injection history approach assumes the cursor is at the end of the last injected text when the next dictation starts, which is true for typical voice-first workflows. Known limitation: if the user moves the cursor mid-text using arrow keys (non-injected key → history reset → treated as fresh start) or types new content before dictating, auto-spacing will not fire for that session. This is the correct conservative fallback. The `INJECTION_STALE` timeout (60 s) acts as a background safety net for inactivity; the keyboard hook is the primary reset signal.