### PR TITLE
fix(ui): smooth page and modal transitions

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,7 +14,7 @@
   import { invoke, listen } from './lib/tauri';
   import { fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx, pageSwap } from './lib/motion';
+  import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx, pageSwap, reducedMotionEnabled } from './lib/motion';
 
   type EffectiveTheme = 'light' | 'dark';
 
@@ -52,13 +52,9 @@
   $effect(() => {
     appStore.currentPage;
     requestAnimationFrame(() => {
-      contentEl?.scrollTo({ top: 0, behavior: reducedMotion() ? 'auto' : 'smooth' });
+      contentEl?.scrollTo({ top: 0, behavior: reducedMotionEnabled() ? 'auto' : 'smooth' });
     });
   });
-
-  function reducedMotion() {
-    return typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
-  }
 
   async function pingConnectivity() {
     try {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,7 +14,7 @@
   import { invoke, listen } from './lib/tauri';
   import { fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx } from './lib/motion';
+  import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx, pageSwap } from './lib/motion';
 
   type EffectiveTheme = 'light' | 'dark';
 
@@ -41,12 +41,24 @@
   let toastTimer: ReturnType<typeof setTimeout>;
   let pageDir = $state<1 | -1>(1);
   let prevPage = $state<string>('home');
+  let contentEl = $state<HTMLDivElement | null>(null);
 
   $effect(() => {
     const next = appStore.currentPage;
     pageDir = directionFromOrder(prevPage, next, NAV_ORDER);
     prevPage = next;
   });
+
+  $effect(() => {
+    appStore.currentPage;
+    requestAnimationFrame(() => {
+      contentEl?.scrollTo({ top: 0, behavior: reducedMotion() ? 'auto' : 'smooth' });
+    });
+  });
+
+  function reducedMotion() {
+    return typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+  }
 
   async function pingConnectivity() {
     try {
@@ -122,12 +134,12 @@
   {/if}
   <div class="body">
     <Sidebar />
-    <div class="content scroll-styled">
+    <div class="content scroll-styled" bind:this={contentEl}>
       {#key appStore.currentPage}
         <div
           class="page-wrapper"
-          in:fly={{ y: pageDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.page + 120), easing: expoOut }}
-          out:fly={{ y: -pageDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base + 100), easing: expoOut }}
+          in:pageSwap={{ axis: 'y', distance: pageDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.panel) }}
+          out:pageSwap={{ axis: 'y', distance: -pageDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base + 40) }}
         >
           {#if appStore.currentPage === 'home'}
             <Home />

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -13,7 +13,7 @@
     type AppMapping,
     type InstalledApp,
   } from '../appMappings';
