### PR TITLE
feat(injection): contextual caps and auto-spacing via injection history tracking

### DIFF
--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -70,7 +70,8 @@ fn vk_to_char(vk: u32, shift: bool) -> Option<char> {
     match vk {
         0x0D => Some('\n'),
         0x20 => Some(' '),
-        0x30..=0x39 => char::from_digit((vk - 0x30) as u32, 10),
+        0x30..=0x39 => char::from_digit(vk - 0x30, 10),
+        0x60..=0x69 => char::from_digit(vk - 0x60, 10),
         0x41..=0x5A => Some((b'a' + (vk as u8 - 0x41)) as char),
         0xBA => Some(if shift { ':' } else { ';' }),
         0xBB => Some(if shift { '+' } else { '=' }),

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -23,9 +23,9 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     MOD_SHIFT, MOD_WIN,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, DispatchMessageW, GetMessageW, SetWindowsHookExW, TranslateMessage, HC_ACTION,
-    KBDLLHOOKSTRUCT, LLKHF_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
-    WM_SYSKEYUP,
+    CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW, SetWindowsHookExW,
+    TranslateMessage, HC_ACTION, KBDLLHOOKSTRUCT, LLKHF_INJECTED, MSG, WH_KEYBOARD_LL,
+    WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 };
 
 // Returns true if the given specific-side VK (or its mirror) is currently held.
@@ -51,6 +51,39 @@ fn vk_matches(vk: u32, key: u32) -> bool {
         164 | 165 => vk == 164 || vk == 165,
         91 | 92 => vk == 91 || vk == 92,
         _ => vk == key,
+    }
+}
+
+fn is_cursor_movement_key(vk: u32) -> bool {
+    matches!(vk,
+        0x21..=0x28 | // PgUp, PgDn, End, Home, Left, Up, Right, Down
+        0x2D |        // Insert
+        0x2E          // Delete (forward)
+    )
+}
+
+/// Maps a VK code to the character it produces (US QWERTY layout).
+/// Letters are always returned lowercase — case doesn't affect sentence-ender
+/// or whitespace checks downstream. Returns None for keys with no stable
+/// printable character (numpad, function keys, etc.); those reset history.
+fn vk_to_char(vk: u32, shift: bool) -> Option<char> {
+    match vk {
+        0x0D => Some('\n'),
+        0x20 => Some(' '),
+        0x30..=0x39 => char::from_digit((vk - 0x30) as u32, 10),
+        0x41..=0x5A => Some((b'a' + (vk as u8 - 0x41)) as char),
+        0xBA => Some(if shift { ':' } else { ';' }),
+        0xBB => Some(if shift { '+' } else { '=' }),
+        0xBC => Some(if shift { '<' } else { ',' }),
+        0xBD => Some(if shift { '_' } else { '-' }),
+        0xBE => Some(if shift { '>' } else { '.' }),
+        0xBF => Some(if shift { '?' } else { '/' }),
+        0xC0 => Some(if shift { '~' } else { '`' }),
+        0xDB => Some(if shift { '{' } else { '[' }),
+        0xDC => Some(if shift { '|' } else { '\\' }),
+        0xDD => Some(if shift { '}' } else { ']' }),
+        0xDE => Some(if shift { '"' } else { '\'' }),
+        _ => None,
     }
 }
 
@@ -353,10 +386,19 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 } else {
                     crate::core::injection::backspace_injection_history();
                 }
-            } else {
-                // Any other key (Enter, character, arrow, Delete, etc.): the
-                // cursor context is unknown — treat the next injection as fresh.
+            } else if is_cursor_movement_key(vk) {
                 crate::core::injection::reset_injection_history();
+            } else if unsafe { modifier_held(VK_CTRL) || modifier_held(VK_ALT) } {
+                // Keyboard shortcut (Ctrl+Z, Ctrl+A, etc.) — context unknown.
+                crate::core::injection::reset_injection_history();
+            } else {
+                let shift = unsafe { modifier_held(0xA0) }; // VK_LSHIFT → checks VK_SHIFT
+                if let Some(ch) = vk_to_char(vk, shift) {
+                    let hwnd = unsafe { GetForegroundWindow().0 as usize };
+                    crate::core::injection::append_or_reset_injection_history(hwnd, ch);
+                } else {
+                    crate::core::injection::reset_injection_history();
+                }
             }
         }
     }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -168,6 +168,43 @@ unsafe fn write_clipboard_unicode(data: &[u16]) -> anyhow::Result<()> {
     }
 }
 
