### PR TITLE
fix: restore cleanup/transcription model selection after gemini rename

### DIFF
--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -25,14 +25,41 @@
   let transcriptionIndicatorStyle = $state('opacity:0;');
   let cleanupIndicatorStyle = $state('opacity:0;');
 
+  // Migrate model IDs that were renamed between releases.
+  const MODEL_MIGRATIONS: Record<string, string> = {
+    'google/gemini-2.5-flash': 'google/gemini-3.5-flash',
+  };
+
+  function resolveModelId(stored: string, validIds: string[]): string {
+    if (validIds.includes(stored)) return stored;
+    const migrated = MODEL_MIGRATIONS[stored];
+    if (migrated && validIds.includes(migrated)) return migrated;
+    return validIds[0];
+  }
+
   async function loadModels() {
     try {
       const [tModel, cModel] = await Promise.all([
         invoke<string | null>('get_setting', { key: 'transcription_model' }),
         invoke<string | null>('get_setting', { key: 'cleanup_model' }),
       ]);
-      if (tModel) transcriptionModel = tModel;
-      if (cModel) cleanupModel = cModel;
+
+      if (tModel) {
+        const resolved = resolveModelId(tModel, transcriptionModels.map(m => m.id));
+        transcriptionModel = resolved;
+        if (resolved !== tModel) {
+          await saveSetting('transcription_model', resolved);
+          await saveSetting('transcription_provider', resolved.split('/')[0] as ProviderId);
+        }
+      }
+      if (cModel) {
+        const resolved = resolveModelId(cModel, cleanupModels.map(m => m.id));
+        cleanupModel = resolved;
+        if (resolved !== cModel) {
+          await saveSetting('cleanup_model', resolved);
+          await saveSetting('cleanup_provider', resolved.split('/')[0] as ProviderId);
+        }
+      }
     } catch (err) {
       console.error('loadModels failed:', err);
     }


### PR DESCRIPTION
# Summary

When `gemini-2.5-flash` was renamed to `gemini-3.5-flash` in #43, users who had previously selected Google for transcription or cleanup had a stale model ID (`google/gemini-2.5-flash`) in their `settings.json`. Since that ID no longer matches any entry in the model list, the selection appeared blank every time the app was reopened — regardless of what the user had chosen.

The fix validates loaded model IDs against the current list on startup, applies a migration map for known renames, and writes the corrected value back to the store so future loads are already in sync.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Manual reproduction: set `cleanup_model` in `settings.json` to `"google/gemini-2.5-flash"`, reopen the app, navigate to Settings → Models — the Google row now shows as selected and the stored value is silently migrated to `"google/gemini-3.5-flash"`.

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes: None.

## UI Evidence

Not applicable (no visual change; fix restores the previously-working selection highlight for affected users).

## Reviewer Notes

`resolveModelId()` falls back to `validIds[0]` (the recommended Groq model) if the stored value is both unknown and unmapped. This is intentional — an unrecognised model ID is safer to reset than to pass through to the API. Add future renames to `MODEL_MIGRATIONS` as needed.