### PR TITLE
fix(injection): clipboard fallback when Open Flow has focus at paste time

### DIFF
--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -190,6 +190,40 @@ unsafe fn write_clipboard_unicode(data: &[u16]) -> anyhow::Result<()> {
     }
 }
 
+/// Write `text` to the OS clipboard without injecting. Used as a fallback
+/// when Open Flow itself holds foreground focus and a normal Ctrl+V paste
+/// would land in our own WebView.
+pub async fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
+    #[cfg(windows)]
+    {
+        let wide: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+        for attempt in 0..3u32 {
+            if unsafe { write_clipboard_unicode(&wide) }.is_ok() {
+                return Ok(());
+            }
+            if attempt < 2 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            }
+        }
+        anyhow::bail!("copy_to_clipboard: clipboard held after 3 attempts")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut child = tokio::process::Command::new("pbcopy")
+            .stdin(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(text.as_bytes()).await?;
+        }
+        child.wait().await?;
+        Ok(())
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        anyhow::bail!("copy_to_clipboard: unsupported platform")
+    }
+}
 
 pub async fn inject_text(
     text: &str,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -68,6 +68,51 @@ fn emit_pipeline_failed(app: &AppHandle) {
     .ok();
 }
 
+/// Returns true if our own process currently owns the foreground window.
+/// Catches the case where the user opened the Open Flow main window while
+/// transcribing — if we tried to Ctrl+V in that state the paste would land
+/// in our own WebView2 and silently disappear.
+fn foreground_is_own_process() -> bool {
+    #[cfg(windows)]
+    unsafe {
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetForegroundWindow, GetWindowThreadProcessId,
+        };
+        let hwnd = GetForegroundWindow();
+        if hwnd.0.is_null() {
+            return false;
+        }
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        pid == std::process::id()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+/// Returns true if `hwnd` belongs to our own process.
+/// Catches the case where recording was started while Open Flow itself had focus.
+#[cfg_attr(not(windows), allow(unused_variables))]
+fn hwnd_is_own_process(hwnd: usize) -> bool {
+    if hwnd == 0 {
+        return false;
+    }
+    #[cfg(windows)]
+    unsafe {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(HWND(hwnd as *mut _), Some(&mut pid));
+        pid == std::process::id()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 // ---------- pill helpers ----------
 
 fn create_pill_if_needed(app: &AppHandle) {
@@ -1667,19 +1712,34 @@ async fn finalize_pipeline_completion(
 
     hide_pill(app);
     let inject_stage = std::time::Instant::now();
-    let injected_text = match injection::inject_text(
-        &final_text_substituted,
-        ctx.target_hwnd,
-        ctx.cfg.contextual_caps_enabled,
-        ctx.cfg.auto_spacing_enabled,
-    )
-    .await
-    {
-        Ok(text) => text,
-        Err(e) => {
-            log::error!("inject: {e}");
-            show_error_pill(app, "Failed to paste - text saved to history").await;
-            final_text_substituted.clone()
+
+    // If Open Flow itself has foreground focus, a Ctrl+V paste would land in our
+    // own WebView2 with no active text field and silently disappear. Detect this
+    // by PID and fall back to clipboard-only so the user can paste manually.
+    let self_inject = foreground_is_own_process() || hwnd_is_own_process(ctx.target_hwnd);
+
+    let injected_text = if self_inject {
+        log::info!("pipeline: self-inject detected — clipboard fallback");
+        if let Err(e) = injection::copy_to_clipboard(&final_text_substituted).await {
+            log::warn!("pipeline: clipboard fallback write failed: {e}");
+        }
+        app.emit("open-flow:error", "Text copied — press Ctrl+V to paste").ok();
+        final_text_substituted.clone()
+    } else {
+        match injection::inject_text(
+            &final_text_substituted,
+            ctx.target_hwnd,
+            ctx.cfg.contextual_caps_enabled,
+            ctx.cfg.auto_spacing_enabled,
+        )
+        .await
+        {
+            Ok(text) => text,
+            Err(e) => {
+                log::error!("inject: {e}");
+                show_error_pill(app, "Failed to paste - text saved to history").await;
+                final_text_substituted.clone()
+            }
         }
     };
     log::debug!(


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Windows AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - The injection subsystem: after cleanup, `inject_text()` calls `SetForegroundWindow(target_hwnd)` to restore focus to the original app, then sends Ctrl+V
> - Problem: if the user opens the Open Flow main window during a transcription (while the pipeline is running), the foreground at paste time is our own WebView2 window
> - `SetForegroundWindow` may not reliably win the race against the already-focused Open Flow window; even when it does, any timing gap means Ctrl+V fires into our own renderer
> - A WebView2 window with no active text input silently swallows the paste — the text disappears with no error and no retry option shown
> - This PR adds PID-based detection of this condition before the paste attempt; if Open Flow owns the foreground, the text is written to the OS clipboard and the user sees a toast: "Text copied — press Ctrl+V to paste"
> - The benefit is that transcribed text is never silently lost; it lands on the clipboard and the user can paste it wherever they need

## What Changed

- `src-tauri/src/core/injection.rs` — added `pub async fn copy_to_clipboard(text)`: writes text to the OS clipboard (Windows: `write_clipboard_unicode` with 3-attempt retry; macOS: `pbcopy`) without triggering a paste sequence
- `src-tauri/src/pipeline.rs` — added `foreground_is_own_process()` and `hwnd_is_own_process(hwnd)` helpers that compare the foreground window's owning PID to `std::process::id()`; `finalize_pipeline_completion` now checks `self_inject` before calling `inject_text` and routes to `copy_to_clipboard` + toast when true

## Verification

1. Start the app (`npm run tauri dev`)
2. Open a text editor (Notepad, VS Code, etc.)
3. Hold the dictation hotkey and speak a sentence
4. While still holding, click the Open Flow main window to bring it into focus
5. Release the hotkey
6. **Expected:** a toast appears in Open Flow: "Text copied — press Ctrl+V to paste"; the text is on the clipboard
7. Click back to the text editor and press Ctrl+V — transcribed text should paste correctly
8. Confirm the entry appears in Open Flow history as normal
9. Also verify the normal path (Open Flow NOT in focus at paste time) still auto-injects as before

## Risks

- Low risk — the check is a PID comparison that only fires when our own process holds the foreground, which is a condition where injection was already silently failing; all other injection paths are unchanged
- The clipboard fallback does not restore the user's previous clipboard contents (the full clipboard-save/restore path only runs inside `inject_text`, which is skipped here); acceptable since the alternative was total text loss

## Model Used

- Anthropic Claude Sonnet 4.6 (claude-sonnet-4-6), tool use + extended context

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable — no new test surface (detection logic is Windows-native PID comparison)
- [x] UI changes include before/after screenshots — N/A (no UI change; toast uses existing `open-flow:error` event)
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together — N/A (no version bump)
- [x] Relevant documentation updated to reflect changes — N/A
- [x] Risks documented above