-  import { animateWidth, MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
+  import { animateWidth, listItemCollapse, MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
 
   let {
     showHeading = true,
@@ -37,10 +37,12 @@
   let appPickerOpen = $state(false);
   let profileDropdownOpen = $state(false);
   let mappingError = $state('');
+  let leavingExes = $state<Set<string>>(new Set());
 
   const pendingExe = $derived(addExe || (appSearch.trim() ? customExeFromSearch(appSearch) : ''));
   const pendingName = $derived(cleanAppName(addName || appSearch || pendingExe));
   const mappedExes = $derived(new Set(mappings.map((mapping) => normalizeExe(mapping.exe))));
+  const visibleMappings = $derived(mappings.filter((mapping) => !leavingExes.has(mapping.exe)));
   const filteredApps = $derived(
     installedApps
       .filter((app) => !mappedExes.has(normalizeExe(app.exe)))
@@ -87,7 +89,19 @@
   }
 
   async function deleteMapping(exe: string) {
-    await saveMappings(mappings.filter((mapping) => normalizeExe(mapping.exe) !== normalizeExe(exe)));
+    const normalizedExe = normalizeExe(exe);
+    if (leavingExes.has(normalizedExe)) return;
+
+    leavingExes = new Set(leavingExes).add(normalizedExe);
+    window.setTimeout(async () => {
+      try {
+        await saveMappings(mappings.filter((mapping) => normalizeExe(mapping.exe) !== normalizedExe));
+      } finally {
+        const nextLeaving = new Set(leavingExes);
+        nextLeaving.delete(normalizedExe);
+        leavingExes = nextLeaving;
+      }
+    }, motionMs(200));
   }
 
   function customExeFromSearch(s: string): string {
@@ -205,31 +219,33 @@
 {/if}
 <p class="panel-note">{intro}</p>
 
-{#if mappings.length > 0}
-  <div class="mapping-list">
-    {#each mappings as mapping (mapping.exe)}
-      <div
-        class="mapping-row"
-        animate:flip={{ duration: motionMs(300), easing: expoOut }}
-        in:fly={{ y: motionPx(10), duration: motionMs(300), easing: expoOut }}
-        out:slide={{ duration: motionMs(200), easing: expoOut }}
-      >
-        <div class="mapping-app-info">
-          <span class="mapping-app-name">{getAppDisplayName(mapping, installedApps)}</span>
-          <span class="mapping-exe-pill" aria-hidden="true">{mapping.exe}</span>
+<div class="mapping-region">
+  {#if mappings.length > 0}
+    <div class="mapping-list">
+      {#each visibleMappings as mapping (mapping.exe)}
+        <div
+          class="mapping-row"
+          animate:flip={{ duration: motionMs(300), easing: expoOut }}
+          in:fly={{ y: motionPx(10), duration: motionMs(300), easing: expoOut }}
+          out:listItemCollapse={{ duration: 200 }}
+        >
+          <div class="mapping-app-info">
+            <span class="mapping-app-name">{getAppDisplayName(mapping, installedApps)}</span>
+            <span class="mapping-exe-pill" aria-hidden="true">{mapping.exe}</span>
+          </div>
+          <span class="mapping-profile-badge">{getProfileLabel(mapping.profile)}</span>
+          <button class="mapping-delete-btn" onclick={() => deleteMapping(mapping.exe)} title="Remove {getAppDisplayName(mapping, installedApps)}">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+              <path d="M18 6 6 18M6 6l12 12"/>
+            </svg>
+          </button>
         </div>
-        <span class="mapping-profile-badge">{getProfileLabel(mapping.profile)}</span>
-        <button class="mapping-delete-btn" onclick={() => deleteMapping(mapping.exe)} title="Remove {getAppDisplayName(mapping, installedApps)}">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
-            <path d="M18 6 6 18M6 6l12 12"/>
-          </svg>
-        </button>
-      </div>
-    {/each}
-  </div>
-{:else}
-  <div class="mapping-empty">{emptyText}</div>
-{/if}
+      {/each}
+    </div>
+  {:else}
+    <div class="mapping-empty" in:fade={{ duration: motionMs(MOTION_MS.fast) }} out:fade={{ duration: motionMs(MOTION_MS.fast) }}>{emptyText}</div>
+  {/if}
+</div>
 
 {#if mappingError}
   <div class="mapping-error">{mappingError}</div>
@@ -365,8 +381,12 @@
     border: 1px solid var(--line);
     border-radius: var(--r-sm);
     overflow: hidden;
-    margin-bottom: 20px;
     max-width: 640px;
+  }
+
+  .mapping-region {
+    max-width: 640px;
+    margin-bottom: 20px;
   }
 
   .mapping-row {

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -77,14 +77,16 @@
     }
   }
 
-  async function saveMappings(updated: AppMapping[]) {
+  async function saveMappings(updated: AppMapping[]): Promise<boolean> {
     mappings = normalizeMappings(updated);
     try {
       await invoke('save_app_mappings', { mappings });
       mappingError = '';
+      return true;
     } catch (err) {
       console.error('save_app_mappings failed:', err);
       mappingError = 'Could not save app tones.';
+      return false;
     }
   }
 
@@ -92,10 +94,14 @@
     const normalizedExe = normalizeExe(exe);
     if (leavingExes.has(normalizedExe)) return;
 
+    const previousMappings = mappings;
     leavingExes = new Set(leavingExes).add(normalizedExe);
     window.setTimeout(async () => {
       try {
-        await saveMappings(mappings.filter((mapping) => normalizeExe(mapping.exe) !== normalizedExe));
+        const saved = await saveMappings(mappings.filter((mapping) => normalizeExe(mapping.exe) !== normalizedExe));
+        if (!saved) {
+          mappings = normalizeMappings(previousMappings);
+        }
       } finally {
         const nextLeaving = new Set(leavingExes);
         nextLeaving.delete(normalizedExe);

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -12,7 +12,6 @@
     transcriptionLanguages,
     type TranscriptionLanguageCode,
   } from '../../transcriptionLanguages';
-  import { getAudioCalibrationCopy } from '../../calibrationCopy';
 
   let selectedLanguage = $state<TranscriptionLanguageCode>('en');
   let languageDropdownOpen = $state(false);
@@ -20,7 +19,12 @@
   let microphones = $state<string[]>([]);
   let selectedMic = $state('');
   let micDropdownOpen = $state(false);
-  const audioCopy = $derived(getAudioCalibrationCopy(selectedLanguage));
+  const microphoneCopy = {
+    inputDeviceLabel: 'Input device',
+    inputDeviceDescription: 'Choose which microphone Open Flow should record from',
+    defaultDevice: 'Default Device',
+    noDevicesFound: 'No devices found',
+  };
   let muteAudio = $state(false);
   let autostart = $state(false);
   let cleanup = $state(true);
@@ -386,21 +390,21 @@
 </div>
 <div class="setting-row">
   <div>
-    <div class="label">{audioCopy.inputDeviceLabel}</div>
-    <div class="desc">{audioCopy.inputDeviceDescription}</div>
+    <div class="label">{microphoneCopy.inputDeviceLabel}</div>
+    <div class="desc">{microphoneCopy.inputDeviceDescription}</div>
   </div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="mic-dropdown" onkeydown={(e) => { if (e.key === 'Escape' && micDropdownOpen) { micDropdownOpen = false; e.stopPropagation(); } }}>
     <button
       class="btn-ghost mic-btn"
-      use:animateWidth={{ text: selectedMic || audioCopy.defaultDevice, max: 180 }}
+      use:animateWidth={{ text: selectedMic || microphoneCopy.defaultDevice, max: 180 }}
       onclick={() => (micDropdownOpen = !micDropdownOpen)}
       aria-haspopup="true"
       aria-expanded={micDropdownOpen}
       aria-controls={MIC_MENU_ID}
       aria-label="Microphone device"
     >
-      <span class="mic-btn-label">{selectedMic || audioCopy.defaultDevice}</span>
+      <span class="mic-btn-label">{selectedMic || microphoneCopy.defaultDevice}</span>
       <svg class:open={micDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="m6 9 6 6 6-6"/>
       </svg>
@@ -415,12 +419,12 @@
         in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
         out:fade={{ duration: motionMs(MOTION_MS.fast) }}
       >
-        <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{audioCopy.defaultDevice}</button>
+        <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{microphoneCopy.defaultDevice}</button>
         {#each microphones as m}
           <button class="mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>{m}</button>
         {/each}
         {#if microphones.length === 0}
-          <div class="mic-empty">{audioCopy.noDevicesFound}</div>
+          <div class="mic-empty">{microphoneCopy.noDevicesFound}</div>
         {/if}
       </div>
     {/if}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -44,6 +44,10 @@ export interface MotionTransitionParams {
   scaleFrom?: number;
 }
 
+interface TransitionOptions {
+  direction?: 'in' | 'out' | 'both';
+}
+
 export function modalBackdrop(_node: Element, params: MotionTransitionParams = {}) {
   const duration = motionMs(params.duration ?? 180);
   return {
@@ -69,14 +73,26 @@ export function modalCard(_node: Element, params: MotionTransitionParams = {}) {
   };
 }
 
-export function pageSwap(_node: Element, params: MotionTransitionParams = {}) {
+export function pageSwap(node: HTMLElement, params: MotionTransitionParams = {}, options: TransitionOptions = {}) {
   const duration = motionMs(params.duration ?? 260);
   const axis = params.axis ?? 'y';
   const distance = params.distance ?? motionPx(MOTION_PX.page);
+  const isOutro = options.direction === 'out';
 
   return {
     duration,
     easing: cubicOut,
+    tick: () => {
+      if (isOutro) {
+        node.inert = true;
+        node.setAttribute('aria-hidden', 'true');
+        node.style.pointerEvents = 'none';
+      } else {
+        node.inert = false;
+        node.removeAttribute('aria-hidden');
+        node.style.pointerEvents = '';
+      }
+    },
     css: (t: number) => {
       const u = 1 - t;
       const x = axis === 'x' ? u * distance : 0;

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,3 +1,5 @@
+import { cubicOut } from 'svelte/easing';
+
 export const MOTION_MS = {
   fast: 150,
   base: 220,
@@ -33,6 +35,83 @@ export function motionMs(ms: number): number {
 
 export function motionPx(px: number): number {
   return reducedMotionEnabled() ? Math.max(2, Math.round(px * 0.5)) : px;
+}
+
+export interface MotionTransitionParams {
+  duration?: number;
+  distance?: number;
+  axis?: 'x' | 'y';
+  scaleFrom?: number;
+}
+
+export function modalBackdrop(_node: Element, params: MotionTransitionParams = {}) {
+  const duration = motionMs(params.duration ?? 180);
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t: number) => `opacity:${t};`,
+  };
+}
+
+export function modalCard(_node: Element, params: MotionTransitionParams = {}) {
+  const duration = motionMs(params.duration ?? 220);
+  const distance = params.distance ?? motionPx(MOTION_PX.panel);
+  const scaleFrom = params.scaleFrom ?? 0.97;
+
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t: number) => {
+      const u = 1 - t;
+      const scale = scaleFrom + (1 - scaleFrom) * t;
+      return `opacity:${t}; transform: translate3d(0, ${u * distance}px, 0) scale(${scale});`;
+    },
+  };
+}
+
+export function pageSwap(_node: Element, params: MotionTransitionParams = {}) {
+  const duration = motionMs(params.duration ?? 260);
+  const axis = params.axis ?? 'y';
+  const distance = params.distance ?? motionPx(MOTION_PX.page);
+
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t: number) => {
+      const u = 1 - t;
+      const x = axis === 'x' ? u * distance : 0;
+      const y = axis === 'y' ? u * distance : 0;
+      return `opacity:${0.001 + t * 0.999}; transform: translate3d(${x}px, ${y}px, 0);`;
+    },
+  };
+}
+
+export function listItemCollapse(node: HTMLElement, params: MotionTransitionParams = {}) {
+  const duration = motionMs(params.duration ?? 200);
+  const style = getComputedStyle(node);
+  const height = node.offsetHeight;
+  const paddingTop = parseFloat(style.paddingTop);
+  const paddingBottom = parseFloat(style.paddingBottom);
+  const marginTop = parseFloat(style.marginTop);
+  const marginBottom = parseFloat(style.marginBottom);
+  const borderTopWidth = parseFloat(style.borderTopWidth);
+  const borderBottomWidth = parseFloat(style.borderBottomWidth);
+
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t: number) => `
+      overflow: hidden;
+      opacity: ${t};
+      height: ${Math.max(0, height * t)}px;
+      padding-top: ${paddingTop * t}px;
+      padding-bottom: ${paddingBottom * t}px;
+      margin-top: ${marginTop * t}px;
+      margin-bottom: ${marginBottom * t}px;
+      border-top-width: ${borderTopWidth * t}px;
+      border-bottom-width: ${borderBottomWidth * t}px;
+    `,
+  };
 }
 
 export interface AnimateWidthParams {

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -90,12 +90,12 @@ export function listItemCollapse(node: HTMLElement, params: MotionTransitionPara
   const duration = motionMs(params.duration ?? 200);
   const style = getComputedStyle(node);
   const height = node.offsetHeight;
-  const paddingTop = parseFloat(style.paddingTop);
-  const paddingBottom = parseFloat(style.paddingBottom);
-  const marginTop = parseFloat(style.marginTop);
-  const marginBottom = parseFloat(style.marginBottom);
-  const borderTopWidth = parseFloat(style.borderTopWidth);
-  const borderBottomWidth = parseFloat(style.borderBottomWidth);
+  const paddingTop = parseFloat(style.paddingTop) || 0;
+  const paddingBottom = parseFloat(style.paddingBottom) || 0;
+  const marginTop = parseFloat(style.marginTop) || 0;
+  const marginBottom = parseFloat(style.marginBottom) || 0;
+  const borderTopWidth = parseFloat(style.borderTopWidth) || 0;
+  const borderBottomWidth = parseFloat(style.borderBottomWidth) || 0;
 
   return {
     duration,

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -49,6 +49,7 @@
     newest: null, oldest: null, alpha: null, most_corrected: null,
   });
   let sortIndicatorStyle = $state('opacity:0;');
+  let leavingIds = $state<Set<number>>(new Set());
 
   const TERM_LIMIT    = 120;
   const MISTAKE_LIMIT = 120;
@@ -96,6 +97,7 @@
 
     return list;
   });
+  const visibleFiltered = $derived(filtered.filter((entry) => !leavingIds.has(entry.id)));
 
   onMount(() => {
     let unlisten: (() => void) | undefined;
@@ -196,14 +198,26 @@
   async function confirmDelete(id: number) {
     if (deleteTarget === id) {
       try {
+        if (leavingIds.has(id)) return;
         if (selected?.id === id) {
           inspectorDir = -1;
           selected = null;
           await tick();
         }
-        await invoke('remove_dictionary_entry', { id });
-        cancelDictionaryFetch();
-        appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
+        leavingIds = new Set(leavingIds).add(id);
+        window.setTimeout(async () => {
+          try {
+            await invoke('remove_dictionary_entry', { id });
+            cancelDictionaryFetch();
+            appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
+          } catch (err) {
+            console.error(err);
+          } finally {
+            const nextLeaving = new Set(leavingIds);
+            nextLeaving.delete(id);
+            leavingIds = nextLeaving;
+          }
+        }, motionMs(200));
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -326,9 +340,11 @@
             <p class="empty-sub">Nothing matches "{search}".</p>
             <button class="btn-ghost" onclick={() => search = ''}>Clear search</button>
           </div>
+        {:else if visibleFiltered.length === 0}
+          <div class="dict-list" aria-hidden="true"></div>
         {:else}
           <div class="dict-list">
-            {#each filtered as e (e.id)}
+            {#each visibleFiltered as e (e.id)}
               <button
                 type="button"
                 class="dict-row"

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
-  import { invoke, listen } from '../tauri';
+  import { emit, invoke, listen } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { flip } from 'svelte/animate';
@@ -212,6 +212,7 @@
             appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
           } catch (err) {
             console.error(err);
+            await emit('open-flow:error', 'Could not delete dictionary term.');
           } finally {
             const nextLeaving = new Set(leavingIds);
             nextLeaving.delete(id);
@@ -478,11 +479,12 @@
     class="modal-card"
     role="dialog"
     aria-modal="true"
+    aria-labelledby="dictionary-modal-title"
     in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
     out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
   >
     <div class="modal-header">
-      <h2 class="modal-title">{modal?.mode === 'add' ? 'Add term' : 'Edit term'}</h2>
+      <h2 id="dictionary-modal-title" class="modal-title">{modal?.mode === 'add' ? 'Add term' : 'Edit term'}</h2>
       <button class="icon-btn" onclick={closeModal} aria-label="Close">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
       </button>

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { invoke, listen } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
+  import { flip } from 'svelte/animate';
+  import { listItemCollapse, modalBackdrop, modalCard, MOTION_MS, MOTION_PX, motionMs, motionPx, pageSwap } from '../motion';
   import { appStore, fetchDictionary, cancelDictionaryFetch, formatIpcError, type DictionaryEntry } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
 
@@ -195,10 +196,14 @@
   async function confirmDelete(id: number) {
     if (deleteTarget === id) {
       try {
+        if (selected?.id === id) {
+          inspectorDir = -1;
+          selected = null;
+          await tick();
+        }
         await invoke('remove_dictionary_entry', { id });
         cancelDictionaryFetch();
         appStore.dictionary = appStore.dictionary.filter((entry) => entry.id !== id);
-        if (selected?.id === id) selected = null;
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -329,6 +334,8 @@
                 class="dict-row"
                 class:is-selected={selected?.id === e.id}
                 aria-pressed={selected?.id === e.id}
+                animate:flip={{ duration: motionMs(MOTION_MS.panel), easing: expoOut }}
+                out:listItemCollapse={{ duration: 200 }}
                 onclick={() => selectRow(e)}
               >
                 <span class="dict-left">
@@ -367,8 +374,8 @@
           {#key selected.id}
             <div
               class="inspector"
-              in:fly={{ x: inspectorDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
-              out:fade={{ duration: 0 }}
+              in:pageSwap={{ axis: 'x', distance: inspectorDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel) }}
+              out:pageSwap={{ axis: 'x', distance: -inspectorDir * motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast + 40) }}
             >
               <div class="insp-trigger">{selected.term}</div>
 
@@ -450,13 +457,13 @@
 
 {#if modal}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <button class="modal-backdrop" aria-label="Close dialog" onclick={closeModal} in:fade={{ duration: 150 }} out:fade={{ duration: 100 }}></button>
+  <button class="modal-backdrop" aria-label="Close dialog" onclick={closeModal} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></button>
   <div
     class="modal-card"
     role="dialog"
     aria-modal="true"
-    in:fly={{ y: 14, duration: 260, easing: expoOut }}
-    out:fly={{ y: 8, duration: 150, easing: expoOut }}
+    in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
+    out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
   >
     <div class="modal-header">
       <h2 class="modal-title">{modal?.mode === 'add' ? 'Add term' : 'Edit term'}</h2>

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -17,6 +17,8 @@
   let section = $state('general');
   let animDir: 1 | -1 = $state(1);
   let appVersion = $state('');
+  let settingsModalEl = $state<HTMLDivElement | null>(null);
+  let previousFocusEl: HTMLElement | null = null;
 
   const sectionOrder = SETTINGS_SECTION_ORDER;
 
@@ -53,6 +55,43 @@
     }
   });
 
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+
+    if (!appStore.settingsOpen) {
+      const target = previousFocusEl;
+      previousFocusEl = null;
+      if (target?.isConnected) {
+        requestAnimationFrame(() => target.focus());
+      }
+      return;
+    }
+
+    if (!previousFocusEl && document.activeElement instanceof HTMLElement) {
+      previousFocusEl = document.activeElement;
+    }
+
+    requestAnimationFrame(() => {
+      const [first] = getFocusableElements();
+      (first ?? settingsModalEl)?.focus();
+    });
+  });
+
+  function getFocusableElements(): HTMLElement[] {
+    if (!settingsModalEl) return [];
+    const selector = [
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'a[href]',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+
+    return Array.from(settingsModalEl.querySelectorAll<HTMLElement>(selector))
+      .filter((el) => !el.hasAttribute('inert') && el.offsetParent !== null);
+  }
+
   function onWindowKeydown(e: KeyboardEvent) {
     if (appStore.settingsOpen && e.key === 'Escape') {
       const target = e.target as HTMLElement | null;
@@ -65,6 +104,29 @@
       close();
     }
   }
+
+  function onModalKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      e.preventDefault();
+      settingsModalEl?.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (e.shiftKey && (active === first || active === settingsModalEl)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 </script>
 
 <svelte:window onkeydown={onWindowKeydown} />
@@ -74,11 +136,13 @@
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
     <div class="settings-overlay" aria-hidden="true" onclick={close} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></div>
     <div
+      bind:this={settingsModalEl}
       class="settings-modal"
       role="dialog"
       aria-modal="true"
       aria-label="Settings"
       tabindex="-1"
+      onkeydown={onModalKeydown}
       in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel + 6), scaleFrom: 0.97 }}
       out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
     >

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { appStore } from '../stores';
   import { icons } from '../icons';
-  import { onDestroy, onMount } from 'svelte';
-  import { fly, fade } from 'svelte/transition';
-  import { expoOut } from 'svelte/easing';
+  import { onMount } from 'svelte';
   import { getVersion } from '../tauri';
-  import { MOTION_MS, MOTION_PX, SETTINGS_SECTION_ORDER, directionFromOrder, motionMs, motionPx } from '../motion';
+  import { MOTION_MS, MOTION_PX, SETTINGS_SECTION_ORDER, directionFromOrder, modalBackdrop, modalCard, motionMs, motionPx, pageSwap } from '../motion';
 
   import GeneralSection from '../components/settings/GeneralSection.svelte';
   import AppMappingsSection from '../components/settings/AppMappingsSection.svelte';
@@ -72,16 +70,17 @@
 <svelte:window onkeydown={onWindowKeydown} />
 
 {#if appStore.settingsOpen}
-  <div class="settings-overlay-wrap" transition:fade={{ duration: 200 }}>
+  <div class="settings-overlay-wrap">
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-    <div class="settings-overlay" aria-hidden="true" onclick={close}></div>
+    <div class="settings-overlay" aria-hidden="true" onclick={close} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></div>
     <div
       class="settings-modal"
       role="dialog"
       aria-modal="true"
       aria-label="Settings"
       tabindex="-1"
-      transition:fly={{ y: 40, duration: 400, easing: expoOut }}
+      in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel + 6), scaleFrom: 0.97 }}
+      out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
     >
       <button type="button" class="settings-close" aria-label="Close settings" onclick={close}>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
@@ -113,8 +112,8 @@
         {#key section}
           <div
             class="panel scroll-styled scroll-thumb-elev"
-            in:fly={{ y: animDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.page + 120), easing: expoOut }}
-            out:fly={{ y: -animDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base + 100), easing: expoOut }}
+            in:pageSwap={{ axis: 'y', distance: animDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.panel) }}
+            out:pageSwap={{ axis: 'y', distance: -animDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base + 40) }}
           >
             {#if section === 'general'}
               <GeneralSection />
@@ -144,7 +143,7 @@
   .settings-overlay-wrap {
     position: absolute;
     inset: 0;
-    z-index: 5;
+    z-index: 60;
     display: grid;
     place-items: center;
   }
@@ -248,11 +247,13 @@
     flex: 1;
     position: relative;
     overflow: hidden;
+    display: grid;
   }
 
   .panel {
-    position: absolute;
-    inset: 0;
+    grid-area: 1 / 1;
+    width: 100%;
+    height: 100%;
     padding: 26px 30px;
     overflow-y: auto;
     scrollbar-gutter: stable;

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
-  import { invoke } from '../tauri';
+  import { emit, invoke } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { flip } from 'svelte/animate';
@@ -201,6 +201,7 @@
             appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
           } catch (err) {
             console.error(err);
+            await emit('open-flow:error', 'Could not delete snippet.');
           } finally {
             const nextLeaving = new Set(leavingIds);
             nextLeaving.delete(id);
@@ -495,11 +496,12 @@
     class="modal-card"
     role="dialog"
     aria-modal="true"
+    aria-labelledby="snippet-modal-title"
     in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
     out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
   >
     <div class="modal-header">
-      <h2 class="modal-title">{modal?.mode === 'add' ? 'New snippet' : 'Edit snippet'}</h2>
+      <h2 id="snippet-modal-title" class="modal-title">{modal?.mode === 'add' ? 'New snippet' : 'Edit snippet'}</h2>
       <button class="icon-btn" onclick={closeModal} aria-label="Close">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
       </button>

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -46,6 +46,7 @@
     most_used: null,
   });
   let sortIndicatorStyle = $state('opacity:0;');
+  let leavingIds = $state<Set<number>>(new Set());
 
   const TRIGGER_LIMIT = 300;
   const countCodePoints = (value: string): number => [...value].length;
@@ -81,6 +82,7 @@
 
     return list;
   });
+  const visibleFiltered = $derived(filtered.filter((snippet) => !leavingIds.has(snippet.id)));
 
 
 
@@ -185,14 +187,26 @@
   async function confirmDelete(id: number) {
     if (deleteTarget === id) {
       try {
+        if (leavingIds.has(id)) return;
         if (selected?.id === id) {
           inspectorDir = -1;
           selected = null;
           await tick();
         }
-        await invoke('remove_snippet', { id });
-        cancelSnippetsFetch();
-        appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
+        leavingIds = new Set(leavingIds).add(id);
+        window.setTimeout(async () => {
+          try {
+            await invoke('remove_snippet', { id });
+            cancelSnippetsFetch();
+            appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
+          } catch (err) {
+            console.error(err);
+          } finally {
+            const nextLeaving = new Set(leavingIds);
+            nextLeaving.delete(id);
+            leavingIds = nextLeaving;
+          }
+        }, motionMs(200));
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -357,9 +371,11 @@
             <p class="empty-sub">Nothing matches "{search}".</p>
             <button class="btn-ghost" onclick={() => search = ''}>Clear search</button>
           </div>
+        {:else if visibleFiltered.length === 0}
+          <div class="snip-list" aria-hidden="true"></div>
         {:else}
           <div class="snip-list">
-            {#each filtered as s (s.id)}
+            {#each visibleFiltered as s (s.id)}
               <button
                 type="button"
                 class="snip-row"

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { invoke } from '../tauri';
   import { fly, fade } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
+  import { flip } from 'svelte/animate';
   import { appStore, fetchSnippets, cancelSnippetsFetch, formatIpcError, type Snippet } from '../stores';
   import MicInputButton from '../components/MicInputButton.svelte';
-  import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../motion';
+  import { listItemCollapse, modalBackdrop, modalCard, MOTION_MS, MOTION_PX, motionMs, motionPx, pageSwap } from '../motion';
 
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_used';
   type CreatedRecordMeta = { id: number; created_at: string };
@@ -184,10 +185,14 @@
   async function confirmDelete(id: number) {
     if (deleteTarget === id) {
       try {
+        if (selected?.id === id) {
+          inspectorDir = -1;
+          selected = null;
+          await tick();
+        }
         await invoke('remove_snippet', { id });
         cancelSnippetsFetch();
         appStore.snippets = appStore.snippets.filter((entry) => entry.id !== id);
-        if (selected?.id === id) selected = null;
       } catch (err) { console.error(err); }
       deleteTarget = null;
     } else {
@@ -360,6 +365,8 @@
                 class="snip-row"
                 class:is-selected={selected?.id === s.id}
                 aria-pressed={selected?.id === s.id}
+                animate:flip={{ duration: motionMs(MOTION_MS.panel), easing: expoOut }}
+                out:listItemCollapse={{ duration: 200 }}
                 onclick={() => selectRow(s)}
               >
                 <span class="snip-left">
@@ -389,8 +396,8 @@
           {#key selected.id}
             <div
               class="inspector"
-              in:fly={{ x: inspectorDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
-              out:fade={{ duration: 0 }}
+              in:pageSwap={{ axis: 'x', distance: inspectorDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel) }}
+              out:pageSwap={{ axis: 'x', distance: -inspectorDir * motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast + 40) }}
             >
               <div class="insp-trigger">{selected.trigger}</div>
               <div class="insp-arrow" aria-hidden="true">
@@ -467,13 +474,13 @@
 {#if modal}
   <div class="modal-overlay">
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <button class="modal-backdrop" aria-label="Close dialog" onclick={closeModal} in:fade={{ duration: 150 }} out:fade={{ duration: 100 }}></button>
+  <button class="modal-backdrop" aria-label="Close dialog" onclick={closeModal} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></button>
   <div
     class="modal-card"
     role="dialog"
     aria-modal="true"
-    in:fly={{ y: 14, duration: 260, easing: expoOut }}
-    out:fly={{ y: 8, duration: 150, easing: expoOut }}
+    in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
+    out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
   >
     <div class="modal-header">
       <h2 class="modal-title">{modal?.mode === 'add' ? 'New snippet' : 'Edit snippet'}</h2>

--- a/src/lib/views/Style.svelte
+++ b/src/lib/views/Style.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { invoke } from '../tauri';
   import { onMount } from 'svelte';
-  import { fly, crossfade } from 'svelte/transition';
+  import { crossfade, fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { saveSetting, type CleanupIntensity, type ToneId } from '../settings';
   import AppMappingsEditor from '../components/AppMappingsEditor.svelte';
-  import { MOTION_MS, MOTION_PX, STYLE_TAB_ORDER, directionFromOrder, motionMs, motionPx } from '../motion';
+  import { MOTION_MS, MOTION_PX, STYLE_TAB_ORDER, directionFromOrder, motionMs, motionPx, pageSwap } from '../motion';
 
   const [send, receive] = crossfade({
     duration: motionMs(MOTION_MS.base),
@@ -95,8 +95,8 @@
     {#key tab}
       <div
         class="tab-wrapper"
-        in:fly={{ x: tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel + 140), easing: expoOut }}
-        out:fly={{ x: -tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.base + 120), easing: expoOut }}
+        in:pageSwap={{ axis: 'x', distance: tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel) }}
+        out:pageSwap={{ axis: 'x', distance: -tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.base + 40) }}
       >
         {#if tab === 'cleanup'}
           <p class="style-intro">Auto-cleanup runs on every dictation. <span>Choose how much rewriting Open Flow does.</span></p>

--- a/tests/smoke/_tauri-mock.cjs
+++ b/tests/smoke/_tauri-mock.cjs
@@ -109,7 +109,7 @@ function tauriMock() {
     if (cmd === 'plugin:event|emit')     return null;
 
     // App plugin (getVersion / getName called by Settings and Home)
-    if (cmd === 'plugin:app|version')       return '0.5.1';
+    if (cmd === 'plugin:app|version')       return '0.11.0';
     if (cmd === 'plugin:app|name')          return 'Open Flow';
     if (cmd === 'plugin:app|tauri_version') return '2.0.0';
 

--- a/tests/smoke/playwright-test-ui.cjs
+++ b/tests/smoke/playwright-test-ui.cjs
@@ -23,6 +23,23 @@ const TIMEOUT = 8_000;
     await page.goto(TARGET_URL, { waitUntil: 'networkidle', timeout: TIMEOUT });
     console.log('Page loaded.');
 
+    // ── Navigation: page swaps should overlap during transition ───────────────
+    await page.locator('h1.page-h:has-text("Welcome back")').waitFor({ state: 'visible', timeout: 3_000 });
+    await page.locator('.nav-item:has-text("Dictionary")').click();
+    await page.waitForTimeout(40);
+    const wrapperCount = await page.locator('.page-wrapper').count();
+    if (wrapperCount < 2) {
+      errors.push(`Expected overlapping page wrappers during nav transition, saw ${wrapperCount}`);
+    } else {
+      const incomingOpacity = await page.locator('.page-wrapper').last().evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
+      if (!(incomingOpacity > 0 && incomingOpacity < 1)) {
+        errors.push(`Incoming page opacity should be mid-transition after nav click, got ${incomingOpacity}`);
+      } else {
+        console.log(`  ✓ Page transition overlap detected (${wrapperCount} wrappers, opacity ${incomingOpacity.toFixed(2)})`);
+      }
+    }
+    await page.locator('h1.page-h:has-text("Dictionary")').waitFor({ state: 'visible', timeout: 3_000 });
+
     // ── Navigation: each click must actually change the visible view ──────────
     const navMap = [
       { label: 'Home',       heading: 'Welcome back' },
@@ -48,10 +65,38 @@ const TIMEOUT = 8_000;
     const settingsBtn = page.locator('.nav-item:has-text("Settings")');
     await settingsBtn.waitFor({ state: 'visible', timeout: TIMEOUT });
     await settingsBtn.click();
+    await page.waitForTimeout(40);
+
+    const backdropOpacityIn = await page.locator('.settings-overlay').evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
+    if (!(backdropOpacityIn > 0 && backdropOpacityIn < 1)) {
+      errors.push(`Settings backdrop should be mid-fade right after open, got opacity ${backdropOpacityIn}`);
+    } else {
+      console.log(`  ✓ Settings backdrop fades in (${backdropOpacityIn.toFixed(2)})`);
+    }
 
     const modal = page.locator('.settings-modal');
     await modal.waitFor({ state: 'visible', timeout: 3_000 });
     console.log('  ✓ Settings modal opened');
+
+    const versionFoot = await page.locator('.settings-foot').textContent();
+    if (!versionFoot?.includes('0.11.0')) {
+      errors.push(`Settings footer version mismatch: "${versionFoot?.trim()}"`);
+    } else {
+      console.log(`  ✓ Settings footer shows ${versionFoot.trim()}`);
+    }
+
+    const offlineToast = page.locator('.offline-toast');
+    if (await offlineToast.isVisible().catch(() => false)) {
+      const [overlayZ, toastZ] = await Promise.all([
+        page.locator('.settings-overlay-wrap').evaluate((el) => Number(getComputedStyle(el).zIndex) || 0),
+        offlineToast.evaluate((el) => Number(getComputedStyle(el).zIndex) || 0),
+      ]);
+      if (overlayZ <= toastZ) {
+        errors.push(`Settings overlay z-index (${overlayZ}) should sit above offline toast (${toastZ})`);
+      } else {
+        console.log(`  ✓ Settings overlay stacks above offline toast (${overlayZ} > ${toastZ})`);
+      }
+    }
 
     // ── Settings sections: each click must show the correct h2 ────────────────
     const sections = ['General', 'API Keys', 'Models', 'Privacy', 'Advanced', 'About'];
@@ -64,6 +109,22 @@ const TIMEOUT = 8_000;
       const h2 = page.locator(`h2.settings-h:has-text("${sec}")`);
       await h2.waitFor({ state: 'visible', timeout: 3_000 });
       console.log(`    ✓ "${sec}" panel rendered`);
+    }
+
+    // ── General language should not localize unrelated UI copy ───────────────
+    await page.locator('.settings-nav-item:has-text("General")').click();
+    await page.locator('h2.settings-h:has-text("General")').waitFor({ state: 'visible', timeout: 3_000 });
+    await page.locator('.language-btn').click();
+    await page.locator('.language-menu').waitFor({ state: 'visible', timeout: 2_000 });
+    await page.locator('.language-item').filter({ hasText: 'Chinese' }).first().click();
+    await page.locator('.language-btn:has-text("Chinese")').waitFor({ state: 'visible', timeout: 2_000 });
+    if (!(await page.locator('.label', { hasText: 'Input device' }).isVisible().catch(() => false))) {
+      errors.push('Input device label disappeared after changing Spoken Language to Chinese');
+    } else {
+      console.log('  ✓ Input device label stays in English after language change');
+    }
+    if (await page.locator('text=输入设备').isVisible().catch(() => false)) {
+      errors.push('Chinese microphone label leaked into General settings after Spoken Language change');
     }
 
     // ── Privacy toggles: verify state actually changes on click ───────────────
@@ -96,6 +157,13 @@ const TIMEOUT = 8_000;
     // ── Settings: close by clicking outside (10, 10) ─────────────────────────
     console.log('  Closing Settings via outside click...');
     await page.mouse.click(10, 10);
+    await page.waitForTimeout(40);
+    const backdropOpacityOut = await page.locator('.settings-overlay').evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
+    if (!(backdropOpacityOut > 0 && backdropOpacityOut < 1)) {
+      errors.push(`Settings backdrop should be mid-fade right after close, got opacity ${backdropOpacityOut}`);
+    } else {
+      console.log(`  ✓ Settings backdrop fades out (${backdropOpacityOut.toFixed(2)})`);
+    }
     await modal.waitFor({ state: 'hidden', timeout: 3_000 });
     console.log('  ✓ Settings modal closed');
 

--- a/tests/smoke/playwright-test-ui.cjs
+++ b/tests/smoke/playwright-test-ui.cjs
@@ -6,6 +6,30 @@ const { tauriMock } = require('./_tauri-mock.cjs');
 const TARGET_URL = 'http://localhost:1420';
 const TIMEOUT = 8_000;
 
+async function waitForIntermediateOpacity(page, selector, label, timeout = 1_000) {
+  const handle = await page.waitForFunction(
+    ({ selector }) => {
+      const el = document.querySelector(selector);
+      if (!el) return false;
+      const opacity = Number.parseFloat(getComputedStyle(el).opacity);
+      return opacity > 0 && opacity < 1 ? opacity : false;
+    },
+    { selector },
+    { timeout },
+  );
+  const opacity = await handle.jsonValue();
+  console.log(`  ✓ ${label} (${Number(opacity).toFixed(2)})`);
+  return opacity;
+}
+
+async function waitForSingleSettingsPanel(page) {
+  await page.waitForFunction(
+    () => document.querySelectorAll('.settings-body .panel').length === 1,
+    null,
+    { timeout: 2_000 },
+  );
+}
+
 (async () => {
   console.log('Starting UI interaction tests...');
   const browser = await chromium.launch({ headless: true });
@@ -26,16 +50,23 @@ const TIMEOUT = 8_000;
     // ── Navigation: page swaps should overlap during transition ───────────────
     await page.locator('h1.page-h:has-text("Welcome back")').waitFor({ state: 'visible', timeout: 3_000 });
     await page.locator('.nav-item:has-text("Dictionary")').click();
-    await page.waitForTimeout(40);
-    const wrapperCount = await page.locator('.page-wrapper').count();
+    const wrapperCountHandle = await page.waitForFunction(
+      () => document.querySelectorAll('.page-wrapper').length >= 2
+        ? document.querySelectorAll('.page-wrapper').length
+        : false,
+      null,
+      { timeout: 1_000 },
+    ).catch(() => null);
+    const wrapperCount = wrapperCountHandle ? await wrapperCountHandle.jsonValue() : 0;
     if (wrapperCount < 2) {
       errors.push(`Expected overlapping page wrappers during nav transition, saw ${wrapperCount}`);
     } else {
-      const incomingOpacity = await page.locator('.page-wrapper').last().evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
-      if (!(incomingOpacity > 0 && incomingOpacity < 1)) {
-        errors.push(`Incoming page opacity should be mid-transition after nav click, got ${incomingOpacity}`);
+      const outgoingHidden = await page.locator('.page-wrapper').first().evaluate((el) => el.inert && el.getAttribute('aria-hidden') === 'true');
+      if (!outgoingHidden) {
+        errors.push('Outgoing page wrapper should be inert and aria-hidden during nav transition');
       } else {
-        console.log(`  ✓ Page transition overlap detected (${wrapperCount} wrappers, opacity ${incomingOpacity.toFixed(2)})`);
+        const incomingOpacity = await waitForIntermediateOpacity(page, '.page-wrapper:last-child', 'Incoming page fades in during nav transition');
+        console.log(`  ✓ Outgoing page wrapper is inert during transition; incoming opacity ${Number(incomingOpacity).toFixed(2)}`);
       }
     }
     await page.locator('h1.page-h:has-text("Dictionary")').waitFor({ state: 'visible', timeout: 3_000 });
@@ -65,18 +96,18 @@ const TIMEOUT = 8_000;
     const settingsBtn = page.locator('.nav-item:has-text("Settings")');
     await settingsBtn.waitFor({ state: 'visible', timeout: TIMEOUT });
     await settingsBtn.click();
-    await page.waitForTimeout(40);
 
-    const backdropOpacityIn = await page.locator('.settings-overlay').evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
-    if (!(backdropOpacityIn > 0 && backdropOpacityIn < 1)) {
-      errors.push(`Settings backdrop should be mid-fade right after open, got opacity ${backdropOpacityIn}`);
-    } else {
-      console.log(`  ✓ Settings backdrop fades in (${backdropOpacityIn.toFixed(2)})`);
-    }
+    await waitForIntermediateOpacity(page, '.settings-overlay', 'Settings backdrop fades in').catch((err) => {
+      errors.push(`Settings backdrop should pass through a mid-fade opacity on open: ${err.message}`);
+    });
 
     const modal = page.locator('.settings-modal');
     await modal.waitFor({ state: 'visible', timeout: 3_000 });
     console.log('  ✓ Settings modal opened');
+    const activeInModal = await modal.evaluate((el) => el.contains(document.activeElement));
+    if (!activeInModal) {
+      errors.push('Settings modal did not move focus inside the dialog on open');
+    }
 
     const versionFoot = await page.locator('.settings-foot').textContent();
     if (!versionFoot?.includes('0.11.0')) {
@@ -114,6 +145,7 @@ const TIMEOUT = 8_000;
     // ── General language should not localize unrelated UI copy ───────────────
     await page.locator('.settings-nav-item:has-text("General")').click();
     await page.locator('h2.settings-h:has-text("General")').waitFor({ state: 'visible', timeout: 3_000 });
+    await waitForSingleSettingsPanel(page);
     await page.locator('.language-btn').click();
     await page.locator('.language-menu').waitFor({ state: 'visible', timeout: 2_000 });
     await page.locator('.language-item').filter({ hasText: 'Chinese' }).first().click();
@@ -131,9 +163,7 @@ const TIMEOUT = 8_000;
     console.log('  Testing Privacy toggles...');
     await page.locator('.settings-nav-item:has-text("Privacy")').click();
     await page.locator('h2.settings-h:has-text("Privacy")').waitFor({ state: 'visible', timeout: 3_000 });
-    // Wait for the previous section's out-transition (350 ms) to fully complete
-    // so we don't grab toggles that are animating out and about to detach.
-    await page.waitForTimeout(450);
+    await waitForSingleSettingsPanel(page);
 
     const toggles = await page.locator('.toggle').all();
     if (toggles.length === 0) {
@@ -157,13 +187,9 @@ const TIMEOUT = 8_000;
     // ── Settings: close by clicking outside (10, 10) ─────────────────────────
     console.log('  Closing Settings via outside click...');
     await page.mouse.click(10, 10);
-    await page.waitForTimeout(40);
-    const backdropOpacityOut = await page.locator('.settings-overlay').evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity));
-    if (!(backdropOpacityOut > 0 && backdropOpacityOut < 1)) {
-      errors.push(`Settings backdrop should be mid-fade right after close, got opacity ${backdropOpacityOut}`);
-    } else {
-      console.log(`  ✓ Settings backdrop fades out (${backdropOpacityOut.toFixed(2)})`);
-    }
+    await waitForIntermediateOpacity(page, '.settings-overlay', 'Settings backdrop fades out').catch((err) => {
+      errors.push(`Settings backdrop should pass through a mid-fade opacity on close: ${err.message}`);
+    });
     await modal.waitFor({ state: 'hidden', timeout: 3_000 });
     console.log('  ✓ Settings modal closed');
 

--- a/tests/smoke/test-app.cjs
+++ b/tests/smoke/test-app.cjs
@@ -62,6 +62,25 @@ const TIMEOUT = 10_000;
     await page.locator('.mapping-exe-pill:has-text("chrome.exe")').waitFor({ state: 'visible', timeout: 3_000 });
     console.log('chrome.exe mapping visible in list.');
 
+    // Deleting should animate out instead of disappearing in a single frame
+    const mappingRow = page.locator('.mapping-row').filter({ hasText: 'chrome.exe' }).first();
+    const deleteBtn = mappingRow.locator('.mapping-delete-btn');
+    await deleteBtn.click();
+    await page.waitForTimeout(40);
+    const rowsDuringDelete = await page.locator('.mapping-row').count();
+    if (rowsDuringDelete < 1) {
+      errors.push('Mapping row unmounted immediately after delete click');
+    } else {
+      const rowOpacity = await mappingRow.evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity)).catch(() => NaN);
+      if (!Number.isNaN(rowOpacity) && !(rowOpacity > 0 && rowOpacity < 1)) {
+        errors.push(`Mapping row should be mid-animation after delete click, got opacity ${rowOpacity}`);
+      } else {
+        console.log(`chrome.exe mapping animating out with ${rowsDuringDelete} row in DOM.`);
+      }
+    }
+    await mappingRow.waitFor({ state: 'hidden', timeout: 3_000 });
+    console.log('chrome.exe mapping removed after animation.');
+
     if (errors.length > 0) {
       console.error('FAIL — JS errors during test:');
       errors.forEach(e => console.error('  ' + e));

--- a/tests/smoke/test-app.cjs
+++ b/tests/smoke/test-app.cjs
@@ -6,6 +6,21 @@ const { tauriMock } = require('./_tauri-mock.cjs');
 const TARGET_URL = 'http://localhost:1420';
 const TIMEOUT = 10_000;
 
+async function waitForMappingRowOpacity(page, exe, timeout = 1_000) {
+  const handle = await page.waitForFunction(
+    ({ exe }) => {
+      const rows = Array.from(document.querySelectorAll('.mapping-row'));
+      const row = rows.find((el) => el.textContent?.includes(exe));
+      if (!row) return false;
+      const opacity = Number.parseFloat(getComputedStyle(row).opacity);
+      return opacity > 0 && opacity < 1 ? opacity : false;
+    },
+    { exe },
+    { timeout },
+  );
+  return Number(await handle.jsonValue());
+}
+
 (async () => {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
@@ -66,17 +81,12 @@ const TIMEOUT = 10_000;
     const mappingRow = page.locator('.mapping-row').filter({ hasText: 'chrome.exe' }).first();
     const deleteBtn = mappingRow.locator('.mapping-delete-btn');
     await deleteBtn.click();
-    await page.waitForTimeout(40);
-    const rowsDuringDelete = await page.locator('.mapping-row').count();
-    if (rowsDuringDelete < 1) {
-      errors.push('Mapping row unmounted immediately after delete click');
-    } else {
-      const rowOpacity = await mappingRow.evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity)).catch(() => NaN);
-      if (!Number.isNaN(rowOpacity) && !(rowOpacity > 0 && rowOpacity < 1)) {
-        errors.push(`Mapping row should be mid-animation after delete click, got opacity ${rowOpacity}`);
-      } else {
-        console.log(`chrome.exe mapping animating out with ${rowsDuringDelete} row in DOM.`);
-      }
+    try {
+      const rowOpacity = await waitForMappingRowOpacity(page, 'chrome.exe');
+      const rowsDuringDelete = await page.locator('.mapping-row').count();
+      console.log(`chrome.exe mapping animating out with ${rowsDuringDelete} row in DOM at opacity ${rowOpacity.toFixed(2)}.`);
+    } catch (err) {
+      errors.push(`Mapping row should pass through a mid-animation opacity after delete click: ${err.message}`);
     }
     await mappingRow.waitFor({ state: 'hidden', timeout: 3_000 });
     console.log('chrome.exe mapping removed after animation.');


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app: hold the hotkey, capture audio, transcribe it, clean it up, then inject the final text back into the active app.
> - This pull request stays in the frontend UI layer rather than the audio capture, pipeline, or injection path.
> - The concrete problem was visible mount and unmount behavior that still felt like hard cuts: page swaps, modal open/close, backdrop dismissal, and row deletion in list-heavy views.
> - Those abrupt transitions made the app feel visually unstable even when the underlying state changes were correct.
> - It needed attention now because the issues were already called out in recorded review, and the fixes were tightly scoped to shared motion helpers and a handful of Svelte views.
> - This pull request centralizes the transition behavior, applies it to the affected surfaces, and closes follow-up review gaps around staged removals, reduced-motion reuse, focus behavior, and transition accessibility.
> - The benefit is a calmer, more consistent UI with smoke coverage around the visible motion behavior reviewers actually notice.

## What Changed

- Added shared motion helpers for modal backdrops, modal cards, page swaps, and collapsing list-item removal in `src/lib/motion.ts`.
- Replaced the main app, settings-panel, and style-tab hard swap transitions with shared page-swap motion and reset content scroll on page changes.
- Marked outgoing `pageSwap` panels `inert`/`aria-hidden` during overlap transitions and restored incoming panels so interrupted transitions do not leave views non-interactive.
- Updated Settings, Dictionary, and Snippets modal/backdrop behavior so overlays fade independently and modal cards animate with opacity, scale, and lift instead of popping.
- Added Settings focus management: focus moves into the dialog, tabs stay inside it, and focus restores to the opener on close.
- Added accessible dialog names for Dictionary and Snippets modals via `aria-labelledby`.
- Added smoother inspector exit motion and row-collapse removal behavior for dictionary and snippet entries, including staged last-row removal so the empty state does not cut off the collapse animation.
- Added staged App Mapping removal so the row collapses before the add form shifts upward.
- Surfaced deletion persistence failures through the existing error event path, and restored App Mapping rows locally if a staged save fails.
- Reused the shared `reducedMotionEnabled` helper in `App.svelte` and hardened `listItemCollapse` against `NaN` style values.
- Fixed Settings layering so the modal stack sits above the offline toast.
- Stopped Spoken Language from localizing unrelated microphone-row copy in General settings.
- Updated smoke coverage to validate motion overlap, inert outgoing pages, modal focus, modal fade timing, Settings layering, footer version, the Spoken Language copy regression, and animated App Mapping deletion.
- Updated the Playwright Tauri app-version mock from `0.5.1` to `0.11.0` so smoke expectations match the current app version.

## Verification

- `npm run check`
- `npm run lint`
- `npm run test:rust`
- `npm run test:smoke`
- Manual reviewer flow:
  - Open Settings and close it again; the backdrop should fade instead of flashing off.
  - Navigate Home -> Dictionary -> Snippets -> Style; content should overlap briefly instead of hard-cutting, while the outgoing page is not focusable/clickable.
  - Open Settings; focus should land inside the dialog and tab navigation should stay inside until close.
  - Delete the last App Mapping row; the row should collapse out before the form shifts upward.
  - Delete the last Dictionary or Snippets entry; the final row should animate out before the empty state appears.
  - Switch Spoken Language to Chinese in General; the microphone label should remain `Input device`.
- Before/after screenshots were captured locally during smoke runs at the existing `G:\Open Flow\screenshot*.png` paths, but are not attached to this PR.

## Risks

- Low-to-moderate risk overall: the changes are confined to Svelte frontend motion behavior and smoke-test coverage.
- Shared transition helpers now drive multiple surfaces, so future timing or accessibility tweaks will affect more than one UI path.
- Dictionary, Snippets, and App Mappings now defer final removal briefly to let collapse animations finish; if that logic regresses, the likely symptom is timing drift or a row reappearing after a failed save rather than data loss.
- Settings now owns basic dialog focus management; future nested popovers should keep their `aria-expanded` state accurate so Escape and Tab behavior remains predictable.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs — work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- OpenAI GPT-5 Codex with tool use in the local repo and GitHub integration.

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above