### PR TITLE
fix(ui): complete Gumpy Task 2.2 list transition optimization

### DIFF
--- a/docs/Gumpy.md
+++ b/docs/Gumpy.md
@@ -38,7 +38,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
     *   *Build Verification*: Run `npm run check` followed by `npm run lint` to confirm zero compilation or TypeScript errors.
     *   *State Test*: Run the Playwright test using `node tests/smoke/playwright-test-state.cjs` to verify that active page routing and modal states update correctly.
 
-#### ✅ Task 1.2: Unifying IPC Error Handling & Logging
+#### Task 1.2: Unifying IPC Error Handling & Logging
 *   **Context**: [stores.ts](file:///g:/Open%20Flow/src/lib/stores.ts#L34-L39) (`fetchSnippets`) and [stores.ts](file:///g:/Open%20Flow/src/lib/stores.ts#L55-L60) (`fetchDictionary`).
 *   **Problem Statement**: Key data-fetching functions swallow all errors inside their catch blocks (`catch { /* dev mode — no backend */ }`). This hides DB lock errors, IPC deserialization failures, and network bugs, leaving the UI empty without diagnostic feedback.
 *   **Actionable Implementation Steps**:
@@ -77,7 +77,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 ### [PR Group 3: UI - Accessibility, Focus & Programmatic Height Fixes]
 *   **Goal**: Align interactive inputs with layout focus designs and fix layout sizing bugs.
 
-#### ✅ Task 3.1: Stopping Dropdown Escape Event Bubbling
+#### Task 3.1: Stopping Dropdown Escape Event Bubbling
 *   **Context**: [GeneralSection.svelte](file:///g:/Open%20Flow/src/lib/components/settings/GeneralSection.svelte#L137-L142) and [Settings.svelte](file:///g:/Open%20Flow/src/lib/views/Settings.svelte#L67).
 *   **Problem Statement**: The Settings modal closes when the user presses `Escape`. However, settings dropdown selectors (like Spoken Language or Microphone) do not capture and stop the `Escape` key event. Pressing `Escape` to close a dropdown propagates to the parent modal and closes the entire Settings sheet, losing unsaved form state.
 *   **Actionable Implementation Steps**:
@@ -86,7 +86,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Manual Action*: Open the Settings modal, expand the Spoken Language dropdown, and press `Escape`. Confirm that only the dropdown list closes, and the parent Settings modal remains open.
 
-#### ✅ Task 3.2: Toggles and API Key Fields Outline Indicators
+#### Task 3.2: Toggles and API Key Fields Outline Indicators
 *   **Context**: [Toggle.svelte](file:///g:/Open%20Flow/src/lib/components/Toggle.svelte#L8-L28) and [ApiKeysSection.svelte](file:///g:/Open%20Flow/src/lib/components/settings/ApiKeysSection.svelte#L80-L90).
 *   **Problem Statement**: The toggle component and API key input fields are accessible via tab navigation but lack focus styles (`:focus` or `:focus-visible`). Keyboard users cannot see which setting toggle or input is currently selected.
 *   **Actionable Implementation Steps**:
@@ -95,7 +95,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Keyboard Walkthrough*: Open the Settings modal and press the `Tab` key repeatedly. Verify that a clear outline highlight follows the active toggle elements and API key inputs.
 
-#### ✅ Task 3.3: Textarea Auto-Grow Svelte Action Recalculation
+#### Task 3.3: Textarea Auto-Grow Svelte Action Recalculation
 *   **Context**: [Snippets.svelte](file:///g:/Open%20Flow/src/lib/views/Snippets.svelte#L151-L156).
 *   **Problem Statement**: The `autoGrow` text layout action listens for native `'input'` DOM events to dynamically adjust textarea heights. However, when users dictate text into a snippet expansion using the `<MicInputButton>`, Svelte updates the value programmatically. Since this bypasses standard browser key input events, the textarea fails to resize, clipping long text.
 *   **Actionable Implementation Steps**:
@@ -104,7 +104,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Dictation Input*: Click the mic button in the Snippets Edit Modal and dictate a multi-sentence phrase. Verify that the textarea automatically scales its height to fit the expanded text.
 
-#### ✅ Task 3.4: Discoverable Clipboard Copy Button in History Card
+#### Task 3.4: Discoverable Clipboard Copy Button in History Card
 *   **Context**: [Home.svelte](file:///g:/Open%20Flow/src/lib/views/Home.svelte#L530).
 *   **Problem Statement**: The copy-to-clipboard button on dictation history entries is hidden (`opacity: 0; pointer-events: none;`) unless the user hovers over the card. This hides the feature from keyboard and mobile/tablet users.
 *   **Actionable Implementation Steps**:
@@ -297,7 +297,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 ### [PR Group 11: Backend - DB Migrations and IPC Async Execution]
 *   **Goal**: Ensure transaction-based database migrations and prevent blocking commands from stalling the async executor.
 
-#### ✅ Task 11.1: Transactional Migration Schemas
+#### Task 11.1: Transactional Migration Schemas
 *   **Context**: [db.rs](file:///g:/Open%20Flow/src-tauri/src/data/db.rs#L118-L259).
 *   **Problem Statement**: Schema updates run inline without transactions, swallowing execution errors and risking database corruption. Date values are also stored as formatted UTC strings prone to timezone drift.
 *   **Actionable Implementation Steps**:

--- a/docs/Gumpy.md
+++ b/docs/Gumpy.md
@@ -77,7 +77,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 ### [PR Group 3: UI - Accessibility, Focus & Programmatic Height Fixes]
 *   **Goal**: Align interactive inputs with layout focus designs and fix layout sizing bugs.
 
-#### Task 3.1: Stopping Dropdown Escape Event Bubbling
+#### ✅ Task 3.1: Stopping Dropdown Escape Event Bubbling
 *   **Context**: [GeneralSection.svelte](file:///g:/Open%20Flow/src/lib/components/settings/GeneralSection.svelte#L137-L142) and [Settings.svelte](file:///g:/Open%20Flow/src/lib/views/Settings.svelte#L67).
 *   **Problem Statement**: The Settings modal closes when the user presses `Escape`. However, settings dropdown selectors (like Spoken Language or Microphone) do not capture and stop the `Escape` key event. Pressing `Escape` to close a dropdown propagates to the parent modal and closes the entire Settings sheet, losing unsaved form state.
 *   **Actionable Implementation Steps**:
@@ -86,7 +86,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Manual Action*: Open the Settings modal, expand the Spoken Language dropdown, and press `Escape`. Confirm that only the dropdown list closes, and the parent Settings modal remains open.
 
-#### Task 3.2: Toggles and API Key Fields Outline Indicators
+#### ✅ Task 3.2: Toggles and API Key Fields Outline Indicators
 *   **Context**: [Toggle.svelte](file:///g:/Open%20Flow/src/lib/components/Toggle.svelte#L8-L28) and [ApiKeysSection.svelte](file:///g:/Open%20Flow/src/lib/components/settings/ApiKeysSection.svelte#L80-L90).
 *   **Problem Statement**: The toggle component and API key input fields are accessible via tab navigation but lack focus styles (`:focus` or `:focus-visible`). Keyboard users cannot see which setting toggle or input is currently selected.
 *   **Actionable Implementation Steps**:
@@ -104,7 +104,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Dictation Input*: Click the mic button in the Snippets Edit Modal and dictate a multi-sentence phrase. Verify that the textarea automatically scales its height to fit the expanded text.
 
-#### Task 3.4: Discoverable Clipboard Copy Button in History Card
+#### ✅ Task 3.4: Discoverable Clipboard Copy Button in History Card
 *   **Context**: [Home.svelte](file:///g:/Open%20Flow/src/lib/views/Home.svelte#L530).
 *   **Problem Statement**: The copy-to-clipboard button on dictation history entries is hidden (`opacity: 0; pointer-events: none;`) unless the user hovers over the card. This hides the feature from keyboard and mobile/tablet users.
 *   **Actionable Implementation Steps**:

--- a/docs/Gumpy.md
+++ b/docs/Gumpy.md
@@ -38,7 +38,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
     *   *Build Verification*: Run `npm run check` followed by `npm run lint` to confirm zero compilation or TypeScript errors.
     *   *State Test*: Run the Playwright test using `node tests/smoke/playwright-test-state.cjs` to verify that active page routing and modal states update correctly.
 
-#### Task 1.2: Unifying IPC Error Handling & Logging
+#### ✅ Task 1.2: Unifying IPC Error Handling & Logging
 *   **Context**: [stores.ts](file:///g:/Open%20Flow/src/lib/stores.ts#L34-L39) (`fetchSnippets`) and [stores.ts](file:///g:/Open%20Flow/src/lib/stores.ts#L55-L60) (`fetchDictionary`).
 *   **Problem Statement**: Key data-fetching functions swallow all errors inside their catch blocks (`catch { /* dev mode — no backend */ }`). This hides DB lock errors, IPC deserialization failures, and network bugs, leaving the UI empty without diagnostic feedback.
 *   **Actionable Implementation Steps**:
@@ -95,7 +95,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *Keyboard Walkthrough*: Open the Settings modal and press the `Tab` key repeatedly. Verify that a clear outline highlight follows the active toggle elements and API key inputs.
 
-#### Task 3.3: Textarea Auto-Grow Svelte Action Recalculation
+#### ✅ Task 3.3: Textarea Auto-Grow Svelte Action Recalculation
 *   **Context**: [Snippets.svelte](file:///g:/Open%20Flow/src/lib/views/Snippets.svelte#L151-L156).
 *   **Problem Statement**: The `autoGrow` text layout action listens for native `'input'` DOM events to dynamically adjust textarea heights. However, when users dictate text into a snippet expansion using the `<MicInputButton>`, Svelte updates the value programmatically. Since this bypasses standard browser key input events, the textarea fails to resize, clipping long text.
 *   **Actionable Implementation Steps**:
@@ -297,7 +297,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 ### [PR Group 11: Backend - DB Migrations and IPC Async Execution]
 *   **Goal**: Ensure transaction-based database migrations and prevent blocking commands from stalling the async executor.
 
-#### Task 11.1: Transactional Migration Schemas
+#### ✅ Task 11.1: Transactional Migration Schemas
 *   **Context**: [db.rs](file:///g:/Open%20Flow/src-tauri/src/data/db.rs#L118-L259).
 *   **Problem Statement**: Schema updates run inline without transactions, swallowing execution errors and risking database corruption. Date values are also stored as formatted UTC strings prone to timezone drift.
 *   **Actionable Implementation Steps**:

--- a/docs/Gumpy.md
+++ b/docs/Gumpy.md
@@ -63,7 +63,7 @@ We have organized the technical debt and usability audit into **11 focused Pull 
 *   **Verification & Test Plan**:
     *   *CPU Profile*: Launch the app in Tauri dev mode, open the frontend dev tools, select the Performance panel, and confirm that no frames are computed and script activity is 0% while the pill is in the `'idle'` state.
 
-#### Task 2.2: Svelte List Transition Optimizations
+#### ✅ Task 2.2: Svelte List Transition Optimizations
 *   **Context**: [Dictionary.svelte](file:///g:/Open%20Flow/src/lib/views/Dictionary.svelte) and [Snippets.svelte](file:///g:/Open%20Flow/src/lib/views/Snippets.svelte).
 *   **Problem Statement**: When lists grow to hundreds of items, applying `in:fly`, `out:fade`, and `animate:flip` transitions directly on wrapper `div` nodes within `{#each}` loops causes major layout stutters and input lag when filtering terms.
 *   **Actionable Implementation Steps**:

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1106,6 +1106,7 @@ fn run_rejection_monitor(
         };
 
         let rejection_threshold = injected_text.chars().count() / 10;
+        let baseline_char_count = baseline_text.chars().count();
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(target.window_secs());
 
@@ -1128,6 +1129,7 @@ fn run_rejection_monitor(
                 // shrank — confirming deletion rather than a stale baseline.
                 None => {
                     !current.contains(injected_text.as_str())
+                        && current.chars().count() < baseline_char_count
                         && current.len() < baseline_text.len()
                 }
             };

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1130,7 +1130,6 @@ fn run_rejection_monitor(
                 None => {
                     !current.contains(injected_text.as_str())
                         && current.chars().count() < baseline_char_count
-                        && current.len() < baseline_text.len()
                 }
             };
 

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -1106,7 +1106,6 @@ fn run_rejection_monitor(
         };
 
         let rejection_threshold = injected_text.chars().count() / 10;
-        let baseline_char_count = baseline_text.chars().count();
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(target.window_secs());
 
@@ -1129,7 +1128,7 @@ fn run_rejection_monitor(
                 // shrank — confirming deletion rather than a stale baseline.
                 None => {
                     !current.contains(injected_text.as_str())
-                        && current.chars().count() < baseline_char_count
+                        && current.len() < baseline_text.len()
                 }
             };
 

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -271,9 +271,6 @@
                 class:is-selected={selected?.id === e.id}
                 role="button"
                 tabindex="0"
-                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.base), easing: expoOut }}
-                out:fade={{ duration: motionMs(MOTION_MS.fast) }}
-                animate:flip={{ duration: motionMs(MOTION_MS.base), easing: expoOut }}
                 onclick={() => selectRow(e)}
                 onkeydown={(ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); selectRow(e); } }}
               >

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -273,9 +273,6 @@
                 class:is-selected={selected?.id === s.id}
                 role="button"
                 tabindex="0"
-                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.base), easing: expoOut }}
-                out:fade={{ duration: motionMs(MOTION_MS.fast) }}
-                animate:flip={{ duration: motionMs(MOTION_MS.base), easing: expoOut }}
                 onclick={() => selectRow(s)}
                 onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectRow(s); } }}
               >


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app with a hotkey-driven pipeline and a Svelte frontend that must stay responsive while dictation data updates in real time.
> - This change is in the UI performance layer, specifically Dictionary and Snippets list rendering behavior.
> - `docs/Gumpy.md` Task 2.2 identified row-level `in:fly`, `out:fade`, and `animate:flip` transitions inside `{#each}` loops as a source of stutter on large lists.
> - Those transition directives were still active, so filtering and list updates still paid animation/layout cost per row.
> - This pull request removes those row-level transitions while keeping existing interaction and smoke-test-sensitive classes intact.
> - The benefit is lower rendering overhead during search/filter interactions, especially with larger dictionary/snippet sets.

## What Changed

- Removed row-level `in:fly`, `out:fade`, and `animate:flip` directives from dictionary list rows in `src/lib/views/Dictionary.svelte`.
- Removed row-level `in:fly`, `out:fade`, and `animate:flip` directives from snippet list rows in `src/lib/views/Snippets.svelte`.
- Marked `Task 2.2` as completed in `docs/Gumpy.md`.

## Verification

- `npm run check` (pass)
- `npm run lint` (pass)
- `npm run test:rust` (pass)
- `node tests/smoke/playwright-test-state.cjs` (fails in current branch baseline: timeout waiting for `.task-tile .summary-item`)

## Risks

- Low risk. Changes are scoped to list-row transition directives only.
- Visual feel is slightly less animated on row insertion/removal by design.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs � work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- OpenAI GPT-5 (Codex CLI agent, tool-assisted editing and verification)

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` � this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above