### PR TITLE
fix: 0.11.0 stabilization and dev startup fixes

### DIFF
--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -214,6 +214,10 @@ pub fn reset_chord_state() {
     CHORD_FIRST_DOWN_MS.store(0, Ordering::SeqCst);
 }
 
+pub fn sync_context_hwnd(hwnd: usize) {
+    LAST_CONTEXT_HWND.store(hwnd, Ordering::SeqCst);
+}
+
 pub fn set_handless_active(v: bool) {
     HANDLESS_ACTIVE.store(v, Ordering::SeqCst);
 }

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 const VK_BACK: u32 = 0x08; // Backspace
 const VK_ESCAPE: u32 = 0x1B; // Escape
@@ -24,9 +24,10 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     MOD_SHIFT, MOD_WIN,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW,
-    GetWindowThreadProcessId, SetWindowsHookExW, TranslateMessage, HC_ACTION, KBDLLHOOKSTRUCT,
-    LLKHF_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+    CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
+    SetWindowsHookExW, TranslateMessage, HC_ACTION, KBDLLHOOKSTRUCT, LLKHF_INJECTED, MSG,
+    WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_MBUTTONDOWN,
+    WM_RBUTTONDOWN, WM_SYSKEYDOWN, WM_SYSKEYUP,
 };
 
 // Returns true if the given specific-side VK (or its mirror) is currently held.
@@ -305,6 +306,18 @@ static HANDLESS_WAITING_KEY1_2: AtomicBool = AtomicBool::new(false);
 static CHORD_FIRST_DOWN_MS: AtomicU64 = AtomicU64::new(0);
 static CHORD_PENDING: AtomicBool = AtomicBool::new(false);
 static CHORD_PENDING_END_MS: AtomicU64 = AtomicU64::new(0);
+static LAST_CONTEXT_HWND: AtomicUsize = AtomicUsize::new(0);
+
+unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    let _ = lparam;
+    if code == HC_ACTION as i32 {
+        let msg = wparam.0 as u32;
+        if matches!(msg, WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN) {
+            crate::core::injection::reset_injection_history();
+        }
+    }
+    CallNextHookEx(None, code, wparam, lparam)
+}
 
 unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     if code == HC_ACTION as i32 {
@@ -452,6 +465,13 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         // context tracking that drives auto-spacing and contextual capitalisation.
         let is_injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
         if !is_injected && is_down && !MODIFIER_VKS.contains(&vk) {
+            let hwnd = unsafe { GetForegroundWindow().0 as usize };
+            if hwnd != 0 {
+                let previous_hwnd = LAST_CONTEXT_HWND.swap(hwnd, Ordering::SeqCst);
+                if previous_hwnd != 0 && previous_hwnd != hwnd {
+                    crate::core::injection::reset_injection_history();
+                }
+            }
             if vk == VK_BACK {
                 // Ctrl+Backspace and Alt+Backspace both delete a whole word —
                 // unknown char count, so reset entirely. Plain Backspace pops
@@ -459,7 +479,7 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 if unsafe { modifier_held(VK_CTRL) || modifier_held(VK_ALT) } {
                     crate::core::injection::reset_injection_history();
                 } else {
-                    crate::core::injection::backspace_injection_history();
+                    crate::core::injection::backspace_injection_history(hwnd);
                 }
             } else if is_cursor_movement_key(vk) {
                 crate::core::injection::reset_injection_history();
@@ -468,7 +488,6 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 crate::core::injection::reset_injection_history();
             } else {
                 if let Some(ch) = vk_to_char(vk) {
-                    let hwnd = unsafe { GetForegroundWindow().0 as usize };
                     crate::core::injection::append_or_reset_injection_history(hwnd, ch);
                 } else {
                     crate::core::injection::reset_injection_history();
@@ -506,13 +525,25 @@ where
         let probe = SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), None, 0)
             .map_err(|e| format!("Failed to install keyboard hook: {e}"))?;
         windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(probe).ok();
+
+        let mouse_probe = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_proc), None, 0)
+            .map_err(|e| format!("Failed to install mouse hook: {e}"))?;
+        windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(mouse_probe).ok();
     }
 
     let handle = std::thread::spawn(|| unsafe {
-        let hook = match SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), None, 0) {
+        let keyboard_hook = match SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), None, 0) {
             Ok(h) => h,
             Err(e) => {
                 log::error!("SetWindowsHookExW failed on hook thread: {e}");
+                return;
+            }
+        };
+        let mouse_hook = match SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_proc), None, 0) {
+            Ok(h) => h,
+            Err(e) => {
+                log::error!("SetWindowsHookExW failed for mouse hook: {e}");
+                windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(keyboard_hook).ok();
                 return;
             }
         };
@@ -531,7 +562,8 @@ where
             DispatchMessageW(&msg);
         }
 
-        windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(hook).ok();
+        windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(mouse_hook).ok();
+        windows::Win32::UI::WindowsAndMessaging::UnhookWindowsHookEx(keyboard_hook).ok();
     });
 
     Ok(handle)

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -686,6 +686,7 @@ pub async fn inject_text(
                         tail,
                         instant: Instant::now(),
                     };
+                    crate::core::hotkey::sync_context_hwnd(target_hwnd);
                 }
             }
 

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -37,64 +37,312 @@ const MODIFIER_GAP_MS: u64 = 30;
 // overwrite it with the original contents.
 const PASTE_SETTLE_MS: u64 = 80;
 
-static LAST_INJECTION: OnceLock<Mutex<Option<(usize, String, Instant)>>> = OnceLock::new();
-
-fn last_injection() -> &'static Mutex<Option<(usize, String, Instant)>> {
-    LAST_INJECTION.get_or_init(|| Mutex::new(None))
+const SENTENCE_ENDERS: &[char] = &['.', '!', '?', '\n', '\r'];
+#[derive(Clone, Debug)]
+enum CursorContextState {
+    Unknown {
+        instant: Instant,
+    },
+    Known {
+        hwnd: usize,
+        tail: String,
+        instant: Instant,
+    },
 }
 
