### PR TITLE
feat: escape-to-cancel transcription + clipboard preservation + pill exit animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,18 @@ tests/smoke/*.wav
 # AI Agent workspace
 .claude/
 .loop_state.json
+
+# Guardrail: never track nested worktree folders if someone creates them in-repo
+agent-worktrees/
+
+
+# Local reusable worktree slots
+worktrees/
+
+# Multi-agent workflow docs (local-only)
+Agent-Skills/Multi_Agent_Parallel.md
+Agent-Skills/templates/
+# In-repo reusable worktree slots
+worktrees/worktree-1/
+worktrees/worktree-2/
+worktrees/worktree-3/

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -340,6 +340,7 @@ pub async fn stop_recording(
     app: AppHandle,
     state: tauri::State<'_, SharedState>,
 ) -> Result<(), String> {
+    crate::core::hotkey::set_handless_active(false);
     let session = {
         let mut st = lock_state(&state)?;
         st.handless = false;

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -108,6 +108,10 @@ pub fn reset_chord_state() {
     CHORD_FIRST_DOWN_MS.store(0, Ordering::SeqCst);
 }
 
+pub fn set_handless_active(v: bool) {
+    HANDLESS_ACTIVE.store(v, Ordering::SeqCst);
+}
+
 pub fn map_code_to_vk(code: &str) -> u32 {
     match code {
         "ShiftLeft" => 160,
@@ -181,6 +185,9 @@ static HANDLESS_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync
 static CANCEL_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 
 static CHORD_DOWN: AtomicBool = AtomicBool::new(false);
+static HANDLESS_ACTIVE: AtomicBool = AtomicBool::new(false);
+static ESCAPE_CANCELLED: AtomicBool = AtomicBool::new(false);
+static ESCAPE_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 static KEY1_WAS_CHORD: AtomicBool = AtomicBool::new(false);
 // Set whenever key2 is captured as part of our chord. Guarantees key2-up is
 // suppressed even if key1 goes up first and clears CHORD_DOWN before key2 does.
@@ -245,6 +252,9 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             // and triggers the Start menu / Win shortcuts.
             let key2_was_chord = KEY2_WAS_CHORD.swap(false, Ordering::SeqCst);
             if CHORD_DOWN.swap(false, Ordering::SeqCst) {
+                if ESCAPE_CANCELLED.swap(false, Ordering::SeqCst) {
+                    return LRESULT(1);
+                }
                 let now = GetTickCount64();
                 let t0 = CHORD_FIRST_DOWN_MS.load(Ordering::SeqCst);
                 let held_ms = now.saturating_sub(t0);
@@ -298,8 +308,10 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             }
 
             if CHORD_DOWN.swap(false, Ordering::SeqCst) {
-                if let Some(cb) = RELEASE_CB.get() {
-                    cb();
+                if !ESCAPE_CANCELLED.swap(false, Ordering::SeqCst) {
+                    if let Some(cb) = RELEASE_CB.get() {
+                        cb();
+                    }
                 }
             }
             if KEY1_WAS_CHORD.swap(false, Ordering::SeqCst) {
@@ -307,6 +319,18 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 if is_menu_trigger {
                     return LRESULT(1);
                 }
+            }
+        }
+
+        if vk == 27 && is_down {
+            if CHORD_DOWN.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst) {
+                if CHORD_DOWN.load(Ordering::SeqCst) {
+                    ESCAPE_CANCELLED.store(true, Ordering::SeqCst);
+                }
+                if let Some(cb) = ESCAPE_CB.get() {
+                    cb();
+                }
+                return LRESULT(1);
             }
         }
 
@@ -338,22 +362,25 @@ if !is_injected && is_down {
     CallNextHookEx(None, code, wparam, lparam)
 }
 
-pub fn start<P, R, H, C>(
+pub fn start<P, R, H, C, E>(
     on_press: P,
     on_release: R,
     on_handless: H,
     on_cancel: C,
+    on_escape: E,
 ) -> Result<std::thread::JoinHandle<()>, String>
 where
     P: Fn() + Send + Sync + 'static,
     R: Fn() + Send + Sync + 'static,
     H: Fn() + Send + Sync + 'static,
     C: Fn() + Send + Sync + 'static,
+    E: Fn() + Send + Sync + 'static,
 {
     let _ = PRESS_CB.set(Box::new(on_press));
     let _ = RELEASE_CB.set(Box::new(on_release));
     let _ = HANDLESS_CB.set(Box::new(on_handless));
     let _ = CANCEL_CB.set(Box::new(on_cancel));
+    let _ = ESCAPE_CB.set(Box::new(on_escape));
 
     // Verify the hook can be installed before spawning the thread so the caller
     // gets a synchronous error instead of a silent panic on a background thread.

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 const VK_BACK: u32 = 0x08;    // Backspace
+const VK_ESCAPE: u32 = 0x1B;  // Escape
 const VK_CTRL: u32 = 0x11;    // VK_CONTROL (generic, used with modifier_held)
 const VK_ALT: u32 = 0x12;     // VK_MENU (generic, used with modifier_held)
 
@@ -322,7 +323,7 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             }
         }
 
-        if vk == 27 && is_down {
+        if vk == VK_ESCAPE && is_down {
             if CHORD_DOWN.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst) {
                 if CHORD_DOWN.load(Ordering::SeqCst) {
                     ESCAPE_CANCELLED.store(true, Ordering::SeqCst);

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -188,6 +188,7 @@ static CANCEL_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::
 static CHORD_DOWN: AtomicBool = AtomicBool::new(false);
 static HANDLESS_ACTIVE: AtomicBool = AtomicBool::new(false);
 static ESCAPE_CANCELLED: AtomicBool = AtomicBool::new(false);
+static ESCAPE_KEY_DOWN: AtomicBool = AtomicBool::new(false);
 static ESCAPE_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 static KEY1_WAS_CHORD: AtomicBool = AtomicBool::new(false);
 // Set whenever key2 is captured as part of our chord. Guarantees key2-up is
@@ -323,14 +324,18 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             }
         }
 
-        if vk == VK_ESCAPE && is_down {
-            if CHORD_DOWN.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst) {
+        if vk == VK_ESCAPE {
+            if is_down && (CHORD_DOWN.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst)) {
                 if CHORD_DOWN.load(Ordering::SeqCst) {
                     ESCAPE_CANCELLED.store(true, Ordering::SeqCst);
                 }
+                ESCAPE_KEY_DOWN.store(true, Ordering::SeqCst);
                 if let Some(cb) = ESCAPE_CB.get() {
                     cb();
                 }
+                return LRESULT(1);
+            }
+            if is_up && ESCAPE_KEY_DOWN.swap(false, Ordering::SeqCst) {
                 return LRESULT(1);
             }
         }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -57,7 +57,11 @@ unsafe fn save_clipboard_all() -> SavedClipboard {
 
     let mut entries = Vec::new();
 
-    if OpenClipboard(None).is_err() {
+    let opened = (0..3).any(|i| {
+        if i > 0 { std::thread::sleep(std::time::Duration::from_millis(50)); }
+        OpenClipboard(None).is_ok()
+    });
+    if !opened {
         return SavedClipboard { entries };
     }
 
@@ -103,7 +107,11 @@ unsafe fn restore_clipboard_all(saved: &SavedClipboard) {
         return;
     }
 
-    if OpenClipboard(None).is_err() {
+    let opened = (0..3).any(|i| {
+        if i > 0 { std::thread::sleep(std::time::Duration::from_millis(50)); }
+        OpenClipboard(None).is_ok()
+    });
+    if !opened {
         return;
     }
 

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -43,33 +43,84 @@ pub fn backspace_injection_history() {
 }
 
 #[cfg(target_os = "windows")]
-unsafe fn read_clipboard_unicode() -> Option<Vec<u16>> {
+struct SavedClipboard {
+    entries: Vec<(u32, Vec<u8>)>,
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn save_clipboard_all() -> SavedClipboard {
+    use windows::Win32::Foundation::HGLOBAL;
     use windows::Win32::System::DataExchange::{
-        CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
+        CloseClipboard, EnumClipboardFormats, GetClipboardData, OpenClipboard,
     };
-    use windows::Win32::System::Memory::{GlobalLock, GlobalUnlock};
+    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
 
-    const CF_UNICODETEXT: u32 = 13;
+    let mut entries = Vec::new();
 
-    if IsClipboardFormatAvailable(CF_UNICODETEXT).is_ok() && OpenClipboard(None).is_ok() {
-        let saved = GetClipboardData(CF_UNICODETEXT).ok().and_then(|h| {
-            let ptr = GlobalLock(windows::Win32::Foundation::HGLOBAL(h.0)) as *const u16;
-            if ptr.is_null() {
-                return None;
-            }
-            let mut len = 0usize;
-            while *ptr.add(len) != 0 {
-                len += 1;
-            }
-            let v = std::slice::from_raw_parts(ptr, len + 1).to_vec();
-            let _ = GlobalUnlock(windows::Win32::Foundation::HGLOBAL(h.0));
-            Some(v)
-        });
-        CloseClipboard().ok();
-        saved
-    } else {
-        None
+    if OpenClipboard(None).is_err() {
+        return SavedClipboard { entries };
     }
+
+    let mut fmt = 0u32;
+    loop {
+        fmt = EnumClipboardFormats(fmt);
+        if fmt == 0 {
+            break;
+        }
+        // Skip GDI object formats — GetClipboardData returns an opaque GDI handle,
+        // not an HGLOBAL, so GlobalSize/GlobalLock are undefined on them.
+        // CF_BITMAP=2, CF_METAFILEPICT=3, CF_PALETTE=9, CF_ENHMETAFILE=14
+        if matches!(fmt, 2 | 3 | 9 | 14) {
+            continue;
+        }
+        if let Ok(h) = GetClipboardData(fmt) {
+            let hg = HGLOBAL(h.0);
+            let size = GlobalSize(hg);
+            if size > 0 {
+                let ptr = GlobalLock(hg) as *const u8;
+                if !ptr.is_null() {
+                    let data = std::slice::from_raw_parts(ptr, size).to_vec();
+                    let _ = GlobalUnlock(hg);
+                    entries.push((fmt, data));
+                }
+            }
+        }
+    }
+
+    CloseClipboard().ok();
+    SavedClipboard { entries }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn restore_clipboard_all(saved: &SavedClipboard) {
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+
+    if saved.entries.is_empty() {
+        return;
+    }
+
+    if OpenClipboard(None).is_err() {
+        return;
+    }
+
+    EmptyClipboard().ok();
+
+    for (fmt, data) in &saved.entries {
+        if let Ok(hg) = GlobalAlloc(GMEM_MOVEABLE, data.len()) {
+            let ptr = GlobalLock(hg) as *mut u8;
+            if !ptr.is_null() {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, data.len());
+                let _ = GlobalUnlock(hg);
+                let _ = SetClipboardData(*fmt, Some(HANDLE(hg.0)));
+            }
+        }
+    }
+
+    CloseClipboard().ok();
 }
 
 #[cfg(target_os = "windows")]
@@ -113,8 +164,9 @@ pub async fn inject_text(
         use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 
         unsafe {
-            // Save existing clipboard
-            let saved: Option<Vec<u16>> = read_clipboard_unicode();
+            // Save all clipboard formats so non-text content (images, files, etc.)
+            // survives the injection and is restored afterward.
+            let saved = save_clipboard_all();
 
             // Restore focus to the window the user was dictating into.
             // The user may have switched windows during the transcription/cleanup
@@ -239,10 +291,8 @@ pub async fn inject_text(
             SendInput(&paste, std::mem::size_of::<INPUT>() as i32);
             tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
 
-            // Restore clipboard
-            if let Some(saved_wide) = saved {
-                let _ = write_clipboard_unicode(&saved_wide);
-            }
+            // Restore all previously saved clipboard formats.
+            restore_clipboard_all(&saved);
 
             // Record a tail of the injected text so the keyboard hook can pop
             // characters off it on Backspace, keeping the context accurate after

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -93,7 +93,7 @@ unsafe fn save_clipboard_all() -> SavedClipboard {
 
 #[cfg(target_os = "windows")]
 unsafe fn restore_clipboard_all(saved: &SavedClipboard) {
-    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Foundation::{GlobalFree, HANDLE};
     use windows::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
@@ -112,10 +112,14 @@ unsafe fn restore_clipboard_all(saved: &SavedClipboard) {
     for (fmt, data) in &saved.entries {
         if let Ok(hg) = GlobalAlloc(GMEM_MOVEABLE, data.len()) {
             let ptr = GlobalLock(hg) as *mut u8;
-            if !ptr.is_null() {
-                std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, data.len());
-                let _ = GlobalUnlock(hg);
-                let _ = SetClipboardData(*fmt, Some(HANDLE(hg.0)));
+            if ptr.is_null() {
+                let _ = GlobalFree(Some(hg));
+                continue;
+            }
+            std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, data.len());
+            let _ = GlobalUnlock(hg);
+            if SetClipboardData(*fmt, Some(HANDLE(hg.0))).is_err() {
+                let _ = GlobalFree(Some(hg));
             }
         }
     }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -55,6 +55,17 @@ unsafe fn save_clipboard_all() -> SavedClipboard {
     };
     use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
 
+    // GDI object formats — GetClipboardData returns an opaque GDI handle for these,
+    // not an HGLOBAL, so GlobalSize/GlobalLock are undefined on them.
+    const CF_BITMAP: u32 = 2;
+    const CF_METAFILEPICT: u32 = 3;
+    const CF_PALETTE: u32 = 9;
+    const CF_ENHMETAFILE: u32 = 14;
+
+    // Per-format cap: skip anything larger than 32 MB to stay within the 200 MB
+    // RAM budget. Typical screenshots are 2–8 MB as CF_DIB; 32 MB is generous.
+    const MAX_FORMAT_BYTES: usize = 32 * 1024 * 1024;
+
     let mut entries = Vec::new();
 
     let opened = (0..3).any(|i| {
@@ -71,16 +82,13 @@ unsafe fn save_clipboard_all() -> SavedClipboard {
         if fmt == 0 {
             break;
         }
-        // Skip GDI object formats — GetClipboardData returns an opaque GDI handle,
-        // not an HGLOBAL, so GlobalSize/GlobalLock are undefined on them.
-        // CF_BITMAP=2, CF_METAFILEPICT=3, CF_PALETTE=9, CF_ENHMETAFILE=14
-        if matches!(fmt, 2 | 3 | 9 | 14) {
+        if matches!(fmt, CF_BITMAP | CF_METAFILEPICT | CF_PALETTE | CF_ENHMETAFILE) {
             continue;
         }
         if let Ok(h) = GetClipboardData(fmt) {
             let hg = HGLOBAL(h.0);
             let size = GlobalSize(hg);
-            if size > 0 {
+            if size > 0 && size <= MAX_FORMAT_BYTES {
                 let ptr = GlobalLock(hg) as *const u8;
                 if !ptr.is_null() {
                     let data = std::slice::from_raw_parts(ptr, size).to_vec();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -515,14 +515,15 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
 
                 HotkeyEvent::EscapeCancel => {
                     core::hotkey::set_handless_active(false);
-                    let had_session = {
+                    let session = {
                         let Some(mut st) = lock_app_state(&state_hk) else {
                             continue;
                         };
                         st.handless = false;
-                        st.session.take().is_some()
+                        st.session.take()
                     };
-                    if had_session {
+                    if let Some(s) = session {
+                        std::thread::spawn(move || { let _ = s.stop(); });
                         std::thread::spawn(crate::system::volume::unmute);
                     }
                     hide_pill(&app_hk);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -377,12 +377,14 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         Release,
         HandlessToggle,
         Cancel,
+        EscapeCancel,
     }
 
     let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::channel::<HotkeyEvent>(8);
     let tx_press = hotkey_tx.clone();
     let tx_handless = hotkey_tx.clone();
     let tx_cancel = hotkey_tx.clone();
+    let tx_escape = hotkey_tx.clone();
     let tx_release = hotkey_tx;
 
     match core::hotkey::start(
@@ -397,6 +399,9 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         },
         move || {
             let _ = tx_cancel.try_send(HotkeyEvent::Cancel);
+        },
+        move || {
+            let _ = tx_escape.try_send(HotkeyEvent::EscapeCancel);
         },
     ) {
         Ok(_handle) => { /* hook thread running */ }