+#[cfg(target_os = "windows")]
+unsafe fn read_clipboard_unicode_str() -> String {
+    use windows::Win32::Foundation::HGLOBAL;
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, GetClipboardData, OpenClipboard,
+    };
+    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+
+    const CF_UNICODETEXT: u32 = 13;
+
+    let opened = (0..3).any(|i| {
+        if i > 0 { std::thread::sleep(std::time::Duration::from_millis(20)); }
+        OpenClipboard(None).is_ok()
+    });
+    if !opened {
+        return String::new();
+    }
+
+    let result = (|| {
+        let h = GetClipboardData(CF_UNICODETEXT).ok()?;
+        let hg = HGLOBAL(h.0);
+        let size = GlobalSize(hg);
+        if size < 2 { return None; }
+        let ptr = GlobalLock(hg) as *const u16;
+        if ptr.is_null() { return None; }
+        let word_count = size / 2;
+        let slice = std::slice::from_raw_parts(ptr, word_count);
+        let end = slice.iter().position(|&w| w == 0).unwrap_or(word_count);
+        let s = String::from_utf16_lossy(&slice[..end]);
+        let _ = GlobalUnlock(hg);
+        Some(s)
+    })();
+
+    CloseClipboard().ok();
+    result.unwrap_or_default()
+}
+
 pub async fn inject_text(
     text: &str,
     target_hwnd: usize,
@@ -177,9 +214,10 @@ pub async fn inject_text(
     #[cfg(target_os = "windows")]
     {
         use windows::Win32::Foundation::HWND;
+        use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, OpenClipboard};
         use windows::Win32::UI::Input::KeyboardAndMouse::{
             SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-            KEYEVENTF_KEYUP, VK_CONTROL, VK_LMENU, VK_V,
+            KEYEVENTF_KEYUP, VK_C, VK_CONTROL, VK_LEFT, VK_LMENU, VK_RIGHT, VK_SHIFT, VK_V,
         };
         use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 
@@ -211,47 +249,121 @@ pub async fn inject_text(
                 },
             };
 
-            // Look up what we last injected into this window. The keyboard hook
-            // resets this whenever the user edits text, so by the time we reach
-            // here the history reflects the actual state of the cursor context.
-            let peeked: Option<char> = if contextual_caps || auto_spacing {
-                match last_injection().lock() {
+            // Retrieve up to 3 characters immediately before the cursor.
+            // Primary source is the injection history (fast, no extra I/O).
+            // When history is absent — fresh field or the user typed manually —
+            // we peek via Shift+Left×3 + Ctrl+C, read the clipboard, then restore
+            // the cursor. Synthetic SendInput events carry LLKHF_INJECTED so the
+            // keyboard hook skips them and history tracking is unaffected.
+            let context: String = if contextual_caps || auto_spacing {
+                let from_history: Option<String> = match last_injection().lock() {
                     Ok(guard) => (*guard)
                         .as_ref()
                         .filter(|(hwnd, _, instant)| {
                             *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
                         })
-                        .and_then(|(_, text, _)| text.chars().next_back()),
+                        .map(|(_, text, _)| {
+                            let chars: Vec<char> = text.chars().collect();
+                            let n = chars.len();
+                            chars[n.saturating_sub(3)..].iter().collect()
+                        }),
                     Err(_) => {
                         log::error!("injection history mutex poisoned");
                         None
                     }
-                }
+                };
                 // guard dropped here — Mutex not held across any await
+
+                match from_history {
+                    Some(ctx) => ctx,
+                    None => {
+                        // Empty the clipboard so we can detect whether Ctrl+C updates it.
+                        {
+                            let opened = (0..3).any(|i| {
+                                if i > 0 {
+                                    std::thread::sleep(std::time::Duration::from_millis(20));
+                                }
+                                OpenClipboard(None).is_ok()
+                            });
+                            if opened {
+                                EmptyClipboard().ok();
+                                CloseClipboard().ok();
+                            }
+                        }
+
+                        // Shift+Left×3 selects up to 3 chars before cursor; Ctrl+C copies them.
+                        let select_copy = [
+                            ki(VK_SHIFT, 0),
+                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
+                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
+                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
+                            ki(VK_SHIFT, KEYEVENTF_KEYUP.0),
+                            ki(VK_CONTROL, 0),
+                            ki(VK_C, 0), ki(VK_C, KEYEVENTF_KEYUP.0),
+                            ki(VK_CONTROL, KEYEVENTF_KEYUP.0),
+                        ];
+                        SendInput(&select_copy, std::mem::size_of::<INPUT>() as i32);
+
+                        tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
+
+                        let peeked_str = read_clipboard_unicode_str();
+
+                        // Restore cursor: Left collapses selection to start (original_pos −
+                        // chars_selected), then Right×n walks back to original_pos. When 0 chars
+                        // were selected (cursor at position 0) Left is a no-op and Right×0 is
+                        // skipped, so the cursor stays in place.
+                        let chars_selected = peeked_str.chars().count().min(3);
+                        SendInput(
+                            &[ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0)],
+                            std::mem::size_of::<INPUT>() as i32,
+                        );
+                        for _ in 0..chars_selected {
+                            SendInput(
+                                &[ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)],
+                                std::mem::size_of::<INPUT>() as i32,
+                            );
+                        }
+
+                        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
+
+                        peeked_str
+                    }
+                }
             } else {
-                None
+                String::new()
             };
 
