### PR TITLE
Remove Accent Themes section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Open Flow handles the entire pipeline from your microphone to your active applic
 - **Snippets:** Create custom abbreviations and auto-expand them during dictation.
 - **Snippet Cleanup Instructions:** Add per-snippet cleanup rules like all caps, no ending period, or always ending with an exclamation mark.
 - **Personal Dictionary:** Teach Open Flow names, brands, and jargon so the cleanup model preserves the exact spelling you want.
-- **Accent Themes:** Choose your aesthetic: Terracotta (default), Moss, Slate, or Ink.
 
 ### Privacy & Offline
 - **Local Transcription History:** Every dictation is saved locally in SQLite on your machine, including raw/cleaned text, model used, word count, and duration.


### PR DESCRIPTION
Removed 'Accent Themes' section from README.

# Summary

<!-- What changed, and why? Keep it short and specific. -->

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] UI change
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only change
- [ ] Build or release change

## Testing

<!-- List exact commands run and their result. If not run, explain why. -->

- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test:rust`
- [ ] `npm run test:smoke`
- [ ] `npm run test:smoke:state`
- [ ] Playwright or manual UI verification, if applicable

## Privacy and Security

- [ ] No API keys, personal data, local private paths, screenshots with private text, or sensitive logs are included.
- [ ] API keys remain outside SQLite and are not logged.
- [ ] Clipboard, hotkey, database, or provider behavior changes are explained below.

Notes:

<!-- Add notes here, or write "None". -->

## UI Evidence

<!-- Add screenshots, recordings, or "Not applicable". -->

## Reviewer Notes

<!-- Anything risky, weird, intentionally limited, or worth reviewing first? -->