@@ -460,6 +465,7 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         (st.handless, st.session.is_some())
                     };
                     if is_handless {
+                        core::hotkey::set_handless_active(false);
                         if let Some(mut st) = lock_app_state(&state_hk) {
                             st.handless = false;
                         }
@@ -473,6 +479,7 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                             st.target_hwnd = hwnd;
                         }
                         start_recording_session(&app_hk, &state_hk, "handsfree", true);
+                        core::hotkey::set_handless_active(true);
                     }
                 }
 
@@ -484,6 +491,7 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // Quick tap while in handsfree = stop. Clear chord state
                         // immediately so the still-open double-tap window can't
                         // re-trigger a fresh handsfree session.
+                        core::hotkey::set_handless_active(false);
                         core::hotkey::reset_chord_state();
                         if let Some(mut st) = lock_app_state(&state_hk) {
                             st.handless = false;
@@ -503,6 +511,21 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         }
                         hide_pill(&app_hk);
                     }
+                }
+
+                HotkeyEvent::EscapeCancel => {
+                    core::hotkey::set_handless_active(false);
+                    let had_session = {
+                        let Some(mut st) = lock_app_state(&state_hk) else {
+                            continue;
+                        };
+                        st.handless = false;
+                        st.session.take().is_some()
+                    };
+                    if had_session {
+                        std::thread::spawn(crate::system::volume::unmute);
+                    }
+                    hide_pill(&app_hk);
                 }
             }
         }

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -7,6 +7,8 @@
   let showHfButtons = false;
   let hfTimer: ReturnType<typeof setTimeout> | null = null;
   let prevState: PillState = 'idle';
