### PR TITLE
fix(snippets): cache isolation, punctuation-tolerant matching, and multi-trigger support

### DIFF
--- a/src-tauri/src/data/snippets.rs
+++ b/src-tauri/src/data/snippets.rs
@@ -34,11 +34,21 @@ fn is_word_char(ch: char) -> bool {
 
 /// Strip all non-alphanumeric characters and collapse whitespace for fuzzy trigger matching.
 fn strip_punctuation_for_matching(s: &str) -> String {
-    let raw: String = s
-        .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
-        .collect();
-    raw.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut result = String::with_capacity(s.len());
+    let mut last_was_space = true;
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            result.push(c);
+            last_was_space = false;
+        } else if !last_was_space {
+            result.push(' ');
+            last_was_space = true;
+        }
+    }
+    if last_was_space && !result.is_empty() {
+        result.pop();
+    }
+    result
 }
 
 /// Split a trigger field into individual trigger phrases.
@@ -102,61 +112,67 @@ pub fn expand_snippets_from(text: &str, snippets: &mut [db::Snippet], db: &Db) -
         snippet_idx: usize,
     }
 
-    // Longest individual alias first — prevents short aliases shadowing longer ones.
-    snippets.sort_by_key(|snippet| {
-        Reverse(
-            parse_triggers(&snippet.trigger)
-                .map(|t| t.len())
-                .max()
-                .unwrap_or(0),
-        )
-    });
+    struct TriggerTarget {
+        needle: String,
+        snippet_idx: usize,
+    }
+
+    // Flatten all aliases into individual targets sorted by needle length descending.
+    // This prevents a shorter alias from one snippet shadowing a longer trigger from another
+    // snippet, which snippet-level sorting by max-length cannot guarantee.
+    let mut targets: Vec<TriggerTarget> = Vec::new();
+    for (snippet_idx, snippet) in snippets.iter().enumerate() {
+        for t in parse_triggers(&snippet.trigger) {
+            let needle = t.to_lowercase();
+            if !needle.is_empty() {
+                targets.push(TriggerTarget { needle, snippet_idx });
+            }
+        }
+    }
+    targets.sort_by_key(|t| Reverse(t.needle.len()));
 
     let mut result = text.to_string();
     let (haystack, source_map) = lowercase_with_source_map(&result);
     let mut all_matches: Vec<Match> = Vec::new();
 
