### PR TITLE
Improve smoke runner reliability and trim smoke skill

### DIFF
--- a/Agent-Skills/SmokeTest.md
+++ b/Agent-Skills/SmokeTest.md
@@ -1,155 +1,65 @@
----
+﻿---
 name: smoke-tests
-description: Guides any AI agent through making the Open Flow smoke tests pass by fixing app code — never the tests.
+description: Minimal guide to run and fix Open Flow smoke tests by changing app code, never smoke tests.
 ---
 
-# Smoke Tests — Open Flow
+# Smoke Tests - Open Flow
 
-You are helping make the Open Flow smoke tests pass. Read every rule before touching any code.
+## Non-negotiables
 
-## Hard Rules — No Exceptions
+1. Do not edit `tests/smoke/*` unless the user explicitly asks.
+2. Fix app code, not tests (`src/lib/views/*`, `src/lib/components/*`).
+3. No fake pass hacks (no hidden nodes, hardcoded values, or selector-only shims).
 
-1. **Never edit any file inside `tests/smoke/`** unless the user explicitly grants permission for a specific session.
-2. **Never fake functionality.** Do not hardcode expected values, hide elements, or add invisible nodes for Playwright. Every assertion must reflect real, working UI.
-3. **Fix the app.** The Svelte components in `src/lib/views/` and `src/lib/components/` are where the work happens.
+## Current test contracts
 
----
+- `test.cjs` (5173): app loads, `.nav-item` exists, `.app` visible.
+- `test-app.cjs` (5173): App Mappings add flow works end-to-end.
+- `playwright-test-ui.cjs` (1420): nav headings render, settings sections render, privacy toggles flip, settings closes.
+- `playwright-test-fixes.cjs` (1420):
+  - Advanced: `.toggle` exists
+  - Advanced: `span.gain-value` exists
+  - General: `button.badge.key-badge` contains `Ctrl`
+  - About: `button.btn-ghost` contains `github.com/MONKE2525E/Open-Flow`
+- `playwright-test-state.cjs` (1420): model and advanced-toggle persistence survive close/reopen.
+- `playwright-test-pipeline.cjs` (no server): WAV + API pipeline checks, `SKIP` when keys are absent.
 
-## The Six Tests and Their Expected Results
+## Required class/selector contracts
 
-### `test.cjs` — port 5173 (Vite dev server)
+- `nav-item`
+- `app`
+- `h1.page-h`
+- `settings-modal`
+- `settings-nav-item`
+- `h2.settings-h`
+- `toggle` with `role="switch"` and `aria-checked`
+- `badge key-badge`
+- `btn-ghost`
+- `model-row` (+ `active`)
 
-Loads the app, waits for at least one `.nav-item` to appear, asserts at least 4 nav items exist and `.app` root is visible. Saves `screenshot.png`. Fails on any JS page errors.
-
-**Pass criteria:** No JS errors on load, ≥4 `.nav-item` elements, `.app` root visible, screenshot writes.
-
----
-
-### `test-app.cjs` — port 5173 (Vite dev server)
-
-Clicks `.nav-item:has-text("Style")`, then `text=App Mappings`. Fills `input[placeholder="e.g. slack.exe"]` with `chrome.exe`, picks `casual`, clicks `button:has-text("Add Mapping")`, then waits for `text=chrome.exe` to appear.
-
-**Pass criteria:** Style nav, App Mappings tab, and the add flow all work end-to-end. The mapping must render in the list via the real store/backend.
-
----
-
-### `playwright-test-ui.cjs` — port 1420 (Tauri window)
-
-Clicks each sidebar nav item and asserts the **view actually changes** by waiting for the corresponding `h1.page-h`:
-
-| Nav label  | Expected heading  |
-|------------|-------------------|
-| Home       | `Welcome back`    |
-| Dictionary | `Dictionary`      |
-| Snippets   | `Snippets`        |
-| Style      | `Style`           |
-
-Then opens Settings, clicks each of the 6 section nav items and asserts `h2.settings-h` renders. Navigates to Privacy, finds all `.toggle` elements, reads `aria-checked` before each click, clicks, asserts `aria-checked` changed. Closes settings via `(10, 10)` click and asserts `.settings-modal` is hidden.
-
-**Pass criteria:**
-- All nav clicks produce the correct heading (not just no crash)
-- Settings section clicks produce the correct `h2.settings-h`
-- Each toggle's `aria-checked` flips on click
-- `.settings-modal` becomes hidden after outside click
-
----
-
-### `playwright-test-fixes.cjs` — port 1420 (Tauri window)
-
-Uses `waitFor({ state: 'visible' })` (not `waitForTimeout`) on every element. Asserts:
-
-| Location             | Selector                                              |
-|----------------------|-------------------------------------------------------|
-| Settings → Advanced  | `div.badge:has-text("30 days")`                       |
-| Settings → Advanced  | `div.badge:has-text("Clipboard (Ctrl+V)")`            |
-| Settings → General   | `button.badge.key-badge:has-text("Ctrl")`             |
-| Settings → About     | `button.btn-ghost:has-text("github.com/MONKE2525E/Open-Flow")` |
-
-**Pass criteria:** All four elements exist with the exact tag+class shown. A `<span class="badge">` won't satisfy `div.badge`; a `<button>` without `.btn-ghost` won't satisfy the About check.
-
----
-
-### `playwright-test-state.cjs` — port 1420 (Tauri window)
-
-Tests that state changes actually persist through a settings close/reopen cycle:
-
-1. All 3 transcription and 3 cleanup model buttons render as `.model-row` elements.
-2. At least one `.model-row.active` exists.
-3. Clicking a non-active model row makes it active; closing and reopening settings shows the new selection still active.
-4. Clicking a `.toggle` in Advanced changes `aria-checked`; closing and reopening settings shows the same value.
-5. Restores original state at the end.
-
-**Pass criteria:** Model selection and toggle state both survive a settings close/reopen cycle — proving the Tauri store write is happening.
-
----
-
-### `playwright-test-pipeline.cjs` — no browser (Node.js only)
-
-Standalone test that hits the API directly. Does **not** require `npm run tauri dev`.
-
-1. Verifies `tests/smoke/smoke_test.wav` exists and has a valid `RIFF/WAVE` header.
-2. Reads the store at `%APPDATA%\com.openflow.app\settings.json` to find configured API keys.
-3. If a Groq or OpenAI key is found: calls the transcription API with the WAV and verifies non-empty output.
-4. If transcript is obtained and Groq key exists: runs cleanup for all three profiles (`casual`, `formal`, `very_casual`) and checks:
-   - Each profile returns non-empty text.
-   - Profiles produce **distinct** outputs (differentiation is real).
-   - `formal` output contains no contractions.
-   - `very_casual` output starts with a lowercase word (only `I` may be uppercase).
-5. If an OpenAI key is also present: runs a bonus gpt-4o-mini cleanup check.
-
-**Pass criteria (with keys):** Transcription non-empty, all profiles distinct, format rules enforced.
-**Skip (without keys):** Reports `SKIP` and exits 0 — not a failure.
-
----
-
-## CSS Class Checklist
-
-When fixing components, verify these classes are applied exactly as written:
-
-- Sidebar nav buttons → `nav-item`
-- App root div → `app`
-- View headings → `h1.page-h` with the view's name as text
-- Settings container → `settings-modal`
-- Settings section buttons → `settings-nav-item`
-- Settings section headings → `h2.settings-h` with the section name as text
-- Privacy / Advanced toggles → `toggle` + `role="switch"` + `aria-checked` attribute
-- Info badges (div) → `badge` on a `<div>`
-- Hotkey badge → `badge key-badge` on a `<kbd>` element
-- About GitHub button → `btn-ghost` on a `<button>`
-- Model buttons → `model-row` (active selection adds `active`)
-
----
-
-## How to Run
+## Run commands
 
 ```bash
-# Port-5173 tests — Vite dev server
-npm run dev            # terminal 1
+# Recommended unified run
+python tests/OnePyFone.py --suite all --fresh-server
+
+# Parallel-safe suites only
+python tests/OnePyFone.py --suite ui,animation --parallel --workers 3 --fresh-server
+
+# Direct runs
+npm run dev
 node tests/smoke/test.cjs
 node tests/smoke/test-app.cjs
 
-# Port-1420 tests — full Tauri window
-npm run tauri dev      # terminal 1
+npm run tauri dev
 node tests/smoke/playwright-test-ui.cjs
 node tests/smoke/playwright-test-fixes.cjs
 node tests/smoke/playwright-test-state.cjs
 
-# Pipeline test — no server needed
 node tests/smoke/playwright-test-pipeline.cjs
 ```
 