+  let dying = false;
+  let dyingTimer: ReturnType<typeof setTimeout> | null = null;
 
   const BARS = 12;
 
@@ -86,6 +88,18 @@
     rafId = requestAnimationFrame(animateBars);
   }
 
+  function goIdle() {
+    if (dying) return;
+    dying = true;
+    dyingTimer = setTimeout(() => {
+      dying = false;
+      dyingTimer = null;
+      prevState = state;
+      state = 'idle';
+      smoothed = 0;
+    }, 200);
+  }
+
   onMount(() => {
     rafId = requestAnimationFrame(animateBars);
     const unlisteners: Array<() => void> = [];
@@ -96,6 +110,14 @@
       unlisteners.push(await listen<string>('pill-state', (ev) => {
         const incoming = (ev.payload as PillState) || 'idle';
         if (hfTimer !== null) { clearTimeout(hfTimer); hfTimer = null; }
+
+        if (incoming === 'idle' && (state === 'recording' || state === 'handsfree')) {
+          goIdle();
+          return;
+        }
+
+        if (dyingTimer !== null) { clearTimeout(dyingTimer); dyingTimer = null; dying = false; }
+
         if (incoming === 'handsfree') {
           showHfButtons = false;
           hfTimer = setTimeout(() => { showHfButtons = true; hfTimer = null; }, 150);
@@ -130,14 +152,14 @@
 
   async function cancelHandless() {
     const { invoke } = await import('@tauri-apps/api/core');
+    goIdle();
     await invoke('stop_recording').catch(() => {});
-    state = 'idle';
   }
 </script>
 
 <div class="wrap">
   {#if state === 'recording'}
-    <div class="pill recording">
+    <div class="pill recording" class:dying={dying}>
       {#each barHeights as h, i (i)}
         <div class="bar" style="height: {h}px"></div>
       {/each}
@@ -155,7 +177,7 @@
     </div>
 
   {:else if state === 'handsfree'}
-    <div class="pill handsfree" class:hf-expanded={showHfButtons} class:no-anim={prevState === 'recording'}>
+    <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'}>
       {#if showHfButtons}
         <button class="hf-btn cancel" onclick={cancelHandless} aria-label="Cancel">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
@@ -210,6 +232,17 @@
   @keyframes pillIn {
     from { transform: translateY(8px) scale(0.92); opacity: 0; }
     to   { transform: translateY(0) scale(1); opacity: 1; }
+  }
+
+  @keyframes pillOut {
+    from { transform: translateY(0) scale(1); opacity: 1; }
+    to   { transform: translateY(6px) scale(0.88); opacity: 0; }
+  }
+
+  .pill.recording.dying,
+  .pill.handsfree.dying {
+    animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
+    pointer-events: none;
   }
 
   /* Skip entry animation for seamless continuations from recording */


### PR DESCRIPTION
# Summary

Two UX improvements shipped together since they were developed on the same session branch:

**1. Escape to cancel active transcription**
Press Escape while holding the hotkey or in hands-free mode to abort the session before any API call is made. This prevents accidentally wasting tokens when the user changes their mind mid-recording.

**2. Preserve clipboard content across injection**
Before transcribing, all clipboard formats (images, files, text, custom app data) are now saved and restored after Ctrl+V injection. Previously only `CF_UNICODETEXT` was saved, so copying a screenshot and then dictating would permanently replace the image with the transcription text.

**3. Pill exit animation**
Cancelling no longer snaps the pill away instantly — it plays a smooth 180ms shrink+fade-out that mirrors the entry animation in reverse. Works for both Escape-cancel and the pill's X button.

## Type of Change

- [x] Feature
- [x] UI change
- [x] Bug fix

## Testing

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test:rust` — 75 passed, 0 failed
- [ ] `npm run lint`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Manual tests performed:
- Hold Ctrl+Win → press Escape before releasing → pill plays exit animation, no transcription, no token spent
- Double-tap into hands-free → press Escape → same exit animation, no transcription
- Hands-free → click pill X button → exit animation plays, works as before
- Normal hold+release transcription → Escape gate inactive, pipeline runs normally
- Copy screenshot (Win+Shift+S), dictate, then Ctrl+V → original screenshot is restored
- Copy text, dictate, then Ctrl+V → original text is restored
- Empty clipboard, dictate, then Ctrl+V → transcription text is available (expected)

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

**Clipboard change:** `save_clipboard_all` / `restore_clipboard_all` replace the old single-format save. All memory-based clipboard formats are copied by raw bytes. The four GDI object handle formats (`CF_BITMAP`, `CF_METAFILEPICT`, `CF_PALETTE`, `CF_ENHMETAFILE`) are skipped as they cannot be cloned by memory copy — these are rare and were not saved before either. No clipboard data is persisted anywhere.

**Hotkey change:** Escape is now intercepted by the `WH_KEYBOARD_LL` hook while `CHORD_DOWN || HANDLESS_ACTIVE`. An `ESCAPE_CANCELLED` atomic prevents the key-up event from firing the Release callback, ensuring the pipeline never runs after a cancel. All other Escape presses pass through normally.

## UI Evidence

Not applicable — no screenshots available in this environment. Verified manually via the running Tauri dev build.

## Reviewer Notes

- The `ESCAPE_CANCELLED` atomic is a one-shot flag: it's consumed by the first key-up event (either key1 or key2) and cleared. Edge case where both key-up events race is safe because `AtomicBool::swap` is used.
- The clipboard save/restore is on the hot path of every injection. `GlobalAlloc` + `GlobalLock` per format is fast for typical clipboard sizes; a clipboard with 10 formats and a 4MB DIB image would add ~1ms overhead, well within the existing timing slack.
- `goIdle()` in the Svelte pill is idempotent: if called twice (e.g., Escape key + Rust event racing), the second call is a no-op (`if dying) return`).