+            // Strip trailing whitespace from context to find the last meaningful char.
+            // "Hello. " → trimmed = "Hello." → last = '.' → capitalize (new sentence).
+            // "Hello"   → trimmed = "Hello"  → last = 'o' → lowercase (mid-sentence).
+            // ""        → no prior context              → capitalize (new/empty field).
             let sentence_enders: &[char] = &['.', '!', '?', '\n', '\r'];
+            let trimmed_ctx = context.trim_end_matches(|c: char| c.is_whitespace());
+            let should_capitalize = trimmed_ctx.is_empty()
+                || trimmed_ctx
+                    .chars()
+                    .next_back()
+                    .map(|c| sentence_enders.contains(&c))
+                    .unwrap_or(true);
+
             let mut adjusted = if contextual_caps {
-                let should_lower = peeked
-                    .map(|c| !sentence_enders.contains(&c))
-                    .unwrap_or(false);
-                if should_lower {
+                if should_capitalize {
+                    text.to_owned()
+                } else {
                     let mut chars = text.chars();
                     match chars.next() {
                         Some(first) => first.to_lowercase().collect::<String>() + chars.as_str(),
                         None => text.to_owned(),
                     }
-                } else {
-                    text.to_owned()
                 }
             } else {
                 text.to_owned()
             };
 
+            // Add a space only when the cursor sits immediately after a non-whitespace
+            // character. Empty context (new field) or trailing whitespace → no space.
             if auto_spacing {
-                if let Some(c) = peeked {
+                if let Some(c) = context.chars().next_back() {
                     if !c.is_whitespace() && !adjusted.starts_with(char::is_whitespace) {
                         adjusted = format!(" {adjusted}");
                     }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -168,42 +168,6 @@ unsafe fn write_clipboard_unicode(data: &[u16]) -> anyhow::Result<()> {
     }
 }
 
-#[cfg(target_os = "windows")]
-unsafe fn read_clipboard_unicode_str() -> String {
-    use windows::Win32::Foundation::HGLOBAL;
-    use windows::Win32::System::DataExchange::{
-        CloseClipboard, GetClipboardData, OpenClipboard,
-    };
-    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
-
-    const CF_UNICODETEXT: u32 = 13;
-
-    let opened = (0..3).any(|i| {
-        if i > 0 { std::thread::sleep(std::time::Duration::from_millis(20)); }
-        OpenClipboard(None).is_ok()
-    });
-    if !opened {
-        return String::new();
-    }
-
-    let result = (|| {
-        let h = GetClipboardData(CF_UNICODETEXT).ok()?;
-        let hg = HGLOBAL(h.0);
-        let size = GlobalSize(hg);
-        if size < 2 { return None; }
-        let ptr = GlobalLock(hg) as *const u16;
-        if ptr.is_null() { return None; }
-        let word_count = size / 2;
-        let slice = std::slice::from_raw_parts(ptr, word_count);
-        let end = slice.iter().position(|&w| w == 0).unwrap_or(word_count);
-        let s = String::from_utf16_lossy(&slice[..end]);
-        let _ = GlobalUnlock(hg);
-        Some(s)
-    })();
-
-    CloseClipboard().ok();
-    result.unwrap_or_default()
-}
 
 pub async fn inject_text(
     text: &str,
@@ -214,10 +178,9 @@ pub async fn inject_text(
     #[cfg(target_os = "windows")]
     {
         use windows::Win32::Foundation::HWND;
-        use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, OpenClipboard};
         use windows::Win32::UI::Input::KeyboardAndMouse::{
             SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-            KEYEVENTF_KEYUP, VK_C, VK_CONTROL, VK_LEFT, VK_LMENU, VK_RIGHT, VK_SHIFT, VK_V,
+            KEYEVENTF_KEYUP, VK_CONTROL, VK_LMENU, VK_V,
         };
         use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 
@@ -249,14 +212,12 @@ pub async fn inject_text(
                 },
             };
 
-            // Retrieve up to 3 characters immediately before the cursor.
-            // Primary source is the injection history (fast, no extra I/O).
-            // When history is absent — fresh field or the user typed manually —
-            // we peek via Shift+Left×3 + Ctrl+C, read the clipboard, then restore
-            // the cursor. Synthetic SendInput events carry LLKHF_INJECTED so the
-            // keyboard hook skips them and history tracking is unaffected.
+            // Retrieve up to 3 characters immediately before the cursor from the
+            // injection history tail. History is cleared whenever the user types,
+            // moves the cursor, or switches windows — so when it's absent the context
+            // is genuinely unknown and we default to capitalising (safe for new fields).
             let context: String = if contextual_caps || auto_spacing {
-                let from_history: Option<String> = match last_injection().lock() {
+                match last_injection().lock() {
                     Ok(guard) => (*guard)
                         .as_ref()
                         .filter(|(hwnd, _, instant)| {
@@ -266,77 +227,11 @@ pub async fn inject_text(
                             let chars: Vec<char> = text.chars().collect();
                             let n = chars.len();
                             chars[n.saturating_sub(3)..].iter().collect()
-                        }),
+                        })
+                        .unwrap_or_default(),
                     Err(_) => {
                         log::error!("injection history mutex poisoned");
-                        None
-                    }
-                };
-                // guard dropped here — Mutex not held across any await
-
-                match from_history {
-                    Some(ctx) => {
-                        log::debug!(
-                            "inject: context_source=history hwnd={target_hwnd} context={ctx:?}"
-                        );
-                        ctx
-                    }
-                    None => {
-                        // SetForegroundWindow already waited 150 ms; give the target window
-                        // another 50 ms to fully absorb keyboard focus before we send
-                        // Shift+Left / Ctrl+C. WebView2 and some other apps need > 150 ms.
-                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-                        // Empty the clipboard so we can detect whether Ctrl+C updates it.
-                        {
-                            let opened = (0..3).any(|i| {
-                                if i > 0 {
-                                    std::thread::sleep(std::time::Duration::from_millis(20));
-                                }
-                                OpenClipboard(None).is_ok()
-                            });
-                            if opened {
-                                EmptyClipboard().ok();
-                                CloseClipboard().ok();
-                            }
-                        }
-
-                        // Shift+Left×3 selects up to 3 chars before cursor; Ctrl+C copies them.
-                        let select_copy = [
-                            ki(VK_SHIFT, 0),
-                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
-                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
-                            ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0),
-                            ki(VK_SHIFT, KEYEVENTF_KEYUP.0),
-                            ki(VK_CONTROL, 0),
-                            ki(VK_C, 0), ki(VK_C, KEYEVENTF_KEYUP.0),
-                            ki(VK_CONTROL, KEYEVENTF_KEYUP.0),
-                        ];
-                        SendInput(&select_copy, std::mem::size_of::<INPUT>() as i32);
-
-                        tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
-
-                        let peeked_str = read_clipboard_unicode_str();
-
-                        log::debug!(
-                            "inject: context_source=peek hwnd={target_hwnd} \
-                             peeked={peeked_str:?} context_len={}",
-                            peeked_str.len()
-                        );
-
-                        // VK_RIGHT collapses any backward Shift+Left selection to its right
-                        // end, which is the original cursor position — regardless of how many
-                        // chars were selected (0–3). If no selection was active (cursor at
-                        // field start), it moves right by 1, but context will be empty there
-                        // so the slight drift is harmless.
-                        SendInput(
-                            &[ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)],
-                            std::mem::size_of::<INPUT>() as i32,
-                        );
-
-                        tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
-
-                        peeked_str
+                        String::new()
                     }
                 }
             } else {

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -265,7 +265,7 @@ pub async fn inject_text(
             // "Hello"   → trimmed = "Hello"  → last = 'o' → lowercase (mid-sentence).
             // ""        → no prior context              → capitalize (new/empty field).
             let sentence_enders: &[char] = &['.', '!', '?', '\n', '\r'];
-            let trimmed_ctx = context.trim_end_matches(|c: char| c.is_whitespace());
+            let trimmed_ctx = context.trim_end_matches(|c: char| c.is_whitespace() && !sentence_enders.contains(&c));
             let should_capitalize = trimmed_ctx.is_empty()
                 || trimmed_ctx
                     .chars()

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -275,8 +275,18 @@ pub async fn inject_text(
                 // guard dropped here — Mutex not held across any await
 
                 match from_history {
-                    Some(ctx) => ctx,
+                    Some(ctx) => {
+                        log::debug!(
+                            "inject: context_source=history hwnd={target_hwnd} context={ctx:?}"
+                        );
+                        ctx
+                    }
                     None => {
+                        // SetForegroundWindow already waited 150 ms; give the target window
+                        // another 50 ms to fully absorb keyboard focus before we send
+                        // Shift+Left / Ctrl+C. WebView2 and some other apps need > 150 ms.
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
                         // Empty the clipboard so we can detect whether Ctrl+C updates it.
                         {
                             let opened = (0..3).any(|i| {
@@ -308,21 +318,21 @@ pub async fn inject_text(
 
                         let peeked_str = read_clipboard_unicode_str();
 
-                        // Restore cursor: Left collapses selection to start (original_pos −
-                        // chars_selected), then Right×n walks back to original_pos. When 0 chars
-                        // were selected (cursor at position 0) Left is a no-op and Right×0 is
-                        // skipped, so the cursor stays in place.
-                        let chars_selected = peeked_str.chars().count().min(3);
+                        log::debug!(
+                            "inject: context_source=peek hwnd={target_hwnd} \
+                             peeked={peeked_str:?} context_len={}",
+                            peeked_str.len()
+                        );
+
+                        // VK_RIGHT collapses any backward Shift+Left selection to its right
+                        // end, which is the original cursor position — regardless of how many
+                        // chars were selected (0–3). If no selection was active (cursor at
+                        // field start), it moves right by 1, but context will be empty there
+                        // so the slight drift is harmless.
                         SendInput(
-                            &[ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0)],
+                            &[ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)],
                             std::mem::size_of::<INPUT>() as i32,
                         );
-                        for _ in 0..chars_selected {
-                            SendInput(
-                                &[ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)],
-                                std::mem::size_of::<INPUT>() as i32,
-                            );
-                        }
 
                         tokio::time::sleep(tokio::time::Duration::from_millis(30)).await;
 

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -245,11 +245,7 @@ pub async fn inject_text(
                         .filter(|(hwnd, _, instant)| {
                             *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
                         })
-                        .map(|(_, text, _)| {
-                            let chars: Vec<char> = text.chars().collect();
-                            let n = chars.len();
-                            chars[n.saturating_sub(3)..].iter().collect()
-                        })
+                        .map(|(_, text, _)| text.clone())
                         .unwrap_or_default(),
                     Err(_) => {
                         log::error!("injection history mutex poisoned");

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -42,6 +42,28 @@ pub fn backspace_injection_history() {
     }
 }
 
+/// Called on a printable character keypress. If the foreground window matches
+/// the injection record, appends `ch` to the tracked tail and refreshes the
+/// timestamp. Otherwise clears the record — the cursor context is unknown.
+pub fn append_or_reset_injection_history(hwnd: usize, ch: char) {
+    if let Ok(mut guard) = last_injection().lock() {
+        let keep = if let Some((stored_hwnd, ref mut text, ref mut time)) = *guard {
+            if stored_hwnd == hwnd {
+                text.push(ch);
+                if text.len() > HISTORY_TAIL {
+                    let excess = text.len() - HISTORY_TAIL;
+                    let mut trim_at = excess;
+                    while !text.is_char_boundary(trim_at) { trim_at += 1; }
+                    *text = text[trim_at..].to_owned();
+                }
+                *time = Instant::now();
+                true
+            } else { false }
+        } else { false };
+        if !keep { *guard = None; }
+    }
+}
+
 #[cfg(target_os = "windows")]
 struct SavedClipboard {
     entries: Vec<(u32, Vec<u8>)>,


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - The injection subsystem handles text insertion via clipboard + Ctrl+V, with contextual capitalisation and auto-spacing to make injected text flow naturally into the target field
> - After injecting text, if the user manually edited it (e.g. backspaced a period, typed a comma) and then dictated again, the keyboard hook was calling `reset_injection_history()` on every keypress — discarding all context
> - With no history, the next injection defaulted to capitalising and skipping the leading space, producing broken results like `"Hello,Hello."` instead of `"Hello, hello."`
> - An earlier attempt used a Shift+Left×3 + Ctrl+C clipboard-peek to recover context, but this was flaky across apps due to focus-settling timing races — intermittently returning `""` which also caused unconditional capitalisation
> - The correct fix is to have the hook track what the user actually typed: navigation keys and modifier-combos reset history (cursor position unknowable), but printable characters are appended to the history tail so context is preserved
> - This PR replaces the fragile clipboard-peek entirely and wires up character-level tracking in the hook, making contextual caps and auto-spacing correct even after manual edits between dictations

## What Changed

- **`injection.rs`** — removed `read_clipboard_unicode_str()` and the entire Shift+Left×3 + Ctrl+C clipboard-peek block (~60 lines); context resolution is now purely history-driven with zero latency and no timing dependencies
- **`injection.rs`** — added `append_or_reset_injection_history(hwnd, ch)`: if the foreground window matches the stored injection record, appends `ch` to the history tail; otherwise clears it
- **`hotkey.rs`** — added `vk_to_char(vk, shift)` mapping US QWERTY VK codes to characters (letters always lowercase, since case doesn't affect sentence-ender detection)
- **`hotkey.rs`** — added `is_cursor_movement_key(vk)` covering arrows, Home/End, PgUp/PgDn, Insert, Delete
- **`hotkey.rs`** — the hook's catch-all keypress branch now routes: navigation/destructive keys → `reset`; Ctrl/Alt combos → `reset`; printable chars → `append_or_reset` via `GetForegroundWindow`; unknown VK → `reset`

## Verification

- Build: `cargo build --manifest-path src-tauri/Cargo.toml` — clean
- Dictate `"Hello."` → backspace period → type `,` → dictate `"hello"` → expect `Hello, hello.`
- Dictate `"Hello."` → dictate `"world"` → expect `Hello. World` (period → capitalise)
- Dictate `"Hello"` → dictate `"world"` → expect `Hello world` (consecutive, no manual edit)
- Dictate `"Hello"` → press Left arrow → dictate `"world"` → expect `World` (arrow resets context)
- Dictate `"Hello"` → Ctrl+Z → dictate `"world"` → expect `World` (modifier-combo resets context)

## Risks

- **Mouse cursor repositioning**: clicking within the same window moves the cursor without a keyboard event, so history may be stale if the user clicks mid-text then types before dictating. This limitation existed before this PR and would require a separate mouse hook to resolve.
- **Non-US keyboard layouts**: `vk_to_char` uses a US QWERTY map. Layout-specific characters return `None` → history resets for those keystrokes (safe fallback, loses context but doesn't corrupt it).
- **Moderate risk overall**: directly modifies the `WH_KEYBOARD_LL` hook callback that runs on every system keypress. Incorrect logic here could corrupt history and cause wrong capitalisation, but cannot crash or drop keystrokes.

## Model Used

- Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`), tool use + long context

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [ ] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above