-All tests exit with code 0 on pass and code 1 on failure so they integrate cleanly with CI.
+## Notes
 
----
-
-## smoke_test.wav
-
-`tests/smoke/smoke_test.wav` is gitignored. The user provides this separately as an ElevenLabs-generated voice recording. It must be a real WAV file (RIFF/WAVE header, ≥5 KB). See the user for the recording script.
-
----
-
-## Slash Commands
-
-- **Claude Code**: `/smoke-tests`
-- **Gemini CLI**: `/smoke-tests`
-- **Codex**: `/smoke-tests`
+- Use `--fresh-server` to avoid stale listener/process false failures.
+- OnePyFone now shows live elapsed seconds while tests run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - Use the Mono font very sparingly only use it when its in technical items like file names folder names, code, etc...
 - docs/ROADMAP.md keeps recorded bugs and long term goals far future plans are not to be acted on unless the user requests so.
 - currently working towards OpenFlow 0.11.0.
-- Always add yourself as a co-author  in all commits you make e.g @Claude, @Codex, etc
+- Always add yourself as a co-author  in all commits you make e.g @Claude, @Codex, etc but dont add a note at the bottom of the PR description
 
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -5,7 +5,7 @@
   import { onDestroy } from 'svelte';
   import Toggle from '../Toggle.svelte';
   import { saveSetting } from '../../settings';
-  import { MOTION_MS, MOTION_PX, motionMs, motionPx, animateWidth } from '../../motion';
+  import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
   import { getAudioCalibrationCopy } from '../../calibrationCopy';
   import type { TranscriptionLanguageCode } from '../../transcriptionLanguages';
 
@@ -21,10 +21,7 @@
 
   let noiseReduction = $state(true);
   let micGain = $state(3.5);
-  let microphones = $state<string[]>([]);
-  let selectedMic = $state('');
   let selectedLanguage = $state<TranscriptionLanguageCode>('en');