-/// Full reset — called on Enter, character keys, arrows, etc. The cursor context
-/// is unknown after such input, so the next injection starts fresh.
-pub fn reset_injection_history() {
-    if let Ok(mut guard) = last_injection().lock() {
-        *guard = None;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_context_detects_sentence_boundary() {
+        assert!(matches!(
+            classify_context("Hello. "),
+            ContextKind::SentenceBoundary
+        ));
+        assert!(matches!(
+            classify_context("Hello?\n"),
+            ContextKind::SentenceBoundary
+        ));
+        assert!(matches!(
+            classify_context(""),
+            ContextKind::SentenceBoundary
+        ));
+    }
+
+    #[test]
+    fn classify_context_detects_continuation() {
+        assert!(matches!(
+            classify_context("hello, "),
+            ContextKind::Continuation
+        ));
+        assert!(matches!(
+            classify_context("path/to/"),
+            ContextKind::Continuation
+        ));
+        assert!(matches!(
+            classify_context("label:"),
+            ContextKind::Continuation
+        ));
+    }
+
+    #[test]
+    fn uppercase_first_word_handles_prefix_symbols() {
+        assert_eq!(uppercase_first_word("hello world"), "Hello world");
+        assert_eq!(uppercase_first_word("\"hello world"), "\"Hello world");
+        assert_eq!(uppercase_first_word("(hello world"), "(Hello world");
+    }
+
+    #[test]
+    fn lowercase_first_word_only_for_safe_words() {
+        assert_eq!(
+            lowercase_first_word_if_safe("The fix is ready"),
+            ("the fix is ready".into(), true)
+        );
+        assert_eq!(
+            lowercase_first_word_if_safe("OpenAI ships model updates"),
+            ("OpenAI ships model updates".into(), false)
+        );
+        assert_eq!(
+            lowercase_first_word_if_safe("I am here"),
+            ("I am here".into(), false)
+        );
+        assert_eq!(
+            lowercase_first_word_if_safe("HTTP server"),
+            ("HTTP server".into(), false)
+        );
+    }
+
+    #[test]
+    fn history_tracks_manual_typing_and_backspace_by_window() {
+        reset_injection_history();
+        append_or_reset_injection_history(11, 'h');
+        append_or_reset_injection_history(11, 'i');
+
+        let state = last_injection().lock().expect("lock");
+        match &*state {
+            CursorContextState::Known { hwnd, tail, .. } => {
+                assert_eq!(*hwnd, 11);
+                assert_eq!(tail, "hi");
+            }
+            CursorContextState::Unknown { .. } => panic!("expected known state"),
+        }
+        drop(state);
+
+        backspace_injection_history(22);
+        let state = last_injection().lock().expect("lock");
+        assert!(matches!(&*state, CursorContextState::Unknown { .. }));
     }
 }
-
-/// Called on Backspace. Pops the last character off the tracked text so the
-/// next injection still knows what's immediately before the cursor after the
-/// deletion. Clears the record entirely once the tracked text empties.
-pub fn backspace_injection_history() {
-    if let Ok(mut guard) = last_injection().lock() {
-        let empty = if let Some((_, ref mut text, ref mut time)) = *guard {
-            text.pop();
-            *time = Instant::now();
-            text.is_empty()
-        } else {
-            false
-        };
-        if empty {
-            *guard = None;
+#[derive(Clone, Copy, Debug)]
+enum ContextKind {
+    Unknown,
+    SentenceBoundary,
+    Continuation,
+}
+impl ContextKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::SentenceBoundary => "sentence_boundary",
+            Self::Continuation => "continuation",
         }
     }
 }
-
-/// Called on a printable character keypress. If the foreground window matches
-/// the injection record, appends `ch` to the tracked tail and refreshes the
-/// timestamp. Otherwise clears the record — the cursor context is unknown.
+#[derive(Clone, Copy, Debug)]
+enum CaseDecision {
+    ContextualCapsDisabled,
+    UnknownContextPreserved,
+    SentenceBoundaryCapitalized,
+    SentenceBoundaryPreservedVeryCasual,
+    ContinuationLowercased,
+    ContinuationPreserved,
+}
+impl CaseDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ContextualCapsDisabled => "contextual_caps_disabled",
+            Self::UnknownContextPreserved => "unknown_context_preserved",
+            Self::SentenceBoundaryCapitalized => "sentence_boundary_capitalized",
+            Self::SentenceBoundaryPreservedVeryCasual => "sentence_boundary_preserved_very_casual",
+            Self::ContinuationLowercased => "continuation_lowercased",
+            Self::ContinuationPreserved => "continuation_preserved",
+        }
+    }
+}
+pub struct InjectionOutcome {
+    pub text: String,
+    pub context_state: &'static str,
+    pub case_decision: &'static str,
+}
+static LAST_INJECTION: OnceLock<Mutex<CursorContextState>> = OnceLock::new();
+fn unknown_context() -> CursorContextState {
+    CursorContextState::Unknown {
+        instant: Instant::now(),
+    }
+}
+fn last_injection() -> &'static Mutex<CursorContextState> {
+    LAST_INJECTION.get_or_init(|| Mutex::new(unknown_context()))
+}
+fn trim_tail_to_limit(text: &mut String) {
+    if text.len() > HISTORY_TAIL {
+        let excess = text.len() - HISTORY_TAIL;
+        let mut trim_at = excess;
+        while !text.is_char_boundary(trim_at) {
+            trim_at += 1;
+        }
+        *text = text[trim_at..].to_owned();
+    }
+}
+fn trimmed_context_for_decision(text: &str) -> &str {
+    text.trim_end_matches(|c: char| c.is_whitespace() && !SENTENCE_ENDERS.contains(&c))
+}
+fn classify_context(tail: &str) -> ContextKind {
+    let trimmed = trimmed_context_for_decision(tail);
+    if trimmed
+        .chars()
+        .next_back()
+        .map(|c| SENTENCE_ENDERS.contains(&c))
+        .unwrap_or(true)
+    {
+        ContextKind::SentenceBoundary
+    } else {
+        ContextKind::Continuation
+    }
+}
+fn is_safe_lowercase_candidate(word: &str) -> bool {
+    if word.is_empty() || word == "I" || word.contains(|c: char| c.is_ascii_digit()) {
+        return false;
+    }
+    if word
+        .chars()
+        .any(|c| !c.is_alphabetic() && c != '\'' && c != '-')
+    {
+        return false;
+    }
+    let lower = word.to_lowercase();
+    let upper = word.to_uppercase();
+    if word == upper || word == lower {
+        return false;
+    }
+    let mut chars = word.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_uppercase() {
+        return false;
+    }
+    if chars.any(|c| c.is_uppercase()) {
+        return false;
+    }
+    const LOWERCASE_WHITELIST: &[&str] = &[
+        "a", "an", "and", "as", "at", "but", "by", "for", "from", "if", "in", "is", "it", "of",
+        "on", "or", "so", "than", "that", "the", "then", "this", "to", "we", "with", "you",
+    ];
+    LOWERCASE_WHITELIST.contains(&lower.as_str())
+}
+fn find_first_alpha_span(text: &str) -> Option<(usize, usize)> {
+    let mut start = None;
+    let mut end = 0usize;
+    for (idx, ch) in text.char_indices() {
+        if start.is_none() {
+            if ch.is_alphabetic() {
+                start = Some(idx);
+                end = idx + ch.len_utf8();
+            }
+            continue;
+        }
+        if ch.is_alphabetic() || ch == '\'' || ch == '-' {
+            end = idx + ch.len_utf8();
+            continue;
+        }
+        break;
+    }
+    start.map(|s| (s, end))
+}
+fn uppercase_first_word(text: &str) -> String {
+    let Some((start, _)) = find_first_alpha_span(text) else {
+        return text.to_owned();
+    };
+    let mut chars = text[start..].chars();
+    let Some(first) = chars.next() else {
+        return text.to_owned();
+    };
+    if !first.is_lowercase() {
+        return text.to_owned();
+    }
+    let first_len = first.len_utf8();
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..start]);
+    out.push_str(&first.to_uppercase().collect::<String>());
+    out.push_str(&text[start + first_len..]);
+    out
+}
+fn lowercase_first_word_if_safe(text: &str) -> (String, bool) {
+    let Some((start, end)) = find_first_alpha_span(text) else {
+        return (text.to_owned(), false);
+    };
+    let word = &text[start..end];
+    if !is_safe_lowercase_candidate(word) {
+        return (text.to_owned(), false);
+    }
+    let mut chars = text[start..].chars();
+    let Some(first) = chars.next() else {
+        return (text.to_owned(), false);
+    };
+    let first_len = first.len_utf8();
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..start]);
+    out.push_str(&first.to_lowercase().collect::<String>());
+    out.push_str(&text[start + first_len..]);
+    (out, true)
+}
+pub fn reset_injection_history() {
+    if let Ok(mut guard) = last_injection().lock() {
+        *guard = unknown_context();
+    }
+}
+pub fn backspace_injection_history(hwnd: usize) {
+    if let Ok(mut guard) = last_injection().lock() {
+        match &mut *guard {
+            CursorContextState::Known {
+                hwnd: stored_hwnd,
+                tail,
+                instant,
+            } if *stored_hwnd == hwnd => {
+                tail.pop();
+                *instant = Instant::now();
+                if tail.is_empty() {
+                    *guard = unknown_context();
+                }
+            }
+            _ => {
+                *guard = unknown_context();
+            }
+        }
+    }
+}
 pub fn append_or_reset_injection_history(hwnd: usize, ch: char) {
     if let Ok(mut guard) = last_injection().lock() {
-        let keep = if let Some((stored_hwnd, ref mut text, ref mut time)) = *guard {
-            if stored_hwnd == hwnd {
-                text.push(ch);
-                if text.len() > HISTORY_TAIL {
-                    let excess = text.len() - HISTORY_TAIL;
-                    let mut trim_at = excess;
-                    while !text.is_char_boundary(trim_at) {
-                        trim_at += 1;
-                    }
-                    *text = text[trim_at..].to_owned();
-                }
-                *time = Instant::now();
-                true
-            } else {
-                false
+        match &mut *guard {
+            CursorContextState::Known {
+                hwnd: stored_hwnd,
+                tail,
+                instant,
+            } if *stored_hwnd == hwnd => {
+                tail.push(ch);
+                trim_tail_to_limit(tail);
+                *instant = Instant::now();
             }
-        } else {
-            false
-        };
-        if !keep {
-            *guard = None;
+            _ => {
+                let mut tail = ch.to_string();
+                trim_tail_to_limit(&mut tail);
+                *guard = CursorContextState::Known {
+                    hwnd,
+                    tail,
+                    instant: Instant::now(),
+                };
+            }
         }
     }
 }
@@ -258,7 +506,8 @@ pub async fn inject_text(
     target_hwnd: usize,
     contextual_caps: bool,
     auto_spacing: bool,
-) -> anyhow::Result<String> {
+    profile: &str,
+) -> anyhow::Result<InjectionOutcome> {
     #[cfg(target_os = "windows")]
     {
         use windows::Win32::Foundation::HWND;
@@ -296,60 +545,70 @@ pub async fn inject_text(
                 },
             };
 
-            // Retrieve up to 3 characters immediately before the cursor from the
-            // injection history tail. History is cleared whenever the user types,
+            // Read cursor context from the tracked tail.
             // moves the cursor, or switches windows — so when it's absent the context
             // is genuinely unknown and we default to capitalising (safe for new fields).
-            let context: String = if contextual_caps || auto_spacing {
+            let (context_tail, context_kind) = if contextual_caps || auto_spacing {
                 match last_injection().lock() {
-                    Ok(guard) => (*guard)
-                        .as_ref()
-                        .filter(|(hwnd, _, instant)| {
-                            *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE
-                        })
-                        .map(|(_, text, _)| text.clone())
-                        .unwrap_or_default(),
+                    Ok(guard) => match &*guard {
+                        CursorContextState::Known {
+                            hwnd,
+                            tail,
+                            instant,
+                        } if *hwnd == target_hwnd && instant.elapsed() < INJECTION_STALE => {
+                            (tail.clone(), classify_context(tail))
+                        }
+                        CursorContextState::Unknown { instant } => {
+                            let _ = instant.elapsed();
+                            (String::new(), ContextKind::Unknown)
+                        }
+                        _ => (String::new(), ContextKind::Unknown),
+                    },
                     Err(_) => {
                         log::error!("injection history mutex poisoned");
-                        String::new()
+                        (String::new(), ContextKind::Unknown)
                     }
                 }
             } else {
-                String::new()
+                (String::new(), ContextKind::Unknown)
             };
 
-            // Strip trailing whitespace from context to find the last meaningful char.
-            // "Hello. " → trimmed = "Hello." → last = '.' → capitalize (new sentence).
-            // "Hello"   → trimmed = "Hello"  → last = 'o' → lowercase (mid-sentence).
-            // ""        → no prior context              → capitalize (new/empty field).
-            let sentence_enders: &[char] = &['.', '!', '?', '\n', '\r'];
-            let trimmed_ctx = context
-                .trim_end_matches(|c: char| c.is_whitespace() && !sentence_enders.contains(&c));
-            let should_capitalize = trimmed_ctx.is_empty()
-                || trimmed_ctx
-                    .chars()
-                    .next_back()
-                    .map(|c| sentence_enders.contains(&c))
-                    .unwrap_or(true);
-
-            let mut adjusted = if contextual_caps {
-                if should_capitalize {
-                    text.to_owned()
-                } else {
-                    let mut chars = text.chars();
-                    match chars.next() {
-                        Some(first) => first.to_lowercase().collect::<String>() + chars.as_str(),
-                        None => text.to_owned(),
+            // Apply profile-aware casing policy using the derived context state.
+            let (mut adjusted, case_decision) = if !contextual_caps {
+                (text.to_owned(), CaseDecision::ContextualCapsDisabled)
+            } else {
+                match context_kind {
+                    ContextKind::Unknown => {
+                        (text.to_owned(), CaseDecision::UnknownContextPreserved)
+                    }
+                    ContextKind::SentenceBoundary => {
+                        if profile == "very_casual" {
+                            (
+                                text.to_owned(),
+                                CaseDecision::SentenceBoundaryPreservedVeryCasual,
+                            )
+                        } else {
+                            (
+                                uppercase_first_word(text),
+                                CaseDecision::SentenceBoundaryCapitalized,
+                            )
+                        }
+                    }
+                    ContextKind::Continuation => {
+                        let (lowered, did_lower) = lowercase_first_word_if_safe(text);
+                        if did_lower {
+                            (lowered, CaseDecision::ContinuationLowercased)
+                        } else {
+                            (text.to_owned(), CaseDecision::ContinuationPreserved)
+                        }
                     }
                 }
-            } else {
-                text.to_owned()
             };
 
             // Add a space only when the cursor sits immediately after a non-whitespace
             // character. Empty context (new field) or trailing whitespace → no space.
             if auto_spacing {
-                if let Some(c) = context.chars().next_back() {
+                if let Some(c) = context_tail.chars().next_back() {
                     if !c.is_whitespace() && !adjusted.starts_with(char::is_whitespace) {
                         adjusted = format!(" {adjusted}");
                     }
@@ -378,7 +637,7 @@ pub async fn inject_text(
             }
             if !clipboard_written {
                 return Err(anyhow::anyhow!(
-                    "OpenClipboard failed after 3 attempts — clipboard held by another process"
+                    "OpenClipboard failed after 3 attempts - clipboard held by another process"
                 ));
             }
 
@@ -418,32 +677,34 @@ pub async fn inject_text(
             // Restore all previously saved clipboard formats.
             restore_clipboard_all(&saved);
 
-            // Record a tail of the injected text so the keyboard hook can pop
-            // characters off it on Backspace, keeping the context accurate after
-            // editing. Only the last HISTORY_TAIL bytes are kept to bound memory use.
             if target_hwnd != 0 && !adjusted.is_empty() {
                 if let Ok(mut guard) = last_injection().lock() {
-                    let tail = if adjusted.len() > HISTORY_TAIL {
-                        let mut start = adjusted.len() - HISTORY_TAIL;
-                        while !adjusted.is_char_boundary(start) {
-                            start += 1;
-                        }
-                        adjusted[start..].to_owned()
-                    } else {
-                        adjusted.clone()
+                    let mut tail = adjusted.clone();
+                    trim_tail_to_limit(&mut tail);
+                    *guard = CursorContextState::Known {
+                        hwnd: target_hwnd,
+                        tail,
+                        instant: Instant::now(),
                     };
-                    *guard = Some((target_hwnd, tail, Instant::now()));
                 }
             }
 
-            Ok(adjusted)
+            Ok(InjectionOutcome {
+                text: adjusted,
+                context_state: context_kind.as_str(),
+                case_decision: case_decision.as_str(),
+            })
         }
     }
 
     #[cfg(not(target_os = "windows"))]
     {
-        log::warn!("inject_text: not on Windows — skipping target_hwnd={target_hwnd}");
+        log::warn!("inject_text: not on Windows - skipping target_hwnd={target_hwnd}");
 
-        Ok(text.to_string())
+        Ok(InjectionOutcome {
+            text: text.to_string(),
+            context_state: "unknown",
+            case_decision: "contextual_caps_disabled",
+        })
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -60,7 +60,10 @@ fn ensure_cleanup_cache_schema(conn: &Connection) -> Result<()> {
         "UPDATE cleanup_cache
          SET created_at_epoch = COALESCE(created_at_epoch, CAST(strftime('%s', created_at || 'Z') AS INTEGER)),
              last_hit_at_epoch = COALESCE(last_hit_at_epoch, CAST(strftime('%s', last_hit_at || 'Z') AS INTEGER)),
-             expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER));
+             expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER))
+         WHERE created_at_epoch IS NULL
+            OR last_hit_at_epoch IS NULL
+            OR expires_at_epoch IS NULL;
          CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
            ON cleanup_cache(expires_at_epoch);
          CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -23,48 +23,58 @@ fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool
     Ok(false)
 }
 
-fn ensure_table_column(conn: &Connection, table: &str, column: &str, def_sql: &str) -> Result<()> {
+fn ensure_table_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    def_sql: &str,
+) -> Result<bool> {
     if table_has_column(conn, table, column)? {
-        return Ok(());
+        return Ok(false);
     }
     conn.execute_batch(def_sql)?;
-    Ok(())
+    Ok(true)
 }
 
 fn ensure_cleanup_cache_schema(conn: &Connection) -> Result<()> {
-    ensure_table_column(
+    let mut repaired = false;
+    repaired |= ensure_table_column(
         conn,
         "cleanup_cache",
         "created_at_epoch",
         "ALTER TABLE cleanup_cache ADD COLUMN created_at_epoch INTEGER;",
     )?;
-    ensure_table_column(
+    repaired |= ensure_table_column(
         conn,
         "cleanup_cache",
         "last_hit_at_epoch",
         "ALTER TABLE cleanup_cache ADD COLUMN last_hit_at_epoch INTEGER;",
     )?;
-    ensure_table_column(
+    repaired |= ensure_table_column(
         conn,
         "cleanup_cache",
         "expires_at_epoch",
         "ALTER TABLE cleanup_cache ADD COLUMN expires_at_epoch INTEGER;",
     )?;
-    ensure_table_column(
+    repaired |= ensure_table_column(
         conn,
         "cleanup_cache",
         "is_snippet",
         "ALTER TABLE cleanup_cache ADD COLUMN is_snippet INTEGER NOT NULL DEFAULT 0;",
     )?;
+    if repaired {
+        conn.execute_batch(
+            "UPDATE cleanup_cache
+             SET created_at_epoch = COALESCE(created_at_epoch, CAST(strftime('%s', created_at || 'Z') AS INTEGER)),
+                 last_hit_at_epoch = COALESCE(last_hit_at_epoch, CAST(strftime('%s', last_hit_at || 'Z') AS INTEGER)),
+                 expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER))
+             WHERE created_at_epoch IS NULL
+                OR last_hit_at_epoch IS NULL
+                OR expires_at_epoch IS NULL;",
+        )?;
+    }
     conn.execute_batch(
-        "UPDATE cleanup_cache
-         SET created_at_epoch = COALESCE(created_at_epoch, CAST(strftime('%s', created_at || 'Z') AS INTEGER)),
-             last_hit_at_epoch = COALESCE(last_hit_at_epoch, CAST(strftime('%s', last_hit_at || 'Z') AS INTEGER)),
-             expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER))
-         WHERE created_at_epoch IS NULL
-            OR last_hit_at_epoch IS NULL
-            OR expires_at_epoch IS NULL;
-         CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
+        "CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
            ON cleanup_cache(expires_at_epoch);
          CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch
            ON cleanup_cache(last_hit_at_epoch);",

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -31,6 +31,44 @@ fn ensure_table_column(conn: &Connection, table: &str, column: &str, def_sql: &s
     Ok(())
 }
 
+fn ensure_cleanup_cache_schema(conn: &Connection) -> Result<()> {
+    ensure_table_column(
+        conn,
+        "cleanup_cache",
+        "created_at_epoch",
+        "ALTER TABLE cleanup_cache ADD COLUMN created_at_epoch INTEGER;",
+    )?;
+    ensure_table_column(
+        conn,
+        "cleanup_cache",
+        "last_hit_at_epoch",
+        "ALTER TABLE cleanup_cache ADD COLUMN last_hit_at_epoch INTEGER;",
+    )?;
+    ensure_table_column(
+        conn,
+        "cleanup_cache",
+        "expires_at_epoch",
+        "ALTER TABLE cleanup_cache ADD COLUMN expires_at_epoch INTEGER;",
+    )?;
+    ensure_table_column(
+        conn,
+        "cleanup_cache",
+        "is_snippet",
+        "ALTER TABLE cleanup_cache ADD COLUMN is_snippet INTEGER NOT NULL DEFAULT 0;",
+    )?;
+    conn.execute_batch(
+        "UPDATE cleanup_cache
+         SET created_at_epoch = COALESCE(created_at_epoch, CAST(strftime('%s', created_at || 'Z') AS INTEGER)),
+             last_hit_at_epoch = COALESCE(last_hit_at_epoch, CAST(strftime('%s', last_hit_at || 'Z') AS INTEGER)),
+             expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER));
+         CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
+           ON cleanup_cache(expires_at_epoch);
+         CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch
+           ON cleanup_cache(last_hit_at_epoch);",
+    )?;
+    Ok(())
+}
+
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS transcriptions (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -109,10 +147,6 @@ CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at
   ON cleanup_cache(expires_at);
 CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
   ON cleanup_cache(last_hit_at);
-CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
-  ON cleanup_cache(expires_at_epoch);
-CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch
-  ON cleanup_cache(last_hit_at_epoch);
 ";
 
 pub fn open(path: &str) -> Result<Db> {
@@ -191,10 +225,6 @@ pub fn open(path: &str) -> Result<Db> {
                ON cleanup_cache(expires_at);
              CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
                ON cleanup_cache(last_hit_at);
-             CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
-               ON cleanup_cache(expires_at_epoch);
-             CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch
-               ON cleanup_cache(last_hit_at_epoch);
              PRAGMA user_version = 3;
              COMMIT;",
         );
@@ -257,12 +287,7 @@ pub fn open(path: &str) -> Result<Db> {
     if user_version < 5 {
         conn.execute_batch("BEGIN;")?;
         if let Err(err) = (|| -> Result<()> {
-            ensure_table_column(
-                &conn,
-                "cleanup_cache",
-                "is_snippet",
-                "ALTER TABLE cleanup_cache ADD COLUMN is_snippet INTEGER NOT NULL DEFAULT 0;",
-            )?;
+            ensure_cleanup_cache_schema(&conn)?;
             conn.execute_batch("PRAGMA user_version = 5;")?;
             Ok(())
         })() {
@@ -274,35 +299,8 @@ pub fn open(path: &str) -> Result<Db> {
     if user_version < 6 {
         conn.execute_batch("BEGIN;")?;
         if let Err(err) = (|| -> Result<()> {
-            ensure_table_column(
-                &conn,
-                "cleanup_cache",
-                "created_at_epoch",
-                "ALTER TABLE cleanup_cache ADD COLUMN created_at_epoch INTEGER;",
-            )?;
-            ensure_table_column(
-                &conn,
-                "cleanup_cache",
-                "last_hit_at_epoch",
-                "ALTER TABLE cleanup_cache ADD COLUMN last_hit_at_epoch INTEGER;",
-            )?;
-            ensure_table_column(
-                &conn,
-                "cleanup_cache",
-                "expires_at_epoch",
-                "ALTER TABLE cleanup_cache ADD COLUMN expires_at_epoch INTEGER;",
-            )?;
-            conn.execute_batch(
-                "UPDATE cleanup_cache
-                 SET created_at_epoch = COALESCE(created_at_epoch, CAST(strftime('%s', created_at || 'Z') AS INTEGER)),
-                     last_hit_at_epoch = COALESCE(last_hit_at_epoch, CAST(strftime('%s', last_hit_at || 'Z') AS INTEGER)),
-                     expires_at_epoch = COALESCE(expires_at_epoch, CAST(strftime('%s', expires_at || 'Z') AS INTEGER));
-                 CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at_epoch
-                   ON cleanup_cache(expires_at_epoch);
-                 CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at_epoch
-                   ON cleanup_cache(last_hit_at_epoch);
-                 PRAGMA user_version = 6;",
-            )?;
+            ensure_cleanup_cache_schema(&conn)?;
+            conn.execute_batch("PRAGMA user_version = 6;")?;
             Ok(())
         })() {
             let _ = conn.execute_batch("ROLLBACK;");
@@ -310,6 +308,7 @@ pub fn open(path: &str) -> Result<Db> {
         }
         conn.execute_batch("COMMIT;")?;
     }
+    ensure_cleanup_cache_schema(&conn)?;
 
     Ok(Arc::new(Mutex::new(conn)))
 }
@@ -988,6 +987,57 @@ mod tests {
         open(":memory:").expect("test db")
     }
 
+    fn temp_db_path(name: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "open_flow_{name}_{}_{}.db",
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    #[test]
+    fn open_repairs_legacy_cleanup_cache_missing_epoch_columns() {
+        let path = temp_db_path("legacy_cleanup_cache");
+        {
+            let conn = Connection::open(&path).expect("create legacy db");
+            conn.execute_batch(
+                "CREATE TABLE cleanup_cache (
+                   key         TEXT PRIMARY KEY,
+                   clean_text  TEXT NOT NULL,
+                   hit_count   INTEGER NOT NULL DEFAULT 0,
+                   created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+                   last_hit_at DATETIME NOT NULL DEFAULT (datetime('now')),
+                   expires_at  DATETIME NOT NULL,
+                   is_snippet  INTEGER NOT NULL DEFAULT 0
+                 );
+                 INSERT INTO cleanup_cache
+                   (key, clean_text, hit_count, created_at, last_hit_at, expires_at, is_snippet)
+                 VALUES
+                   ('legacy', 'hello', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00', '2999-01-01 00:00:00', 0);
+                 PRAGMA user_version = 6;",
+            )
+            .expect("seed legacy db");
+        }
+
+        let db = open(path.to_str().expect("path string")).expect("open repairs legacy db");
+        assert!(cleanup_cache_get_active(&db, "legacy")
+            .expect("query repaired row")
+            .is_some());
+
+        let conn = lock_conn(&db).expect("lock");
+        assert!(table_has_column(&conn, "cleanup_cache", "expires_at_epoch").expect("column"));
+        assert!(table_has_column(&conn, "cleanup_cache", "last_hit_at_epoch").expect("column"));
+        drop(conn);
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(path.with_extension("db-shm"));
+    }
+
     #[test]
     fn auto_learn_does_not_overwrite_manual_dictionary_entry() {
         let db = test_db();
@@ -1087,11 +1137,9 @@ mod tests {
         .expect("null out epoch");
         drop(conn);
 
-        assert!(
-            cleanup_cache_get_active(&db, "legacy")
-                .expect("query")
-                .is_some()
-        );
+        assert!(cleanup_cache_get_active(&db, "legacy")
+            .expect("query")
+            .is_some());
     }
 
     #[test]
@@ -1121,7 +1169,8 @@ mod tests {
     #[test]
     fn cleanup_cache_epoch_columns_treat_utc_text_as_utc() {
         let db = test_db();
-        cleanup_cache_insert_new(&db, "utc", "value", "2026-01-01 00:00:00", false).expect("insert");
+        cleanup_cache_insert_new(&db, "utc", "value", "2026-01-01 00:00:00", false)
+            .expect("insert");
 
         let conn = lock_conn(&db).expect("lock");
         let inserted_expiry_epoch: i64 = conn
@@ -1134,14 +1183,8 @@ mod tests {
         drop(conn);
         assert_eq!(inserted_expiry_epoch, 1_767_225_600);
 
-        cleanup_cache_touch_hit(
-            &db,
-            "utc",
-            2,
-            "2026-01-02 03:04:05",
-            "2026-02-03 04:05:06",
-        )
-        .expect("touch");
+        cleanup_cache_touch_hit(&db, "utc", 2, "2026-01-02 03:04:05", "2026-02-03 04:05:06")
+            .expect("touch");
         let conn = lock_conn(&db).expect("lock");
         let (last_hit_epoch, expires_epoch): (i64, i64) = conn
             .query_row(

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -647,6 +647,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
             api_used: &api_used,
             target_hwnd,
             cfg: &cfg,
+            profile: &profile,
             process_name,
             cleanup_cache_key,
             captured_at: retry_captured_at,
@@ -1204,6 +1205,7 @@ pub async fn retry_transcription_impl(
             api_used: &api_used,
             target_hwnd: capture.target_hwnd,
             cfg: &cfg,
+            profile: &capture.profile,
             process_name: capture.process_name,
             cleanup_cache_key,
             captured_at: capture.captured_at,
@@ -1220,6 +1222,7 @@ struct PipelineCompletionContext<'a> {
     api_used: &'a str,
     target_hwnd: usize,
     cfg: &'a store::PipelineConfig,
+    profile: &'a str,
     process_name: String,
     cleanup_cache_key: String,
     captured_at: std::time::Instant,
@@ -1294,25 +1297,33 @@ async fn finalize_pipeline_completion(
 
     hide_pill(app);
     let inject_stage = std::time::Instant::now();
-    let injected_text = match injection::inject_text(
+    let injected = match injection::inject_text(
         &final_text_substituted,
         ctx.target_hwnd,
         ctx.cfg.contextual_caps_enabled,
         ctx.cfg.auto_spacing_enabled,
+        ctx.profile,
     )
     .await
     {
-        Ok(text) => text,
+        Ok(outcome) => outcome,
         Err(e) => {
             log::error!("inject: {e}");
             show_error_pill(app, "Failed to paste - text saved to history").await;
-            final_text_substituted.clone()
+            injection::InjectionOutcome {
+                text: final_text_substituted.clone(),
+                context_state: "unknown",
+                case_decision: "inject_failed",
+            }
         }
     };
+    let injected_text = injected.text;
     log::debug!(
-        "pipeline: injection done contextual_caps={} auto_spacing={} output_chars={} stage_ms={}",
+        "pipeline: injection done contextual_caps={} auto_spacing={} context_state={} case_decision={} output_chars={} stage_ms={}",
         ctx.cfg.contextual_caps_enabled,
         ctx.cfg.auto_spacing_enabled,
+        injected.context_state,
+        injected.case_decision,
         injected_text.chars().count(),
         inject_stage.elapsed().as_millis()
     );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,7 +10,7 @@
   import Settings from './lib/views/Settings.svelte';
   import DictationPill from './lib/components/layout/DictationPill.svelte';
   import Setup from './lib/views/Setup.svelte';
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke, listen } from './lib/tauri';
   import { fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx } from './lib/motion';
@@ -74,15 +74,12 @@
         appStore.setupComplete = false;
       }
 
-      try {
-        const { listen } = await import('@tauri-apps/api/event');
-        const unlisten = await listen<string>('open-flow:error', (ev) => {
-          errorToast = ev.payload ?? 'Something went wrong';
-          clearTimeout(toastTimer);
-          toastTimer = setTimeout(() => { errorToast = ''; }, 5000);
-        });
-        cleanupFn = unlisten;
-      } catch {}
+      const unlisten = await listen<string>('open-flow:error', (ev) => {
+        errorToast = ev.payload ?? 'Something went wrong';
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { errorToast = ''; }, 5000);
+      });
+      cleanupFn = unlisten;
     })();
 
     const media = window.matchMedia?.('(prefers-color-scheme: dark)');

--- a/src/lib/calibration.ts
+++ b/src/lib/calibration.ts
@@ -1,6 +1,5 @@
 import { writable, get } from 'svelte/store';
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
+import { invoke, listen } from './tauri';
 import { saveSetting } from './settings';
 
 // TARGET_CALIBRATION_FACTOR is set to 2.25 as specified by the system design to optimize input levels for the downstream transcription model.

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../tauri';
   import { onMount } from 'svelte';
   import { fly, slide, fade } from 'svelte/transition';
   import { flip } from 'svelte/animate';

--- a/src/lib/components/MicInputButton.svelte
+++ b/src/lib/components/MicInputButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../tauri';
 
   let { onResult }: { onResult: (text: string) => void } = $props();
 

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { appStore } from '../../stores';
   import { icons } from '../../icons';
   import { tweened } from 'svelte/motion';

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { appStore, type UpdateInfo } from '../../stores';
   import { saveSetting } from '../../settings';
 

--- a/src/lib/components/settings/ApiKeysSection.svelte
+++ b/src/lib/components/settings/ApiKeysSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
 
   const keyProviders: { id: 'groq' | 'openai' | 'google'; label: string; ph: string; models: string }[] = [
     { id: 'groq',   label: 'Groq',   ph: 'gsk_…',  models: 'whisper-large-v3-turbo · llama-3.3-70b' },

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { slide, fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { onDestroy } from 'svelte';

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { onMount } from 'svelte';
   import Toggle from '../Toggle.svelte';
 

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { emit, invoke } from '../../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';
@@ -295,7 +295,6 @@
         }
         if (!available) {
           hotkeyState = 'error';
-          const { emit } = await import('@tauri-apps/api/event');
           await emit('open-flow:error', 'Hotkey may already be in use by another application');
           setTimeout(() => { hotkeyState = 'idle'; }, HOTKEY_ERROR_MS);
           return;
@@ -307,7 +306,6 @@
       } catch (e) {
         console.error('Failed to save hotkey', e);
         hotkeyState = 'error';
-        const { emit } = await import('@tauri-apps/api/event');
         await emit('open-flow:error', 'Failed to save hotkey - key may not be recognized');
         setTimeout(() => { hotkeyState = 'idle'; }, HOTKEY_ERROR_MS);
       }

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { fly, slide } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invoke } from './tauri';
 import type { TranscriptionLanguageCode } from './transcriptionLanguages';
 
 export type ProviderId = 'groq' | 'openai' | 'google';

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { invoke } from './tauri';
 
 export type PageId = 'home' | 'dictionary' | 'snippets' | 'style';
 export type AppearanceMode = 'system' | 'light' | 'dark';

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -80,7 +80,7 @@ function readDevSettings(): Record<string, unknown> {
 }
 
 function writeDevSetting(key: string, value: unknown) {
-  if (typeof localStorage === 'undefined') return;
+  if (typeof localStorage === 'undefined' || !key) return;
   try {
     const next = { ...readDevSettings(), [key]: value };
     localStorage.setItem(DEV_STORAGE_KEY, JSON.stringify(next));
@@ -99,7 +99,10 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'get_setting':
       return getDevSetting(String(args?.key ?? '')) as T;
     case 'save_setting':
-      writeDevSetting(String(args?.key ?? ''), args?.value);
+      if (typeof args?.key !== 'string' || args.key.length === 0) {
+        return undefined as T;
+      }
+      writeDevSetting(args.key, args?.value);
       return undefined as T;
     case 'get_all_settings':
       return { ...defaultSettings, ...readDevSettings() } as T;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -81,8 +81,12 @@ function readDevSettings(): Record<string, unknown> {
 
 function writeDevSetting(key: string, value: unknown) {
   if (typeof localStorage === 'undefined') return;
-  const next = { ...readDevSettings(), [key]: value };
-  localStorage.setItem(DEV_STORAGE_KEY, JSON.stringify(next));
+  try {
+    const next = { ...readDevSettings(), [key]: value };
+    localStorage.setItem(DEV_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Browser dev mode should keep working even when persistent storage is blocked.
+  }
 }
 
 function getDevSetting(key: string): unknown {
@@ -99,12 +103,15 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return undefined as T;
     case 'get_all_settings':
       return { ...defaultSettings, ...readDevSettings() } as T;
+    case 'get_app_mappings':
+      return getDevSetting('app_mappings') as T;
     case 'get_recent':
     case 'get_snippets':
     case 'get_dictionary':
     case 'get_recent_auto_learn_activity':
     case 'get_microphones':
     case 'get_recent_logs':
+    case 'get_installed_apps':
       return [] as T;
     case 'get_stats':
       return { total_words: 0, avg_wpm: 0, day_streak: 0 } as T;
@@ -135,7 +142,6 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return '' as T;
     case 'save_api_key':
     case 'delete_api_key':
-    case 'save_app_mappings':
     case 'set_autostart':
     case 'save_hotkey':
     case 'hide_main':
@@ -152,6 +158,11 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'start_calibration_monitoring':
     case 'stop_calibration_monitoring':
       return undefined as T;
+    case 'save_app_mappings':
+      writeDevSetting('app_mappings', args?.mappings ?? []);
+      return undefined as T;
+    case 'download_logs':
+      return 'browser-dev://open-flow-logs.txt' as T;
     default:
       throw new Error(`Tauri command "${command}" is unavailable in browser dev mode.`);
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,0 +1,193 @@
+import { getVersion as getTauriVersion } from '@tauri-apps/api/app';
+import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import { emit as tauriEmit, listen as tauriListen } from '@tauri-apps/api/event';
+
+declare const __APP_VERSION__: string;
+
+type CommandArgs = Record<string, unknown>;
+type EventEnvelope<T> = {
+  event: string;
+  id: number;
+  payload: T;
+};
+type EventHandler<T> = (event: EventEnvelope<T>) => void;
+type UnlistenFn = () => void;
+
+const DEV_STORAGE_KEY = 'open-flow:dev-settings';
+
+const defaultProviderModels = {
+  groq: ['whisper-large-v3-turbo', 'whisper-large-v3'],
+  openai: ['gpt-4o-mini-transcribe', 'gpt-4o-transcribe'],
+  google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
+};
+
+const defaultCleanupModels = {
+  groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+  openai: ['gpt-4o-mini', 'gpt-4o'],
+  google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
+};
+
+const defaultSettings: Record<string, unknown> = {
+  setup_complete: true,
+  force_setup_on_launch: false,
+  appearance_mode: 'system',
+  transcription_provider: 'groq',
+  transcription_language: 'en',
+  cleanup_provider: 'groq',
+  transcription_model: 'groq/whisper-large-v3-turbo',
+  cleanup_model: 'groq/llama-3.3-70b-versatile',
+  transcription_default_model: 'groq/whisper-large-v3-turbo',
+  cleanup_default_model: 'groq/llama-3.3-70b-versatile',
+  transcription_models_by_provider: defaultProviderModels,
+  cleanup_models_by_provider: defaultCleanupModels,
+  transcription_fallback_models: [],
+  cleanup_fallback_models: [],
+  cleanup_enabled: true,
+  default_tone: 'casual',
+  cleanup_intensity: 'medium',
+  app_mappings: [],
+  noise_reduction: true,
+  mute_audio: false,
+  autostart_enabled: false,
+  mic_gain: 3.5,
+  app_context_hint: false,
+  auto_learn_enabled: false,
+  contextual_caps_enabled: true,
+  auto_spacing_enabled: true,
+  history_retention: '30 days',
+  microphone_device: null,
+  update_dismissed_version: null,
+  advanced_model_ui: false,
+  hotkey: ['ControlLeft', 'MetaLeft'],
+};
+
+function hasTauriInternals(): boolean {
+  if (typeof window === 'undefined') return false;
+  const maybeWindow = window as Window & {
+    __TAURI_INTERNALS__?: { invoke?: unknown };
+  };
+  return typeof maybeWindow.__TAURI_INTERNALS__?.invoke === 'function';
+}
+
+function readDevSettings(): Record<string, unknown> {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(DEV_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeDevSetting(key: string, value: unknown) {
+  if (typeof localStorage === 'undefined') return;
+  const next = { ...readDevSettings(), [key]: value };
+  localStorage.setItem(DEV_STORAGE_KEY, JSON.stringify(next));
+}
+
+function getDevSetting(key: string): unknown {
+  const saved = readDevSettings();
+  return key in saved ? saved[key] : defaultSettings[key] ?? null;
+}
+
+async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
+  switch (command) {
+    case 'get_setting':
+      return getDevSetting(String(args?.key ?? '')) as T;
+    case 'save_setting':
+      writeDevSetting(String(args?.key ?? ''), args?.value);
+      return undefined as T;
+    case 'get_all_settings':
+      return { ...defaultSettings, ...readDevSettings() } as T;
+    case 'get_recent':
+    case 'get_snippets':
+    case 'get_dictionary':
+    case 'get_recent_auto_learn_activity':
+    case 'get_microphones':
+    case 'get_recent_logs':
+      return [] as T;
+    case 'get_stats':
+      return { total_words: 0, avg_wpm: 0, day_streak: 0 } as T;
+    case 'get_memory_mb':
+      return 0 as T;
+    case 'get_api_key_status':
+      return { groq: false, openai: false, google: false } as T;
+    case 'check_for_update':
+      return null as T;
+    case 'check_connectivity':
+      return (typeof navigator === 'undefined' ? true : navigator.onLine) as T;
+    case 'get_cleanup_cache_status':
+      return { entry_count: 0, is_space_constrained: false, free_bytes: null } as T;
+    case 'get_auto_learn_status_summary':
+      return {
+        monitors_started: 0,
+        anchor_misses: 0,
+        low_confidence_rejections: 0,
+        promotions: 0,
+        duplicate_monitor_skips: 0,
+        timeout_finishes: 0,
+      } as T;
+    case 'clear_cleanup_cache':
+      return 0 as T;
+    case 'check_hotkey':
+      return true as T;
+    case 'stop_and_transcribe_input':
+      return '' as T;
+    case 'save_api_key':
+    case 'delete_api_key':
+    case 'save_app_mappings':
+    case 'set_autostart':
+    case 'save_hotkey':
+    case 'hide_main':
+    case 'start_input_recording':
+    case 'retry_transcription':
+    case 'install_update':
+    case 'set_dev_logging_enabled':
+    case 'create_dictionary_entry':
+    case 'edit_dictionary_entry':
+    case 'remove_dictionary_entry':
+    case 'create_snippet':
+    case 'edit_snippet':
+    case 'remove_snippet':
+    case 'start_calibration_monitoring':
+    case 'stop_calibration_monitoring':
+      return undefined as T;
+    default:
+      throw new Error(`Tauri command "${command}" is unavailable in browser dev mode.`);
+  }
+}
+
+export function isTauriRuntime(): boolean {
+  return hasTauriInternals();
+}
+
+export function invoke<T = unknown>(command: string, args?: CommandArgs): Promise<T> {
+  if (hasTauriInternals()) {
+    return tauriInvoke<T>(command, args);
+  }
+  return devInvoke<T>(command, args);
+}
+
+export function listen<T>(
+  event: string,
+  handler: EventHandler<T>,
+): Promise<UnlistenFn> {
+  if (hasTauriInternals()) {
+    return tauriListen<T>(event, handler as Parameters<typeof tauriListen<T>>[1]);
+  }
+  return Promise.resolve(() => {});
+}
+
+export function emit<T>(event: string, payload?: T): Promise<void> {
+  if (hasTauriInternals()) {
+    return tauriEmit(event, payload);
+  }
+  return Promise.resolve();
+}
+
+export function getVersion(): Promise<string> {
+  if (hasTauriInternals()) {
+    return getTauriVersion();
+  }
+  return Promise.resolve(__APP_VERSION__);
+}

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { invoke } from '@tauri-apps/api/core';
-  import { listen } from '@tauri-apps/api/event';
+  import { invoke, listen } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -186,7 +186,20 @@
   onMount(() => {
     getVersion().then(v => currentVersion = v);
     load();
-    let unlisten: (() => void) | undefined;
+    let mounted = true;
+    const unlisteners: (() => void)[] = [];
+
+    function trackListener(promise: Promise<() => void>) {
+      promise
+        .then((cleanup) => {
+          if (!mounted) {
+            cleanup();
+            return;
+          }
+          unlisteners.push(cleanup);
+        })
+        .catch(() => {});
+    }
 
     // Check for updates, skip banner if user dismissed this version
     invoke<UpdateInfo | null>('check_for_update').then(async (update) => {
@@ -199,24 +212,26 @@
       }
     }).catch(() => {});
 
-    listen('open-flow:transcribed', () => {
+    trackListener(listen('open-flow:transcribed', () => {
       failedEntry = null;
       if (failedTimer) { clearTimeout(failedTimer); failedTimer = null; }
       load();
-    }).then(u => unlisten = u).catch(() => {});
+    }));
 
-    listen<string>('open-flow:pipeline-failed', (ev) => {
+    trackListener(listen<string>('open-flow:pipeline-failed', (ev) => {
       failedEntry = { created_at: ev.payload };
       if (failedTimer) clearTimeout(failedTimer);
       failedTimer = setTimeout(() => {
         failedEntry = null;
         failedTimer = null;
       }, 10 * 60 * 1000);
-    }).then(u => unlistenFailed = u).catch(() => {});
+    }));
 
     return () => {
-      if (unlisten) unlisten();
-      if (unlistenFailed) unlistenFailed();
+      mounted = false;
+      while (unlisteners.length > 0) {
+        unlisteners.pop()?.();
+      }
       if (failedTimer) {
         clearTimeout(failedTimer);
         failedTimer = null;

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -3,8 +3,7 @@
   import { fly } from 'svelte/transition';
   import { flip } from 'svelte/animate';
   import { expoOut } from 'svelte/easing';
-  import { invoke } from '@tauri-apps/api/core';
-  import { getVersion } from '@tauri-apps/api/app';
+  import { invoke, getVersion, listen } from '../tauri';
   import { icons } from '../icons';
   import { appStore, type UpdateInfo } from '../stores';
   import { saveSetting } from '../settings';
@@ -200,22 +199,20 @@
       }
     }).catch(() => {});
 
-    import('@tauri-apps/api/event').then(({ listen }) => {
-      listen('open-flow:transcribed', () => {
-        failedEntry = null;
-        if (failedTimer) { clearTimeout(failedTimer); failedTimer = null; }
-        load();
-      }).then(u => unlisten = u).catch(() => {});
+    listen('open-flow:transcribed', () => {
+      failedEntry = null;
+      if (failedTimer) { clearTimeout(failedTimer); failedTimer = null; }
+      load();
+    }).then(u => unlisten = u).catch(() => {});
 
-      listen<string>('open-flow:pipeline-failed', (ev) => {
-        failedEntry = { created_at: ev.payload };
-        if (failedTimer) clearTimeout(failedTimer);
-        failedTimer = setTimeout(() => {
-          failedEntry = null;
-          failedTimer = null;
-        }, 10 * 60 * 1000);
-      }).then(u => unlistenFailed = u).catch(() => {});
-    }).catch(() => {});
+    listen<string>('open-flow:pipeline-failed', (ev) => {
+      failedEntry = { created_at: ev.payload };
+      if (failedTimer) clearTimeout(failedTimer);
+      failedTimer = setTimeout(() => {
+        failedEntry = null;
+        failedTimer = null;
+      }, 10 * 60 * 1000);
+    }).then(u => unlistenFailed = u).catch(() => {});
 
     return () => {
       if (unlisten) unlisten();

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -4,7 +4,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { getVersion } from '@tauri-apps/api/app';
+  import { getVersion } from '../tauri';
   import { MOTION_MS, MOTION_PX, SETTINGS_SECTION_ORDER, directionFromOrder, motionMs, motionPx } from '../motion';
 
   import GeneralSection from '../components/settings/GeneralSection.svelte';

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../tauri';
   import { onMount, onDestroy } from 'svelte';
   import { appStore } from '../stores';
   import { animateWidth } from '../motion';

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { appStore, fetchSnippets, type Snippet } from '../stores';

--- a/src/lib/views/Style.svelte
+++ b/src/lib/views/Style.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from '@tauri-apps/api/core';
+  import { invoke } from '../tauri';
   import { onMount } from 'svelte';
   import { fly, crossfade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import pkg from './package.json';
 
 export default defineConfig({
   plugins: [svelte()],
   clearScreen: false,
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
﻿## Thinking Path

> - Open Flow is a Windows AI dictation app with a Tauri desktop shell and a Svelte frontend.
> - This PR touches the dev boot path, local browser verification, and the SQLite cache migration layer.
> - The dirty worktree already contained two linked stabilization threads: a frontend Tauri shim for `npm run dev` and a cleanup-cache schema repair for older local databases.
> - The backend hotkey, injection, and pipeline changes are the rest of the current stabilization work and belong with the same 0.11.0 hardening pass.
> - This pull request packages those changes into one branch based on the latest `origin/dev`.
> - The benefit is that dev startup no longer panics, browser preview no longer crashes on missing Tauri APIs, and the current stabilization work is reviewable from a clean base.

## What Changed

- Added a small `src/lib/tauri.ts` facade so frontend code can run in browser Vite dev mode without Tauri APIs.
- Updated the frontend imports to use that facade and injected the app version through `vite.config.ts`.
- Fixed `cleanup_cache` startup repair so older local databases missing epoch columns are migrated instead of crashing on boot.
- Kept the current hotkey, injection, and pipeline stabilization work together in the same branch.

## Verification

- `git branch --show-current`
- `git merge-base HEAD origin/dev`
- `git log --oneline origin/dev..HEAD`
- `npm run check`
- `npm run lint`
- `npm run test:rust`
- `npm run build`
- `npm run tauri dev`
- Playwright browser smoke against `http://localhost:1420/` with no console or page errors.

## Risks

- The database repair path now alters legacy local databases at startup. That is the right fix, but it still needs a fresh-eye review.
- The browser Tauri facade returns safe defaults in dev mode, so it is for UI verification only and does not replace real desktop behavior.
- The broader hotkey/injection changes increase the review surface because they touch core dictation behavior.

## Model Used

- OpenAI GPT-5 via Codex

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above
