### PR TITLE
fix(pipeline): count words from raw transcription for accurate WPM

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -902,7 +902,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
     );
 
     let db = app.state::<DbHandle>();
-    let words = final_text.split_whitespace().count() as i64;
+    let words = raw.split_whitespace().count() as i64;
     if let Err(e) =
         db::insert_transcription(&db, &raw, &final_text, words, duration_ms as i64, &api_used)
     {


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - **Subsystem: pipeline / data** — specifically the `words` field written to the `transcriptions` table after each pipeline run
> - The `words` field was being counted from `final_text` (the snippet-expanded, LLM-cleaned output) rather than `raw` (the literal API transcription of what was spoken)
> - Snippet triggers are intentionally short to say but can expand into many words — saying a 2-second trigger that expands to 50 words produces a WPM reading of ~1500, completely distorting the average
> - This PR fixes the word count source to `raw` so WPM reflects actual speaking rate
> - The benefit is accurate WPM stats that correspond to how fast the user actually spoke

## What Changed

- `src-tauri/src/pipeline.rs` — one-line fix: `words` now computed from `raw` (API transcription output after math normalization) instead of `final_text` (snippet-expanded + LLM-cleaned text)

## Verification

1. Run `npm run tauri dev`
2. Record a snippet trigger that expands into many words (e.g. a 2–3 word trigger → 30+ word expansion)
3. Check the Home screen WPM stat — should now show a realistic speaking rate (~100–160 WPM) rather than an inflated value
4. Also verify a normal dictation (no snippets) still produces a sane WPM reading

## Risks

Low risk. The `raw` variable is already in scope at the DB insert site and is passed as `raw_text` in the same call. The SQL `query_stats()` WPM formula (`words * 60000 / duration_ms`) is unchanged — only the input word count is corrected. No schema changes, no migration needed.

## Model Used

- Anthropic Claude Sonnet 4.6 — standard tool use, no extended thinking

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable — no test changes needed for a one-line data-source fix
- [x] UI changes include before/after screenshots — no UI changes
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together — no version bump
- [x] Relevant documentation updated to reflect changes — no doc changes needed
- [x] Risks documented above