### PR TITLE
fix(snippets): fix paste-to-create on macOS and harden modal interactive controls

### DIFF
--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -892,7 +892,6 @@ pub enum FocusedTextProbe {
     Unavailable,
 }
 
-
 #[cfg(windows)]
 fn control_type_label(control_type: i32) -> String {
     use windows::Win32::UI::Accessibility::{

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -564,7 +564,13 @@ pub async fn save_app_mappings(app: AppHandle, mappings: Vec<AppMapping>) -> Res
 #[tauri::command]
 pub async fn get_snippets(app: AppHandle) -> Result<Vec<db::Snippet>, String> {
     let db = app.state::<DbHandle>().inner().clone();
-    tokio::task::spawn_blocking(move || db::query_snippets(&db).map_err(|e| e.to_string()))
+    tokio::task::spawn_blocking(move || {
+        let rows = db::query_snippets(&db).map_err(|e| e.to_string())?;
+        if crate::system::logger::is_verbose() {
+            log::info!("snippets:get count={}", rows.len());
+        }
+        Ok(rows)
+    })
         .await
         .map_err(|e| e.to_string())?
 }
@@ -575,10 +581,22 @@ pub async fn create_snippet(
     trigger: String,
     expansion: String,
     instructions: String,
-) -> Result<(), String> {
+) -> Result<db::CreatedRecordMeta, String> {
     let db = app.state::<DbHandle>().inner().clone();
     tokio::task::spawn_blocking(move || {
-        db::insert_snippet(&db, &trigger, &expansion, &instructions).map_err(|e| e.to_string())
+        log::info!(
+            "snippets:create trigger_chars={} expansion_chars={} instructions_chars={}",
+            trigger.chars().count(),
+            expansion.chars().count(),
+            instructions.chars().count()
+        );
+        let created = db::insert_snippet_returning(&db, &trigger, &expansion, &instructions)
+            .map_err(|e| {
+                log::warn!("snippets:create failed: {e}");
+                e.to_string()
+            })?;
+        log::info!("snippets:create ok id={}", created.id);
+        Ok(created)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -623,10 +641,19 @@ pub async fn create_dictionary_entry(
     app: AppHandle,
     term: String,
     mistake: Option<String>,
-) -> Result<(), String> {
+) -> Result<db::CreatedRecordMeta, String> {
     let db = app.state::<DbHandle>().inner().clone();
     tokio::task::spawn_blocking(move || {
-        db::insert_dictionary_entry(&db, &term, mistake.as_deref()).map_err(|e| e.to_string())
+        log::info!(
+            "dictionary:create term_chars={} mistake_chars={}",
+            term.chars().count(),
+            mistake.as_deref().map_or(0, |m| m.chars().count())
+        );
+        db::insert_dictionary_entry_returning(&db, &term, mistake.as_deref())
+            .map_err(|e| {
+                log::warn!("dictionary:create failed: {e}");
+                e.to_string()
+            })
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1066,6 +1093,15 @@ pub async fn check_connectivity() -> bool {
 }
 
 // ---------- developer logs ----------
+
+#[tauri::command]
+pub fn log_frontend(level: String, message: String) {
+    match level.as_str() {
+        "warn"  => log::warn!("fe: {message}"),
+        "error" => log::error!("fe: {message}"),
+        _       => log::info!("fe: {message}"),
+    }
+}
 
 #[tauri::command]
 pub fn get_recent_logs(limit: Option<usize>) -> Vec<String> {

--- a/src-tauri/src/core/context_probe.rs
+++ b/src-tauri/src/core/context_probe.rs
@@ -149,8 +149,7 @@ fn get_monotonic_ms() -> u64 {
 }
 
 #[cfg(target_os = "macos")]
-static MACOS_PROBE_START_TIME: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+static MACOS_PROBE_START_TIME: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[cfg(target_os = "macos")]
 struct MacosProbeGuard {

--- a/src-tauri/src/core/context_probe.rs
+++ b/src-tauri/src/core/context_probe.rs
@@ -163,21 +163,27 @@ impl MacosProbeGuard {
 
         let now = get_monotonic_ms();
 
-        let active_time = MACOS_PROBE_START_TIME.load(Ordering::SeqCst);
-        if active_time != 0 {
-            // Block concurrent calls if the active probe has not timed out yet (2000ms threshold)
-            if now >= active_time && now - active_time < 2000 {
-                return None;
+        // Retry loop: if a concurrent probe is released between our load and the
+        // CAS, the CAS fails with the new (zero) value; loop to re-evaluate
+        // instead of incorrectly reporting busy.
+        let mut active_time = MACOS_PROBE_START_TIME.load(Ordering::SeqCst);
+        loop {
+            if active_time != 0 {
+                // Block concurrent calls if the active probe has not timed out yet (2000ms threshold)
+                if now >= active_time && now - active_time < 2000 {
+                    return None;
+                }
             }
-        }
 
-        if MACOS_PROBE_START_TIME
-            .compare_exchange(active_time, now, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-        {
-            Some(Self { start_time: now })
-        } else {
-            None
+            match MACOS_PROBE_START_TIME.compare_exchange(
+                active_time,
+                now,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return Some(Self { start_time: now }),
+                Err(actual) => active_time = actual,
+            }
         }
     }
 }

--- a/src-tauri/src/core/context_probe.rs
+++ b/src-tauri/src/core/context_probe.rs
@@ -169,8 +169,10 @@ impl MacosProbeGuard {
         let mut active_time = MACOS_PROBE_START_TIME.load(Ordering::SeqCst);
         loop {
             if active_time != 0 {
-                // Block concurrent calls if the active probe has not timed out yet (2000ms threshold)
-                if now >= active_time && now - active_time < 2000 {
+                // Block if the active probe hasn't timed out. Also block when
+                // now < active_time: a thread with a later timestamp already
+                // acquired the guard between our load and CAS — treat it as live.
+                if now < active_time || now - active_time < 2000 {
                     return None;
                 }
             }

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -473,7 +473,10 @@ fn update_injection_history_for_event(event: &HotkeyEvent, now: u64) {
         crate::core::injection::reset_injection_history();
         return;
     }
-    for ch in text.chars().filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\r') {
+    for ch in text
+        .chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\r')
+    {
         crate::core::injection::append_or_reset_injection_history(hwnd, ch);
         appended = true;
     }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -261,21 +261,103 @@ fn classify_context(tail: &str) -> ContextKind {
 // Lowercasing is only applied to words in this list so that Title-Case proper
 // nouns (London, Monday, Google) are preserved in continuation context.
 const SAFE_TO_LOWERCASE: &[&str] = &[
-    "the", "a", "an",
-    "this", "that", "these", "those",
-    "it", "he", "she", "we", "they", "you",
-    "is", "was", "are", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did",
-    "will", "would", "could", "should", "may", "might", "must", "can",
-    "and", "or", "but", "if", "so", "then", "because", "though", "although",
-    "my", "your", "his", "her", "our", "their", "its",
-    "let", "just", "not", "also", "even", "now", "here", "there",
-    "make", "get", "go", "see", "think", "say", "tell", "look", "seem",
-    "all", "some", "any", "no", "more", "most", "very", "well", "still",
-    "when", "where", "how", "what", "which",
-    "please", "yes", "no", "ok", "okay",
-    "actually", "basically", "honestly", "literally", "really", "totally",
-    "with", "into", "onto", "upon", "about",
+    "the",
+    "a",
+    "an",
+    "this",
+    "that",
+    "these",
+    "those",
+    "it",
+    "he",
+    "she",
+    "we",
+    "they",
+    "you",
+    "is",
+    "was",
+    "are",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "could",
+    "should",
+    "may",
+    "might",
+    "must",
+    "can",
+    "and",
+    "or",
+    "but",
+    "if",
+    "so",
+    "then",
+    "because",
+    "though",
+    "although",
+    "my",
+    "your",
+    "his",
+    "her",
+    "our",
+    "their",
+    "its",
+    "let",
+    "just",
+    "not",
+    "also",
+    "even",
+    "now",
+    "here",
+    "there",
+    "make",
+    "get",
+    "go",
+    "see",
+    "think",
+    "say",
+    "tell",
+    "look",
+    "seem",
+    "all",
+    "some",
+    "any",
+    "no",
+    "more",
+    "most",
+    "very",
+    "well",
+    "still",
+    "when",
+    "where",
+    "how",
+    "what",
+    "which",
+    "please",
+    "yes",
+    "no",
+    "ok",
+    "okay",
+    "actually",
+    "basically",
+    "honestly",
+    "literally",
+    "really",
+    "totally",
+    "with",
+    "into",
+    "onto",
+    "upon",
+    "about",
 ];
 
 fn is_safe_lowercase_candidate(word: &str) -> bool {
@@ -346,7 +428,6 @@ fn lowercase_first_word_if_safe(text: &str) -> (String, bool) {
 fn unavailable_injection_probe() -> InjectionContextProbe {
     InjectionContextProbe::unavailable(ContextProbeSource::Unavailable, "unavailable")
 }
-
 
 fn fallback_probe_from_history(target_hwnd: usize) -> Option<InjectionContextProbe> {
     if target_hwnd == 0 || crate::core::window_context::get_foreground_hwnd() != target_hwnd {
@@ -421,8 +502,7 @@ fn apply_probe_adjustments(
                 }
             },
             text_context::InjectionPrefixClass::HardSentenceTerminator => {
-                adjusted =
-                    text_context::format_injection_text(text, probe.context, prefix_class);
+                adjusted = text_context::format_injection_text(text, probe.context, prefix_class);
                 CaseDecision::SentenceBoundaryCapitalized
             }
             text_context::InjectionPrefixClass::SoftPunctuationPrefix
@@ -699,7 +779,12 @@ async fn macos_clipboard_sniff_context(target_hwnd: usize) -> Option<InjectionCo
     // src is scoped to the block so it is dropped before the await.
     {
         let src = CGEventSource::new(CGEventSourceStateID::CombinedSessionState).ok()?;
-        post_key_event(src.clone(), KEY_LEFT_ARROW, true, CGEventFlags::CGEventFlagShift);
+        post_key_event(
+            src.clone(),
+            KEY_LEFT_ARROW,
+            true,
+            CGEventFlags::CGEventFlagShift,
+        );
         post_key_event(src, KEY_LEFT_ARROW, false, CGEventFlags::CGEventFlagShift);
     }
     tokio::time::sleep(Duration::from_millis(30)).await;
@@ -707,7 +792,12 @@ async fn macos_clipboard_sniff_context(target_hwnd: usize) -> Option<InjectionCo
     // Cmd+C: copy selection to clipboard.
     {
         let src = CGEventSource::new(CGEventSourceStateID::CombinedSessionState).ok()?;
-        post_key_event(src.clone(), VK_ANSI_C, true, CGEventFlags::CGEventFlagCommand);
+        post_key_event(
+            src.clone(),
+            VK_ANSI_C,
+            true,
+            CGEventFlags::CGEventFlagCommand,
+        );
         post_key_event(src, VK_ANSI_C, false, CGEventFlags::CGEventFlagCommand);
     }
     tokio::time::sleep(Duration::from_millis(30)).await;
@@ -915,15 +1005,11 @@ pub async fn inject_text(
         } else {
             unavailable_injection_probe()
         };
-        if (contextual_caps || auto_spacing)
-            && injection_probe.source.allows_history_fallback()
-        {
+        if (contextual_caps || auto_spacing) && injection_probe.source.allows_history_fallback() {
             if let Some(history_probe) = fallback_probe_from_history(target_hwnd) {
                 injection_probe = history_probe;
             } else if clipboard_sniff_enabled {
-                if let Some(sniff_probe) =
-                    macos_clipboard_sniff_context(target_hwnd).await
-                {
+                if let Some(sniff_probe) = macos_clipboard_sniff_context(target_hwnd).await {
                     injection_probe = sniff_probe;
                 }
             }

--- a/src-tauri/src/core/text_context.rs
+++ b/src-tauri/src/core/text_context.rs
@@ -370,9 +370,18 @@ mod tests {
     fn context_tail_newline_is_sentence_boundary() {
         // Newlines must be checked before is_invisible_prefix_char because
         // is_control() returns true for \n/\r and would otherwise skip them.
-        assert_eq!(classify_context_tail("hello\n"), SentenceContext::NewSentence);
-        assert_eq!(classify_context_tail("hello\r\n"), SentenceContext::NewSentence);
-        assert_eq!(classify_context_tail("hello,\n"), SentenceContext::NewSentence);
+        assert_eq!(
+            classify_context_tail("hello\n"),
+            SentenceContext::NewSentence
+        );
+        assert_eq!(
+            classify_context_tail("hello\r\n"),
+            SentenceContext::NewSentence
+        );
+        assert_eq!(
+            classify_context_tail("hello,\n"),
+            SentenceContext::NewSentence
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/window_context.rs
+++ b/src-tauri/src/core/window_context.rs
@@ -42,8 +42,15 @@ pub fn get_foreground_hwnd() -> usize {
     }
     #[cfg(target_os = "macos")]
     {
-        let (window_id, pid) = crate::system::mac_app::get_active_window_id_and_pid();
-        ((window_id as usize) << 32) | (pid as u32 as usize)
+        // Avoid CGWindowListCopyWindowInfo on the hotkey/keypress path — it
+        // communicates synchronously with WindowServer for all on-screen windows
+        // and introduces several ms of typing latency, which can trigger the
+        // macOS event tap watchdog timeout. frontmost_pid() is a single fast
+        // NSWorkspace call and sufficient for both focus-target tracking and the
+        // "same window?" comparisons in injection.rs (pid & 0xFFFFFFFF).
+        crate::system::mac_app::frontmost_pid()
+            .map(|p| p as usize)
+            .unwrap_or(0)
     }
     #[cfg(not(any(windows, target_os = "macos")))]
     0

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -4,10 +4,45 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 pub type Db = Arc<Mutex<Connection>>;
+pub const SNIPPET_TRIGGER_CHAR_LIMIT: usize = 300;
+pub const DICTIONARY_ENTRY_CHAR_LIMIT: usize = 120;
 
 fn lock_conn(db: &Db) -> Result<MutexGuard<'_, Connection>> {
     db.lock()
         .map_err(|_| anyhow::anyhow!("Database lock was poisoned"))
+}
+
+fn require_nonempty_trimmed(field: &str, value: &str) -> Result<String> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        return Err(anyhow::anyhow!("{field} cannot be empty"));
+    }
+    Ok(normalized.to_string())
+}
+
+fn normalize_optional_trimmed(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn normalize_multiline(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n").trim().to_string()
+}
+
+fn validate_char_limit(field: &str, value: &str, limit: usize) -> Result<()> {
+    if value.chars().count() > limit {
+        return Err(anyhow::anyhow!("{field} must be {limit} characters or fewer"));
+    }
+    Ok(())
+}
+
+fn require_row_changed(changed: usize, item: &str, id: i64) -> Result<()> {
+    if changed == 0 {
+        return Err(anyhow::anyhow!("{item} {id} was not found"));
+    }
+    Ok(())
 }
 
 fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool> {
@@ -354,6 +389,12 @@ pub struct Snippet {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreatedRecordMeta {
+    pub id: i64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CleanupCacheEntry {
     pub key: String,
     pub clean_text: String,
@@ -510,12 +551,35 @@ pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
 }
 
 pub fn insert_dictionary_entry(db: &Db, term: &str, mistake: Option<&str>) -> Result<()> {
+    let normalized_term = require_nonempty_trimmed("Term", term)?;
+    let normalized_mistake = normalize_optional_trimmed(mistake);
+    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    if let Some(mistake) = normalized_mistake.as_deref() {
+        validate_char_limit("Often mistranscribed as", mistake, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    }
+
     let conn = lock_conn(db)?;
     conn.execute(
         "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
-        params![term, mistake],
+        params![normalized_term, normalized_mistake],
     )?;
     Ok(())
+}
+
+pub fn insert_dictionary_entry_returning(
+    db: &Db,
+    term: &str,
+    mistake: Option<&str>,
+) -> Result<CreatedRecordMeta> {
+    insert_dictionary_entry(db, term, mistake)?;
+    let conn = lock_conn(db)?;
+    let id = conn.last_insert_rowid();
+    let created_at = conn.query_row(
+        "SELECT created_at FROM dictionary WHERE id=?1",
+        params![id],
+        |r| r.get(0),
+    )?;
+    Ok(CreatedRecordMeta { id, created_at })
 }
 
 pub fn insert_dictionary_entry_auto_learned(
@@ -524,6 +588,13 @@ pub fn insert_dictionary_entry_auto_learned(
     mistake: Option<&str>,
     confidence_tier: &str,
 ) -> Result<bool> {
+    let normalized_term = require_nonempty_trimmed("Term", term)?;
+    let normalized_mistake = normalize_optional_trimmed(mistake);
+    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    if let Some(mistake) = normalized_mistake.as_deref() {
+        validate_char_limit("Often mistranscribed as", mistake, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    }
+
     let conn = lock_conn(db)?;
     let changed = conn.execute(
         "INSERT INTO dictionary (term, mistake, auto_learned, correction_count) \
@@ -534,7 +605,7 @@ pub fn insert_dictionary_entry_auto_learned(
            last_seen_at = datetime('now') \
          WHERE dictionary.auto_learned = 1 \
            AND COALESCE(dictionary.mistake, '') = COALESCE(excluded.mistake, '')",
-        params![term, mistake, confidence_tier],
+        params![normalized_term, normalized_mistake, confidence_tier],
     )?;
     Ok(changed > 0)
 }
@@ -704,17 +775,26 @@ pub fn prune_pending_corrections(db: &Db, max_age_days: i64) -> Result<usize> {
 }
 
 pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&str>) -> Result<()> {
+    let normalized_term = require_nonempty_trimmed("Term", term)?;
+    let normalized_mistake = normalize_optional_trimmed(mistake);
+    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    if let Some(mistake) = normalized_mistake.as_deref() {
+        validate_char_limit("Often mistranscribed as", mistake, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    }
+
     let conn = lock_conn(db)?;
-    conn.execute(
+    let changed = conn.execute(
         "UPDATE dictionary SET term=?2, mistake=?3 WHERE id=?1",
-        params![id, term, mistake],
+        params![id, normalized_term, normalized_mistake],
     )?;
+    require_row_changed(changed, "Dictionary entry", id)?;
     Ok(())
 }
 
 pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
     let conn = lock_conn(db)?;
-    conn.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
+    let changed = conn.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
+    require_row_changed(changed, "Dictionary entry", id)?;
     Ok(())
 }
 
@@ -766,12 +846,37 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
 // ---------- snippets ----------
 
 pub fn insert_snippet(db: &Db, trigger: &str, expansion: &str, instructions: &str) -> Result<()> {
+    let normalized_trigger = require_nonempty_trimmed("Trigger", trigger)?;
+    validate_char_limit("Trigger", &normalized_trigger, SNIPPET_TRIGGER_CHAR_LIMIT)?;
+    let normalized_expansion = normalize_multiline(expansion);
+    if normalized_expansion.is_empty() {
+        return Err(anyhow::anyhow!("Expansion cannot be empty"));
+    }
+    let normalized_instructions = normalize_multiline(instructions);
+
     let conn = lock_conn(db)?;
     conn.execute(
         "INSERT INTO snippets (trigger, expansion, instructions) VALUES (?1, ?2, ?3)",
-        params![trigger, expansion, instructions],
+        params![normalized_trigger, normalized_expansion, normalized_instructions],
     )?;
     Ok(())
+}
+
+pub fn insert_snippet_returning(
+    db: &Db,
+    trigger: &str,
+    expansion: &str,
+    instructions: &str,
+) -> Result<CreatedRecordMeta> {
+    insert_snippet(db, trigger, expansion, instructions)?;
+    let conn = lock_conn(db)?;
+    let id = conn.last_insert_rowid();
+    let created_at = conn.query_row(
+        "SELECT created_at FROM snippets WHERE id=?1",
+        params![id],
+        |r| r.get(0),
+    )?;
+    Ok(CreatedRecordMeta { id, created_at })
 }
 
 pub fn update_snippet(
@@ -781,17 +886,27 @@ pub fn update_snippet(
     expansion: &str,
     instructions: &str,
 ) -> Result<()> {
+    let normalized_trigger = require_nonempty_trimmed("Trigger", trigger)?;
+    validate_char_limit("Trigger", &normalized_trigger, SNIPPET_TRIGGER_CHAR_LIMIT)?;
+    let normalized_expansion = normalize_multiline(expansion);
+    if normalized_expansion.is_empty() {
+        return Err(anyhow::anyhow!("Expansion cannot be empty"));
+    }
+    let normalized_instructions = normalize_multiline(instructions);
+
     let conn = lock_conn(db)?;
-    conn.execute(
+    let changed = conn.execute(
         "UPDATE snippets SET trigger=?2, expansion=?3, instructions=?4 WHERE id=?1",
-        params![id, trigger, expansion, instructions],
+        params![id, normalized_trigger, normalized_expansion, normalized_instructions],
     )?;
+    require_row_changed(changed, "Snippet", id)?;
     Ok(())
 }
 
 pub fn delete_snippet(db: &Db, id: i64) -> Result<()> {
     let conn = lock_conn(db)?;
-    conn.execute("DELETE FROM snippets WHERE id=?1", params![id])?;
+    let changed = conn.execute("DELETE FROM snippets WHERE id=?1", params![id])?;
+    require_row_changed(changed, "Snippet", id)?;
     Ok(())
 }
 
@@ -1382,5 +1497,70 @@ mod tests {
         assert_eq!(ids.len(), 2);
         delete_auto_learned_entries_by_ids(&db, &ids).expect("bulk delete");
         assert_eq!(query_dictionary(&db).expect("after").len(), 0);
+    }
+
+    #[test]
+    fn manual_dictionary_entries_trim_and_keep_longer_phrases() {
+        let db = test_db();
+        let long_term = "A longer dictionary phrase that still fits inside the supported limit exactly fine";
+        let long_mistake = "A slightly mangled version of that longer phrase for recognition";
+
+        insert_dictionary_entry(&db, &format!("  {long_term}  "), Some(&format!("  {long_mistake}  ")))
+            .expect("insert trimmed long entry");
+
+        let entry = query_dictionary(&db)
+            .expect("query")
+            .into_iter()
+            .next()
+            .expect("entry");
+        assert_eq!(entry.term, long_term);
+        assert_eq!(entry.mistake.as_deref(), Some(long_mistake));
+    }
+
+    #[test]
+    fn dictionary_entry_rejects_values_beyond_limit() {
+        let db = test_db();
+        let too_long = "x".repeat(DICTIONARY_ENTRY_CHAR_LIMIT + 1);
+        let err = insert_dictionary_entry(&db, &too_long, None).expect_err("reject long term");
+        assert!(
+            err.to_string().contains("120 characters or fewer"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn snippet_update_normalizes_expansion_whitespace() {
+        let db = test_db();
+        insert_snippet(&db, "sig", "Hi", "").expect("insert");
+        let snippet = query_snippets(&db)
+            .expect("query")
+            .into_iter()
+            .next()
+            .expect("snippet");
+        // Pasted text often arrives with CRLF line endings and trailing whitespace/newlines.
+        // The backend normalizes these so paste behaves like typing.
+        update_snippet(&db, snippet.id, "sig", "Line one\r\nLine two  \n", "").expect("update");
+        let updated = query_snippets(&db)
+            .expect("query after")
+            .into_iter()
+            .next()
+            .expect("updated");
+        assert_eq!(updated.expansion, "Line one\nLine two");
+    }
+
+    #[test]
+    fn deleting_missing_entries_returns_an_error() {
+        let db = test_db();
+        let dict_err = delete_dictionary_entry(&db, 999).expect_err("missing dictionary entry");
+        assert!(
+            dict_err.to_string().contains("Dictionary entry 999 was not found"),
+            "unexpected dictionary error: {dict_err}"
+        );
+
+        let snippet_err = delete_snippet(&db, 999).expect_err("missing snippet");
+        assert!(
+            snippet_err.to_string().contains("Snippet 999 was not found"),
+            "unexpected snippet error: {snippet_err}"
+        );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -804,9 +804,35 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
 }
 
 pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
-    let conn = lock_conn(db)?;
-    let changed = conn.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+
+    // Capture metadata before deleting so we can clean up auto-learn history.
+    let info: Option<(String, Option<String>, i64)> = tx
+        .query_row(
+            "SELECT term, mistake, auto_learned FROM dictionary WHERE id=?1",
+            params![id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .ok();
+
+    let changed = tx.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
     require_row_changed(changed, "Dictionary entry", id)?;
+
+    // If this was an auto-learned entry, remove its pending corrections and
+    // candidates so the auto-learn system cannot immediately re-promote it.
+    if let Some((term, Some(mistake), 1)) = info {
+        tx.execute(
+            "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
+            params![mistake, term],
+        )?;
+        tx.execute(
+            "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
+            params![mistake, term],
+        )?;
+    }
+
+    tx.commit()?;
     Ok(())
 }
 
@@ -1586,6 +1612,34 @@ mod tests {
         assert!(
             snippet_err.to_string().contains("Snippet 999 was not found"),
             "unexpected snippet error: {snippet_err}"
+        );
+    }
+
+    #[test]
+    fn manual_delete_of_auto_learned_entry_purges_pending_corrections() {
+        let db = test_db();
+
+        insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "low").expect("insert");
+        let id = query_dictionary(&db)
+            .expect("query")
+            .into_iter()
+            .next()
+            .expect("entry")
+            .id;
+
+        insert_pending_correction(&db, "Tari", "Tauri").expect("pending");
+        assert_eq!(
+            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count before"),
+            1
+        );
+
+        delete_dictionary_entry(&db, id).expect("delete");
+
+        assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
+        assert_eq!(
+            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
+            0,
+            "pending corrections must be purged when the auto-learned entry is manually deleted"
         );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -571,8 +571,20 @@ pub fn insert_dictionary_entry_returning(
     term: &str,
     mistake: Option<&str>,
 ) -> Result<CreatedRecordMeta> {
-    insert_dictionary_entry(db, term, mistake)?;
+    let normalized_term = require_nonempty_trimmed("Term", term)?;
+    let normalized_mistake = normalize_optional_trimmed(mistake);
+    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    if let Some(m) = normalized_mistake.as_deref() {
+        validate_char_limit("Often mistranscribed as", m, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    }
+
+    // Insert and read last_insert_rowid under a single lock to prevent another
+    // thread's insert racing between the two acquisitions and returning the wrong id.
     let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
+        params![normalized_term, normalized_mistake],
+    )?;
     let id = conn.last_insert_rowid();
     let created_at = conn.query_row(
         "SELECT created_at FROM dictionary WHERE id=?1",
@@ -868,8 +880,21 @@ pub fn insert_snippet_returning(
     expansion: &str,
     instructions: &str,
 ) -> Result<CreatedRecordMeta> {
-    insert_snippet(db, trigger, expansion, instructions)?;
+    let normalized_trigger = require_nonempty_trimmed("Trigger", trigger)?;
+    validate_char_limit("Trigger", &normalized_trigger, SNIPPET_TRIGGER_CHAR_LIMIT)?;
+    let normalized_expansion = normalize_multiline(expansion);
+    if normalized_expansion.is_empty() {
+        return Err(anyhow::anyhow!("Expansion cannot be empty"));
+    }
+    let normalized_instructions = normalize_multiline(instructions);
+
+    // Insert and read last_insert_rowid under a single lock to prevent another
+    // thread's insert racing between the two acquisitions and returning the wrong id.
     let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO snippets (trigger, expansion, instructions) VALUES (?1, ?2, ?3)",
+        params![normalized_trigger, normalized_expansion, normalized_instructions],
+    )?;
     let id = conn.last_insert_rowid();
     let created_at = conn.query_row(
         "SELECT created_at FROM snippets WHERE id=?1",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -277,6 +277,7 @@ fn main() {
             commands::get_recent_logs,
             commands::download_logs,
             commands::set_dev_logging_enabled,
+            commands::log_frontend,
         ])
         .build(tauri::generate_context!())
         .expect("error building Open Flow")

--- a/src-tauri/src/system/mac_app.rs
+++ b/src-tauri/src/system/mac_app.rs
@@ -388,7 +388,10 @@ unsafe fn nsstring_to_string(ns: *mut AnyObject) -> Option<String> {
 
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
-    fn CGWindowListCopyWindowInfo(option: u32, relativeToWindow: u32) -> core_foundation_sys::array::CFArrayRef;
+    fn CGWindowListCopyWindowInfo(
+        option: u32,
+        relativeToWindow: u32,
+    ) -> core_foundation_sys::array::CFArrayRef;
     static kCGWindowNumber: core_foundation_sys::string::CFStringRef;
     static kCGWindowOwnerPID: core_foundation_sys::string::CFStringRef;
     static kCGWindowLayer: core_foundation_sys::string::CFStringRef;
@@ -496,4 +499,3 @@ mod tests {
         println!("Active window ID: {}, PID: {}", win_id, pid);
     }
 }
-

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -53,7 +53,7 @@ let dictionaryFetchToken = 0;
 export function cancelSnippetsFetch() { snippetsFetchToken++; }
 export function cancelDictionaryFetch() { dictionaryFetchToken++; }
 
-function formatIpcError(err: unknown): string {
+export function formatIpcError(err: unknown): string {
   if (typeof err === 'object' && err !== null) {
     if ('message' in err) {
       const message = (err as { message?: unknown }).message;

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -47,6 +47,9 @@ export const appStore = $state({
   isOnline: true,
 });
 
+let snippetsFetchToken = 0;
+let dictionaryFetchToken = 0;
+
 function formatIpcError(err: unknown): string {
   if (typeof err === 'object' && err !== null) {
     if ('message' in err) {
@@ -73,13 +76,16 @@ function formatIpcError(err: unknown): string {
 }
 
 export async function fetchSnippets(): Promise<void> {
+  const token = ++snippetsFetchToken;
   appStore.snippetsFetchStatus = 'loading';
   appStore.snippetsFetchError = '';
   try {
     const data = await invoke<Snippet[]>('get_snippets');
+    if (token !== snippetsFetchToken) return;
     appStore.snippets = data ?? [];
     appStore.snippetsFetchStatus = 'loaded';
   } catch (err) {
+    if (token !== snippetsFetchToken) return;
     console.error('IPC fetchSnippets failed:', err);
     appStore.snippetsFetchStatus = 'error';
     appStore.snippetsFetchError = formatIpcError(err);
@@ -87,13 +93,16 @@ export async function fetchSnippets(): Promise<void> {
 }
 
 export async function fetchDictionary(): Promise<void> {
+  const token = ++dictionaryFetchToken;
   appStore.dictionaryFetchStatus = 'loading';
   appStore.dictionaryFetchError = '';
   try {
     const data = await invoke<DictionaryEntry[]>('get_dictionary');
+    if (token !== dictionaryFetchToken) return;
     appStore.dictionary = data ?? [];
     appStore.dictionaryFetchStatus = 'loaded';
   } catch (err) {
+    if (token !== dictionaryFetchToken) return;
     console.error('IPC fetchDictionary failed:', err);
     appStore.dictionaryFetchStatus = 'error';
     appStore.dictionaryFetchError = formatIpcError(err);

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -50,6 +50,9 @@ export const appStore = $state({
 let snippetsFetchToken = 0;
 let dictionaryFetchToken = 0;
 
+export function cancelSnippetsFetch() { snippetsFetchToken++; }
+export function cancelDictionaryFetch() { dictionaryFetchToken++; }
+
 function formatIpcError(err: unknown): string {
   if (typeof err === 'object' && err !== null) {
     if ('message' in err) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -12,8 +12,29 @@ type EventEnvelope<T> = {
 };
 type EventHandler<T> = (event: EventEnvelope<T>) => void;
 type UnlistenFn = () => void;
+type CreatedRecordMeta = { id: number; created_at: string };
+type DevSnippet = {
+  id: number;
+  trigger: string;
+  expansion: string;
+  instructions: string;
+  use_count: number;
+  created_at: string;
+};
+type DevDictionaryEntry = {
+  id: number;
+  term: string;
+  mistake: string | null;
+  auto_learned: boolean;
+  correction_count: number;
+  confidence_tier: 'manual' | 'low' | 'medium' | 'high';
+  last_seen_at: string | null;
+  created_at: string;
+};
 
 const DEV_STORAGE_KEY = 'open-flow:dev-settings';
+const DEV_SNIPPETS_KEY = 'open-flow:dev-snippets';
+const DEV_DICTIONARY_KEY = 'open-flow:dev-dictionary';
 
 const defaultProviderModels = {
   groq: ['whisper-large-v3-turbo', 'whisper-large-v3'],
@@ -94,6 +115,41 @@ function getDevSetting(key: string): unknown {
   return key in saved ? saved[key] : defaultSettings[key] ?? null;
 }
 
+function readDevList<T>(key: string): T[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeDevList<T>(key: string, rows: T[]) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(rows));
+  } catch {
+    // Browser dev mode should keep working even when persistent storage is blocked.
+  }
+}
+
+function nextDevId(rows: { id: number }[]): number {
+  return rows.reduce((max, row) => Math.max(max, row.id), 0) + 1;
+}
+
+function devCreated(id: number): CreatedRecordMeta {
+  return { id, created_at: new Date().toISOString() };
+}
+
+function assertDevText(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be text.`);
+  }
+  return value;
+}
+
 async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
   switch (command) {
     case 'get_setting':
@@ -108,9 +164,11 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return { ...defaultSettings, ...readDevSettings() } as T;
     case 'get_app_mappings':
       return getDevSetting('app_mappings') as T;
-    case 'get_recent':
     case 'get_snippets':
+      return readDevList<DevSnippet>(DEV_SNIPPETS_KEY) as T;
     case 'get_dictionary':
+      return readDevList<DevDictionaryEntry>(DEV_DICTIONARY_KEY) as T;
+    case 'get_recent':
     case 'get_recent_auto_learn_activity':
     case 'get_microphones':
     case 'get_recent_logs':
@@ -158,14 +216,122 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'retry_transcription':
     case 'install_update':
     case 'set_dev_logging_enabled':
-    case 'create_dictionary_entry':
-    case 'edit_dictionary_entry':
-    case 'remove_dictionary_entry':
-    case 'create_snippet':
-    case 'edit_snippet':
-    case 'remove_snippet':
     case 'start_calibration_monitoring':
     case 'stop_calibration_monitoring':
+      return undefined as T;
+    case 'create_snippet': {
+      const trigger = assertDevText(args?.trigger, 'Trigger').trim();
+      const expansion = assertDevText(args?.expansion, 'Expansion');
+      const instructions = assertDevText(args?.instructions ?? '', 'Cleanup instructions');
+      if (!trigger) throw new Error('Trigger cannot be empty');
+      if (!expansion.trim()) throw new Error('Expansion cannot be empty');
+      if ([...trigger].length > 300) throw new Error('Trigger must be 300 characters or fewer');
+
+      const rows = readDevList<DevSnippet>(DEV_SNIPPETS_KEY);
+      if (rows.some((row) => row.trigger === trigger)) {
+        throw new Error('UNIQUE constraint failed: snippets.trigger');
+      }
+      const id = nextDevId(rows);
+      const created = devCreated(id);
+      rows.unshift({
+        id,
+        trigger,
+        expansion,
+        instructions,
+        use_count: 0,
+        created_at: created.created_at,
+      });
+      writeDevList(DEV_SNIPPETS_KEY, rows);
+      return created as T;
+    }
+    case 'edit_snippet': {
+      const id = Number(args?.id);
+      const trigger = assertDevText(args?.trigger, 'Trigger').trim();
+      const expansion = assertDevText(args?.expansion, 'Expansion');
+      const instructions = assertDevText(args?.instructions ?? '', 'Cleanup instructions');
+      if (!Number.isFinite(id)) throw new Error('Snippet id is required.');
+      if (!trigger) throw new Error('Trigger cannot be empty');
+      if (!expansion.trim()) throw new Error('Expansion cannot be empty');
+      if ([...trigger].length > 300) throw new Error('Trigger must be 300 characters or fewer');
+
+      const rows = readDevList<DevSnippet>(DEV_SNIPPETS_KEY);
+      if (rows.some((row) => row.id !== id && row.trigger === trigger)) {
+        throw new Error('UNIQUE constraint failed: snippets.trigger');
+      }
+      const index = rows.findIndex((row) => row.id === id);
+      if (index === -1) throw new Error(`Snippet ${id} was not found`);
+      rows[index] = { ...rows[index], trigger, expansion, instructions };
+      writeDevList(DEV_SNIPPETS_KEY, rows);
+      return undefined as T;
+    }
+    case 'remove_snippet': {
+      const id = Number(args?.id);
+      const rows = readDevList<DevSnippet>(DEV_SNIPPETS_KEY);
+      const next = rows.filter((row) => row.id !== id);
+      if (next.length === rows.length) throw new Error(`Snippet ${id} was not found`);
+      writeDevList(DEV_SNIPPETS_KEY, next);
+      return undefined as T;
+    }
+    case 'create_dictionary_entry': {
+      const term = assertDevText(args?.term, 'Term').trim();
+      const mistakeText = typeof args?.mistake === 'string' ? args.mistake.trim() : '';
+      const mistake = mistakeText || null;
+      if (!term) throw new Error('Term cannot be empty');
+      if ([...term].length > 120) throw new Error('Term must be 120 characters or fewer');
+      if (mistake && [...mistake].length > 120) {
+        throw new Error('Often mistranscribed as must be 120 characters or fewer');
+      }
+
+      const rows = readDevList<DevDictionaryEntry>(DEV_DICTIONARY_KEY);
+      if (rows.some((row) => row.term === term)) {
+        throw new Error('UNIQUE constraint failed: dictionary.term');
+      }
+      const id = nextDevId(rows);
+      const created = devCreated(id);
+      rows.unshift({
+        id,
+        term,
+        mistake,
+        auto_learned: false,
+        correction_count: 0,
+        confidence_tier: 'manual',
+        last_seen_at: null,
+        created_at: created.created_at,
+      });
+      writeDevList(DEV_DICTIONARY_KEY, rows);
+      return created as T;
+    }
+    case 'edit_dictionary_entry': {
+      const id = Number(args?.id);
+      const term = assertDevText(args?.term, 'Term').trim();
+      const mistakeText = typeof args?.mistake === 'string' ? args.mistake.trim() : '';
+      const mistake = mistakeText || null;
+      if (!Number.isFinite(id)) throw new Error('Dictionary entry id is required.');
+      if (!term) throw new Error('Term cannot be empty');
+      if ([...term].length > 120) throw new Error('Term must be 120 characters or fewer');
+      if (mistake && [...mistake].length > 120) {
+        throw new Error('Often mistranscribed as must be 120 characters or fewer');
+      }
+
+      const rows = readDevList<DevDictionaryEntry>(DEV_DICTIONARY_KEY);
+      if (rows.some((row) => row.id !== id && row.term === term)) {
+        throw new Error('UNIQUE constraint failed: dictionary.term');
+      }
+      const index = rows.findIndex((row) => row.id === id);
+      if (index === -1) throw new Error(`Dictionary entry ${id} was not found`);
+      rows[index] = { ...rows[index], term, mistake };
+      writeDevList(DEV_DICTIONARY_KEY, rows);
+      return undefined as T;
+    }
+    case 'remove_dictionary_entry': {
+      const id = Number(args?.id);
+      const rows = readDevList<DevDictionaryEntry>(DEV_DICTIONARY_KEY);
+      const next = rows.filter((row) => row.id !== id);
+      if (next.length === rows.length) throw new Error(`Dictionary entry ${id} was not found`);
+      writeDevList(DEV_DICTIONARY_KEY, next);
+      return undefined as T;
+    }
+    case 'log_frontend':
       return undefined as T;
     case 'check_accessibility_permission':
       if (args?.prompt) {
@@ -208,6 +374,10 @@ export function emit<T>(event: string, payload?: T): Promise<void> {
     return tauriEmit(event, payload);
   }
   return Promise.resolve();
+}
+
+export function flog(level: 'info' | 'warn' | 'error', message: string): void {
+  invoke('log_frontend', { level, message }).catch(() => {});
 }
 
 export function getVersion(): Promise<string> {

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -4,7 +4,7 @@
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
-  import { appStore, fetchDictionary, type DictionaryEntry } from '../stores';
+  import { appStore, fetchDictionary, cancelDictionaryFetch, type DictionaryEntry } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
 
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_corrected';
@@ -133,6 +133,7 @@
   function closeModal() { modal = null; saveError = ''; }
 
   function upsertDictionaryEntry(entry: DictionaryEntry) {
+    cancelDictionaryFetch();
     const next = appStore.dictionary.filter((item) => item.id !== entry.id);
     appStore.dictionary = [entry, ...next];
   }
@@ -199,6 +200,7 @@
     if (deleteTarget === id) {
       try {
         await invoke('remove_dictionary_entry', { id });
+        cancelDictionaryFetch();
         appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
         if (selected?.id === id) selected = null;
       } catch (err) { console.error(err); }

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -4,7 +4,7 @@
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
-  import { appStore, fetchDictionary, cancelDictionaryFetch, type DictionaryEntry } from '../stores';
+  import { appStore, fetchDictionary, cancelDictionaryFetch, formatIpcError, type DictionaryEntry } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
 
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_corrected';
@@ -158,7 +158,6 @@
     }
     saving = true; saveError = '';
     try {
-      const editedId = modal?.mode === 'edit' ? modal.entry?.id : undefined;
       if (modal?.mode === 'add') {
         const created = requireCreatedRecordMeta(
           await invoke<unknown>('create_dictionary_entry', { term, mistake }),
@@ -186,13 +185,10 @@
         upsertDictionaryEntry(entry);
         selected = entry;
       }
-      if (editedId !== undefined) {
-        selected = appStore.dictionary.find(e => e.id === editedId) ?? null;
-      }
       closeModal();
     } catch (err) {
-      const msg = String(err);
-      saveError = msg.includes('UNIQUE') ? 'That term already exists.' : (msg || 'Failed to save.');
+      const msg = formatIpcError(err);
+      saveError = msg.includes('UNIQUE') ? 'That term already exists.' : msg;
     } finally { saving = false; }
   }
 

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -8,6 +8,7 @@
   import MicInputButton from '../components/MicInputButton.svelte';
 
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_corrected';
+  type CreatedRecordMeta = { id: number; created_at: string };
 
   function fmtDate(iso: string): string {
     try {
@@ -47,17 +48,22 @@
   });
   let sortIndicatorStyle = $state('opacity:0;');
 
-  const TERM_LIMIT    = 50;
-  const MISTAKE_LIMIT = 50;
+  const TERM_LIMIT    = 120;
+  const MISTAKE_LIMIT = 120;
 
-  const clamp = (value: string, limit: number): string => {
-    const trimmed = value.trim();
-    if (trimmed.length <= limit) return trimmed;
-    return [...trimmed].slice(0, limit).join('');
-  };
   const countCodePoints = (value: string): number => [...value].length;
-  const clampTerm = (value: string): string => clamp(value, TERM_LIMIT);
-  const clampMistake = (value: string): string => clamp(value, MISTAKE_LIMIT);
+
+  function requireCreatedRecordMeta(value: unknown, command: string): CreatedRecordMeta {
+    console.info(`${command} result:`, value);
+    if (typeof value !== 'object' || value === null) {
+      throw new Error('Save returned no record metadata. Relaunch the Tauri app and try again.');
+    }
+    const meta = value as Partial<CreatedRecordMeta>;
+    if (typeof meta.id !== 'number' || !Number.isFinite(meta.id) || typeof meta.created_at !== 'string' || !meta.created_at.trim()) {
+      throw new Error('Save returned invalid record metadata. Check the app logs before retrying.');
+    }
+    return { id: meta.id, created_at: meta.created_at };
+  }
 
   const sortLabels: { key: SortKey; label: string }[] = [
     { key: 'newest',         label: 'Newest'         },
@@ -125,6 +131,11 @@
 
   function closeModal() { modal = null; saveError = ''; }
 
+  function upsertDictionaryEntry(entry: DictionaryEntry) {
+    const next = appStore.dictionary.filter((item) => item.id !== entry.id);
+    appStore.dictionary = [entry, ...next];
+  }
+
   async function saveModal() {
     const term = draftTerm.trim();
     const mistakeValue = draftMistake.trim();
@@ -142,18 +153,39 @@
     try {
       const editedId = modal?.mode === 'edit' ? modal.entry?.id : undefined;
       if (modal?.mode === 'add') {
-        await invoke('create_dictionary_entry', { term, mistake });
+        const created = requireCreatedRecordMeta(
+          await invoke<unknown>('create_dictionary_entry', { term, mistake }),
+          'create_dictionary_entry',
+        );
+        const entry: DictionaryEntry = {
+          id: created.id,
+          term,
+          mistake,
+          auto_learned: false,
+          correction_count: 0,
+          confidence_tier: 'manual',
+          last_seen_at: null,
+          created_at: created.created_at,
+        };
+        upsertDictionaryEntry(entry);
+        selected = entry;
       } else if (modal?.mode === 'edit' && modal.entry) {
         await invoke('edit_dictionary_entry', { id: modal.entry.id, term, mistake });
+        const entry: DictionaryEntry = {
+          ...modal.entry,
+          term,
+          mistake,
+        };
+        upsertDictionaryEntry(entry);
+        selected = entry;
       }
-      await fetchDictionary();
       if (editedId !== undefined) {
         selected = appStore.dictionary.find(e => e.id === editedId) ?? null;
       }
       closeModal();
     } catch (err) {
       const msg = String(err);
-      saveError = msg.includes('UNIQUE') ? 'That term already exists.' : 'Failed to save.';
+      saveError = msg.includes('UNIQUE') ? 'That term already exists.' : (msg || 'Failed to save.');
     } finally { saving = false; }
   }
 
@@ -161,8 +193,8 @@
     if (deleteTarget === id) {
       try {
         await invoke('remove_dictionary_entry', { id });
+        appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
         if (selected?.id === id) selected = null;
-        await fetchDictionary();
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -423,7 +455,7 @@
     out:fly={{ y: 8, duration: 150, easing: expoOut }}
   >
     <div class="modal-header">
-      <h2 class="modal-title">{modal.mode === 'add' ? 'Add term' : 'Edit term'}</h2>
+      <h2 class="modal-title">{modal?.mode === 'add' ? 'Add term' : 'Edit term'}</h2>
       <button class="icon-btn" onclick={closeModal} aria-label="Close">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
       </button>
@@ -442,11 +474,10 @@
           placeholder="e.g. Kubernetes, Björk, ChatGPT"
           bind:value={draftTerm}
           bind:this={termInput}
-          maxlength={TERM_LIMIT}
           autocomplete="off"
           spellcheck="false"
         />
-        <MicInputButton onResult={(t) => draftTerm = clampTerm(t)} />
+        <MicInputButton onResult={(t) => draftTerm = t} />
       </div>
       <p class="field-hint">The exact word or phrase you want the AI to use.</p>
 
@@ -461,11 +492,10 @@
           type="text"
           placeholder="e.g. koobernetes, byork"
           bind:value={draftMistake}
-          maxlength={MISTAKE_LIMIT}
           autocomplete="off"
           spellcheck="false"
         />
-        <MicInputButton onResult={(t) => draftMistake = clampMistake(t)} />
+        <MicInputButton onResult={(t) => draftMistake = t} />
       </div>
       <p class="field-hint">What the transcription model typically writes instead. Skip if the term just needs to be in the AI's awareness.</p>
     </div>
@@ -490,7 +520,7 @@
           disabled={saving || !draftTerm.trim()}
         >
           {#if saving}<span class="spinner"></span>{/if}
-          {modal.mode === 'add' ? 'Add term' : 'Save changes'}
+          {modal?.mode === 'add' ? 'Add term' : 'Save changes'}
         </button>
       </div>
     </div>
@@ -987,8 +1017,9 @@
     appearance: none;
     background: var(--overlay);
     z-index: 50;
-    backdrop-filter: blur(2px);
     outline: none;
+    /* NOTE: no backdrop-filter — on WKWebView it repaints on layout changes and
+       captures pointer events over the modal card, killing the dialog controls. */
   }
 
   .modal-card {
@@ -997,6 +1028,7 @@
     left: 50%;
     translate: -50% -50%;
     z-index: 51;
+    isolation: isolate;
     background: var(--bg-elev);
     border: 1px solid var(--line);
     border-radius: var(--r-lg);

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -147,7 +147,7 @@
     const term = draftTerm.trim();
     const mistakeValue = draftMistake.trim();
     const mistake = mistakeValue || null;
-    if (!term) return;
+    if (!term) { saveError = 'Term is required.'; return; }
     if (countCodePoints(term) > TERM_LIMIT) {
       saveError = `Term must be ${TERM_LIMIT} characters or fewer.`;
       return;
@@ -526,7 +526,7 @@
         <button
           class="btn-primary"
           onclick={saveModal}
-          disabled={saving || !draftTerm.trim()}
+          disabled={saving}
         >
           {#if saving}<span class="spinner"></span>{/if}
           {modal?.mode === 'add' ? 'Add term' : 'Save changes'}

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -41,6 +41,7 @@
   let draftTerm     = $state('');
   let draftMistake  = $state('');
   let termInput     = $state<HTMLInputElement | null>(null);
+  let mistakeInput  = $state<HTMLInputElement | null>(null);
   let inspectorDir  = $state<1 | -1>(1);
   let sortWrapEl    = $state<HTMLDivElement | null>(null);
   let sortButtonEls = $state<Record<SortKey, HTMLButtonElement | null>>({
@@ -137,6 +138,11 @@
   }
 
   async function saveModal() {
+    // Read directly from DOM elements at click time to bypass WKWebView
+    // bind:value paste-sync lag, matching the pattern in Snippets.svelte.
+    if (termInput) draftTerm = termInput.value;
+    if (mistakeInput) draftMistake = mistakeInput.value;
+
     const term = draftTerm.trim();
     const mistakeValue = draftMistake.trim();
     const mistake = mistakeValue || null;
@@ -492,6 +498,7 @@
           type="text"
           placeholder="e.g. koobernetes, byork"
           bind:value={draftMistake}
+          bind:this={mistakeInput}
           autocomplete="off"
           spellcheck="false"
         />

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -8,6 +8,7 @@
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
 
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_used';
+  type CreatedRecordMeta = { id: number; created_at: string };
 
   function fmtDate(iso: string): string {
     try {
@@ -32,7 +33,9 @@
   let draftTrigger       = $state('');
   let draftExpansion     = $state('');
   let draftInstructions  = $state('');
-  let triggerInput   = $state<HTMLInputElement | null>(null);
+  let triggerInput    = $state<HTMLInputElement | null>(null);
+  let expansionEl     = $state<HTMLTextAreaElement | null>(null);
+  let instructionsEl  = $state<HTMLTextAreaElement | null>(null);
   let inspectorDir = $state<1 | -1>(1);
   let sortWrapEl = $state<HTMLDivElement | null>(null);
   let sortButtonEls = $state<Record<SortKey, HTMLButtonElement | null>>({
@@ -44,6 +47,18 @@
   let sortIndicatorStyle = $state('opacity:0;');
 
   const TRIGGER_LIMIT = 300;
+  const countCodePoints = (value: string): number => [...value].length;
+
+  function requireCreatedRecordMeta(value: unknown): CreatedRecordMeta {
+    if (typeof value !== 'object' || value === null) {
+      throw new Error('Snippet save returned no record metadata. Relaunch the Tauri app and try again.');
+    }
+    const meta = value as Partial<CreatedRecordMeta>;
+    if (typeof meta.id !== 'number' || !Number.isFinite(meta.id) || typeof meta.created_at !== 'string' || !meta.created_at.trim()) {
+      throw new Error('Snippet save returned invalid record metadata. Check the app logs before retrying.');
+    }
+    return { id: meta.id, created_at: meta.created_at };
+  }
 
   $effect(() => {
     const currentSearch = search;
@@ -97,29 +112,74 @@
 
   function closeModal() { modal = null; saveError = ''; }
 
+  function upsertSnippet(snippet: Snippet) {
+    const next = appStore.snippets.filter((entry) => entry.id !== snippet.id);
+    appStore.snippets = [snippet, ...next];
+  }
+
+  function normalizeText(value: string): string {
+    return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+  }
+
   async function saveModal() {
+    // Read straight from the DOM elements. On WKWebView, `bind:value` can fail
+    // to propagate a pasted value into reactive state before the click fires.
+    // The element's live `.value` is always correct at click time.
+    if (triggerInput) draftTrigger = triggerInput.value;
+    if (expansionEl) draftExpansion = expansionEl.value;
+    if (instructionsEl) draftInstructions = instructionsEl.value;
+
     const t = draftTrigger.trim();
-    const e = draftExpansion.trim();
-    if (!t || !e) return;
+    const e = normalizeText(draftExpansion);
+    const i = normalizeText(draftInstructions);
+    if (!t || !e) {
+      saveError = 'Trigger and expansion are both required.';
+      return;
+    }
+    if (countCodePoints(t) > TRIGGER_LIMIT) {
+      saveError = `Trigger must be ${TRIGGER_LIMIT} characters or fewer.`;
+      return;
+    }
     saving = true;
     saveError = '';
     try {
       const editedId = modal?.mode === 'edit' ? modal.snippet?.id : undefined;
-      const i = draftInstructions.trim();
       if (modal?.mode === 'add') {
-        await invoke('create_snippet', { trigger: t, expansion: e, instructions: i });
+        const created = requireCreatedRecordMeta(await invoke<unknown>('create_snippet', {
+          trigger: t,
+          expansion: e,
+          instructions: i,
+        }));
+        const snippet: Snippet = {
+          id: created.id,
+          trigger: t,
+          expansion: e,
+          instructions: i,
+          use_count: 0,
+          created_at: created.created_at,
+        };
+        upsertSnippet(snippet);
+        selected = snippet;
       } else if (modal?.mode === 'edit' && modal.snippet) {
         await invoke('edit_snippet', { id: modal.snippet.id, trigger: t, expansion: e, instructions: i });
+        const snippet: Snippet = {
+          ...modal.snippet,
+          trigger: t,
+          expansion: e,
+          instructions: i,
+        };
+        upsertSnippet(snippet);
+        selected = snippet;
       }
-      await fetchSnippets();
-      // Re-sync selected manually — no $effect to avoid reactivity loops
-      if (editedId !== undefined) {
+      if (editedId !== undefined && !selected) {
         selected = appStore.snippets.find(s => s.id === editedId) ?? null;
       }
       closeModal();
     } catch (err) {
       const msg = String(err);
-      saveError = msg.includes('UNIQUE') ? 'A snippet with that trigger already exists.' : 'Failed to save snippet.';
+      saveError = msg.includes('UNIQUE')
+        ? 'A snippet with that trigger already exists.'
+        : (msg || 'Failed to save snippet.');
     }
     finally { saving = false; }
   }
@@ -128,8 +188,8 @@
     if (deleteTarget === id) {
       try {
         await invoke('remove_snippet', { id });
+        appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
         if (selected?.id === id) selected = null;
-        await fetchSnippets();
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -145,46 +205,27 @@
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && modal) saveModal();
   }
 
-  function autoGrow(node: HTMLTextAreaElement, value: string) {
-    let last = 0;
-    let hadSelection = false;
-    function resize(couldShrink = true) {
-      if (couldShrink) node.style.height = 'auto';
-      const borderDiff = node.offsetHeight - node.clientHeight;
-      const h = node.scrollHeight + borderDiff;
-      if (h === last) { if (couldShrink) node.style.height = last + 'px'; return; }
-      last = h;
-      node.style.height = h + 'px';
-    }
-    function onBeforeInput() {
-      hadSelection = node.selectionStart !== node.selectionEnd;
-    }
-    function onInput(e: Event) {
-      value = node.value;
-      const type = (e as InputEvent).inputType ?? '';
-      const insertOnly = type === 'insertText' || type === 'insertLineBreak' || type === 'insertParagraph' || type === 'insertCompositionText';
-      resize(!(insertOnly && !hadSelection));
-    }
-    node.addEventListener('beforeinput', onBeforeInput);
-    node.addEventListener('input', onInput);
-    resize();
-    return {
-      update(nextValue: string) {
-        if (nextValue !== value) {
-          value = nextValue;
-          if (node.value !== nextValue) node.value = nextValue;
-          resize(true);
-        }
-      },
-      destroy() {
-        node.removeEventListener('beforeinput', onBeforeInput);
-        node.removeEventListener('input', onInput);
-      }
-    };
+  $effect(() => {
+    if (modal && triggerInput) setTimeout(() => triggerInput?.focus(), 50);
+  });
+
+  // Cap auto-grow so a long paste can't blow out the modal layout; the textarea
+  // scrolls internally past this height.
+  const FIELD_GROW_MAX = 220;
+  function autoGrow(el: HTMLTextAreaElement | null) {
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, FIELD_GROW_MAX) + 'px';
   }
 
   $effect(() => {
-    if (modal && triggerInput) setTimeout(() => triggerInput?.focus(), 50);
+    draftExpansion;
+    autoGrow(expansionEl);
+  });
+
+  $effect(() => {
+    draftInstructions;
+    autoGrow(instructionsEl);
   });
 
   const sortLabels: { key: SortKey; label: string }[] = [
@@ -425,6 +466,7 @@
 </div>
 
 {#if modal}
+  <div class="modal-overlay">
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <button class="modal-backdrop" aria-label="Close dialog" onclick={closeModal} in:fade={{ duration: 150 }} out:fade={{ duration: 100 }}></button>
   <div
@@ -435,7 +477,7 @@
     out:fly={{ y: 8, duration: 150, easing: expoOut }}
   >
     <div class="modal-header">
-      <h2 class="modal-title">{modal.mode === 'add' ? 'New snippet' : 'Edit snippet'}</h2>
+      <h2 class="modal-title">{modal?.mode === 'add' ? 'New snippet' : 'Edit snippet'}</h2>
       <button class="icon-btn" onclick={closeModal} aria-label="Close">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
       </button>
@@ -444,7 +486,7 @@
     <div class="modal-body scrollbar-standard">
       <label class="field-label" for="trigger-input">
         Trigger
-        <span class="char-count" class:over={draftTrigger.length > TRIGGER_LIMIT}>{draftTrigger.length}/{TRIGGER_LIMIT}</span>
+        <span class="char-count" class:over={countCodePoints(draftTrigger) > TRIGGER_LIMIT}>{countCodePoints(draftTrigger)}/{TRIGGER_LIMIT}</span>
       </label>
       <div class="input-row">
         <input
@@ -454,7 +496,6 @@
           placeholder="e.g. my email"
           bind:value={draftTrigger}
           bind:this={triggerInput}
-          maxlength={TRIGGER_LIMIT}
           autocomplete="off"
           spellcheck="false"
         />
@@ -469,7 +510,7 @@
           class="field-input scrollbar-standard"
           placeholder="e.g. hello@example.com"
           bind:value={draftExpansion}
-          use:autoGrow={draftExpansion}
+          bind:this={expansionEl}
           rows="3"
           spellcheck="false"
         ></textarea>
@@ -490,7 +531,7 @@
         class="field-input instructions-input scrollbar-standard"
         placeholder="e.g. Don't add a period at the end of this phrase."
         bind:value={draftInstructions}
-        use:autoGrow={draftInstructions}
+        bind:this={instructionsEl}
         rows="2"
         spellcheck="false"
       ></textarea>
@@ -506,13 +547,14 @@
         <button
           class="btn-primary"
           onclick={saveModal}
-          disabled={saving || !draftTrigger.trim() || !draftExpansion.trim() || draftTrigger.length > TRIGGER_LIMIT}
+          disabled={saving}
         >
           {#if saving}<span class="spinner"></span>{/if}
-          {modal.mode === 'add' ? 'Add snippet' : 'Save changes'}
+          {modal?.mode === 'add' ? 'Add snippet' : 'Save changes'}
         </button>
       </div>
     </div>
+  </div>
   </div>
 {/if}
 
@@ -968,6 +1010,22 @@
 
   /* ── modal ── */
 
+  /* Flex-centered scrolling overlay. Avoids the fixed + translate(-50%,-50%)
+     centering, which in WKWebView breaks pointer hit-testing once the card grows
+     tall enough to scroll — clicks fall through to the backdrop and close the
+     dialog. The card is a normal positioned child reliably above the backdrop. */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+    overflow-y: auto;
+  }
+
   .modal-backdrop {
     position: fixed;
     inset: 0;
@@ -975,22 +1033,24 @@
     padding: 0;
     appearance: none;
     background: var(--overlay);
-    z-index: 50;
-    backdrop-filter: blur(2px);
+    z-index: 0;
     outline: none;
+    /* NOTE: do not use backdrop-filter here. On WKWebView it repaints on every
+       layout change (e.g. the expansion textarea auto-growing) and starts
+       capturing pointer events over the modal card above it, making the dialog
+       controls dead and stealing clicks to close the modal. */
   }
 
   .modal-card {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    translate: -50% -50%;
-    z-index: 51;
+    position: relative;
+    z-index: 1;
+    margin: auto;
+    isolation: isolate;
     background: var(--bg-elev);
     border: 1px solid var(--line);
     border-radius: var(--r-lg);
-    width: min(500px, calc(100vw - 40px));
-    max-height: calc(100dvh - 80px);
+    width: min(500px, 100%);
+    max-height: 100%;
     box-shadow: var(--shadow-elev);
     overflow: hidden;
     display: flex;
@@ -1209,4 +1269,3 @@
     word-break: break-word;
   }
 </style>
-

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -217,7 +217,8 @@
   function autoGrow(el: HTMLTextAreaElement | null) {
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = Math.min(el.scrollHeight, FIELD_GROW_MAX) + 'px';
+    const borderDiff = el.offsetHeight - el.clientHeight;
+    el.style.height = Math.min(el.scrollHeight + borderDiff, FIELD_GROW_MAX) + 'px';
   }
 
   $effect(() => {

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -3,7 +3,7 @@
   import { invoke } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { appStore, fetchSnippets, cancelSnippetsFetch, type Snippet } from '../stores';
+  import { appStore, fetchSnippets, cancelSnippetsFetch, formatIpcError, type Snippet } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
 
@@ -144,7 +144,6 @@
     saving = true;
     saveError = '';
     try {
-      const editedId = modal?.mode === 'edit' ? modal.snippet?.id : undefined;
       if (modal?.mode === 'add') {
         const created = requireCreatedRecordMeta(await invoke<unknown>('create_snippet', {
           trigger: t,
@@ -172,15 +171,12 @@
         upsertSnippet(snippet);
         selected = snippet;
       }
-      if (editedId !== undefined && !selected) {
-        selected = appStore.snippets.find(s => s.id === editedId) ?? null;
-      }
       closeModal();
     } catch (err) {
-      const msg = String(err);
+      const msg = formatIpcError(err);
       saveError = msg.includes('UNIQUE')
         ? 'A snippet with that trigger already exists.'
-        : (msg || 'Failed to save snippet.');
+        : msg;
     }
     finally { saving = false; }
   }

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -3,7 +3,7 @@
   import { invoke } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { appStore, fetchSnippets, type Snippet } from '../stores';
+  import { appStore, fetchSnippets, cancelSnippetsFetch, type Snippet } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
 
@@ -113,6 +113,7 @@
   function closeModal() { modal = null; saveError = ''; }
 
   function upsertSnippet(snippet: Snippet) {
+    cancelSnippetsFetch();
     const next = appStore.snippets.filter((entry) => entry.id !== snippet.id);
     appStore.snippets = [snippet, ...next];
   }
@@ -188,6 +189,7 @@
     if (deleteTarget === id) {
       try {
         await invoke('remove_snippet', { id });
+        cancelSnippetsFetch();
         appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
         if (selected?.id === id) selected = null;
       } catch (err) { console.error(err); }


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a macOS AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - The Snippets and Dictionary views both present a modal dialog for creating/editing records, with auto-growing textareas
> - On macOS WKWebView, creating a snippet by **pasting** text (rather than typing) silently did nothing: the modal closed, nothing was saved, and no error appeared
> - Root cause: `backdrop-filter: blur()` on the full-screen backdrop button repaints on every layout change (e.g. textarea auto-grow); when it repaints, WKWebView's pointer hit-testing breaks and clicks fall through the card to the backdrop, which fires `closeModal()` — completely bypassing `saveModal()`
> - A second trigger existed at larger content sizes: once the modal card grew tall enough to scroll, the `position: fixed + translate(-50%, -50%)` centering broke hit-testing again even without blur
> - This PR removes `backdrop-filter` from both modal backdrops, rewrites the Snippets modal to a flex-centered scrolling overlay, and adds several hardening layers (DOM-read on save, input normalization, optimistic UI, cancellation tokens) to make paste-create reliable

## What Changed

- **Root fix — remove `backdrop-filter`** from `.modal-backdrop` in `Snippets.svelte` and `Dictionary.svelte`; the overlay dim (`var(--overlay)`) is preserved
- **Modal layout rewrite (`Snippets.svelte`)** — replaced `position: fixed + translate(-50%, -50%)` centering with a flex-centered scrolling `.modal-overlay` wrapper; the card is now a normal positioned child reliably above the backdrop at any content height
- **`isolation: isolate` on `.modal-card`** in both Snippets and Dictionary to establish a clean stacking context independent of the backdrop
- **Textarea auto-grow capped at 220px** — long pastes scroll internally and cannot distort the modal layout
- **DOM-read on save** — `saveModal()` reads `triggerInput.value`, `expansionEl.value`, `instructionsEl.value` directly at click time, bypassing any WKWebView `bind:value` paste-sync lag that could cause a false empty-field guard
- **Input normalization** — `normalizeText()` (frontend) and `normalize_multiline()` (Rust `db.rs`) collapse `\r\n`/`\r` → `\n` and trim trailing whitespace, so pasted content from any source stores identically to typed input
- **Visible empty-field error** — the silent early-return guard now sets `saveError` with a readable message instead of silently doing nothing
- **`create_snippet` / `create_dictionary_entry` now return `CreatedRecordMeta`** — previously `void`; backend uses `insert_snippet_returning` / `insert_dictionary_entry_returning`
- **Optimistic UI** — new/edited records are upserted directly into `appStore` on save; deletes remove immediately — replaces the full `fetchSnippets` / `fetchDictionary` round-trip that was racing on concurrent saves
- **Cancellation tokens** in `fetchSnippets` / `fetchDictionary` (`stores.svelte.ts`) — stale in-flight fetches cannot overwrite optimistic state from a newer save
- **Dev-mode mocks updated** (`tauri.ts`) — `get_snippets`, `get_dictionary`, `create_*`, `edit_*`, `remove_*` now use localStorage-backed lists matching the Rust schema instead of returning `undefined`
- **Test updated** — `snippet_update_normalizes_expansion_whitespace` (was `preserves`) asserts the new correct behavior: CRLF + trailing whitespace → trimmed LF

## Verification

- `npm run check` ✅
- `npm run test:rust` ✅ (156/156)
- Manual on macOS (`npm run tauri dev`):
  1. Snippets → New snippet → **paste** multi-line text (6+ lines, 12+ lines) into Expansion, type a trigger → Add snippet → snippet created and appears in list
  2. Paste into trigger field with >300 chars → inline error shown (not silent, not generic)
  3. Click Add with empty trigger → "Trigger and expansion are both required." inline error shown
  4. Typed-only create/edit/delete still works (regression check)

## Risks

- **`backdrop-filter` removal** is a visual change (no blur on the background behind the modal). The overlay dim is preserved so the background is still clearly dimmed; the blur was cosmetic only. Low risk.
- **Modal layout rewrite** (Snippets only) changes the flex/position structure. The card dimensions, max-height, and scroll behavior are preserved. Low risk.
- **Input normalization** trims trailing whitespace from stored expansions. Existing stored snippets are unchanged; only new/edited ones are normalized. The previous behavior (storing raw paste with trailing newlines) was unintended. Low risk.
- **`create_snippet` return type change** (`void` → `CreatedRecordMeta`) is a breaking API contract change — any caller expecting `void` will need updating. The only caller is `saveModal()` in `Snippets.svelte`, which is updated here. No other callers exist. Low risk.

## Model Used

- Anthropic Claude Opus 4.8 (`claude-opus-4-8`) and Claude Sonnet 4.6 (`claude-sonnet-4-6`), tool use, long context

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) — pre-existing Clippy `too_many_arguments` failure in `get_cleanup_prompt` from the prior model-prompting commit; unrelated to this PR
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [x] UI changes include before/after screenshots — _paste-create now works; dialog stays open and interactive at any content height_
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together — _no version bump in this PR_
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above