-  let micDropdownOpen = $state(false);
   const audioCopy = $derived(getAudioCalibrationCopy(selectedLanguage));
 
   $effect(() => {
@@ -35,19 +32,15 @@
 
   async function loadSettings() {
     try {
-      const [nr, savedGain, mics, curMic, language] = await Promise.all([
+      const [nr, savedGain, language] = await Promise.all([
         invoke<boolean | null>('get_setting', { key: 'noise_reduction' }),
         invoke<number | null>('get_setting', { key: 'mic_gain' }),
-        invoke<string[]>('get_microphones'),
-        invoke<string | null>('get_setting', { key: 'microphone_device' }),
         invoke<TranscriptionLanguageCode | null>('get_setting', { key: 'transcription_language' }),
       ]);
       noiseReduction = nr ?? true;
       if (savedGain !== null && savedGain !== undefined) {
         micGain = Math.max(1, Math.min(8, savedGain));
       }
-      microphones = mics ?? [];
-      selectedMic = curMic ?? '';
       if (language) selectedLanguage = language;
     } catch (err) {
       console.error('AudioSection load failed:', err);
@@ -72,22 +65,6 @@
     }
   }
 
-  async function saveMic(name: string) {
-    selectedMic = name;
-    micDropdownOpen = false;
-    try {
-      await saveSetting('microphone_device', name || null);
-    } catch (err) {
-      console.error('saveMic failed:', err);
-    }
-  }
-
-  function closeMicDropdown(e: MouseEvent) {
-    if (!(e.target as HTMLElement).closest('.mic-dropdown')) {
-      micDropdownOpen = false;
-    }
-  }
-
   onDestroy(() => {
     cancelCalibration();
   });
@@ -95,51 +72,7 @@
   loadSettings();
 </script>
 
-<svelte:window onclick={closeMicDropdown} onkeydown={(e) => e.key === 'Escape' && (micDropdownOpen = false)} />
-
-<h2 class="settings-h">
-  Microphone
-  <span class="sr-only">Microphone</span>
-</h2>
-
-<div class="setting-row">
-  <div>
-    <div class="label">{audioCopy.inputDeviceLabel}</div>
-    <div class="desc">{audioCopy.inputDeviceDescription}</div>
-  </div>
-  <div class="mic-dropdown">
-    <button
-      class="btn-ghost mic-btn"
-      use:animateWidth={{ text: selectedMic || audioCopy.defaultDevice, max: 180 }}
-      onclick={() => (micDropdownOpen = !micDropdownOpen)}
-    >
-      <span class="mic-btn-label">{selectedMic || audioCopy.defaultDevice}</span>
-      <svg class:open={micDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="m6 9 6 6 6-6"/>
-      </svg>
-    </button>
-    {#if micDropdownOpen}
-      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-      <div
-        class="mic-menu scroll-styled scroll-thumb-elev"
-        role="presentation"
-        onclick={(e) => e.stopPropagation()}
-        in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
-        out:fade={{ duration: motionMs(MOTION_MS.fast) }}
-      >
-        <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{audioCopy.defaultDevice}</button>
-        {#each microphones as m}
-          <button class="mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>
-            {m}
-          </button>
-        {/each}
-        {#if microphones.length === 0}
-          <div class="mic-empty">{audioCopy.noDevicesFound}</div>
-        {/if}
-      </div>
-    {/if}
-  </div>
-</div>
+<h2 class="settings-h">Advanced</h2>
 
 <div class="setting-row gain-row">
   <div class="gain-header">
@@ -225,93 +158,6 @@
 </div>
 
 <style>
-  .mic-dropdown {
-    position: relative;
-  }
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-  .mic-btn {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    height: 32px;
-    padding: 0 12px;
-    border-radius: var(--r-md);
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 500;
-  }
-  .mic-btn svg {
-    transition: transform 0.2s;
-  }
-  .mic-btn svg.open {
-    transform: rotate(180deg);
-  }
-  .mic-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    width: 220px;
-    max-height: 240px;
-    overflow-y: auto;
-    background: var(--bg-elev);
-    border: 1px solid var(--line-strong);
-    border-radius: var(--r-md);
-    box-shadow: 0 4px 16px var(--shadow-md);
-    z-index: 10;
-    padding: 4px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-  .mic-btn-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex: 1;
-    text-align: left;
-  }
-  .mic-item {
-    width: 100%;
-    text-align: left;
-    padding: 6px 10px;
-    border-radius: var(--r-sm);
-    font-size: 12.5px;
-    color: var(--ink-soft);
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .mic-item:hover {
-    background: var(--paper-2);
-    color: var(--ink);
-  }
-  .mic-item.active {
-    background: var(--accent-soft);
-    color: var(--accent-ink);
-    font-weight: 500;
-  }
-  .mic-empty {
-    padding: 8px 10px;
-    font-size: 12px;
-    color: var(--ink-mute);
-    text-align: center;
-  }
 
   /* Calibration row styles */
   .cal-row {

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -5,7 +5,6 @@
   import { onDestroy } from 'svelte';
   import Toggle from '../Toggle.svelte';
   import { saveSetting } from '../../settings';
-  import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
   import { getAudioCalibrationCopy } from '../../calibrationCopy';
   import type { TranscriptionLanguageCode } from '../../transcriptionLanguages';
 

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core';
-  import { tick } from 'svelte';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';
@@ -129,15 +128,18 @@
     });
   }
 
-  function closeMicDropdown(e: MouseEvent) {
-    if (!(e.target as HTMLElement).closest('.mic-dropdown')) micDropdownOpen = false;
+  function handleWindowClick(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    if (micDropdownOpen && !target.closest('.mic-dropdown')) micDropdownOpen = false;
+    if (languageDropdownOpen && !target.closest('.language-dropdown')) languageDropdownOpen = false;
   }
 
-  $effect(() => {
-    if (micDropdownOpen) {
-      tick().then(() => window.addEventListener('click', closeMicDropdown, { once: true }));
+  function handleWindowKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      micDropdownOpen = false;
+      languageDropdownOpen = false;
     }
-  });
+  }
 
   async function saveMic(name: string) {
     selectedMic = name;
@@ -148,16 +150,6 @@
       console.error('saveMic failed:', err);
     }
   }
-
-  function closeLanguageDropdown(e: MouseEvent) {
-    if (!(e.target as HTMLElement).closest('.language-dropdown')) languageDropdownOpen = false;
-  }
-
-  $effect(() => {
-    if (languageDropdownOpen) {
-      tick().then(() => window.addEventListener('click', closeLanguageDropdown, { once: true }));
-    }
-  });
 
   async function saveLanguage(code: TranscriptionLanguageCode) {
     languageTouched = true;
@@ -328,6 +320,7 @@
 
   loadSettings();
 </script>
+<svelte:window onclick={handleWindowClick} onkeydown={handleWindowKeydown} />
 
 <h2 class="settings-h">General</h2>
 <div class="setting-row">
@@ -397,7 +390,13 @@
     </button>
     {#if micDropdownOpen}
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-      <div class="mic-menu scroll-styled scroll-thumb-elev" role="presentation" onclick={(e) => e.stopPropagation()}>
+      <div
+        class="mic-menu scroll-styled scroll-thumb-elev"
+        role="presentation"
+        onclick={(e) => e.stopPropagation()}
+        in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
+        out:fade={{ duration: motionMs(MOTION_MS.fast) }}
+      >
         <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{audioCopy.defaultDevice}</button>
         {#each microphones as m}
           <button class="mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>{m}</button>

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -12,10 +12,15 @@
     transcriptionLanguages,
     type TranscriptionLanguageCode,
   } from '../../transcriptionLanguages';
+  import { getAudioCalibrationCopy } from '../../calibrationCopy';
 
   let selectedLanguage = $state<TranscriptionLanguageCode>('en');
   let languageDropdownOpen = $state(false);
   let languageTouched = false;
+  let microphones = $state<string[]>([]);
+  let selectedMic = $state('');
+  let micDropdownOpen = $state(false);
+  const audioCopy = $derived(getAudioCalibrationCopy(selectedLanguage));
   let muteAudio = $state(false);
   let autostart = $state(false);
   let cleanup = $state(true);
@@ -90,6 +95,8 @@
       invoke<boolean | null>('get_setting', { key: 'cleanup_enabled' }),
       invoke<boolean | null>('get_setting', { key: 'contextual_caps_enabled' }),
       invoke<boolean | null>('get_setting', { key: 'auto_spacing_enabled' }),
+      invoke<string[]>('get_microphones'),
+      invoke<string | null>('get_setting', { key: 'microphone_device' }),
     ]);
 
     const val = <T>(i: number, fallback: T): T =>
@@ -114,9 +121,34 @@
       selectedLanguage = language;
     }
 
+    const mics = results[8].status === 'fulfilled' ? (results[8] as PromiseFulfilledResult<string[]>).value : [];
+    microphones = mics ?? [];
+    const curMic = results[9].status === 'fulfilled' ? (results[9] as PromiseFulfilledResult<string | null>).value : null;
+    selectedMic = curMic ?? '';
+
     results.forEach((r, i) => {
       if (r.status === 'rejected') console.error(`GeneralSection: invoke[${i}] failed:`, r.reason);
     });
+  }
+
+  function closeMicDropdown(e: MouseEvent) {
+    if (!(e.target as HTMLElement).closest('.mic-dropdown')) micDropdownOpen = false;
+  }
+
+  $effect(() => {
+    if (micDropdownOpen) {
+      tick().then(() => window.addEventListener('click', closeMicDropdown, { once: true }));
+    }
+  });
+
+  async function saveMic(name: string) {
+    selectedMic = name;
+    micDropdownOpen = false;
+    try {
+      await saveSetting('microphone_device', name || null);
+    } catch (err) {
+      console.error('saveMic failed:', err);
+    }
   }
 
   function closeLanguageDropdown(e: MouseEvent) {
@@ -350,6 +382,36 @@
   </div>
 </div>
 <div class="setting-row">
+  <div>
+    <div class="label">{audioCopy.inputDeviceLabel}</div>
+    <div class="desc">{audioCopy.inputDeviceDescription}</div>
+  </div>
+  <div class="mic-dropdown">
+    <button
+      class="btn-ghost mic-btn"
+      use:animateWidth={{ text: selectedMic || audioCopy.defaultDevice, max: 180 }}
+      onclick={() => (micDropdownOpen = !micDropdownOpen)}
+    >
+      <span class="mic-btn-label">{selectedMic || audioCopy.defaultDevice}</span>
+      <svg class:open={micDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="m6 9 6 6 6-6"/>
+      </svg>
+    </button>
+    {#if micDropdownOpen}
+      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <div class="mic-menu scroll-styled scroll-thumb-elev" role="presentation" onclick={(e) => e.stopPropagation()}>
+        <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{audioCopy.defaultDevice}</button>
+        {#each microphones as m}
+          <button class="mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>{m}</button>
+        {/each}
+        {#if microphones.length === 0}
+          <div class="mic-empty">{audioCopy.noDevicesFound}</div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>
+<div class="setting-row">
   <div><div class="label">Mute PC Audio</div><div class="desc">Mutes Windows volume while dictating to prevent audio interference</div></div>
   <Toggle checked={muteAudio} onchange={handleMuteAudio} />
 </div>
@@ -412,6 +474,65 @@
   .keybind-btn.success { background: color-mix(in srgb, var(--accent) 82%, white 18%); color: var(--on-accent); transform: scale(1.03); }
   .keybind-btn.error { background: var(--danger-bg); color: var(--danger); border-color: var(--danger-line); animation: none; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.7; } }
+  .mic-dropdown { position: relative; flex-shrink: 0; }
+  .mic-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 32px;
+    padding: 0 12px;
+    border-radius: var(--r-md);
+    background: var(--paper-2);
+    border: 1px solid var(--line);
+    color: var(--ink);
+    font-size: 13px;
+    font-weight: 500;
+    max-width: 180px;
+  }
+  .mic-btn svg { transition: transform 0.2s; }
+  .mic-btn svg.open { transform: rotate(180deg); }
+  .mic-btn-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    text-align: left;
+  }
+  .mic-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    width: 220px;
+    max-height: 240px;
+    overflow-y: auto;
+    background: var(--bg-elev);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-md);
+    box-shadow: 0 4px 16px var(--shadow-md);
+    z-index: 10;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .mic-item {
+    width: 100%;
+    text-align: left;
+    padding: 6px 10px;
+    border-radius: var(--r-sm);
+    font-size: 12.5px;
+    color: var(--ink-soft);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mic-item:hover { background: var(--paper-2); color: var(--ink); }
+  .mic-item.active { background: var(--accent-soft); color: var(--accent-ink); font-weight: 500; }
+  .mic-empty { padding: 8px 10px; font-size: 12px; color: var(--ink-mute); text-align: center; }
   .language-dropdown { position: relative; flex-shrink: 0; }
   .language-btn { max-width: 210px; }
   .language-btn span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -121,10 +121,8 @@
       selectedLanguage = language;
     }
 
-    const mics = results[8].status === 'fulfilled' ? (results[8] as PromiseFulfilledResult<string[]>).value : [];
-    microphones = mics ?? [];
-    const curMic = results[9].status === 'fulfilled' ? (results[9] as PromiseFulfilledResult<string | null>).value : null;
-    selectedMic = curMic ?? '';
+    microphones = val<string[]>(8, []);
+    selectedMic = val<string | null>(9, null) ?? '';
 
     results.forEach((r, i) => {
       if (r.status === 'rejected') console.error(`GeneralSection: invoke[${i}] failed:`, r.reason);

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -29,7 +29,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Microphone',  icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Advanced',    icon: 'mic'      as keyof typeof icons },
       ...($devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
     { group: 'Account', items: [

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python3
+"""
+OnePyFone — Open Flow Unified Test Runner
+==========================================
+
+Runs every test suite in the project with one command. Stdlib only — no pip.
+
+QUICKSTART
+    python tests/OnePyFone.py              # full suite, auto-starts Tauri server
+    python tests/OnePyFone.py --suite rust # Rust unit tests only (no server)
+    python tests/OnePyFone.py --loops 3   # run 3x for flakiness detection
+
+OPTIONS
+    --suite SUITE      Suites to run, comma-separated or "all" (default: all)
+                       Available: preflight | rust | pipeline | ui | state | animation
+    --loops N          Run the entire suite N times (default: 1)
+    --until-pass       Stop looping early the moment all tests pass (use with --loops)
+    --vite             Start Vite dev server on :5173 instead of Tauri on :1420
+    --no-server        Skip server lifecycle — assume it is already running
+    --verbose, -v      Print full output even for passing tests
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+HOW TO ADD MORE TESTS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. ADD A NEW .cjs SMOKE TEST
+   Drop your .cjs file in tests/smoke/, then register it in SMOKE_TESTS below:
+
+       ("my-test.cjs", "ui", "Human-readable description", {
+           "retry":        2,     # re-run up to N times on failure (0 = no retry)
+           "timeout_s":   60,     # kill the process if it exceeds this many seconds
+           "needs_server": True,  # False for tests that call external APIs directly
+       }),
+
+   Suite names: preflight | rust | pipeline | ui | state | animation
+   To create a new group, add its name to SUITE_ORDER then tag tests with it.
+
+2. ADD A PYTHON-NATIVE TEST
+   Subclass PythonTest, implement run(), and append to PYTHON_TESTS:
+
+       class MyCheck(PythonTest):
+           name         = "My custom check"
+           suite        = "ui"       # group this appears in
+           retry        = 1
+           timeout_s    = 30
+           needs_server = True       # set False if the check needs no dev server
+
+           def run(self) -> "TestResult":
+               ok  = some_condition()
+               msg = "all good" if ok else "expected X, got Y"
+               return TestResult(passed=ok, output=msg)
+
+       PYTHON_TESTS.append(MyCheck())
+
+   Python tests in a suite always run before Node.js tests in that suite,
+   so they act as fast pre-checks (e.g. AudioFixtureCheck runs before the
+   Node pipeline test to surface a missing WAV file immediately).
+
+3. ADD A NEW SUITE
+   Insert the new name into SUITE_ORDER at the position you want it to run:
+
+       SUITE_ORDER = ["preflight", "rust", "pipeline", "ui", "state", "animation", "mygroup"]
+
+   Tag any test with suite="mygroup" and it will appear grouped under [mygroup].
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"""
+
+import argparse
+import atexit
+import concurrent.futures
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import threading
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Force UTF-8 output on Windows so box-drawing and tick characters render correctly.
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+# ═══ PATHS ════════════════════════════════════════════════════════════════════
+
+ROOT       = Path(__file__).parent.parent.resolve()
+SMOKE_DIR  = Path(__file__).parent / "smoke"
+AUDIO_WAV  = SMOKE_DIR / "smoke_test.wav"
+CARGO_TOML = ROOT / "src-tauri" / "Cargo.toml"
+
+# ═══ PORTS ════════════════════════════════════════════════════════════════════
+
+PORT_TAURI = 1420
+PORT_VITE  = 5173
+
+# Set in main() so _exec_node can read it without passing port through every call.
+_active_test_url: str = f"http://localhost:{PORT_TAURI}"
+PARALLEL_SAFE_SUITES = {"ui", "animation"}
+_PRINT_LOCK = threading.Lock()
+
+# ═══ SUITE ORDER ══════════════════════════════════════════════════════════════
+# Controls the display order. Tests in unlisted suites appear at the end.
+
+SUITE_ORDER = ["preflight", "rust", "pipeline", "ui", "state", "animation"]
+
+# ═══ SMOKE TEST REGISTRY ══════════════════════════════════════════════════════
+# Format: (filename, suite, description, options)
+# Filenames are relative to tests/smoke/. Missing files are silently skipped.
+
+SMOKE_TESTS = [
+    # ── SUITE: ui ─────────────────────────────────────────────────────────────
+    ("test.cjs",                         "ui",        "App mount & DOM structure",        {"retry": 1, "timeout_s": 45}),
+    ("playwright-test-ui.cjs",           "ui",        "Navigation & interaction",         {"retry": 2, "timeout_s": 90}),
+    ("playwright-test-fixes.cjs",        "ui",        "Element contract assertions",      {"retry": 1, "timeout_s": 45}),
+    ("test-app.cjs",                     "ui",        "App mappings flow",                {"retry": 2, "timeout_s": 90}),
+    ("test-dictionary-ui.cjs",           "ui",        "Dictionary UI interaction",        {"retry": 2, "timeout_s": 90}),
+
+    # ── SUITE: state ──────────────────────────────────────────────────────────
+    ("playwright-test-state.cjs",        "state",     "Settings state persistence",       {"retry": 2, "timeout_s": 90}),
+    ("playwright-test-appearance.cjs",   "state",     "Appearance mode persistence",      {"retry": 2, "timeout_s": 90}),
+    ("playwright-test-devmode.cjs",      "state",     "Developer mode unlock",            {"retry": 1, "timeout_s": 45}),
+
+    # ── SUITE: pipeline (no browser required) ─────────────────────────────────
+    ("playwright-test-pipeline.cjs",     "pipeline",  "API pipeline (smoke_test.wav)",    {"retry": 1, "timeout_s": 120, "needs_server": False}),
+
+    # ── SUITE: animation ──────────────────────────────────────────────────────
+    ("test-all-dropdown-animations.cjs", "animation", "All dropdown width animations",    {"retry": 3, "timeout_s": 90}),
+    ("test-animation-full.cjs",          "animation", "Mic dropdown animation (full)",    {"retry": 2, "timeout_s": 45}),
+    ("test-mic-dropdown-animation.cjs",  "animation", "Mic dropdown animation (smoke)",   {"retry": 2, "timeout_s": 45}),
+]
+
+# ═══ DATA CLASSES ═════════════════════════════════════════════════════════════
+
+@dataclass
+class TestResult:
+    passed:   bool
+    output:   str   = ""
+    duration: float = 0.0
+    attempts: int   = 1
+
+
+@dataclass
+class TestEntry:
+    script:       Optional[str]    # .cjs filename, or None for Python tests
+    suite:        str
+    desc:         str
+    retry:        int  = 1
+    timeout_s:    int  = 60
+    needs_server: bool = True
+    py_test:      object = None    # PythonTest instance
+
+# ═══ PYTHON TEST BASE ═════════════════════════════════════════════════════════
+
+
+class PythonTest:
+    """Subclass this to add a native Python test. See module docstring."""
+    name:         str  = "Unnamed"
+    suite:        str  = "preflight"
+    retry:        int  = 1
+    timeout_s:    int  = 30
+    needs_server: bool = False
+
+    def run(self) -> TestResult:
+        raise NotImplementedError
+
+# ═══ PYTHON TEST IMPLEMENTATIONS ══════════════════════════════════════════════
+
+
+class EnvCheck(PythonTest):
+    """Verifies node, cargo, node_modules, and the audio fixture are all present."""
+    name  = "Environment check"
+    suite = "preflight"
+
+    def run(self) -> TestResult:
+        t0     = time.monotonic()
+        issues = []
+
+        r_node = subprocess.run(["node", "--version"], capture_output=True, text=True)
+        if r_node.returncode != 0:
+            issues.append("node not found — install Node.js 18+")
+
+        if not (ROOT / "node_modules").is_dir():
+            issues.append("node_modules missing — run: npm install")
+
+        if not (ROOT / "node_modules" / "playwright").is_dir():
+            issues.append("playwright package missing — run: npm install")
+
+        r_cargo = subprocess.run(["cargo", "--version"], capture_output=True, text=True)
+        if r_cargo.returncode != 0:
+            issues.append("cargo not found — install Rust toolchain from rustup.rs")
+
+        if not AUDIO_WAV.exists():
+            issues.append(f"smoke_test.wav missing at {AUDIO_WAV}")
+
+        if issues:
+            return TestResult(False, "\n".join(f"  {i}" for i in issues), time.monotonic() - t0)
+
+        size_mb   = AUDIO_WAV.stat().st_size / 1_048_576
+        node_ver  = r_node.stdout.strip()
+        cargo_ver = r_cargo.stdout.strip().split()[1] if r_cargo.stdout else "?"
+        out = f"node {node_ver} · cargo {cargo_ver} · smoke_test.wav {size_mb:.1f} MB"
+        return TestResult(True, out, time.monotonic() - t0)
+
+
+class AudioFixtureCheck(PythonTest):
+    """Verifies smoke_test.wav exists, is large enough, and has a valid RIFF/WAVE header."""
+    name  = "Audio fixture (smoke_test.wav)"
+    suite = "pipeline"
+
+    def run(self) -> TestResult:
+        t0 = time.monotonic()
+        if not AUDIO_WAV.exists():
+            return TestResult(False, f"Not found at {AUDIO_WAV}", time.monotonic() - t0)
+
+        size = AUDIO_WAV.stat().st_size
+        if size < 5_000:
+            return TestResult(False, f"Only {size} bytes — file is likely corrupt", time.monotonic() - t0)
+
+        with open(AUDIO_WAV, "rb") as f:
+            header = f.read(12)
+        if header[:4] != b"RIFF" or header[8:12] != b"WAVE":
+            return TestResult(False, "Invalid RIFF/WAVE header", time.monotonic() - t0)
+
+        return TestResult(True, f"{size / 1_048_576:.2f} MB · RIFF/WAVE header OK", time.monotonic() - t0)
+
+
+class RustTestSuite(PythonTest):
+    """Runs the full Rust test suite via cargo and reports per-test failures by name."""
+    name      = "Rust unit tests"
+    suite     = "rust"
+    retry     = 1
+    timeout_s = 300
+
+    def run(self) -> TestResult:
+        t0 = time.monotonic()
+        try:
+            r = subprocess.run(
+                ["cargo", "test", "--manifest-path", str(CARGO_TOML)],
+                capture_output=True, text=True, cwd=ROOT, timeout=self.timeout_s,
+            )
+        except subprocess.TimeoutExpired:
+            return TestResult(False, f"Timed out after {self.timeout_s}s", time.monotonic() - t0)
+
+        output = r.stdout + r.stderr
+
+        m = re.search(r"test result: (\w+)\. (\d+) passed; (\d+) failed", output)
+        if m:
+            ok     = m.group(1) == "ok" and int(m.group(3)) == 0
+            n_pass = int(m.group(2))
+            n_fail = int(m.group(3))
+            summary = f"{n_pass} passed, {n_fail} failed"
+            if not ok:
+                fails = re.findall(r"FAILED\s+(\S+)", output)
+                if fails:
+                    summary += "\n  Failed: " + ", ".join(fails[:15])
+                summary += "\n\n" + output[-2000:]
+        else:
+            ok      = r.returncode == 0
+            summary = "Tests completed" if ok else output[-1500:]
+
+        return TestResult(ok, summary, time.monotonic() - t0)
+
+
+# ═══ PYTHON TEST LIST ═════════════════════════════════════════════════════════
+# Python tests run before Node.js tests in the same suite (stable sort).
+# Append new PythonTest instances here.
+
+PYTHON_TESTS: List[PythonTest] = [
+    EnvCheck(),
+    AudioFixtureCheck(),
+    RustTestSuite(),
+]
+
+# ═══ COLORS ═══════════════════════════════════════════════════════════════════
+
+_USE_COLOR: bool = sys.stdout.isatty()
+
+if _USE_COLOR and sys.platform == "win32":
+    # Enable VT100 processing in Windows Console Host / PowerShell
+    try:
+        import ctypes
+        ctypes.windll.kernel32.SetConsoleMode(ctypes.windll.kernel32.GetStdHandle(-11), 7)
+    except Exception:
+        _USE_COLOR = False
+
+
+def _c(code: str, t: str) -> str:
+    return f"\033[{code}m{t}\033[0m" if _USE_COLOR else t
+
+
+def green(t: str)  -> str: return _c("32", t)
+def red(t: str)    -> str: return _c("31", t)
+def yellow(t: str) -> str: return _c("33", t)
+def bold(t: str)   -> str: return _c("1",  t)
+def dim(t: str)    -> str: return _c("2",  t)
+def cyan(t: str)   -> str: return _c("36", t)
+
+
+PASS_  = green("✓")  if _USE_COLOR else "PASS"
+FAIL_  = red("✗")    if _USE_COLOR else "FAIL"
+RETRY_ = yellow("↻") if _USE_COLOR else ".."
+BAR    = "━" * 62
+
+# ═══ SERVER MANAGER ═══════════════════════════════════════════════════════════
+
+
+class ServerManager:
+    """Manages the lifecycle of the Tauri or Vite dev server."""
+
+    def __init__(self) -> None:
+        self._proc: Optional[subprocess.Popen] = None
+        self._port: Optional[int] = None
+        atexit.register(self.stop)
+
+    def is_port_open(self, port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            try:
+                s.connect(("127.0.0.1", port))
+                return True
+            except (socket.timeout, ConnectionRefusedError, OSError):
+                return False
+
+    def is_http_ready(self, port: int, timeout_s: float = 1.5) -> bool:
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}", timeout=timeout_s):
+                return True
+        except Exception:
+            return False
+
+    def start(self, mode: str) -> bool:
+        """Start the dev server if not already running. Returns True on success."""
+        port = PORT_TAURI if mode == "tauri" else PORT_VITE
+
+        if self.is_port_open(port) and self.is_http_ready(port):
+            self._port = port
+            return True  # already running — nothing to start
+
+        if mode == "tauri":
+            print(f"    {dim('note: first Tauri run compiles Rust — this can take several minutes')}")
+        print(f"    starting {mode} dev server on :{port} ...", end=" ", flush=True)
+
+        # On Windows use shell=True so "npm run tauri dev" works as documented.
+        # CREATE_NEW_PROCESS_GROUP lets taskkill /T kill the entire tree later.
+        if sys.platform == "win32":
+            cmd_str = "npm run tauri dev" if mode == "tauri" else "npm run dev"
+            self._proc = subprocess.Popen(
+                cmd_str, shell=True, cwd=ROOT,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
+        else:
+            import os as _os
+            cmd_list = ["npm", "run", "tauri", "dev"] if mode == "tauri" else ["npm", "run", "dev"]
+            self._proc = subprocess.Popen(
+                cmd_list, cwd=ROOT,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                preexec_fn=_os.setsid,
+            )
+
+        self._port = port
+        if self._wait_for_http(port, timeout=180):
+            print(green("ready"))
+            return True
+
+        print(red("timed out"))
+        self.stop()
+        return False
+
+    def stop(self) -> None:
+        """Kill the dev server process tree."""
+        if self._proc is None:
+            return
+        try:
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(self._proc.pid)],
+                    capture_output=True,
+                )
+            else:
+                import os as _os, signal as _sig
+                _os.killpg(_os.getpgid(self._proc.pid), _sig.SIGTERM)
+            self._proc.wait(timeout=10)
+        except Exception:
+            try:
+                self._proc.kill()
+            except Exception:
+                pass
+        self._proc = None
+
+    def _wait_for_port(self, port: int, timeout: int) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.is_port_open(port):
+                return True
+            time.sleep(0.5)
+        return False
+
+    def _wait_for_http(self, port: int, timeout: int) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.is_http_ready(port):
+                return True
+            time.sleep(0.5)
+        return False
+
+
+def _kill_port_owner(port: int) -> bool:
+    """Best-effort kill of the listener process on a port (Windows only)."""
+    if sys.platform != "win32":
+        return False
+    cmd = (
+        "try { "
+        f"$p = Get-NetTCPConnection -LocalPort {port} -State Listen | Select-Object -First 1 -ExpandProperty OwningProcess; "
+        "if ($p) { Stop-Process -Id $p -Force; Write-Output 'killed'; } "
+        "} catch {}"
+    )
+    r = subprocess.run(["powershell", "-NoProfile", "-Command", cmd], capture_output=True, text=True)
+    return "killed" in (r.stdout or "")
+
+# ═══ TEST EXECUTION ═══════════════════════════════════════════════════════════
+
+
+def _exec_node(entry: TestEntry) -> TestResult:
+    t0 = time.monotonic()
+    # Pass TEST_URL so tests like test-dictionary-ui.cjs that default to :5173
+    # connect to whichever server OnePyFone actually started.
+    env = {**os.environ, "TEST_URL": _active_test_url}
+    try:
+        r = subprocess.run(
+            ["node", str(SMOKE_DIR / entry.script)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=ROOT, timeout=entry.timeout_s, env=env,
+        )
+        return TestResult(r.returncode == 0, (r.stdout + r.stderr).strip(), time.monotonic() - t0)
+    except subprocess.TimeoutExpired:
+        return TestResult(False, f"Timed out after {entry.timeout_s}s", time.monotonic() - t0)
+    except FileNotFoundError:
+        return TestResult(False, "node executable not found in PATH", time.monotonic() - t0)
+
+
+def _exec_python(entry: TestEntry) -> TestResult:
+    try:
+        return entry.py_test.run()
+    except Exception as exc:
+        return TestResult(False, f"Unhandled exception: {exc}")
+
+
+def _run_one(entry: TestEntry) -> TestResult:
+    return _exec_python(entry) if entry.py_test is not None else _exec_node(entry)
+
+
+def run_with_retry(entry: TestEntry, idx: int, total: int) -> TestResult:
+    """Run a test, retrying on failure up to entry.retry times."""
+    result = TestResult(False)
+    for attempt in range(1, entry.retry + 2):
+        stop_heartbeat = threading.Event()
+        start_t = time.monotonic()
+
+        def _heartbeat() -> None:
+            while not stop_heartbeat.wait(1.0):
+                elapsed_s = int(time.monotonic() - start_t)
+                with _PRINT_LOCK:
+                    _show_running_elapsed(entry.desc, idx, total, elapsed_s)
+
+        with _PRINT_LOCK:
+            _show_running(entry.desc, idx, total)
+        heartbeat_t = threading.Thread(target=_heartbeat, daemon=True)
+        heartbeat_t.start()
+        try:
+            result = _run_one(entry)
+        finally:
+            stop_heartbeat.set()
+            heartbeat_t.join(timeout=0.2)
+        result.attempts = attempt
+        if result.passed or attempt > entry.retry:
+            return result
+        with _PRINT_LOCK:
+            _print_retry_line(entry.desc, attempt, entry.retry, idx, total)
+        time.sleep(2)
+    return result  # unreachable; satisfies type checker
+
+# ═══ ENTRY BUILDER ════════════════════════════════════════════════════════════
+
+
+def _build_entries(suites: List[str]) -> List[TestEntry]:
+    """Build an ordered list of TestEntry objects for the requested suites."""
+    suite_set = set(suites)
+    order     = {s: i for i, s in enumerate(SUITE_ORDER)}
+    entries: List[TestEntry] = []
+
+    # Python tests first so they precede Node tests within the same suite.
+    for pt in PYTHON_TESTS:
+        if pt.suite in suite_set:
+            entries.append(TestEntry(
+                script=None, suite=pt.suite, desc=pt.name,
+                retry=pt.retry, timeout_s=pt.timeout_s,
+                needs_server=pt.needs_server, py_test=pt,
+            ))
+
+    # Node.js smoke tests.
+    for (script, suite, desc, opts) in SMOKE_TESTS:
+        if suite not in suite_set:
+            continue
+        path = SMOKE_DIR / script
+        if not path.exists():
+            continue
+        entries.append(TestEntry(
+            script=script, suite=suite, desc=desc,
+            retry=opts.get("retry", 1),
+            timeout_s=opts.get("timeout_s", 60),
+            needs_server=opts.get("needs_server", True),
+        ))
+
+    # Stable sort preserves Python-before-Node ordering within each suite.
+    entries.sort(key=lambda e: order.get(e.suite, 99))
+    return entries
+
+# ═══ REPORTER ═════════════════════════════════════════════════════════════════
+
+
+def _print_banner(loop: int, loops: int, suites: List[str], server_label: str) -> None:
+    print()
+    print(bold(BAR))
+    print(f"  {bold('Open Flow')} {dim('·')} {cyan('OnePyFone')} {dim('unified test runner')}")
+    loop_label = f"loop {loop}/{loops}" if loops > 1 else "single run"
+    print(f"  {dim(loop_label)}  ·  suites: {', '.join(suites)}  ·  {dim(server_label)}")
+    print(bold(BAR))
+
+
+def _prog(idx: int, total: int) -> str:
+    """Dimmed [N/T] progress tag."""
+    return dim(f"[{idx:2}/{total}]")
+
+
+def _show_running(desc: str, idx: int, total: int) -> None:
+    """Print a 'running' placeholder that the result line will overwrite."""
+    if not _USE_COLOR:
+        return
+    arrow = dim("▶")
+    print(f"\033[2K\r    {_prog(idx, total)}  {arrow}  {desc}", end="", flush=True)
+
+
+def _show_running_elapsed(desc: str, idx: int, total: int, elapsed_s: int) -> None:
+    """Refresh the running placeholder with elapsed seconds."""
+    if not _USE_COLOR:
+        return
+    arrow = dim("▶")
+    elapsed = dim(f"{elapsed_s}s")
+    print(f"\033[2K\r    {_prog(idx, total)}  {arrow}  {desc}  {elapsed}", end="", flush=True)
+
+
+def _clear_running() -> None:
+    """Erase the running placeholder before printing a permanent line."""
+    if _USE_COLOR:
+        print("\033[2K\r", end="", flush=True)
+
+
+def _print_suite_header(suite: str) -> None:
+    print(f"\n  {dim('[' + suite + ']')}")
+
+
+def _draw_bottom_bar(done: int, total: int, n_fail: int) -> None:
+    """Render the persistent bottom progress bar (no trailing newline so it's overwriteable)."""
+    if not _USE_COLOR:
+        return
+    pct    = int(done / total * 100) if total else 0
+    filled = int(done / total * 26) if total else 0
+    bar    = "█" * filled + "░" * (26 - filled)
+    counts = f"{done}/{total}"
+    if n_fail:
+        badge = red(f"  {n_fail} failed")
+    elif done > 0:
+        badge = green("  passing")
+    else:
+        badge = ""
+    print(f"\n  {dim(bar)}  {dim(counts)}  {dim(str(pct) + '%')}{badge}", end="", flush=True)
+
+
+def _print_result_line(desc: str, result: TestResult, verbose: bool, idx: int, total: int) -> None:
+    _clear_running()
+    mark = PASS_ if result.passed else FAIL_
+    dur  = dim(f"{result.duration:.1f}s")
+    print(f"    {_prog(idx, total)}  {mark}  {desc:<45} {dur}")
+    if verbose or not result.passed:
+        for line in result.output.splitlines():
+            print(f"               {dim(line)}")
+
+
+def _print_retry_line(desc: str, attempt: int, max_retries: int, idx: int, total: int) -> None:
+    _clear_running()
+    print(f"    {_prog(idx, total)}  {FAIL_}  {desc:<45} {yellow(f'(retry {attempt}/{max_retries})')}")
+
+
+def _print_summary(results: Dict[str, TestResult], elapsed: float) -> int:
+    n_pass  = sum(1 for r in results.values() if r.passed)
+    n_total = len(results)
+    n_fail  = n_total - n_pass
+    print()
+    print(bold(BAR))
+    if n_fail == 0:
+        mark   = green("✓") if _USE_COLOR else "PASS"
+        status = bold(green("ALL TESTS PASSED")) if _USE_COLOR else "ALL TESTS PASSED"
+        print(f"  {mark}  {status}  ·  {n_pass}/{n_total}  ·  {_fmt_time(elapsed)}")
+    else:
+        mark   = red("✗") if _USE_COLOR else "FAIL"
+        status = bold(red(f"{n_fail} TEST{'S' if n_fail > 1 else ''} FAILED")) if _USE_COLOR else f"{n_fail} FAILED"
+        print(f"  {mark}  {status}  ·  {n_pass}/{n_total} passed  ·  {_fmt_time(elapsed)}")
+    print(bold(BAR))
+    print()
+    return 0 if n_fail == 0 else 1
+
+
+def _print_loop_table(summaries: List[Dict[str, TestResult]]) -> None:
+    n     = len(summaries)
+    names = list(summaries[0].keys())
+    print(f"\n  {bold(f'Loop results ({n} runs):')}")
+    print(f"  {'Test':<49} {'Pass':>5}  Flaky")
+    print(f"  {'─' * 62}")
+    any_flaky = False
+    for name in names:
+        passes = sum(1 for s in summaries if s.get(name, TestResult(False)).passed)
+        flaky  = 0 < passes < n
+        any_flaky = any_flaky or flaky
+        flag = yellow("Yes ←") if flaky else dim("No")
+        print(f"  {name:<49} {passes}/{n}   {flag}")
+    total      = len(names) * n
+    total_pass = sum(sum(1 for r in s.values() if r.passed) for s in summaries)
+    suffix     = f"  {yellow('Flaky tests detected.')}" if any_flaky else ""
+    print()
+    print(bold(f"  {total_pass}/{total} passed across {n} loops.{suffix}"))
+    print()
+
+
+def _fmt_time(secs: float) -> str:
+    m = int(secs // 60)
+    s = int(secs % 60)
+    return f"{m}m {s:02d}s" if m else f"{s:.1f}s"
+
+# ═══ LOOP RUNNER ══════════════════════════════════════════════════════════════
+
+
+def _run_sequential(entries: List[TestEntry], verbose: bool, start_idx: int, total: int) -> Dict[str, TestResult]:
+    results: Dict[str, TestResult] = {}
+    n_fail = 0
+    for offset, entry in enumerate(entries):
+        idx = start_idx + offset
+        result = run_with_retry(entry, idx, total)
+        with _PRINT_LOCK:
+            _print_result_line(entry.desc, result, verbose, idx, total)
+        if not result.passed:
+            n_fail += 1
+        results[entry.desc] = result
+        with _PRINT_LOCK:
+            _draw_bottom_bar(idx, total, n_fail)
+    return results
+
+
+def _run_parallel(entries: List[TestEntry], verbose: bool, start_idx: int, total: int, workers: int) -> Dict[str, TestResult]:
+    results: Dict[str, TestResult] = {}
+    n_fail = 0
+    indexed = [(start_idx + i, e) for i, e in enumerate(entries)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        future_map = {
+            pool.submit(run_with_retry, entry, idx, total): (idx, entry.desc)
+            for idx, entry in indexed
+        }
+        for future in concurrent.futures.as_completed(future_map):
+            idx, desc = future_map[future]
+            result = future.result()
+            with _PRINT_LOCK:
+                _print_result_line(desc, result, verbose, idx, total)
+            if not result.passed:
+                n_fail += 1
+            results[desc] = result
+            done = len(results)
+            with _PRINT_LOCK:
+                _draw_bottom_bar(start_idx + done - 1, total, n_fail)
+    return results
+
+
+def _run_loop(entries: List[TestEntry], verbose: bool, parallel: bool, workers: int) -> Dict[str, TestResult]:
+    results: Dict[str, TestResult] = {}
+    total = len(entries)
+    by_suite: Dict[str, List[TestEntry]] = {}
+    for entry in entries:
+        by_suite.setdefault(entry.suite, []).append(entry)
+
+    start_idx = 1
+    for suite in [s for s in SUITE_ORDER if s in by_suite]:
+        suite_entries = by_suite[suite]
+        with _PRINT_LOCK:
+            _print_suite_header(suite)
+        run_parallel = parallel and workers > 1 and suite in PARALLEL_SAFE_SUITES and len(suite_entries) > 1
+        suite_results = (
+            _run_parallel(suite_entries, verbose, start_idx, total, workers)
+            if run_parallel else
+            _run_sequential(suite_entries, verbose, start_idx, total)
+        )
+        results.update(suite_results)
+        start_idx += len(suite_entries)
+
+    if total > 0 and _USE_COLOR:
+        with _PRINT_LOCK:
+            print()
+    return results
+
+# ═══ MAIN ═════════════════════════════════════════════════════════════════════
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="OnePyFone",
+        description="Open Flow unified test runner — stdlib only, no pip",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Suites: preflight | rust | pipeline | ui | state | animation | all",
+    )
+    ap.add_argument("--suite",      default="all", metavar="SUITE",
+                    help="Suite(s) to run, comma-separated or 'all'")
+    ap.add_argument("--loops",      type=int, default=1, metavar="N",
+                    help="Run N times (flakiness detection)")
+    ap.add_argument("--until-pass", action="store_true",
+                    help="Stop looping early when all tests pass (use with --loops)")
+    ap.add_argument("--vite",       action="store_true",
+                    help="Use Vite dev server on :5173 instead of Tauri on :1420")
+    ap.add_argument("--no-server",  action="store_true",
+                    help="Skip server lifecycle — assume it is already running")
+    ap.add_argument("--verbose", "-v", action="store_true",
+                    help="Show full output even for passing tests")
+    ap.add_argument("--parallel", action="store_true",
+                    help="Run parallel-safe suites (ui/animation) concurrently")
+    ap.add_argument("--workers", type=int, default=4, metavar="N",
+                    help="Max worker threads for --parallel (default: 4)")
+    ap.add_argument("--fresh-server", action="store_true",
+                    help="Kill any existing listener on the test port before starting server")
+    args = ap.parse_args()
+
+    suites = list(SUITE_ORDER) if args.suite == "all" else [
+        s.strip() for s in args.suite.split(",") if s.strip()
+    ]
+
+    entries = _build_entries(suites)
+    if not entries:
+        print(red("No tests match the requested suite(s)."))
+        return 1
+
+    server_mode  = "vite" if args.vite else "tauri"
+    port         = PORT_VITE if args.vite else PORT_TAURI
+    needs_server = any(e.needs_server for e in entries)
+
+    # Tell _exec_node which URL to hand to tests that take TEST_URL (e.g. test-dictionary-ui.cjs).
+    global _active_test_url
+    _active_test_url = f"http://localhost:{port}"
+
+    server = ServerManager()
+
+    if needs_server and not args.no_server:
+        print(f"\n  {bold('Server')}")
+        if args.fresh_server and _kill_port_owner(port):
+            print(f"    {dim(f'killed existing process on :{port}')}")
+            time.sleep(0.5)
+        if server.is_port_open(port):
+            if server.is_http_ready(port):
+                print(f"    {PASS_}  {server_mode} already running on :{port}")
+            else:
+                print(f"    {yellow('!')}  port :{port} is open but HTTP is not ready, restarting...")
+                _kill_port_owner(port)
+                if not server.start(server_mode):
+                    print(red(f"\n  Could not start {server_mode} dev server."))
+                    return 1
+        elif not server.start(server_mode):
+            print(red(f"\n  Could not start {server_mode} dev server."))
+            print(  f"  • Is npm installed and are node_modules present?")
+            print(  f"  • Use --no-server if the server is already running elsewhere.")
+            print(  f"  • Use --suite rust or --suite pipeline to run without a server.")
+            return 1
+
+    loops      = max(1, args.loops)
+    summaries: List[Dict[str, TestResult]] = []
+    final_exit = 0
+
+    try:
+        for loop in range(1, loops + 1):
+            server_label = f"{server_mode} :{port}" if needs_server else "no server"
+            _print_banner(loop, loops, suites, server_label)
+            t0      = time.monotonic()
+            workers = max(1, args.workers)
+            results = _run_loop(entries, args.verbose, args.parallel, workers)
+            code    = _print_summary(results, time.monotonic() - t0)
+            summaries.append(results)
+            if code != 0:
+                final_exit = 1
+            if args.until_pass and code == 0:
+                if loops > 1:
+                    print(green("  All tests passed — stopping early."))
+                break
+    finally:
+        if needs_server and not args.no_server:
+            server.stop()
+
+    if len(summaries) > 1:
+        _print_loop_table(summaries)
+
+    # Pause so the window stays open when launched by double-clicking.
+    if sys.stdin.isatty():
+        try:
+            input(f"  {'Press Enter to close...'}\n")
+        except (EOFError, KeyboardInterrupt):
+            pass
+
+    return final_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -352,21 +352,24 @@ class ServerManager:
 
         # On Windows use shell=True so "npm run tauri dev" works as documented.
         # CREATE_NEW_PROCESS_GROUP lets taskkill /T kill the entire tree later.
-        if sys.platform == "win32":
-            cmd_str = "npm run tauri dev" if mode == "tauri" else "npm run dev"
-            self._proc = subprocess.Popen(
-                cmd_str, shell=True, cwd=ROOT,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-            )
-        else:
-            import os as _os
-            cmd_list = ["npm", "run", "tauri", "dev"] if mode == "tauri" else ["npm", "run", "dev"]
-            self._proc = subprocess.Popen(
-                cmd_list, cwd=ROOT,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                preexec_fn=_os.setsid,
-            )
+        try:
+            if sys.platform == "win32":
+                cmd_str = "npm run tauri dev" if mode == "tauri" else "npm run dev"
+                self._proc = subprocess.Popen(
+                    cmd_str, shell=True, cwd=ROOT,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                )
+            else:
+                import os as _os
+                cmd_list = ["npm", "run", "tauri", "dev"] if mode == "tauri" else ["npm", "run", "dev"]
+                self._proc = subprocess.Popen(
+                    cmd_list, cwd=ROOT,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    preexec_fn=_os.setsid,
+                )
+        except FileNotFoundError:
+            return False
 
         self._port = port
         if self._wait_for_http(port, timeout=180):

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -182,9 +182,12 @@ class EnvCheck(PythonTest):
         t0     = time.monotonic()
         issues = []
 
-        r_node = subprocess.run(["node", "--version"], capture_output=True, text=True)
-        if r_node.returncode != 0:
-            issues.append("node not found — install Node.js 18+")
+        try:
+            r_node = subprocess.run(["node", "--version"], capture_output=True, text=True)
+            if r_node.returncode != 0:
+                issues.append("node not found — install Node.js 18+")
+        except FileNotFoundError:
+            issues.append("node executable not found in PATH")
 
         if not (ROOT / "node_modules").is_dir():
             issues.append("node_modules missing — run: npm install")

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -457,7 +457,7 @@ def _run_one(entry: TestEntry) -> TestResult:
     return _exec_python(entry) if entry.py_test is not None else _exec_node(entry)
 
 
-def run_with_retry(entry: TestEntry, idx: int, total: int) -> TestResult:
+def run_with_retry(entry: TestEntry, idx: int, total: int, show_elapsed: bool = True) -> TestResult:
     """Run a test, retrying on failure up to entry.retry times."""
     result = TestResult(False)
     for attempt in range(1, entry.retry + 2):
@@ -472,13 +472,16 @@ def run_with_retry(entry: TestEntry, idx: int, total: int) -> TestResult:
 
         with _PRINT_LOCK:
             _show_running(entry.desc, idx, total)
-        heartbeat_t = threading.Thread(target=_heartbeat, daemon=True)
-        heartbeat_t.start()
+        heartbeat_t = None
+        if show_elapsed:
+            heartbeat_t = threading.Thread(target=_heartbeat, daemon=True)
+            heartbeat_t.start()
         try:
             result = _run_one(entry)
         finally:
             stop_heartbeat.set()
-            heartbeat_t.join(timeout=0.2)
+            if heartbeat_t is not None:
+                heartbeat_t.join(timeout=0.2)
         result.attempts = attempt
         if result.passed or attempt > entry.retry:
             return result
@@ -652,7 +655,7 @@ def _run_sequential(entries: List[TestEntry], verbose: bool, start_idx: int, tot
     n_fail = 0
     for offset, entry in enumerate(entries):
         idx = start_idx + offset
-        result = run_with_retry(entry, idx, total)
+        result = run_with_retry(entry, idx, total, show_elapsed=True)
         with _PRINT_LOCK:
             _print_result_line(entry.desc, result, verbose, idx, total)
         if not result.passed:
@@ -669,7 +672,7 @@ def _run_parallel(entries: List[TestEntry], verbose: bool, start_idx: int, total
     indexed = [(start_idx + i, e) for i, e in enumerate(entries)]
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
         future_map = {
-            pool.submit(run_with_retry, entry, idx, total): (idx, entry.desc)
+            pool.submit(run_with_retry, entry, idx, total, False): (idx, entry.desc)
             for idx, entry in indexed
         }
         for future in concurrent.futures.as_completed(future_map):

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -70,6 +70,7 @@ import atexit
 import concurrent.futures
 import os
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -435,9 +436,36 @@ def _kill_port_owner(port: int) -> bool:
     )
     try:
         r = subprocess.run(["powershell", "-NoProfile", "-Command", cmd], capture_output=True, text=True)
-        return "killed" in (r.stdout or "")
     except FileNotFoundError:
         return False
+    return "killed" in (r.stdout or "")
+
+
+def _cleanup_test_artifacts() -> int:
+    """Delete screenshot artifacts produced by smoke tests. Returns removed count."""
+    removed = 0
+    roots = [ROOT, SMOKE_DIR]
+    file_patterns = ["screenshot*.png", "tmp-*.png"]
+    dir_names = {"tmp-screenshots"}
+
+    for root in roots:
+        for pattern in file_patterns:
+            for p in root.glob(pattern):
+                if p.is_file():
+                    try:
+                        p.unlink()
+                        removed += 1
+                    except OSError:
+                        pass
+        for name in dir_names:
+            d = root / name
+            if d.is_dir():
+                try:
+                    shutil.rmtree(d)
+                    removed += 1
+                except OSError:
+                    pass
+    return removed
 
 # ═══ TEST EXECUTION ═══════════════════════════════════════════════════════════
 
@@ -757,6 +785,8 @@ def main() -> int:
                     help="Max worker threads for --parallel (default: 4)")
     ap.add_argument("--fresh-server", action="store_true",
                     help="Kill any existing listener on the test port before starting server")
+    ap.add_argument("--keep-artifacts", action="store_true",
+                    help="Keep screenshots and temp screenshot folders after run")
     args = ap.parse_args()
 
     suites = list(SUITE_ORDER) if args.suite == "all" else [
@@ -821,6 +851,10 @@ def main() -> int:
     finally:
         if needs_server and not args.no_server:
             server.stop()
+        if not args.keep_artifacts:
+            removed = _cleanup_test_artifacts()
+            if removed > 0:
+                print(dim(f"  cleaned {removed} test artifact(s)"))
 
     if len(summaries) > 1:
         _print_loop_table(summaries)

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -247,12 +247,15 @@ class RustTestSuite(PythonTest):
     def run(self) -> TestResult:
         t0 = time.monotonic()
         try:
+        try:
             r = subprocess.run(
                 ["cargo", "test", "--manifest-path", str(CARGO_TOML)],
                 capture_output=True, text=True, cwd=ROOT, timeout=self.timeout_s,
             )
         except subprocess.TimeoutExpired:
             return TestResult(False, f"Timed out after {self.timeout_s}s", time.monotonic() - t0)
+        except FileNotFoundError:
+            return TestResult(False, "cargo executable not found in PATH", time.monotonic() - t0)
 
         output = r.stdout + r.stderr
 

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -195,9 +195,12 @@ class EnvCheck(PythonTest):
         if not (ROOT / "node_modules" / "playwright").is_dir():
             issues.append("playwright package missing — run: npm install")
 
-        r_cargo = subprocess.run(["cargo", "--version"], capture_output=True, text=True)
-        if r_cargo.returncode != 0:
-            issues.append("cargo not found — install Rust toolchain from rustup.rs")
+        try:
+            r_cargo = subprocess.run(["cargo", "--version"], capture_output=True, text=True)
+            if r_cargo.returncode != 0:
+                issues.append("cargo not found — install Rust toolchain from rustup.rs")
+        except FileNotFoundError:
+            issues.append("cargo executable not found in PATH")
 
         if not AUDIO_WAV.exists():
             issues.append(f"smoke_test.wav missing at {AUDIO_WAV}")

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -247,7 +247,6 @@ class RustTestSuite(PythonTest):
     def run(self) -> TestResult:
         t0 = time.monotonic()
         try:
-        try:
             r = subprocess.run(
                 ["cargo", "test", "--manifest-path", str(CARGO_TOML)],
                 capture_output=True, text=True, cwd=ROOT, timeout=self.timeout_s,

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -425,8 +425,11 @@ def _kill_port_owner(port: int) -> bool:
         "if ($p) { Stop-Process -Id $p -Force; Write-Output 'killed'; } "
         "} catch {}"
     )
-    r = subprocess.run(["powershell", "-NoProfile", "-Command", cmd], capture_output=True, text=True)
-    return "killed" in (r.stdout or "")
+    try:
+        r = subprocess.run(["powershell", "-NoProfile", "-Command", cmd], capture_output=True, text=True)
+        return "killed" in (r.stdout or "")
+    except FileNotFoundError:
+        return False
 
 # ═══ TEST EXECUTION ═══════════════════════════════════════════════════════════
 


### PR DESCRIPTION
﻿# Summary

Improves OnePyFone smoke runner reliability and updates the smoke-test skill to a minimal, current contract-focused guide.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] UI change
- [ ] Refactor
- [x] Documentation
- [x] Test-only change
- [ ] Build or release change

## Testing

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [x] Playwright or manual UI verification, if applicable

Commands run:
- `python -m py_compile tests/OnePyFone.py` (pass)
- `python tests/OnePyFone.py --suite preflight,rust --verbose` (pass)
- `node tests/smoke/playwright-test-ui.cjs` under clean local server startup (pass)
- `node tests/smoke/playwright-test-fixes.cjs` under clean local server startup (pass)
- `node tests/smoke/playwright-test-state.cjs` under clean local server startup (pass)
- `node tests/smoke/test-all-dropdown-animations.cjs` under clean local server startup (pass)

## Privacy and Security

- [x] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [x] API keys remain outside SQLite and are not logged.
- [x] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:
- No backend data-path changes. Runner changes are process orchestration and output/liveness only.

## UI Evidence

Not applicable.

## Reviewer Notes

- Main fix is around stale/half-ready dev server handling in `tests/OnePyFone.py` (`--fresh-server`, HTTP readiness checks, and running elapsed heartbeat).
- Smoke skill was intentionally reduced to only high-signal contracts and commands.
