### PR TITLE
fix(ui): rename Advanced settings tab to Microphone

### DIFF
--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -77,7 +77,7 @@
   loadSettings();
 </script>
 
-<h2 class="settings-h">Advanced</h2>
+<h2 class="settings-h">Microphone</h2>
 
 <div class="setting-row gain-row">
   <div class="gain-header">

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -29,7 +29,7 @@
       { id: 'keys',     label: 'API Keys',     icon: 'key'      as keyof typeof icons },
       { id: 'models',   label: 'Models',       icon: 'command'  as keyof typeof icons },
       { id: 'privacy',  label: 'Privacy',      icon: 'lock'     as keyof typeof icons },
-      { id: 'advanced', label: 'Advanced',    icon: 'mic'      as keyof typeof icons },
+      { id: 'advanced', label: 'Microphone',  icon: 'mic'      as keyof typeof icons },
       ...(appStore.devModeEnabled ? [{ id: 'developer', label: 'Developer', icon: 'command' as keyof typeof icons }] : []),
     ]},
     { group: 'Open Flow', items: [


### PR DESCRIPTION
## Thinking Path

> - Open Flow is a desktop AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - The **settings UI** subsystem organises configuration into labelled sidebar tabs
> - The tab housing microphone controls (gain, noise reduction, device selection) was labelled **"Advanced"**, which is ambiguous and doesn't describe its contents
> - A clear, self-descriptive label reduces confusion for new users exploring settings
> - This pull request renames the "Advanced" sidebar tab and its matching section heading to "Microphone"
> - The benefit is an immediately obvious label that matches the mic icon already used on the tab

## What Changed

- `src/lib/views/Settings.svelte` — updated nav item `label` from `'Advanced'` to `'Microphone'`
- `src/lib/components/settings/AudioSection.svelte` — updated `<h2>` section heading from `Advanced` to `Microphone`

## Verification

- Open Settings → confirm the sidebar tab now reads **Microphone** (was **Advanced**)
- Click the tab → confirm the section heading inside also reads **Microphone**
- All other tabs unaffected

## Risks

- Low risk — label-only change; no logic, data, or store keys modified

## Model Used

- Anthropic Claude Sonnet 4.6 (claude-sonnet-4-6), tool use mode via Claude Code CLI

## Checklist

- [x] Thinking path traces from Open Flow context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable — N/A (label change only)
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together — N/A
- [x] Relevant documentation updated to reflect changes — N/A
- [x] Risks documented above