### PR TITLE
feat(settings): JSON import/export for settings, dictionary, and snippets

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -50,7 +50,7 @@ fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), String> 
         | store::DEFAULT_TONE
         | store::CLEANUP_INTENSITY
         | store::MICROPHONE_DEVICE
-        | "history_retention"
+        | store::HISTORY_RETENTION
         | store::UPDATE_DISMISSED_VERSION => value.is_string() || value.is_null(),
         store::TRANSCRIPTION_MODELS_BY_PROVIDER | store::CLEANUP_MODELS_BY_PROVIDER => {
             is_model_map(value)
@@ -72,7 +72,7 @@ fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), String> 
         | store::SETUP_COMPLETE
         | store::FORCE_SETUP_ON_LAUNCH
         | store::ADVANCED_MODEL_UI
-        | "autostart_enabled" => value.is_boolean(),
+        | store::AUTOSTART_ENABLED => value.is_boolean(),
         store::MIC_GAIN => value.as_f64().is_some_and(|v| (1.0..=8.0).contains(&v)),
         store::APP_MAPPINGS => serde_json::from_value::<Vec<AppMapping>>(value.clone()).is_ok(),
         store::HOTKEY => value
@@ -183,7 +183,9 @@ pub struct CleanupCacheStatus {
 
 // ---------- import / export ----------
 
-#[derive(serde::Serialize, serde::Deserialize)]
+// Stats are included in the backup for informational reference only; they derive
+// from transcription history which is not backed up and cannot be restored.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct ExportStats {
     pub total_words: i64,
     pub avg_wpm: f64,
@@ -212,6 +214,7 @@ pub struct ExportPayload {
     pub version: String,
     pub app_version: String,
     pub exported_at: String,
+    #[serde(default, skip_deserializing)]
     pub stats: ExportStats,
     pub settings: serde_json::Value,
     #[serde(default)]
@@ -254,7 +257,7 @@ const EXPORTABLE_SETTINGS: &[&str] = &[
     store::APPEARANCE_MODE,
     store::ADVANCED_MODEL_UI,
     store::HOTKEY,
-    "history_retention",
+    store::HISTORY_RETENTION,
     store::NOISE_REDUCTION,
     store::MUTE_AUDIO,
     store::APP_CONTEXT_HINT,
@@ -262,7 +265,7 @@ const EXPORTABLE_SETTINGS: &[&str] = &[
     store::AUTO_LEARN_EVENT_MODE,
     store::CONTEXTUAL_CAPS,
     store::AUTO_SPACING,
-    "autostart_enabled",
+    store::AUTOSTART_ENABLED,
     store::APP_MAPPINGS,
 ];
 
@@ -298,13 +301,13 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         cleanup_enabled: bool_val(store::CLEANUP_ENABLED),
         noise_reduction: bool_val(store::NOISE_REDUCTION),
         mute_audio: bool_val(store::MUTE_AUDIO),
-        autostart_enabled: bool_val("autostart_enabled"),
+        autostart_enabled: bool_val(store::AUTOSTART_ENABLED),
         app_context_hint: bool_val(store::APP_CONTEXT_HINT),
         auto_learn_enabled: bool_val(store::AUTO_LEARN_ENABLED),
         contextual_caps_enabled: bool_val(store::CONTEXTUAL_CAPS),
         auto_spacing_enabled: bool_val(store::AUTO_SPACING),
         mic_gain: f64_val(store::MIC_GAIN),
-        history_retention: str_val("history_retention"),
+        history_retention: str_val(store::HISTORY_RETENTION),
         microphone_device: str_val(store::MICROPHONE_DEVICE),
         update_dismissed_version: str_val(store::UPDATE_DISMISSED_VERSION),
         hotkey: s.get(store::HOTKEY).and_then(|v| {
@@ -958,7 +961,7 @@ pub async fn set_autostart(_app: AppHandle, enabled: bool) -> Result<(), String>
     }
 
     let store = _app.store("settings.json").map_err(|e| e.to_string())?;
-    store.set("autostart_enabled", serde_json::json!(enabled));
+    store.set(store::AUTOSTART_ENABLED, serde_json::json!(enabled));
     store.save().map_err(|e| e.to_string())
 }
 
@@ -1345,8 +1348,8 @@ pub async fn import_data(
                         }
                         settings_applied += 1;
                     }
-                    Err(_) => {
-                        log::warn!("import_data: skipping invalid setting '{key}'");
+                    Err(e) => {
+                        log::warn!("import_data: skipping invalid setting '{key}': {e}");
                         settings_skipped += 1;
                     }
                 }
@@ -1365,16 +1368,14 @@ pub async fn import_data(
                 dictionary_skipped += 1;
                 continue;
             }
-            match db::insert_dictionary_entry_returning(&db, &entry.term, entry.mistake.as_deref()) {
-                Ok(_) => dictionary_inserted += 1,
+            match db::insert_dictionary_entry_from_backup(&db, &entry.term, entry.mistake.as_deref(), entry.auto_learned, &entry.confidence_tier, entry.correction_count) {
+                Ok(()) => dictionary_inserted += 1,
                 Err(e) => {
                     let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") {
-                        dictionary_skipped += 1;
-                    } else {
+                    if !msg.contains("UNIQUE constraint failed") {
                         log::warn!("import_data: dictionary insert error for '{}': {msg}", entry.term);
-                        dictionary_skipped += 1;
                     }
+                    dictionary_skipped += 1;
                 }
             }
         }
@@ -1390,12 +1391,10 @@ pub async fn import_data(
                 Ok(_) => snippets_inserted += 1,
                 Err(e) => {
                     let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") {
-                        snippets_skipped += 1;
-                    } else {
+                    if !msg.contains("UNIQUE constraint failed") {
                         log::warn!("import_data: snippet insert error for '{}': {msg}", snippet.trigger);
-                        snippets_skipped += 1;
                     }
+                    snippets_skipped += 1;
                 }
             }
         }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -230,6 +230,12 @@ pub struct ImportSummary {
     pub snippets_skipped: usize,
 }
 
+// Keys intentionally absent from this list (validated by validate_setting but never exported):
+//   MIC_GAIN            — device-specific calibration
+//   MICROPHONE_DEVICE   — device-specific hardware identifier
+//   SETUP_COMPLETE / FORCE_SETUP_ON_LAUNCH — one-time setup flags
+//   UPDATE_DISMISSED_VERSION — transient UI state
+// When adding a new setting to validate_setting, decide here whether it should also be exported.
 const EXPORTABLE_SETTINGS: &[&str] = &[
     store::TRANSCRIPTION_PROVIDER,
     store::TRANSCRIPTION_MODEL,
@@ -1247,10 +1253,11 @@ pub async fn export_data(
         let dictionary = db::query_dictionary(&db).map_err(|e| e.to_string())?;
         let snippets = db::query_snippets(&db).map_err(|e| e.to_string())?;
 
+        let now = chrono::Local::now();
         let payload = ExportPayload {
             version: "1".to_string(),
             app_version: env!("CARGO_PKG_VERSION").to_string(),
-            exported_at: chrono::Utc::now().to_rfc3339(),
+            exported_at: now.to_rfc3339(),
             stats: ExportStats {
                 total_words: stats.total_words,
                 avg_wpm: stats.avg_wpm,
@@ -1287,8 +1294,7 @@ pub async fn export_data(
             .map_err(|e| format!("Failed to resolve Downloads directory: {e}"))?;
         std::fs::create_dir_all(&downloads)
             .map_err(|e| format!("Failed to create Downloads path: {e}"))?;
-        let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
-        let path = downloads.join(format!("open-flow-backup-{ts}.json"));
+        let path = downloads.join(format!("open-flow-backup-{}.json", now.format("%Y%m%d-%H%M%S")));
         std::fs::write(&path, json)
             .map_err(|e| format!("Failed to write backup file: {e}"))?;
 
@@ -1322,6 +1328,9 @@ pub async fn import_data(
         let mut settings_skipped = 0usize;
         let mut appearance_mode_applied = false;
 
+        if !payload.settings.is_object() {
+            log::warn!("import_data: 'settings' field is not a JSON object — skipping settings restore");
+        }
         if let Some(obj) = payload.settings.as_object() {
             for (key, value) in obj {
                 if !EXPORTABLE_SETTINGS.contains(&key.as_str()) {
@@ -1360,7 +1369,7 @@ pub async fn import_data(
                 Ok(_) => dictionary_inserted += 1,
                 Err(e) => {
                     let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") || msg.contains("unique") {
+                    if msg.contains("UNIQUE constraint failed") {
                         dictionary_skipped += 1;
                     } else {
                         log::warn!("import_data: dictionary insert error for '{}': {msg}", entry.term);
@@ -1381,7 +1390,7 @@ pub async fn import_data(
                 Ok(_) => snippets_inserted += 1,
                 Err(e) => {
                     let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") || msg.contains("unique") {
+                    if msg.contains("UNIQUE constraint failed") {
                         snippets_skipped += 1;
                     } else {
                         log::warn!("import_data: snippet insert error for '{}': {msg}", snippet.trigger);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -181,6 +181,85 @@ pub struct CleanupCacheStatus {
     pub free_bytes: u64,
 }
 
+// ---------- import / export ----------
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ExportStats {
+    pub total_words: i64,
+    pub avg_wpm: f64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ExportDictionaryEntry {
+    pub term: String,
+    pub mistake: Option<String>,
+    pub auto_learned: bool,
+    pub confidence_tier: String,
+    pub correction_count: i64,
+    pub created_at: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ExportSnippet {
+    pub trigger: String,
+    pub expansion: String,
+    pub instructions: String,
+    pub created_at: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ExportPayload {
+    pub version: String,
+    pub app_version: String,
+    pub exported_at: String,
+    pub stats: ExportStats,
+    pub settings: serde_json::Value,
+    #[serde(default)]
+    pub dictionary: Vec<ExportDictionaryEntry>,
+    #[serde(default)]
+    pub snippets: Vec<ExportSnippet>,
+}
+
+#[derive(serde::Serialize)]
+pub struct ImportSummary {
+    pub settings_applied: usize,
+    pub settings_skipped: usize,
+    pub dictionary_inserted: usize,
+    pub dictionary_skipped: usize,
+    pub snippets_inserted: usize,
+    pub snippets_skipped: usize,
+}
+
+const EXPORTABLE_SETTINGS: &[&str] = &[
+    store::TRANSCRIPTION_PROVIDER,
+    store::TRANSCRIPTION_MODEL,
+    store::TRANSCRIPTION_LANGUAGE,
+    store::TRANSCRIPTION_DEFAULT_MODEL,
+    store::TRANSCRIPTION_MODELS_BY_PROVIDER,
+    store::TRANSCRIPTION_FALLBACK_MODELS,
+    store::CLEANUP_PROVIDER,
+    store::CLEANUP_MODEL,
+    store::CLEANUP_DEFAULT_MODEL,
+    store::CLEANUP_MODELS_BY_PROVIDER,
+    store::CLEANUP_FALLBACK_MODELS,
+    store::CLEANUP_ENABLED,
+    store::CLEANUP_INTENSITY,
+    store::DEFAULT_TONE,
+    store::APPEARANCE_MODE,
+    store::ADVANCED_MODEL_UI,
+    store::HOTKEY,
+    "history_retention",
+    store::NOISE_REDUCTION,
+    store::MUTE_AUDIO,
+    store::APP_CONTEXT_HINT,
+    store::AUTO_LEARN_ENABLED,
+    store::AUTO_LEARN_EVENT_MODE,
+    store::CONTEXTUAL_CAPS,
+    store::AUTO_SPACING,
+    "autostart_enabled",
+    store::APP_MAPPINGS,
+];
+
 #[tauri::command]
 pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
     let s = app.store("settings.json").map_err(|e| e.to_string())?;
@@ -1147,6 +1226,189 @@ pub async fn download_logs(app: AppHandle) -> Result<String, String> {
 #[tauri::command]
 pub fn set_dev_logging_enabled(enabled: bool) {
     crate::system::logger::set_verbose(enabled);
+}
+
+#[tauri::command]
+pub async fn export_data(
+    app: AppHandle,
+    db: tauri::State<'_, crate::DbHandle>,
+) -> Result<String, String> {
+    let db = db.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let store = app.store("settings.json").map_err(|e| e.to_string())?;
+        let mut settings_map = serde_json::Map::new();
+        for &key in EXPORTABLE_SETTINGS {
+            if let Some(value) = store.get(key) {
+                settings_map.insert(key.to_string(), value);
+            }
+        }
+
+        let stats = db::query_stats(&db).map_err(|e| e.to_string())?;
+        let dictionary = db::query_dictionary(&db).map_err(|e| e.to_string())?;
+        let snippets = db::query_snippets(&db).map_err(|e| e.to_string())?;
+
+        let payload = ExportPayload {
+            version: "1".to_string(),
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            exported_at: chrono::Utc::now().to_rfc3339(),
+            stats: ExportStats {
+                total_words: stats.total_words,
+                avg_wpm: stats.avg_wpm,
+            },
+            settings: serde_json::Value::Object(settings_map),
+            dictionary: dictionary
+                .into_iter()
+                .map(|e| ExportDictionaryEntry {
+                    term: e.term,
+                    mistake: e.mistake,
+                    auto_learned: e.auto_learned,
+                    confidence_tier: e.confidence_tier,
+                    correction_count: e.correction_count,
+                    created_at: e.created_at,
+                })
+                .collect(),
+            snippets: snippets
+                .into_iter()
+                .map(|s| ExportSnippet {
+                    trigger: s.trigger,
+                    expansion: s.expansion,
+                    instructions: s.instructions,
+                    created_at: s.created_at,
+                })
+                .collect(),
+        };
+
+        let json = serde_json::to_string_pretty(&payload)
+            .map_err(|e| format!("Serialization failed: {e}"))?;
+
+        let downloads = app
+            .path()
+            .download_dir()
+            .map_err(|e| format!("Failed to resolve Downloads directory: {e}"))?;
+        std::fs::create_dir_all(&downloads)
+            .map_err(|e| format!("Failed to create Downloads path: {e}"))?;
+        let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+        let path = downloads.join(format!("open-flow-backup-{ts}.json"));
+        std::fs::write(&path, json)
+            .map_err(|e| format!("Failed to write backup file: {e}"))?;
+
+        log::info!("export_data: wrote {}", path.display());
+        Ok(path.display().to_string())
+    })
+    .await
+    .map_err(|e| format!("export_data task panicked: {e}"))?
+}
+
+#[tauri::command]
+pub async fn import_data(
+    app: AppHandle,
+    db: tauri::State<'_, crate::DbHandle>,
+    json: String,
+) -> Result<ImportSummary, String> {
+    let db = db.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let payload: ExportPayload = serde_json::from_str(&json)
+            .map_err(|e| format!("Invalid backup file: {e}"))?;
+
+        if payload.version != "1" {
+            return Err(format!(
+                "Unsupported backup version '{}'. Only version '1' is supported.",
+                payload.version
+            ));
+        }
+
+        let store = app.store("settings.json").map_err(|e| e.to_string())?;
+        let mut settings_applied = 0usize;
+        let mut settings_skipped = 0usize;
+        let mut appearance_mode_applied = false;
+
+        if let Some(obj) = payload.settings.as_object() {
+            for (key, value) in obj {
+                if !EXPORTABLE_SETTINGS.contains(&key.as_str()) {
+                    settings_skipped += 1;
+                    continue;
+                }
+                match validate_setting(key, value) {
+                    Ok(()) => {
+                        store.set(key.clone(), value.clone());
+                        if key == store::APPEARANCE_MODE {
+                            appearance_mode_applied = true;
+                        }
+                        settings_applied += 1;
+                    }
+                    Err(_) => {
+                        log::warn!("import_data: skipping invalid setting '{key}'");
+                        settings_skipped += 1;
+                    }
+                }
+            }
+            store.save().map_err(|e| e.to_string())?;
+        }
+
+        if appearance_mode_applied {
+            crate::apply_runtime_icons(&app, None);
+        }
+
+        let mut dictionary_inserted = 0usize;
+        let mut dictionary_skipped = 0usize;
+        for entry in &payload.dictionary {
+            if entry.term.trim().is_empty() {
+                dictionary_skipped += 1;
+                continue;
+            }
+            match db::insert_dictionary_entry_returning(&db, &entry.term, entry.mistake.as_deref()) {
+                Ok(_) => dictionary_inserted += 1,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("UNIQUE constraint failed") || msg.contains("unique") {
+                        dictionary_skipped += 1;
+                    } else {
+                        log::warn!("import_data: dictionary insert error for '{}': {msg}", entry.term);
+                        dictionary_skipped += 1;
+                    }
+                }
+            }
+        }
+
+        let mut snippets_inserted = 0usize;
+        let mut snippets_skipped = 0usize;
+        for snippet in &payload.snippets {
+            if snippet.trigger.trim().is_empty() || snippet.expansion.trim().is_empty() {
+                snippets_skipped += 1;
+                continue;
+            }
+            match db::insert_snippet_returning(&db, &snippet.trigger, &snippet.expansion, &snippet.instructions) {
+                Ok(_) => snippets_inserted += 1,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("UNIQUE constraint failed") || msg.contains("unique") {
+                        snippets_skipped += 1;
+                    } else {
+                        log::warn!("import_data: snippet insert error for '{}': {msg}", snippet.trigger);
+                        snippets_skipped += 1;
+                    }
+                }
+            }
+        }
+
+        log::info!(
+            "import_data: settings={}/skip={} dict={}/skip={} snip={}/skip={}",
+            settings_applied, settings_skipped,
+            dictionary_inserted, dictionary_skipped,
+            snippets_inserted, snippets_skipped,
+        );
+
+        Ok(ImportSummary {
+            settings_applied,
+            settings_skipped,
+            dictionary_inserted,
+            dictionary_skipped,
+            snippets_inserted,
+            snippets_skipped,
+        })
+    })
+    .await
+    .map_err(|e| format!("import_data task panicked: {e}"))?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -605,6 +605,29 @@ pub fn insert_dictionary_entry_returning(
     Ok(CreatedRecordMeta { id, created_at })
 }
 
+pub fn insert_dictionary_entry_from_backup(
+    db: &Db,
+    term: &str,
+    mistake: Option<&str>,
+    auto_learned: bool,
+    confidence_tier: &str,
+    correction_count: i64,
+) -> Result<()> {
+    let normalized_term = require_nonempty_trimmed("Term", term)?;
+    let normalized_mistake = normalize_optional_trimmed(mistake);
+    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    if let Some(m) = normalized_mistake.as_deref() {
+        validate_char_limit("Often mistranscribed as", m, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+    }
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
+        params![normalized_term, normalized_mistake, auto_learned as i64, correction_count, confidence_tier],
+    )?;
+    Ok(())
+}
+
 pub fn insert_dictionary_entry_auto_learned(
     db: &Db,
     term: &str,

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -35,6 +35,8 @@ pub const ADVANCED_MODEL_UI: &str = "advanced_model_ui";
 pub const CREDENTIALS_MIGRATED: &str = "credentials_migrated_v1";
 pub const MACOS_CLIPBOARD_SNIFF: &str = "macos_clipboard_sniff_enabled";
 pub const UPDATE_DISMISSED_VERSION: &str = "update_dismissed_version";
+pub const HISTORY_RETENTION: &str = "history_retention";
+pub const AUTOSTART_ENABLED: &str = "autostart_enabled";
 
 // ---------- pipeline config ----------
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -280,6 +280,8 @@ fn main() {
             commands::get_recent_logs,
             commands::download_logs,
             commands::set_dev_logging_enabled,
+            commands::export_data,
+            commands::import_data,
             commands::log_frontend,
         ])
         .build(tauri::generate_context!())

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -5,7 +5,6 @@
 
   let { appVersion }: { appVersion: string } = $props();
 
-
   type UpdateCheckState = 'idle' | 'checking' | 'up-to-date' | 'available';
   let updateCheckState: UpdateCheckState = $state('idle');
   let installingFromAbout = $state(false);

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -5,6 +5,7 @@
 
   let { appVersion }: { appVersion: string } = $props();
 
+
   type UpdateCheckState = 'idle' | 'checking' | 'up-to-date' | 'available';
   let updateCheckState: UpdateCheckState = $state('idle');
   let installingFromAbout = $state(false);

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -129,6 +129,65 @@
   });
 
   loadSettings();
+
+  // ---------- import / export ----------
+
+  type ImportSummary = {
+    settings_applied: number;
+    settings_skipped: number;
+    dictionary_inserted: number;
+    dictionary_skipped: number;
+    snippets_inserted: number;
+    snippets_skipped: number;
+  };
+
+  let exporting = $state(false);
+  let exportMsg = $state('');
+  let exportMsgKind = $state<'ok' | 'err' | ''>('');
+  let importing = $state(false);
+  let importMsg = $state('');
+  let importMsgKind = $state<'ok' | 'err' | ''>('');
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  async function handleExport() {
+    exporting = true;
+    exportMsg = '';
+    exportMsgKind = '';
+    try {
+      const path = await invoke<string>('export_data');
+      exportMsg = `Saved to ${path}`;
+      exportMsgKind = 'ok';
+    } catch {
+      exportMsg = 'Export failed.';
+      exportMsgKind = 'err';
+    } finally {
+      exporting = false;
+    }
+  }
+
+  async function handleFileSelected(e: Event) {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    importing = true;
+    importMsg = '';
+    importMsgKind = '';
+    try {
+      const json = await file.text();
+      const s = await invoke<ImportSummary>('import_data', { json });
+      importMsg = `Applied ${s.settings_applied} settings, ${s.dictionary_inserted} dictionary entries, ${s.snippets_inserted} snippets.`;
+      importMsgKind = 'ok';
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      importMsg =
+        msg.startsWith('Invalid backup') || msg.startsWith('Unsupported backup')
+          ? msg
+          : 'Import failed.';
+      importMsgKind = 'err';
+    } finally {
+      importing = false;
+      if (fileInput) fileInput.value = '';
+    }
+  }
 </script>
 
 <h2 class="settings-h">Privacy</h2>
@@ -235,7 +294,58 @@
   </button>
 </div>
 
+<h2 class="settings-h data-h">Data</h2>
+<div class="setting-row">
+  <div>
+    <div class="label">Export Backup</div>
+    {#if exportMsg}
+      <div
+        class="desc data-status"
+        class:data-ok={exportMsgKind === 'ok'}
+        class:data-err={exportMsgKind === 'err'}
+      >{exportMsg}</div>
+    {/if}
+  </div>
+  <button class="btn-ghost" onclick={handleExport} disabled={exporting}>
+    {exporting ? 'Exporting…' : 'Export'}
+  </button>
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Import Backup</div>
+    {#if importMsg}
+      <div
+        class="desc data-status"
+        class:data-ok={importMsgKind === 'ok'}
+        class:data-err={importMsgKind === 'err'}
+      >{importMsg}</div>
+    {/if}
+  </div>
+  <button class="btn-ghost" onclick={() => fileInput?.click()} disabled={importing}>
+    {importing ? 'Importing…' : 'Import'}
+  </button>
+</div>
+<input
+  bind:this={fileInput}
+  type="file"
+  accept=".json"
+  style="display:none"
+  onchange={handleFileSelected}
+/>
+
 <style>
+  .data-h { margin-top: 36px; }
+
+  .data-ok { color: var(--success); }
+  .data-err { color: var(--accent); }
+  .data-status {
+    animation: data-drop 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes data-drop {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
   .history-dropdown { position: relative; flex-shrink: 0; }
   .mic-btn { display: flex; align-items: center; gap: 6px; max-width: 180px; }
   .mic-btn svg { transition: transform 150ms; }

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -334,7 +334,7 @@
 />
 
 <style>
-  .data-h { margin-top: 52px; margin-bottom: 2px !important; }
+  .data-h { --settings-h-mb: 2px; margin-top: 52px; }
 
   .data-ok { color: var(--success); }
   .data-err { color: var(--accent); }

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -334,7 +334,7 @@
 />
 
 <style>
-  .data-h { margin-top: 36px; }
+  .data-h { margin-top: 52px; margin-bottom: 2px !important; }
 
   .data-ok { color: var(--success); }
   .data-err { color: var(--accent); }

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -32,7 +32,7 @@
       { id: 'advanced', label: 'Advanced',    icon: 'mic'      as keyof typeof icons },
       ...(appStore.devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
-    { group: 'Account', items: [
+    { group: 'Open Flow', items: [
       { id: 'about', label: 'About', icon: 'help' as keyof typeof icons },
     ]},
   ]);

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -328,7 +328,7 @@
     font-family: var(--serif);
     font-size: 19px;
     font-weight: 500;
-    margin: 0 0 14px;
+    margin: 0 0 var(--settings-h-mb, 14px);
     letter-spacing: -0.015em;
     color: var(--ink);
   }

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -29,7 +29,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Advanced',    icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Microphone',  icon: 'mic'      as keyof typeof icons },
       ...(appStore.devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
     { group: 'Open Flow', items: [


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - This PR touches the settings subsystem: the `tauri-plugin-store` settings layer, the SQLite dictionary/snippets tables, and the Privacy settings UI
> - Users have no way to back up or transfer their configuration, dictionary, and snippets across machines or after a reinstall
> - A JSON backup/restore is a natural baseline data-portability feature expected of any desktop app managing user data
> - This pull request adds `export_data` and `import_data` Tauri commands plus a Data section in the Privacy settings tab
> - The benefit is that users can snapshot and restore their full configuration (excluding sensitive and device-specific values) without touching any API keys or calibration data

## What Changed

- **`src-tauri/src/commands/mod.rs`** — Added `ExportPayload`, `ExportStats`, `ExportDictionaryEntry`, `ExportSnippet`, and `ImportSummary` structs; `EXPORTABLE_SETTINGS` allowlist const; `export_data` command (collects settings + DB data, writes `open-flow-backup-YYYYMMDD-HHMMSS.json` to Downloads); `import_data` command (parses + validates JSON, overwrites settings via `validate_setting`, merges dictionary/snippets skipping UNIQUE violations)
- **`src-tauri/src/main.rs`** — Registered `export_data` and `import_data` in `invoke_handler`
- **`src/lib/components/settings/PrivacySection.svelte`** — Added Data section at bottom with Export Backup and Import Backup rows; inline status messages animate in on action
- **`src/lib/components/settings/AboutSection.svelte`** — Removed Data section (moved to Privacy); restored to original state
- **`src/lib/views/Settings.svelte`** — Renamed "Account" nav group to "Open Flow"

## Verification

- `npm run check` — 0 errors, 0 warnings
- `cargo check` — clean
- Settings → Privacy → Data section visible with Export and Import buttons
- Click Export → `open-flow-backup-YYYYMMDD-HHMMSS.json` appears in Downloads; success message shows path
- Inspect JSON: all expected keys present; `mic_gain`, `microphone_device`, `setup_complete`, `update_dismissed_version` absent; no API keys
- Modify a setting and snippet, then Import the backup → summary shows counts; values restored
- Import a crafted JSON with `mic_gain` included → key is silently skipped (allowlist gate)
- Import malformed JSON → "Invalid backup file: …" error message shown
- Import with `"version": "2"` → "Unsupported backup version" error shown
- Import with duplicate dictionary term → entry skipped, count reflected in summary

## Risks

- Low risk — export is read-only; import runs all values through the existing `validate_setting` gate plus an explicit `EXPORTABLE_SETTINGS` allowlist, so no excluded key (mic gain, API keys, device paths, system flags) can be written by a crafted backup file
- No schema migrations — the feature is additive only (new commands, no DB changes)
- UNIQUE constraint violations on dictionary/snippets are caught per-entry and counted as skipped rather than aborting the import