### PR TITLE
feat: self-inject clipboard fallback, macOS app context hint, CI dev trigger — 0.12.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,8 +69,17 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+            librsvg2-dev patchelf libxdo-dev libssl-dev libayatana-appindicator3-dev
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Prepare report directory
         run: mkdir -p tests/reports

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -72,8 +72,9 @@ jobs:
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
-            librsvg2-dev patchelf libxdo-dev libssl-dev libayatana-appindicator3-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev librsvg2-dev \
+            patchelf libxdo-dev libssl-dev libayatana-appindicator3-dev \
+            libasound2-dev
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-flow",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Open Flow - An open-source AI dictation app for Windows",
   "main": "index.js",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "open-flow"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-flow"
-version = "0.11.0"
+version = "0.12.0"
 description = "Open Flow — local-first AI dictation"
 authors = ["Open Flow Team"]
 edition = "2021"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1094,6 +1094,7 @@ pub fn open_microphone_settings() -> Result<(), String> {
 /// Keychain dialog if the app hasn't been granted "Always Allow" yet.
 /// Returns "authorized" | "not_configured" | "denied".
 #[tauri::command]
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 pub async fn check_keychain_access(provider: String) -> String {
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/core/context_probe.rs
+++ b/src-tauri/src/core/context_probe.rs
@@ -18,6 +18,7 @@ impl SelectionState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum ContextProbeSource {
     CaretLocal,
     EmptyField,

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -219,6 +219,7 @@ pub fn set_handless_active(v: bool) {
     HANDLESS_ACTIVE.store(v, Ordering::SeqCst);
 }
 
+#[allow(dead_code)]
 pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
 
 pub fn map_code_to_vk(code: &str) -> u32 {

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -932,11 +932,11 @@ pub async fn inject_text(
             } else {
                 unavailable_injection_probe()
             };
-            if contextual_caps || auto_spacing {
-                if injection_probe.source.allows_history_fallback() {
-                    if let Some(history_probe) = fallback_probe_from_history(target_hwnd) {
-                        injection_probe = history_probe;
-                    }
+            if (contextual_caps || auto_spacing)
+                && injection_probe.source.allows_history_fallback()
+            {
+                if let Some(history_probe) = fallback_probe_from_history(target_hwnd) {
+                    injection_probe = history_probe;
                 }
             }
             let (adjusted, context_kind, case_decision) = apply_probe_adjustments(

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -754,6 +754,35 @@ fn post_key_event(
     }
 }
 
+/// Write `text` to the OS clipboard without injecting. Used as a fallback
+/// when Open Flow itself holds foreground focus and a normal paste would
+/// land in our own WebView.
+pub async fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
+    #[cfg(windows)]
+    {
+        let wide: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+        for attempt in 0..3u32 {
+            if unsafe { write_clipboard_unicode(&wide) }.is_ok() {
+                return Ok(());
+            }
+            if attempt < 2 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            }
+        }
+        anyhow::bail!("copy_to_clipboard: clipboard held after 3 attempts")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        crate::system::mac_app::pasteboard_set_string(text);
+        Ok(())
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        let _ = text;
+        anyhow::bail!("copy_to_clipboard: unsupported platform")
+    }
+}
+
 #[cfg(target_os = "macos")]
 async fn macos_clipboard_sniff_context(target_hwnd: usize) -> Option<InjectionContextProbe> {
     use core_graphics::event::{CGEventFlags, CGKeyCode};

--- a/src-tauri/src/core/window_context.rs
+++ b/src-tauri/src/core/window_context.rs
@@ -9,6 +9,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowTextW, GetWindowThreadProcessId,
 };
 
+#[cfg(windows)]
 const BROWSER_EXES: &[(&str, &str)] = &[
     ("chrome.exe", "Google Chrome"),
     ("msedge.exe", "Microsoft Edge"),
@@ -19,7 +20,11 @@ const BROWSER_EXES: &[(&str, &str)] = &[
     ("arc.exe", "Arc"),
     ("waterfox.exe", "Waterfox"),
     ("librewolf.exe", "LibreWolf"),
-    // macOS app names (process name is "<localized name>.app", lowercased)
+];
+
+// Process name convention on macOS: "<localized name>.app" lowercased.
+#[cfg(target_os = "macos")]
+const BROWSER_EXES: &[(&str, &str)] = &[
     ("google chrome.app", "Google Chrome"),
     ("safari.app", "Safari"),
     ("microsoft edge.app", "Microsoft Edge"),
@@ -30,7 +35,14 @@ const BROWSER_EXES: &[(&str, &str)] = &[
 
 #[allow(dead_code)]
 pub fn is_browser_process_name(process_name: &str) -> bool {
-    BROWSER_EXES.iter().any(|(exe, _)| *exe == process_name)
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        BROWSER_EXES.iter().any(|(exe, _)| *exe == process_name)
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        false
+    }
 }
 /// The focus target to refocus before paste. On Windows this is the foreground
 /// `HWND`; on macOS it is the frontmost application's PID (both fit in a `usize`).
@@ -108,29 +120,35 @@ pub fn get_process_name_for_hwnd(hwnd: usize) -> Option<String> {
 }
 
 /// Returns a human-readable context hint for the cleanup prompt, e.g.
-/// "Google Chrome — GitHub · Build software better, together" or "slack.exe".
+/// "Google Chrome — GitHub · Build software better, together" or "Slack".
 /// Returns `None` if there is no useful context to add.
 pub fn get_app_context_hint(process_name: &str) -> Option<String> {
-    let browser = BROWSER_EXES
-        .iter()
-        .find(|(exe, _)| *exe == process_name)
-        .map(|(_, name)| *name);
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        let browser = BROWSER_EXES
+            .iter()
+            .find(|(exe, _)| *exe == process_name)
+            .map(|(_, name)| *name);
 
-    if let Some(browser_name) = browser {
-        let title = get_active_window_title().unwrap_or_default();
-        if title.is_empty() {
-            return Some(browser_name.to_string());
+        if let Some(browser_name) = browser {
+            let title = get_active_window_title().unwrap_or_default();
+            if title.is_empty() {
+                return Some(browser_name.to_string());
+            }
+            let page = strip_browser_suffix(&title, browser_name);
+            if page.is_empty() {
+                return Some(browser_name.to_string());
+            }
+            return Some(format!("{browser_name} — {page}"));
         }
-        let page = strip_browser_suffix(&title, browser_name);
-        if page.is_empty() {
-            return Some(browser_name.to_string());
-        }
-        return Some(format!("{browser_name} — {page}"));
     }
 
-    // For non-browsers just return the process name so the model at least knows
-    // which app the user is in.
-    Some(process_name.to_string())
+    // For non-browsers strip the platform suffix so the model sees "Slack"
+    // rather than "slack.exe" / "slack.app".
+    let friendly = process_name
+        .trim_end_matches(".exe")
+        .trim_end_matches(".app");
+    Some(friendly.to_string())
 }
 
 fn get_active_window_title() -> Option<String> {

--- a/src-tauri/src/data/credentials.rs
+++ b/src-tauri/src/data/credentials.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, Manager, Wry};
+use tauri::{AppHandle, Wry};
 use tauri_plugin_store::Store;
 
 #[cfg(windows)]

--- a/src-tauri/src/data/credentials.rs
+++ b/src-tauri/src/data/credentials.rs
@@ -1,4 +1,6 @@
 use tauri::{AppHandle, Wry};
+#[cfg(target_os = "macos")]
+use tauri::Manager;
 use tauri_plugin_store::Store;
 
 #[cfg(windows)]

--- a/src-tauri/src/data/credentials.rs
+++ b/src-tauri/src/data/credentials.rs
@@ -419,6 +419,7 @@ pub fn read_for_status(provider: &str) -> Result<bool, String> {
 }
 
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
 pub fn read_for_status(_provider: &str) -> Result<bool, String> {
     Ok(true)
 }

--- a/src-tauri/src/data/credentials.rs
+++ b/src-tauri/src/data/credentials.rs
@@ -455,6 +455,11 @@ pub fn has(_provider: &str) -> bool {
     false
 }
 
+#[cfg(not(any(windows, target_os = "macos")))]
+pub fn delete(_provider: &str) -> Result<(), String> {
+    Ok(())
+}
+
 /// Moves any plaintext API keys from settings.json or legacy macOS
 /// credentials.json files into the OS secret store, then keeps retrying cleanup
 /// until plaintext remnants are gone.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -286,10 +286,10 @@ fn main() {
         ])
         .build(tauri::generate_context!())
         .expect("error building Open Flow")
-        .run(|app, event| {
+        .run(|_app, _event| {
             #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = event {
-                show_main_window(app);
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                show_main_window(_app);
             }
         });
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -203,12 +203,12 @@ fn main() {
                         }
                     }
                     #[cfg(target_os = "macos")]
-                    tauri::WindowEvent::Resized(_) => {
-                        if window.is_minimized().unwrap_or(false) {
-                            crate::system::mac_app::set_regular_activation_policy_on_main_thread(
-                                window.app_handle(),
-                            );
-                        }
+                    tauri::WindowEvent::Resized(_)
+                        if window.is_minimized().unwrap_or(false) =>
+                    {
+                        crate::system::mac_app::set_regular_activation_policy_on_main_thread(
+                            window.app_handle(),
+                        );
                     }
                     tauri::WindowEvent::Focused(true) => {
                         #[cfg(target_os = "macos")]

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -18,6 +18,7 @@ const MIN_RECORDING_RMS: f32 = 0.008;
 const RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
 const PILL_WIDTH_POINTS: f64 = 140.0;
 const PILL_HEIGHT_POINTS: f64 = 44.0;
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const PILL_BOTTOM_GAP_POINTS: f64 = 16.0;
 
 fn transcription_provider_from_str(s: &str) -> transcription::Provider {

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -73,6 +73,51 @@ fn emit_pipeline_failed(app: &AppHandle) {
     .ok();
 }
 
+/// Returns true if our own process currently owns the foreground window.
+/// Catches the case where the user opened the Open Flow main window while
+/// transcribing — if we tried to Ctrl+V / Cmd+V in that state the paste would
+/// land in our own WebView and silently disappear.
+fn foreground_is_own_process() -> bool {
+    #[cfg(windows)]
+    unsafe {
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetForegroundWindow, GetWindowThreadProcessId,
+        };
+        let hwnd = GetForegroundWindow();
+        if hwnd.0.is_null() {
+            return false;
+        }
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        pid == std::process::id()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+/// Returns true if `hwnd` belongs to our own process.
+/// Catches the case where recording was started while Open Flow itself had focus.
+#[cfg_attr(not(windows), allow(unused_variables))]
+fn hwnd_is_own_process(hwnd: usize) -> bool {
+    if hwnd == 0 {
+        return false;
+    }
+    #[cfg(windows)]
+    unsafe {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(HWND(hwnd as *mut _), Some(&mut pid));
+        pid == std::process::id()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 // ---------- pill helpers ----------
 
 fn create_pill_if_needed(app: &AppHandle) {
@@ -1975,26 +2020,47 @@ async fn finalize_pipeline_completion(
 
     hide_pill(app);
     let inject_stage = std::time::Instant::now();
-    let injected = match injection::inject_text(
-        &final_text_substituted,
-        ctx.target_hwnd,
-        ctx.cfg.contextual_caps_enabled,
-        ctx.cfg.auto_spacing_enabled,
-        ctx.profile,
-        ctx.cfg.macos_clipboard_sniff_enabled,
-    )
-    .await
-    {
-        Ok(outcome) => outcome,
-        Err(e) => {
-            log::error!("inject: {e}");
-            show_error_pill(app, "Failed to paste - text saved to history").await;
-            injection::InjectionOutcome {
-                text: final_text_substituted.clone(),
-                context_state: "unknown",
-                case_decision: "inject_failed",
-                probe_source: "unavailable",
-                selection_state: "unknown",
+
+    // If Open Flow itself has foreground focus, a Ctrl+V / Cmd+V paste would
+    // land in our own WebView with no active text field and silently disappear.
+    // Detect this by PID and fall back to clipboard-only so the user can paste manually.
+    let self_inject = foreground_is_own_process() || hwnd_is_own_process(ctx.target_hwnd);
+
+    let injected = if self_inject {
+        log::info!("pipeline: self-inject detected — clipboard fallback");
+        if let Err(e) = injection::copy_to_clipboard(&final_text_substituted).await {
+            log::warn!("pipeline: clipboard fallback write failed: {e}");
+        }
+        app.emit("open-flow:error", "Text copied — press Ctrl+V to paste").ok();
+        injection::InjectionOutcome {
+            text: final_text_substituted.clone(),
+            context_state: "self_inject",
+            case_decision: "clipboard_fallback",
+            probe_source: "unavailable",
+            selection_state: "unknown",
+        }
+    } else {
+        match injection::inject_text(
+            &final_text_substituted,
+            ctx.target_hwnd,
+            ctx.cfg.contextual_caps_enabled,
+            ctx.cfg.auto_spacing_enabled,
+            ctx.profile,
+            ctx.cfg.macos_clipboard_sniff_enabled,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                log::error!("inject: {e}");
+                show_error_pill(app, "Failed to paste - text saved to history").await;
+                injection::InjectionOutcome {
+                    text: final_text_substituted.clone(),
+                    context_state: "unknown",
+                    case_decision: "inject_failed",
+                    probe_source: "unavailable",
+                    selection_state: "unknown",
+                }
             }
         }
     };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "Open Flow",
   "mainBinaryName": "Open Flow",
   "identifier": "com.openflow.app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -392,7 +392,6 @@
             <div
               class="inspector"
               in:pageSwap={{ axis: 'x', distance: inspectorDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel) }}
-              out:pageSwap={{ axis: 'x', distance: -inspectorDir * motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast + 40) }}
             >
               <div class="insp-trigger">{selected.term}</div>
 

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -29,7 +29,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Microphone',  icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Advanced',    icon: 'mic'      as keyof typeof icons },
       ...(appStore.devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
     { group: 'Open Flow', items: [

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -629,7 +629,7 @@
     {:else if isMac && step === permissionStep}
       <div class="step">
         <div class="step-header">
-          <h2>Grant macOS permissions</h2>
+          <h2>Check your macOS permissions</h2>
           <p class="step-sub">Open Flow needs these to hear your voice and type for you.</p>
         </div>
 


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a cross-platform AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - Two separate bugs were identified on the current `dev` branch
> - **Bug 1 (pipeline):** If the Open Flow main window had focus when recording started, `inject_text` would paste into our own WebView2/WebKit and silently disappear. No error, text lost.
> - **Bug 2 (macOS):** `get_app_context_hint` returned `"unknown"` on macOS because `BROWSER_EXES` mixed Windows and macOS entries in one array (dead code per platform) and the non-browser fallback never stripped the `.app` / `.exe` suffix — so the model always saw `APP CONTEXT: unknown` or `APP CONTEXT: slack.app`
> - This PR fixes both, adds a `copy_to_clipboard` fallback path, cleans up the CI trigger, and bumps to 0.12.0

## What Changed

- **`src-tauri/src/pipeline.rs`** — Add `foreground_is_own_process()` / `hwnd_is_own_process()` helpers. Before the paste step, detect self-injection and fall back to `copy_to_clipboard()` with an error toast ("Text copied — press Ctrl+V to paste") instead of silently losing text
- **`src-tauri/src/core/injection.rs`** — Add `copy_to_clipboard()`: retries `write_clipboard_unicode` on Windows; uses `mac_app::pasteboard_set_string` on macOS (no `pbcopy` subprocess)
- **`src-tauri/src/core/window_context.rs`** — Split `BROWSER_EXES` into `#[cfg(windows)]` and `#[cfg(target_os = "macos")]` consts so each platform only compiles what it can match; strip `.exe`/`.app` suffix in the non-browser `get_app_context_hint` fallback so the model sees `"Slack"` not `"slack.app"`; update `is_browser_process_name` accordingly
- **`.github/workflows/pr-checks.yml`** — Add `dev` to the branch trigger so PRs targeting `dev` actually run CI (the macOS matrix job was already present)
- **Version bump to 0.12.0** across `Cargo.toml`, `package.json`, `tauri.conf.json`

## Verification

- **Self-inject:** Open the Open Flow main window, start recording, release — text should appear in clipboard with error toast instead of silently disappearing
- **macOS app context:** Enable `app_context_hint` in General settings, dictate ≥50 words in Slack → cleanup prompt should show `APP CONTEXT: Slack` (not `slack.app`); in Chrome → `APP CONTEXT: Google Chrome`
- **Windows regression:** Dictation, injection, app-context hint, all profiles — behavior unchanged
- `npm run check` / `npm run lint` / `npm run test:rust`

## Risks

- Self-inject path is Windows-only for detection (`foreground_is_own_process` / `hwnd_is_own_process` return `false` on macOS) — on macOS the self-inject guard is inoperative but macOS injection is Cmd+V via CGEvent which behaves differently; acceptable for now
- `copy_to_clipboard` on macOS calls `pasteboard_set_string` synchronously — no settle delay before the user pastes manually, which is fine since the user controls the timing

## Model Used

- Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Claude Code CLI

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above