-    for (snippet_idx, snippet) in snippets.iter().enumerate() {
-        for needle in parse_triggers(&snippet.trigger).map(|t| t.to_lowercase()) {
-            if needle.is_empty() {
-                continue;
-            }
+    for target in &targets {
+        let needle = &target.needle;
+        let snippet_idx = target.snippet_idx;
 
-            let mut search_from = 0;
-            while let Some(pos) = haystack[search_from..].find(&needle) {
-                let abs = search_from + pos;
-                let before_ok = abs == 0
-                    || !haystack[..abs]
-                        .chars()
-                        .next_back()
-                        .map(is_word_char)
-                        .unwrap_or(false);
-                let after_ok = abs + needle.len() >= haystack.len()
-                    || !haystack[abs + needle.len()..]
-                        .chars()
-                        .next()
-                        .map(is_word_char)
-                        .unwrap_or(false);
-                if before_ok && after_ok {
-                    let start = source_map[abs];
-                    let end_lower = abs + needle.len();
-                    let mut end = if end_lower >= haystack.len() {
-                        result.len()
-                    } else {
-                        source_map[end_lower]
-                    };
-                    if end <= start {
-                        let last_src = source_map[end_lower.saturating_sub(1)];
-                        end = end_of_char_at(&result, last_src);
-                    }
-                    all_matches.push(Match {
-                        start,
-                        end,
-                        snippet_idx,
-                    });
+        let mut search_from = 0;
+        while let Some(pos) = haystack[search_from..].find(needle.as_str()) {
+            let abs = search_from + pos;
+            let before_ok = abs == 0
+                || !haystack[..abs]
+                    .chars()
+                    .next_back()
+                    .map(is_word_char)
+                    .unwrap_or(false);
+            let after_ok = abs + needle.len() >= haystack.len()
+                || !haystack[abs + needle.len()..]
+                    .chars()
+                    .next()
+                    .map(is_word_char)
+                    .unwrap_or(false);
+            if before_ok && after_ok {
+                let start = source_map[abs];
+                let end_lower = abs + needle.len();
+                let mut end = if end_lower >= haystack.len() {
+                    result.len()
+                } else {
+                    source_map[end_lower]
+                };
+                if end <= start {
+                    let last_src = source_map[end_lower.saturating_sub(1)];
+                    end = end_of_char_at(&result, last_src);
                 }
-                search_from = abs + needle.len();
+                all_matches.push(Match {
+                    start,
+                    end,
+                    snippet_idx,
+                });
             }
+            search_from = abs + needle.len();
         }
     }
 

--- a/src-tauri/src/data/snippets.rs
+++ b/src-tauri/src/data/snippets.rs
@@ -32,12 +32,28 @@ fn is_word_char(ch: char) -> bool {
     ch.is_alphanumeric() || ch == '_' || ch == '\'' || ch == '\u{2019}' || ch == '-'
 }
 
-/// If the entire transcription is just a snippet trigger (ignoring trailing punctuation
+/// Strip all non-alphanumeric characters and collapse whitespace for fuzzy trigger matching.
+fn strip_punctuation_for_matching(s: &str) -> String {
+    let raw: String = s
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect();
+    raw.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Split a trigger field into individual trigger phrases.
+/// A trigger field may contain multiple phrases separated by commas,
+/// e.g. "Gemini Goal, Gemini Gold". Empty segments are filtered out.
+fn parse_triggers(trigger: &str) -> impl Iterator<Item = &str> {
+    trigger.split(',').map(|t| t.trim()).filter(|t| !t.is_empty())
+}
+
+/// If the entire transcription is just a snippet trigger (ignoring punctuation
 /// added by the transcription model), return the expansion directly.
 ///
 /// The transcription model always appends a period — "roblox" becomes "roblox." —
 /// which `expand_snippets` would leave as an orphaned "." after replacing the trigger.
-/// This function strips that punctuation before matching and returns the raw expansion
+/// This function strips all punctuation before matching and returns the raw expansion
 /// text, so no period bleeds through. Also increments the snippet's use_count.
 ///
 pub fn try_pure_snippet_expand_from(
@@ -45,24 +61,28 @@ pub fn try_pure_snippet_expand_from(
     snippets: &[db::Snippet],
     db: &Db,
 ) -> Option<String> {
-    let normalized = text
-        .trim()
-        .trim_end_matches(['.', ',', '?', '!'])
-        .to_lowercase();
-    let matched = snippets
-        .iter()
-        .find(|s| s.trigger.to_lowercase() == normalized)?;
+    let normalized = strip_punctuation_for_matching(&text.to_lowercase());
+    let matched = snippets.iter().find(|s| {
+        parse_triggers(&s.trigger)
+            .any(|t| strip_punctuation_for_matching(&t.to_lowercase()) == normalized)
+    })?;
     let _ = db::increment_snippet_use(db, matched.id);
     Some(matched.expansion.clone())
 }
 
 pub fn collect_snippet_instructions_from(text: &str, snippets: &[db::Snippet]) -> String {
     let text_lower = text.to_lowercase();
+    let text_stripped = strip_punctuation_for_matching(&text_lower);
     let mut active_instructions: Vec<String> = Vec::new();
 
     for snippet in snippets.iter() {
-        let needle = snippet.trigger.to_lowercase();
-        if text_lower.contains(&needle) && !snippet.instructions.is_empty() {
+        let found = parse_triggers(&snippet.trigger).any(|t| {
+            let needle = t.to_lowercase();
+            let needle_stripped = strip_punctuation_for_matching(&needle);
+            text_lower.contains(&needle)
+                || (!needle_stripped.is_empty() && text_stripped.contains(&needle_stripped))
+        });
+        if found && !snippet.instructions.is_empty() {
             active_instructions.push(snippet.instructions.clone());
         }
     }
@@ -82,53 +102,61 @@ pub fn expand_snippets_from(text: &str, snippets: &mut [db::Snippet], db: &Db) -
         snippet_idx: usize,
     }
 
-    // Longest triggers first — prevents short prefix matches shadowing longer ones.
-    snippets.sort_by_key(|snippet| Reverse(snippet.trigger.len()));
+    // Longest individual alias first — prevents short aliases shadowing longer ones.
+    snippets.sort_by_key(|snippet| {
+        Reverse(
+            parse_triggers(&snippet.trigger)
+                .map(|t| t.len())
+                .max()
+                .unwrap_or(0),
+        )
+    });
 
     let mut result = text.to_string();
     let (haystack, source_map) = lowercase_with_source_map(&result);
     let mut all_matches: Vec<Match> = Vec::new();
 
     for (snippet_idx, snippet) in snippets.iter().enumerate() {
-        let needle = snippet.trigger.to_lowercase();
-        if needle.is_empty() {
-            continue;
-        }
-
-        let mut search_from = 0;
-        while let Some(pos) = haystack[search_from..].find(&needle) {
-            let abs = search_from + pos;
-            let before_ok = abs == 0
-                || !haystack[..abs]
-                    .chars()
-                    .next_back()
-                    .map(is_word_char)
-                    .unwrap_or(false);
-            let after_ok = abs + needle.len() >= haystack.len()
-                || !haystack[abs + needle.len()..]
-                    .chars()
-                    .next()
-                    .map(is_word_char)
-                    .unwrap_or(false);
-            if before_ok && after_ok {
-                let start = source_map[abs];
-                let end_lower = abs + needle.len();
-                let mut end = if end_lower >= haystack.len() {
-                    result.len()
-                } else {
-                    source_map[end_lower]
-                };
-                if end <= start {
-                    let last_src = source_map[end_lower.saturating_sub(1)];
-                    end = end_of_char_at(&result, last_src);
-                }
-                all_matches.push(Match {
-                    start,
-                    end,
-                    snippet_idx,
-                });
+        for needle in parse_triggers(&snippet.trigger).map(|t| t.to_lowercase()) {
+            if needle.is_empty() {
+                continue;
             }
-            search_from = abs + needle.len();
+
+            let mut search_from = 0;
+            while let Some(pos) = haystack[search_from..].find(&needle) {
+                let abs = search_from + pos;
+                let before_ok = abs == 0
+                    || !haystack[..abs]
+                        .chars()
+                        .next_back()
+                        .map(is_word_char)
+                        .unwrap_or(false);
+                let after_ok = abs + needle.len() >= haystack.len()
+                    || !haystack[abs + needle.len()..]
+                        .chars()
+                        .next()
+                        .map(is_word_char)
+                        .unwrap_or(false);
+                if before_ok && after_ok {
+                    let start = source_map[abs];
+                    let end_lower = abs + needle.len();
+                    let mut end = if end_lower >= haystack.len() {
+                        result.len()
+                    } else {
+                        source_map[end_lower]
+                    };
+                    if end <= start {
+                        let last_src = source_map[end_lower.saturating_sub(1)];
+                        end = end_of_char_at(&result, last_src);
+                    }
+                    all_matches.push(Match {
+                        start,
+                        end,
+                        snippet_idx,
+                    });
+                }
+                search_from = abs + needle.len();
+            }
         }
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1047,13 +1047,19 @@ async fn run_cleanup_and_snippets_for_db(
         profile,
     ) {
         let has_snippets = !snippet_instructions.is_empty();
-        let (cache_tokens, cache_separators) = number_parser::tokenize_cache_key_parts(raw);
+        let (cache_tokens, cache_separators) = number_parser::tokenize_cache_key_parts(&expanded);
         let allow_cache = should_use_cleanup_cache_tokens(&cache_tokens)
-            && (raw.chars().count() <= 200 || has_snippets);
+            && (expanded.chars().count() <= 200 || has_snippets);
         let cache_key = if allow_cache {
             let base_cache_key =
                 number_parser::normalize_cleanup_cache_key_parts(&cache_tokens, &cache_separators);
-            style_scoped_cleanup_cache_key(&base_cache_key, profile, &cfg.cleanup_intensity)
+            let mut key =
+                style_scoped_cleanup_cache_key(&base_cache_key, profile, &cfg.cleanup_intensity);
+            if !key.is_empty() && has_snippets {
+                let fp = snippet_instructions_fingerprint(&snippet_instructions);
+                key = format!("{key}|snip:{fp:x}");
+            }
+            key
         } else {
             String::new()
         };
@@ -1213,6 +1219,15 @@ fn style_scoped_cleanup_cache_key(
         return String::new();
     }
     format!("{base_key}|profile:{profile}|intensity:{cleanup_intensity}")
+}
+
+fn snippet_instructions_fingerprint(instructions: &str) -> u64 {
+    // djb2 hash — deterministic across runs, no external dep
+    let mut h: u64 = 5381;
+    for b in instructions.bytes() {
+        h = h.wrapping_shl(5).wrapping_add(h).wrapping_add(b as u64);
+    }
+    h
 }
 
 #[cfg(any(test, debug_assertions))]

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -517,7 +517,7 @@
           id="trigger-input"
           class="field-input"
           type="text"
-          placeholder="e.g. my email"
+          placeholder="e.g. my email, my e-mail"
           bind:value={draftTrigger}
           bind:this={triggerInput}
           autocomplete="off"
@@ -525,7 +525,7 @@
         />
         <MicInputButton onResult={(t) => draftTrigger = t} />
       </div>
-      <p class="field-hint">Speak this phrase to trigger the expansion.</p>
+      <p class="field-hint">Speak any of these phrases to trigger the expansion. Separate multiple triggers with commas.</p>
 
       <label class="field-label" for="expansion-input">Expansion</label>
       <div class="input-row input-row--top">


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a Tauri dictation app — hotkey hold → audio capture → transcription → LLM cleanup (with snippet/dictionary injection) → text injection
> - The snippet subsystem handles trigger matching, pure-expansion fast-paths, and instruction collection for the cleanup LLM
> - **Cache bug:** the cleanup cache was keyed on the raw transcription, not the post-expansion text — a cached result from a pre-snippet run would be served even after a snippet was created for that phrase, and vice versa
> - **Punctuation bug:** `try_pure_snippet_expand_from` only stripped trailing `.`,`,`,`?`,`!` — transcription providers also inject colons, internal commas, etc., causing misses on the pure-snippet fast path
> - **Multi-trigger gap:** each snippet had exactly one trigger, so there was no way to enumerate common transcription variants (e.g. "Gemini Gold" vs "Gemini Goal") without duplicating the snippet
> - This PR addresses all three problems in `snippets.rs` and `pipeline.rs` with no schema changes, and updates the frontend hint text to surface the new comma-separated trigger syntax

## What Changed

- **Cache key isolation** (`pipeline.rs`): cache token generation now uses the snippet-expanded text instead of raw transcription; a deterministic djb2 fingerprint of active snippet instructions is appended when present — same raw input with different snippet state produces a different cache key
- **Full punctuation stripping** (`snippets.rs`): `try_pure_snippet_expand_from` now uses `strip_punctuation_for_matching` (strips all non-alphanumeric chars, collapses whitespace) on both the transcription and the trigger — "Gemini, Goal." now correctly matches trigger "Gemini Goal"
- **Instruction collection fuzzy fallback** (`snippets.rs`): `collect_snippet_instructions_from` now also checks the punctuation-normalized text, so instruction-bearing snippets are found even when the transcription adds internal commas to a multi-word trigger
- **Multi-trigger support** (`snippets.rs`): commas in the trigger field are treated as alias separators — `parse_triggers()` helper splits and trims; all three matching functions (`try_pure_snippet_expand_from`, `collect_snippet_instructions_from`, `expand_snippets_from`) iterate over all aliases; `expand_snippets_from` sorts by longest individual alias (not full string length)
- **Frontend hint** (`Snippets.svelte`): placeholder updated to `"e.g. my email, my e-mail"`; hint updated to explain comma-separated triggers

## Verification

- Create snippet with trigger `"Gemini Goal, Gemini Gold"` — confirm both aliases fire the pure-snippet fast path (`pure_fast_path=true` in logs)
- Confirm `"Gemini, Goal."` (with internal comma from transcription) also fires the same snippet
- Confirm an existing single-trigger snippet still works without change
- Dictate the same phrase twice with a snippet active — confirm second run hits the cache (`cleanup cache hit` in logs) without going to the LLM
- Dictate the same phrase once without a snippet, once after adding one — confirm no stale cache hit on the second run
- `npm run test:rust` — 175 tests, 0 failures

## Risks

- Low risk overall — no schema changes, no new external dependencies
- `parse_triggers` splitting on commas means any existing snippet whose trigger contains a literal comma will now be treated as having two aliases rather than one literal trigger; this is intentional and the only way to create such a snippet going forward is to use the UI which shows the new hint text
- The djb2 fingerprint invalidates existing cache entries for instruction-bearing snippets (they will get a cache miss once and rebuild correctly)

## Model Used

- Anthropic Claude Sonnet 4.6 (claude-sonnet-4-6), tool use + extended reasoning via Claude Code

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above