### PR TITLE
feat(auto-learn): add evidence-based dictionary learning

### DIFF
--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -456,8 +456,8 @@ fn record_evidence_and_maybe_promote(
     // corroborate against each other instead of fragmenting across rows.
     // `correct` keeps its casing — it's the dictionary term and may be a
     // proper noun.
-    let wrong = wrong.to_lowercase();
-    let wrong = wrong.as_str();
+    let wrong_lower = wrong.to_lowercase();
+    let wrong = wrong_lower.as_str();
 
     // Skip pairs in the never-learn list.
     if db::is_never_learn_pair(db, wrong, correct).unwrap_or(false) {

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -164,7 +164,11 @@ fn dedupe_candidate_pairs(candidates: Vec<CandidateCorrection>) -> Vec<Candidate
     let mut recorded_this_session = HashSet::new();
     let mut deduped = Vec::new();
     for candidate in candidates {
-        let key = (candidate.mistake.clone(), candidate.correction.clone());
+        // `mistake` is lowercased before being stored as `wrong_word` (see
+        // record_evidence_and_maybe_promote), so dedupe on the same
+        // normalization or differently-cased duplicates within a session
+        // would inflate the evidence score for one pair.
+        let key = (candidate.mistake.to_lowercase(), candidate.correction.clone());
         if recorded_this_session.insert(key) {
             deduped.push(candidate);
         }
@@ -536,6 +540,12 @@ fn record_evidence_and_maybe_promote(
             }
         }
     } else if ev.score >= SCORE_SUGGEST {
+        // If the term is already auto-learned (or otherwise present in the
+        // dictionary for this mistake), query_dictionary_suggestions filters
+        // it out anyway — skip the redundant write.
+        if db::is_already_auto_learned(db, correct, wrong).unwrap_or(false) {
+            return EvidenceRecordOutcome::Recorded;
+        }
         let summary = format!(
             "sessions={} sources={} score={:.2}",
             ev.distinct_sessions, ev.distinct_sources, ev.score
@@ -1723,6 +1733,48 @@ mod tests {
     }
 
     #[test]
+    fn evidence_path_skips_suggestion_for_already_auto_learned_pair() {
+        let db = db::open(":memory:").expect("test db");
+
+        // Simulate a pair that was already auto-learned in a prior session.
+        db::insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("koobernetes"), "high")
+            .expect("seed auto-learned entry");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-2",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded,
+            "already auto-learned pairs should not be re-queued as suggestions"
+        );
+
+        let suggestions = db::query_dictionary_suggestions(&db).expect("suggestions");
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
     fn evidence_session_id_daily_is_stable_within_a_day() {
         let a = evidence_session_id_daily("some raw text", "notepad.exe");
         let b = evidence_session_id_daily("some raw text", "notepad.exe");
@@ -1947,6 +1999,26 @@ mod tests {
         assert_eq!(deduped[0].correction, "Kubernetes");
         assert_eq!(deduped[1].mistake, "rock");
         assert_eq!(deduped[1].correction, "qroq");
+    }
+
+    #[test]
+    fn cleanup_divergence_deduplicates_pairs_differing_only_in_mistake_casing() {
+        let deduped = dedupe_candidate_pairs(vec![
+            CandidateCorrection {
+                mistake: "Koobernetes".into(),
+                correction: "Kubernetes".into(),
+                confidence: 0.9,
+            },
+            CandidateCorrection {
+                mistake: "koobernetes".into(),
+                correction: "Kubernetes".into(),
+                confidence: 0.7,
+            },
+        ]);
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].mistake, "Koobernetes");
+        assert_eq!(deduped[0].correction, "Kubernetes");
     }
 
     #[test]

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -151,6 +151,18 @@ fn evidence_session_id(seed: &str, app_context: &str) -> String {
     format!("{seed_hash}:{app_hash}:{now_nanos}")
 }
 
+fn dedupe_candidate_pairs(candidates: Vec<CandidateCorrection>) -> Vec<CandidateCorrection> {
+    let mut recorded_this_session = HashSet::new();
+    let mut deduped = Vec::new();
+    for candidate in candidates {
+        let key = (candidate.mistake.clone(), candidate.correction.clone());
+        if recorded_this_session.insert(key) {
+            deduped.push(candidate);
+        }
+    }
+    deduped
+}
+
 fn monitor_key(injected_text: &str, app_context: &str) -> String {
     let (lhs, rhs) = pair_hash(injected_text, app_context);
     format!("{rhs}:{lhs}")
@@ -461,7 +473,7 @@ pub fn record_cleanup_divergence(
         return;
     }
 
-    let candidates = detect_span_corrections(raw, clean);
+    let candidates = dedupe_candidate_pairs(detect_span_corrections(raw, clean));
     if candidates.is_empty() {
         return;
     }
@@ -2001,6 +2013,33 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].mistake.as_deref(), Some("manual typo"));
         assert!(!entries[0].auto_learned);
+    }
+
+    #[test]
+    fn cleanup_divergence_deduplicates_identical_pairs_in_one_session() {
+        let deduped = dedupe_candidate_pairs(vec![
+            CandidateCorrection {
+                mistake: "Koobernetes".into(),
+                correction: "Kubernetes".into(),
+                confidence: 0.9,
+            },
+            CandidateCorrection {
+                mistake: "Koobernetes".into(),
+                correction: "Kubernetes".into(),
+                confidence: 0.7,
+            },
+            CandidateCorrection {
+                mistake: "rock".into(),
+                correction: "qroq".into(),
+                confidence: 0.8,
+            },
+        ]);
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].mistake, "Koobernetes");
+        assert_eq!(deduped[0].correction, "Kubernetes");
+        assert_eq!(deduped[1].mistake, "rock");
+        assert_eq!(deduped[1].correction, "qroq");
     }
 
     #[test]

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -13,6 +13,7 @@ use crate::core::context_probe::{ContextProbeSource, InjectionContextProbe};
 #[cfg(windows)]
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
+use crate::core::correction_diff::{detect_span_corrections, CandidateCorrection};
 use crate::core::text_context::is_invisible_prefix_char as is_invisible_probe_char;
 #[cfg(any(windows, test))]
 use crate::core::text_context::SentenceContext;
@@ -30,10 +31,6 @@ const CACHE_REJECTION_WINDOW_SECS: u64 = 10;
 const PENDING_RETENTION_DAYS: i64 = 2;
 const PROMOTION_THRESHOLD: i64 = 2;
 const STABLE_TEXT_OBSERVATIONS_REQUIRED: usize = 2;
-const MIN_CANDIDATE_NORM_LEN: usize = 2;
-const MAX_SPAN_GROWTH_WORDS: usize = 5;
-const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
-const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
 const MIN_CANDIDATE_CONFIDENCE: f64 = 0.45;
 const PAIR_COOLDOWN_MINUTES: i64 = 0;
 
@@ -93,39 +90,10 @@ impl Drop for EventModeHookGuard {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WordToken {
-    raw: String,
-    norm: String,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct CandidateCorrection {
-    mistake: String,
-    correction: String,
-    confidence: f64,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct CorrectionMetrics {
-    a_len: usize,
-    b_len: usize,
-    max_len: usize,
-    distance: usize,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct TextAnchor {
     start: usize,
     end: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AlignOp {
-    Equal,
-    Replace,
-    Insert,
-    Delete,
 }
 
 #[derive(Debug, Default)]
@@ -158,220 +126,6 @@ impl StableTextGate {
     }
 }
 
-fn edit_distance(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let (m, n) = (a.len(), b.len());
-    let mut row: Vec<usize> = (0..=n).collect();
-    for i in 1..=m {
-        let mut prev = row[0];
-        row[0] = i;
-        for j in 1..=n {
-            let old = row[j];
-            row[j] = if a[i - 1] == b[j - 1] {
-                prev
-            } else {
-                1 + prev.min(row[j]).min(row[j - 1])
-            };
-            prev = old;
-        }
-    }
-    row[n]
-}
-
-fn is_word_char(c: char) -> bool {
-    c.is_alphanumeric() || matches!(c, '\'' | '-' | '_')
-}
-
-fn normalize_word(word: &str) -> String {
-    word.chars()
-        .filter(|c| is_word_char(*c))
-        .flat_map(char::to_lowercase)
-        .collect()
-}
-
-fn tokenize_words(text: &str) -> Vec<WordToken> {
-    let mut tokens = Vec::new();
-    let mut start = None;
-
-    for (idx, ch) in text.char_indices() {
-        if is_word_char(ch) {
-            if start.is_none() {
-                start = Some(idx);
-            }
-        } else if let Some(s) = start.take() {
-            let raw = &text[s..idx];
-            let norm = normalize_word(raw);
-            if !norm.is_empty() {
-                tokens.push(WordToken {
-                    raw: raw.to_string(),
-                    norm,
-                });
-            }
-        }
-    }
-
-    if let Some(s) = start {
-        let raw = &text[s..];
-        let norm = normalize_word(raw);
-        if !norm.is_empty() {
-            tokens.push(WordToken {
-                raw: raw.to_string(),
-                norm,
-            });
-        }
-    }
-
-    tokens
-}
-
-fn has_distinctive_features(token: &str) -> bool {
-    if !token.is_ascii() {
-        return true;
-    }
-    if token.len() >= 4
-        && token
-            .chars()
-            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
-    {
-        return true;
-    }
-    if token
-        .chars()
-        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
-    {
-        return true;
-    }
-
-    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
-    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
-}
-
-fn is_common_word(word: &str) -> bool {
-    matches!(
-        word,
-        "a" | "about"
-            | "after"
-            | "all"
-            | "also"
-            | "am"
-            | "an"
-            | "and"
-            | "are"
-            | "as"
-            | "ask"
-            | "at"
-            | "be"
-            | "but"
-            | "by"
-            | "can"
-            | "do"
-            | "for"
-            | "from"
-            | "get"
-            | "go"
-            | "had"
-            | "has"
-            | "have"
-            | "he"
-            | "her"
-            | "him"
-            | "his"
-            | "i"
-            | "if"
-            | "in"
-            | "is"
-            | "it"
-            | "its"
-            | "just"
-            | "me"
-            | "my"
-            | "no"
-            | "not"
-            | "of"
-            | "on"
-            | "or"
-            | "our"
-            | "out"
-            | "so"
-            | "ship"
-            | "shop"
-            | "that"
-            | "the"
-            | "them"
-            | "then"
-            | "there"
-            | "their"
-            | "they"
-            | "this"
-            | "to"
-            | "up"
-            | "us"
-            | "was"
-            | "we"
-            | "what"
-            | "when"
-            | "with"
-            | "you"
-            | "your"
-    )
-}
-
-fn compute_correction_metrics(original: &WordToken, corrected: &WordToken) -> CorrectionMetrics {
-    let a_len = original.norm.chars().count();
-    let b_len = corrected.norm.chars().count();
-    let max_len = a_len.max(b_len);
-    let distance = edit_distance(&original.norm, &corrected.norm);
-    CorrectionMetrics {
-        a_len,
-        b_len,
-        max_len,
-        distance,
-    }
-}
-
-fn is_candidate_correction(
-    original: &WordToken,
-    corrected: &WordToken,
-    metrics: CorrectionMetrics,
-) -> bool {
-    if original.norm.is_empty() || corrected.norm.is_empty() {
-        return false;
-    }
-    if original.norm == corrected.norm {
-        return false;
-    }
-    if metrics.a_len < MIN_CANDIDATE_NORM_LEN || metrics.b_len < MIN_CANDIDATE_NORM_LEN {
-        return false;
-    }
-
-    let original_distinct = has_distinctive_features(&original.raw);
-    let corrected_distinct = has_distinctive_features(&corrected.raw);
-    if metrics.max_len <= 3 && !original_distinct && !corrected_distinct {
-        return false;
-    }
-
-    if is_common_word(&original.norm)
-        && is_common_word(&corrected.norm)
-        && !original_distinct
-        && !corrected_distinct
-    {
-        return false;
-    }
-
-    if is_plain_suffix_completion(&original.norm, &corrected.norm)
-        && !original_distinct
-        && !corrected_distinct
-    {
-        return false;
-    }
-
-    metrics.distance <= 2_usize.max(metrics.max_len / 2)
-        || ((original_distinct || corrected_distinct)
-            && metrics.max_len >= 4
-            && metrics.distance <= 3)
-}
-
 fn pair_hash(left: &str, right: &str) -> (String, String) {
     // FNV-1a 64-bit with a fixed offset/prime gives stable hashes across
     // app versions and process runs. This is telemetry bucketing, not crypto.
@@ -388,51 +142,18 @@ fn pair_hash(left: &str, right: &str) -> (String, String) {
     (hash_str(left), hash_str(right))
 }
 
+fn evidence_session_id(seed: &str, app_context: &str) -> String {
+    let (seed_hash, app_hash) = pair_hash(seed, app_context);
+    let now_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("{seed_hash}:{app_hash}:{now_nanos}")
+}
+
 fn monitor_key(injected_text: &str, app_context: &str) -> String {
     let (lhs, rhs) = pair_hash(injected_text, app_context);
     format!("{rhs}:{lhs}")
-}
-
-fn candidate_confidence(
-    original: &WordToken,
-    corrected: &WordToken,
-    metrics: CorrectionMetrics,
-    changed_ops: usize,
-    replacements_len: usize,
-) -> f64 {
-    let distance = metrics.distance as f64;
-    let max_len = metrics.max_len.max(1) as f64;
-    let ratio_score = 1.0 - (distance / max_len).min(1.0);
-
-    let mut score = ratio_score * 0.55;
-    if has_distinctive_features(&original.raw) || has_distinctive_features(&corrected.raw) {
-        score += 0.25;
-    }
-    if is_common_word(&original.norm) && is_common_word(&corrected.norm) {
-        score -= 0.2;
-    }
-    score -= (changed_ops.saturating_sub(1) as f64) * 0.07;
-    score -= (replacements_len.saturating_sub(1) as f64) * 0.08;
-    score.clamp(0.0, 1.0)
-}
-
-fn is_plain_suffix_completion(original: &str, corrected: &str) -> bool {
-    if let Some(suffix) = corrected.strip_prefix(original) {
-        return is_low_signal_suffix(suffix);
-    }
-
-    if let Some(suffix) = original.strip_prefix(corrected) {
-        return is_low_signal_suffix(suffix);
-    }
-
-    false
-}
-
-fn is_low_signal_suffix(suffix: &str) -> bool {
-    matches!(suffix, "s" | "d" | "e" | "g" | "ed" | "er" | "es" | "ing")
-        || suffix
-            .chars()
-            .all(|ch| matches!(ch, 'a' | 'e' | 'i' | 'o' | 'u'))
 }
 
 fn find_unique_anchor(haystack: &str, needle: &str) -> Option<TextAnchor> {
@@ -552,135 +273,6 @@ fn capture_baseline_text_any(injected_text: &str) -> Option<String> {
     } else {
         None
     }
-}
-
-fn align_word_ops(
-    original: &[WordToken],
-    current: &[WordToken],
-) -> Vec<(AlignOp, Option<usize>, Option<usize>)> {
-    let m = original.len();
-    let n = current.len();
-    let mut dp = vec![vec![0usize; n + 1]; m + 1];
-
-    for (i, row) in dp.iter_mut().enumerate().take(m + 1) {
-        row[0] = i;
-    }
-    for (j, cell) in dp[0].iter_mut().enumerate().take(n + 1) {
-        *cell = j;
-    }
-
-    for i in 1..=m {
-        for j in 1..=n {
-            let replace_cost = if original[i - 1].norm == current[j - 1].norm {
-                0
-            } else {
-                1
-            };
-            dp[i][j] = (dp[i - 1][j - 1] + replace_cost)
-                .min(dp[i - 1][j] + 1)
-                .min(dp[i][j - 1] + 1);
-        }
-    }
-
-    let mut ops = Vec::new();
-    let (mut i, mut j) = (m, n);
-    while i > 0 || j > 0 {
-        if i > 0 && j > 0 {
-            let replace_cost = if original[i - 1].norm == current[j - 1].norm {
-                0
-            } else {
-                1
-            };
-            if dp[i][j] == dp[i - 1][j - 1] + replace_cost {
-                let op = if replace_cost == 0 {
-                    AlignOp::Equal
-                } else {
-                    AlignOp::Replace
-                };
-                ops.push((op, Some(i - 1), Some(j - 1)));
-                i -= 1;
-                j -= 1;
-                continue;
-            }
-        }
-        if i > 0 && dp[i][j] == dp[i - 1][j] + 1 {
-            ops.push((AlignOp::Delete, Some(i - 1), None));
-            i -= 1;
-        } else {
-            ops.push((AlignOp::Insert, None, Some(j - 1)));
-            j -= 1;
-        }
-    }
-
-    ops.reverse();
-    ops
-}
-
-fn detect_span_corrections(original_span: &str, current_span: &str) -> Vec<CandidateCorrection> {
-    let original = tokenize_words(original_span);
-    let current = tokenize_words(current_span);
-
-    if original.is_empty() || current.is_empty() {
-        return vec![];
-    }
-    if current.len() > original.len() * 2 + MAX_SPAN_GROWTH_WORDS {
-        return vec![];
-    }
-
-    let ops = align_word_ops(&original, &current);
-    let changed_ops = ops
-        .iter()
-        .filter(|(op, _, _)| *op != AlignOp::Equal)
-        .count();
-    if changed_ops > MAX_CHANGED_OPS_PER_SPAN {
-        log::debug!("auto-learn: rejected span with too many changed word operations");
-        return vec![];
-    }
-
-    let replacements: Vec<_> = ops
-        .iter()
-        .filter_map(|(op, old_idx, new_idx)| {
-            if *op == AlignOp::Replace {
-                Some((old_idx.unwrap(), new_idx.unwrap()))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if replacements.len() > MAX_REPLACEMENTS_PER_SPAN {
-        log::debug!("auto-learn: rejected span with too many replacements");
-        return vec![];
-    }
-
-    let replacements_len = replacements.len();
-    replacements
-        .into_iter()
-        .filter_map(|(old_idx, new_idx)| {
-            let old = &original[old_idx];
-            let new = &current[new_idx];
-            if old.norm.is_empty() || new.norm.is_empty() || old.norm == new.norm {
-                return None;
-            }
-            let metrics = compute_correction_metrics(old, new);
-            if is_candidate_correction(old, new, metrics) {
-                Some(CandidateCorrection {
-                    mistake: old.raw.clone(),
-                    correction: new.raw.clone(),
-                    confidence: candidate_confidence(
-                        old,
-                        new,
-                        metrics,
-                        changed_ops,
-                        replacements_len,
-                    ),
-                })
-            } else {
-                log::debug!("auto-learn: rejected low-confidence candidate");
-                None
-            }
-        })
-        .collect()
 }
 
 fn detect_corrections_from_anchored_text(
@@ -850,6 +442,217 @@ fn record_candidate(
             false
         }
     }
+}
+
+/// Source A: diff raw vs clean LLM output and feed divergence as evidence.
+/// Called from the pipeline immediately after cleanup, before injection.
+/// Works cross-platform (no accessibility required).
+pub fn record_cleanup_divergence(
+    raw: &str,
+    clean: &str,
+    app_context: &str,
+    db: DbHandle,
+    app: tauri::AppHandle,
+    window_days: i64,
+) {
+    use crate::core::correction_diff::is_plausible_transcription_confusion;
+
+    if raw.trim().is_empty() || clean.trim().is_empty() || raw == clean {
+        return;
+    }
+
+    let candidates = detect_span_corrections(raw, clean);
+    if candidates.is_empty() {
+        return;
+    }
+
+    let session_id = evidence_session_id(raw, app_context);
+    for candidate in candidates {
+        // Gate: must be a plausible transcription confusion, not a grammar fix.
+        if !is_plausible_transcription_confusion(&candidate.mistake, &candidate.correction) {
+            log::debug!(
+                "auto-learn: divergence candidate rejected by phonetic gate: {:?} → {:?}",
+                candidate.mistake,
+                candidate.correction
+            );
+            continue;
+        }
+        record_evidence_and_promote(
+            &db,
+            &app,
+            &candidate.mistake,
+            &candidate.correction,
+            "cleanup_divergence",
+            SOURCE_WEIGHT_CLEANUP_DIVERGENCE,
+            candidate.confidence,
+            &session_id,
+            app_context,
+            window_days,
+        );
+    }
+}
+
+// Thresholds for the evidence scoring engine.
+const SCORE_AUTO: f64 = 1.6;
+const SCORE_SUGGEST: f64 = 0.7;
+const EVIDENCE_HALF_LIFE_DAYS: f64 = 1.5;
+// Source weights: post-edit (user typed it themselves) is stronger than cleanup divergence.
+pub const SOURCE_WEIGHT_POST_EDIT: f64 = 1.0;
+pub const SOURCE_WEIGHT_CLEANUP_DIVERGENCE: f64 = 0.6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EvidenceRecordOutcome {
+    Ignored,
+    Recorded,
+    Suggested,
+    Promoted,
+    PromotionSkipped,
+}
+
+/// Insert one evidence observation and run the scoring engine.
+/// Returns true if a new dictionary entry was auto-promoted.
+/// source: "post_edit" | "cleanup_divergence"
+/// window_days: from PipelineConfig.auto_learn_window_days
+pub fn record_evidence_and_promote(
+    db: &DbHandle,
+    app: &tauri::AppHandle,
+    wrong: &str,
+    correct: &str,
+    source: &str,
+    weight: f64,
+    confidence: f64,
+    session_id: &str,
+    app_context: &str,
+    window_days: i64,
+) -> bool {
+    match record_evidence_and_maybe_promote(
+        db,
+        wrong,
+        correct,
+        source,
+        weight,
+        confidence,
+        session_id,
+        app_context,
+        window_days,
+    ) {
+        EvidenceRecordOutcome::Promoted => {
+            app.emit("open-flow:dictionary-updated", ()).ok();
+            true
+        }
+        EvidenceRecordOutcome::Suggested => {
+            app.emit("open-flow:suggestion-added", ()).ok();
+            false
+        }
+        _ => false,
+    }
+}
+
+fn record_evidence_and_maybe_promote(
+    db: &DbHandle,
+    wrong: &str,
+    correct: &str,
+    source: &str,
+    weight: f64,
+    confidence: f64,
+    session_id: &str,
+    app_context: &str,
+    window_days: i64,
+) -> EvidenceRecordOutcome {
+    // Skip pairs in the never-learn list.
+    if db::is_never_learn_pair(db, wrong, correct).unwrap_or(false) {
+        return EvidenceRecordOutcome::Ignored;
+    }
+
+    if confidence < MIN_CANDIDATE_CONFIDENCE {
+        return EvidenceRecordOutcome::Ignored;
+    }
+
+    if let Err(e) = db::insert_correction_evidence(
+        db,
+        wrong,
+        correct,
+        source,
+        weight,
+        confidence,
+        session_id,
+        app_context,
+    ) {
+        log::warn!("auto-learn: evidence insert failed: {e}");
+        return EvidenceRecordOutcome::Ignored;
+    }
+
+    let ev = match db::compute_evidence_score(
+        db,
+        wrong,
+        correct,
+        window_days,
+        EVIDENCE_HALF_LIFE_DAYS,
+    ) {
+        Ok(ev) => ev,
+        Err(e) => {
+            log::warn!("auto-learn: score computation failed: {e}");
+            return EvidenceRecordOutcome::Recorded;
+        }
+    };
+
+    let corroborated = ev.distinct_sessions >= 2 || ev.distinct_sources >= 2;
+    if !corroborated {
+        return EvidenceRecordOutcome::Recorded;
+    }
+
+    if ev.score >= SCORE_AUTO {
+        // Auto-add.
+        let tier = if ev.score >= SCORE_AUTO * 1.5 {
+            "high"
+        } else {
+            "medium"
+        };
+        match db::insert_dictionary_entry_auto_learned(db, correct, Some(wrong), tier) {
+            Ok(true) => {
+                let _ = db::delete_dictionary_suggestion(db, wrong, correct);
+                let _ = db::log_auto_learn_event(
+                    db,
+                    "promotion",
+                    "promoted",
+                    app_context,
+                    "",
+                    "",
+                    ev.score,
+                );
+                log::info!(
+                    "auto-learn: auto-promoted {wrong:?} → {correct:?} (score={:.2})",
+                    ev.score
+                );
+                return EvidenceRecordOutcome::Promoted;
+            }
+            Ok(false) => {
+                log::debug!("auto-learn: auto-promote skipped (manual entry or mismatch)");
+                return EvidenceRecordOutcome::PromotionSkipped;
+            }
+            Err(e) => {
+                log::warn!("auto-learn: auto-promote failed: {e}");
+                return EvidenceRecordOutcome::PromotionSkipped;
+            }
+        }
+    } else if ev.score >= SCORE_SUGGEST {
+        let summary = format!(
+            "sessions={} sources={} score={:.2}",
+            ev.distinct_sessions, ev.distinct_sources, ev.score
+        );
+        if let Err(e) = db::upsert_dictionary_suggestion(db, wrong, correct, ev.score, &summary) {
+            log::warn!("auto-learn: suggestion upsert failed: {e}");
+            return EvidenceRecordOutcome::Recorded;
+        } else {
+            log::debug!(
+                "auto-learn: suggestion upserted {wrong:?} → {correct:?} (score={:.2})",
+                ev.score
+            );
+            return EvidenceRecordOutcome::Suggested;
+        }
+    }
+
+    EvidenceRecordOutcome::Recorded
 }
 
 #[cfg(windows)]
@@ -1441,7 +1244,12 @@ pub fn read_focused_text_probe() -> FocusedTextProbe {
     FocusedTextProbe::Unavailable
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
+pub fn read_focused_text() -> Option<String> {
+    crate::core::context_probe_macos::read_focused_text_sync()
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
 pub fn read_focused_text() -> Option<String> {
     None
 }
@@ -1471,7 +1279,13 @@ fn event_mode_poll_sleep_duration(hook_ready: bool) -> std::time::Duration {
     }
 }
 
-pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, app: AppHandle) {
+pub fn start_monitor(
+    injected_text: String,
+    app_context: String,
+    db: DbHandle,
+    app: AppHandle,
+    window_days: i64,
+) {
     if injected_text.split_whitespace().count() < 2 {
         let _ = db::log_auto_learn_event(&db, "monitor", "too_short", &app_context, "", "", 0.0);
         return;
@@ -1536,6 +1350,8 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
         let deadline =
             std::time::Instant::now() + std::time::Duration::from_secs(MONITOR_WINDOW_SECS);
         let mut recorded_this_session: HashSet<(String, String)> = HashSet::new();
+        // Stable within this monitor, unique across repeated identical dictations.
+        let session_id = evidence_session_id(&injected_text, &app_context);
         #[cfg(windows)]
         let mut last_event_seq = VALUE_CHANGE_SEQ.load(Ordering::Relaxed);
 
@@ -1594,17 +1410,23 @@ pub fn start_monitor(injected_text: String, app_context: String, db: DbHandle, a
                 detect_corrections_from_anchored_text(&injected_text, &baseline_text, stable_text);
 
             for candidate in diffs {
-                if record_candidate(
-                    &db,
-                    &mut recorded_this_session,
-                    &app_context,
-                    candidate.mistake,
-                    candidate.correction,
-                    candidate.confidence,
-                ) {
-                    log::info!("auto-learn: promoted candidate pair");
-                    app.emit("open-flow:dictionary-updated", ()).ok();
+                let key = (candidate.mistake.clone(), candidate.correction.clone());
+                if recorded_this_session.contains(&key) {
+                    continue;
                 }
+                recorded_this_session.insert(key);
+                record_evidence_and_promote(
+                    &db,
+                    &app,
+                    &candidate.mistake,
+                    &candidate.correction,
+                    "post_edit",
+                    SOURCE_WEIGHT_POST_EDIT,
+                    candidate.confidence,
+                    &session_id,
+                    &app_context,
+                    window_days,
+                );
             }
         }
         let _ = db::log_auto_learn_event(&db, "monitor", "timeout", &app_context, "", "", 0.0);
@@ -2001,6 +1823,184 @@ mod tests {
         assert_eq!(entries[0].term, "qroq");
         assert_eq!(entries[0].mistake.as_deref(), Some("rock"));
         assert!(entries[0].auto_learned);
+    }
+
+    #[test]
+    fn evidence_path_creates_suggestion_after_corroborated_score() {
+        let db = db::open(":memory:").expect("test db");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-2",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Suggested
+        );
+
+        let suggestions = db::query_dictionary_suggestions(&db).expect("suggestions");
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].wrong_word, "Koobernetes");
+        assert_eq!(suggestions[0].correct_word, "Kubernetes");
+    }
+
+    #[test]
+    fn evidence_path_promotes_after_corroborated_auto_score() {
+        let db = db::open(":memory:").expect("test db");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-2",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Promoted
+        );
+
+        let entries = db::query_dictionary(&db).expect("dictionary");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].term, "Kubernetes");
+        assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
+        assert!(entries[0].auto_learned);
+    }
+
+    #[test]
+    fn evidence_path_corroborates_two_sources_in_one_session() {
+        let db = db::open(":memory:").expect("test db");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "cleanup_divergence",
+                SOURCE_WEIGHT_CLEANUP_DIVERGENCE,
+                0.8,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.8,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Suggested
+        );
+    }
+
+    #[test]
+    fn evidence_path_respects_never_learn_pairs() {
+        let db = db::open(":memory:").expect("test db");
+        db::insert_never_learn_pair(&db, "Koobernetes", "Kubernetes").expect("never learn");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Ignored
+        );
+
+        let score =
+            db::compute_evidence_score(&db, "Koobernetes", "Kubernetes", 3, 1.5).expect("score");
+        assert_eq!(score.score, 0.0);
+    }
+
+    #[test]
+    fn evidence_path_keeps_manual_conflict_as_suggestion_problem() {
+        let db = db::open(":memory:").expect("test db");
+        db::insert_dictionary_entry(&db, "Kubernetes", Some("manual typo")).expect("manual");
+
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-2",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::PromotionSkipped
+        );
+
+        let entries = db::query_dictionary(&db).expect("dictionary");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].mistake.as_deref(), Some("manual typo"));
+        assert!(!entries[0].auto_learned);
     }
 
     #[test]

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -156,7 +156,9 @@ fn evidence_session_id(seed: &str, app_context: &str) -> String {
 /// different day (or be corroborated by the post-edit source) to count twice.
 fn evidence_session_id_daily(seed: &str, app_context: &str) -> String {
     let (seed_hash, app_hash) = pair_hash(seed, app_context);
-    let day = chrono::Local::now().format("%Y-%m-%d");
+    // Use UTC rather than local time so the day boundary doesn't shift if the
+    // user's system timezone changes (travel, DST) between dictations.
+    let day = chrono::Utc::now().format("%Y-%m-%d");
     format!("{seed_hash}:{app_hash}:{day}")
 }
 

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -29,10 +29,8 @@ const REJECTION_WINDOW_SECS: u64 = 8;
 const REJECTION_POLL_MS: u64 = 500;
 const CACHE_REJECTION_WINDOW_SECS: u64 = 10;
 const PENDING_RETENTION_DAYS: i64 = 2;
-const PROMOTION_THRESHOLD: i64 = 2;
 const STABLE_TEXT_OBSERVATIONS_REQUIRED: usize = 2;
 const MIN_CANDIDATE_CONFIDENCE: f64 = 0.45;
-const PAIR_COOLDOWN_MINUTES: i64 = 0;
 
 static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -149,6 +147,17 @@ fn evidence_session_id(seed: &str, app_context: &str) -> String {
         .map(|d| d.as_nanos())
         .unwrap_or_default();
     format!("{seed_hash}:{app_hash}:{now_nanos}")
+}
+
+/// Day-bucketed session id for the cleanup-divergence source. Every dictation
+/// runs this source automatically, so a per-call timestamp would let two
+/// back-to-back dictations trivially satisfy the "distinct sessions" check.
+/// Bucketing by calendar day requires the same divergence to recur on a
+/// different day (or be corroborated by the post-edit source) to count twice.
+fn evidence_session_id_daily(seed: &str, app_context: &str) -> String {
+    let (seed_hash, app_hash) = pair_hash(seed, app_context);
+    let day = chrono::Local::now().format("%Y-%m-%d");
+    format!("{seed_hash}:{app_hash}:{day}")
 }
 
 fn dedupe_candidate_pairs(candidates: Vec<CandidateCorrection>) -> Vec<CandidateCorrection> {
@@ -314,155 +323,13 @@ fn diff_words(original: &str, current: &str) -> Vec<(String, String)> {
         .collect()
 }
 
-fn record_candidate(
-    db: &DbHandle,
-    recorded_this_session: &mut HashSet<(String, String)>,
-    app_context: &str,
-    mistake: String,
-    correction: String,
-    confidence: f64,
-) -> bool {
-    let key = (mistake.clone(), correction.clone());
-    if recorded_this_session.contains(&key) {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "duplicate_in_session",
-            app_context,
-            "",
-            "",
-            confidence,
-        );
-        return false;
-    }
-    recorded_this_session.insert(key);
-    let (mistake_hash, correction_hash) = pair_hash(&mistake, &correction);
-
-    if confidence < MIN_CANDIDATE_CONFIDENCE {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "low_confidence",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
-
-    if !db::upsert_auto_learn_candidate(
-        db,
-        &mistake,
-        &correction,
-        confidence,
-        PAIR_COOLDOWN_MINUTES,
-    )
-    .unwrap_or(false)
-    {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "cooldown_skip",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
-
-    if let Err(e) = db::insert_pending_correction(db, &mistake, &correction) {
-        log::warn!("auto-learn pending insert failed: {e}");
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "pending_insert_failed",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
-
-    let count =
-        db::count_pending_corrections_recent(db, &mistake, &correction, PENDING_RETENTION_DAYS)
-            .unwrap_or(0);
-
-    if count < PROMOTION_THRESHOLD {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "below_threshold",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
-
-    let tier = if confidence >= 0.85 {
-        "high"
-    } else if confidence >= 0.72 {
-        "medium"
-    } else {
-        "low"
-    };
-
-    match db::insert_dictionary_entry_auto_learned(db, &correction, Some(&mistake), tier) {
-        Ok(true) => {
-            let _ = db::mark_auto_learn_candidate_promoted(db, &mistake, &correction);
-            let _ = db::log_auto_learn_event(
-                db,
-                "promotion",
-                "promoted",
-                app_context,
-                &mistake_hash,
-                &correction_hash,
-                confidence,
-            );
-            true
-        }
-        Ok(false) => {
-            log::debug!(
-                "auto-learn: promotion skipped because dictionary entry is manual or mismatched"
-            );
-            let _ = db::log_auto_learn_event(
-                db,
-                "promotion",
-                "promotion_skipped",
-                app_context,
-                &mistake_hash,
-                &correction_hash,
-                confidence,
-            );
-            false
-        }
-        Err(e) => {
-            log::warn!("auto-learn dictionary promotion failed: {e}");
-            let _ = db::log_auto_learn_event(
-                db,
-                "promotion",
-                "promotion_failed",
-                app_context,
-                &mistake_hash,
-                &correction_hash,
-                confidence,
-            );
-            false
-        }
-    }
-}
-
 /// Source A: diff raw vs clean LLM output and feed divergence as evidence.
 /// Called from the pipeline immediately after cleanup, before injection.
 /// Works cross-platform (no accessibility required).
 pub fn record_cleanup_divergence(
-    raw: &str,
-    clean: &str,
-    app_context: &str,
+    raw: String,
+    clean: String,
+    app_context: String,
     db: DbHandle,
     app: tauri::AppHandle,
     window_days: i64,
@@ -473,35 +340,37 @@ pub fn record_cleanup_divergence(
         return;
     }
 
-    let candidates = dedupe_candidate_pairs(detect_span_corrections(raw, clean));
-    if candidates.is_empty() {
-        return;
-    }
-
-    let session_id = evidence_session_id(raw, app_context);
-    for candidate in candidates {
-        // Gate: must be a plausible transcription confusion, not a grammar fix.
-        if !is_plausible_transcription_confusion(&candidate.mistake, &candidate.correction) {
-            log::debug!(
-                "auto-learn: divergence candidate rejected by phonetic gate: {:?} → {:?}",
-                candidate.mistake,
-                candidate.correction
-            );
-            continue;
+    tokio::task::spawn_blocking(move || {
+        let candidates = dedupe_candidate_pairs(detect_span_corrections(&raw, &clean));
+        if candidates.is_empty() {
+            return;
         }
-        record_evidence_and_promote(
-            &db,
-            &app,
-            &candidate.mistake,
-            &candidate.correction,
-            "cleanup_divergence",
-            SOURCE_WEIGHT_CLEANUP_DIVERGENCE,
-            candidate.confidence,
-            &session_id,
-            app_context,
-            window_days,
-        );
-    }
+
+        let session_id = evidence_session_id_daily(&raw, &app_context);
+        for candidate in candidates {
+            // Gate: must be a plausible transcription confusion, not a grammar fix.
+            if !is_plausible_transcription_confusion(&candidate.mistake, &candidate.correction) {
+                log::debug!(
+                    "auto-learn: divergence candidate rejected by phonetic gate: {:?} → {:?}",
+                    candidate.mistake,
+                    candidate.correction
+                );
+                continue;
+            }
+            record_evidence_and_promote(
+                &db,
+                &app,
+                &candidate.mistake,
+                &candidate.correction,
+                "cleanup_divergence",
+                SOURCE_WEIGHT_CLEANUP_DIVERGENCE,
+                candidate.confidence,
+                &session_id,
+                &app_context,
+                window_days,
+            );
+        }
+    });
 }
 
 // Thresholds for the evidence scoring engine.
@@ -525,6 +394,9 @@ enum EvidenceRecordOutcome {
 /// Returns true if a new dictionary entry was auto-promoted.
 /// source: "post_edit" | "cleanup_divergence"
 /// window_days: from PipelineConfig.auto_learn_window_days
+// Each argument is an independent piece of the evidence observation (who/what/where/how-confident);
+// grouping them into a struct would just move the same fields one layer out without reducing complexity.
+#[allow(clippy::too_many_arguments)]
 pub fn record_evidence_and_promote(
     db: &DbHandle,
     app: &tauri::AppHandle,
@@ -560,6 +432,8 @@ pub fn record_evidence_and_promote(
     }
 }
 
+// See record_evidence_and_promote: one argument per evidence-observation field.
+#[allow(clippy::too_many_arguments)]
 fn record_evidence_and_maybe_promote(
     db: &DbHandle,
     wrong: &str,
@@ -571,6 +445,14 @@ fn record_evidence_and_maybe_promote(
     app_context: &str,
     window_days: i64,
 ) -> EvidenceRecordOutcome {
+    // Whisper's capitalization of a mistranscribed word is inconsistent
+    // ("Koobernetes" vs "koobernetes"); normalize so identical mistakes
+    // corroborate against each other instead of fragmenting across rows.
+    // `correct` keeps its casing — it's the dictionary term and may be a
+    // proper noun.
+    let wrong = wrong.to_lowercase();
+    let wrong = wrong.as_str();
+
     // Skip pairs in the never-learn list.
     if db::is_never_learn_pair(db, wrong, correct).unwrap_or(false) {
         return EvidenceRecordOutcome::Ignored;
@@ -620,13 +502,19 @@ fn record_evidence_and_maybe_promote(
         } else {
             "medium"
         };
+        let already_learned = db::is_already_auto_learned(db, correct, wrong).unwrap_or(false);
         match db::insert_dictionary_entry_auto_learned(db, correct, Some(wrong), tier) {
             Ok(true) => {
                 let _ = db::delete_dictionary_suggestion(db, wrong, correct);
+                if already_learned {
+                    // Already promoted previously — bump correction_count quietly,
+                    // but don't re-log/re-emit on every subsequent observation.
+                    return EvidenceRecordOutcome::Recorded;
+                }
                 let _ = db::log_auto_learn_event(
                     db,
                     "promotion",
-                    "promoted",
+                    "auto_promoted",
                     app_context,
                     "",
                     "",
@@ -1258,6 +1146,7 @@ pub fn read_focused_text_probe() -> FocusedTextProbe {
 
 #[cfg(target_os = "macos")]
 pub fn read_focused_text() -> Option<String> {
+    let _guard = crate::core::context_probe::MacosProbeGuard::acquire()?;
     crate::core::context_probe_macos::read_focused_text_sync()
 }
 
@@ -1754,90 +1643,6 @@ mod tests {
     }
 
     #[test]
-    fn repeated_candidate_counts_once_per_session() {
-        let db = db::open(":memory:").expect("test db");
-        let mut recorded = HashSet::new();
-
-        assert!(!record_candidate(
-            &db,
-            &mut recorded,
-            "test-app",
-            "Koobernetes".to_string(),
-            "Kubernetes".to_string(),
-            0.9,
-        ));
-        assert!(!record_candidate(
-            &db,
-            &mut recorded,
-            "test-app",
-            "Koobernetes".to_string(),
-            "Kubernetes".to_string(),
-            0.9,
-        ));
-
-        let count = db::count_pending_corrections_recent(
-            &db,
-            "Koobernetes",
-            "Kubernetes",
-            PENDING_RETENTION_DAYS,
-        )
-        .expect("pending count");
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn candidate_promotes_after_two_sessions() {
-        let db = db::open(":memory:").expect("test db");
-
-        for expected in [false, true] {
-            let mut recorded = HashSet::new();
-            assert_eq!(
-                record_candidate(
-                    &db,
-                    &mut recorded,
-                    "test-app",
-                    "Koobernetes".to_string(),
-                    "Kubernetes".to_string(),
-                    0.9,
-                ),
-                expected
-            );
-        }
-
-        let entries = db::query_dictionary(&db).expect("dictionary");
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].term, "Kubernetes");
-        assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
-        assert!(entries[0].auto_learned);
-    }
-
-    #[test]
-    fn short_technical_term_promotes_only_after_two_sessions() {
-        let db = db::open(":memory:").expect("test db");
-
-        for expected in [false, true] {
-            let mut recorded = HashSet::new();
-            assert_eq!(
-                record_candidate(
-                    &db,
-                    &mut recorded,
-                    "test-app",
-                    "rock".to_string(),
-                    "qroq".to_string(),
-                    0.9,
-                ),
-                expected
-            );
-        }
-
-        let entries = db::query_dictionary(&db).expect("dictionary");
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].term, "qroq");
-        assert_eq!(entries[0].mistake.as_deref(), Some("rock"));
-        assert!(entries[0].auto_learned);
-    }
-
-    #[test]
     fn evidence_path_creates_suggestion_after_corroborated_score() {
         let db = db::open(":memory:").expect("test db");
 
@@ -1872,8 +1677,59 @@ mod tests {
 
         let suggestions = db::query_dictionary_suggestions(&db).expect("suggestions");
         assert_eq!(suggestions.len(), 1);
-        assert_eq!(suggestions[0].wrong_word, "Koobernetes");
+        // `wrong` is normalized to lowercase before storage (see record_evidence_and_maybe_promote).
+        assert_eq!(suggestions[0].wrong_word, "koobernetes");
         assert_eq!(suggestions[0].correct_word, "Kubernetes");
+    }
+
+    #[test]
+    fn evidence_path_merges_case_variants_of_wrong_word() {
+        let db = db::open(":memory:").expect("test db");
+
+        // Whisper's casing of a mistranscribed word is inconsistent across
+        // dictations; both variants must corroborate as the same pair.
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-1",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.5,
+                "session-2",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Suggested
+        );
+
+        let suggestions = db::query_dictionary_suggestions(&db).expect("suggestions");
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].wrong_word, "koobernetes");
+    }
+
+    #[test]
+    fn evidence_session_id_daily_is_stable_within_a_day() {
+        let a = evidence_session_id_daily("some raw text", "notepad.exe");
+        let b = evidence_session_id_daily("some raw text", "notepad.exe");
+        assert_eq!(a, b, "same seed/context on the same day must bucket together");
+
+        let c = evidence_session_id_daily("different text", "notepad.exe");
+        assert_ne!(a, c, "different seeds must not collide");
     }
 
     #[test]
@@ -1912,8 +1768,58 @@ mod tests {
         let entries = db::query_dictionary(&db).expect("dictionary");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].term, "Kubernetes");
-        assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
+        // `wrong` is normalized to lowercase before storage (see record_evidence_and_maybe_promote).
+        assert_eq!(entries[0].mistake.as_deref(), Some("koobernetes"));
         assert!(entries[0].auto_learned);
+    }
+
+    #[test]
+    fn evidence_path_does_not_repromote_already_learned_pair() {
+        let db = db::open(":memory:").expect("test db");
+
+        for session in ["session-1", "session-2"] {
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                session,
+                "test-app",
+                3,
+            );
+        }
+
+        // A third corroborated observation after the pair is already learned
+        // must not re-emit a promotion event or re-trigger Promoted.
+        assert_eq!(
+            record_evidence_and_maybe_promote(
+                &db,
+                "Koobernetes",
+                "Kubernetes",
+                "post_edit",
+                SOURCE_WEIGHT_POST_EDIT,
+                0.9,
+                "session-3",
+                "test-app",
+                3,
+            ),
+            EvidenceRecordOutcome::Recorded
+        );
+
+        let summary = db::get_auto_learn_status_summary(&db).expect("summary");
+        assert_eq!(
+            summary.promotions, 1,
+            "repeated evidence for an already-learned pair must not inflate the promotion count"
+        );
+
+        let entries = db::query_dictionary(&db).expect("dictionary");
+        assert_eq!(entries.len(), 1);
+        // First corroborated call (session-2) inserts the row (count=1); the
+        // third call bumps correction_count via ON CONFLICT but is reported
+        // as `Recorded`, not a fresh `Promoted`.
+        assert_eq!(entries[0].correction_count, 2);
     }
 
     #[test]
@@ -1953,7 +1859,8 @@ mod tests {
     #[test]
     fn evidence_path_respects_never_learn_pairs() {
         let db = db::open(":memory:").expect("test db");
-        db::insert_never_learn_pair(&db, "Koobernetes", "Kubernetes").expect("never learn");
+        // `wrong` is normalized to lowercase before the never-learn lookup.
+        db::insert_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("never learn");
 
         assert_eq!(
             record_evidence_and_maybe_promote(
@@ -2157,18 +2064,23 @@ mod tests {
                 let db = db::open(":memory:").expect("test db");
                 let (mistake, correction) = expected[0].clone();
 
-                for expected_promoted in [false, true] {
-                    let mut recorded = HashSet::new();
+                for (session_id, expected_outcome) in [
+                    ("session-1", EvidenceRecordOutcome::Recorded),
+                    ("session-2", EvidenceRecordOutcome::Promoted),
+                ] {
                     assert_eq!(
-                        record_candidate(
+                        record_evidence_and_maybe_promote(
                             &db,
-                            &mut recorded,
-                            "test-app",
-                            mistake.clone(),
-                            correction.clone(),
+                            &mistake,
+                            &correction,
+                            "post_edit",
+                            SOURCE_WEIGHT_POST_EDIT,
                             0.9,
+                            session_id,
+                            "test-app",
+                            3,
                         ),
-                        expected_promoted,
+                        expected_outcome,
                         "case {} promotion threshold",
                         case.name
                     );

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -845,7 +845,7 @@ pub async fn approve_dictionary_suggestion(
     let db = app.state::<DbHandle>().inner().clone();
     let applied = tokio::task::spawn_blocking(move || -> Result<bool, String> {
         let wrong_lower = wrong.to_lowercase();
-        let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(&wrong_lower), "medium")
+        let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(wrong_lower.as_str()), "medium")
             .map_err(|e| e.to_string())?;
         db::delete_dictionary_suggestion(&db, &wrong_lower, &correct).map_err(|e| e.to_string())?;
         if inserted {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -212,6 +212,12 @@ pub struct ExportSnippet {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
+pub struct ExportNeverLearnPair {
+    pub wrong: String,
+    pub correct: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct ExportPayload {
     pub version: String,
     pub app_version: String,
@@ -223,6 +229,8 @@ pub struct ExportPayload {
     pub dictionary: Vec<ExportDictionaryEntry>,
     #[serde(default)]
     pub snippets: Vec<ExportSnippet>,
+    #[serde(default)]
+    pub never_learn_pairs: Vec<ExportNeverLearnPair>,
 }
 
 #[derive(serde::Serialize)]
@@ -235,6 +243,8 @@ pub struct ImportSummary {
     pub snippets_inserted: usize,
     pub snippets_skipped: usize,
     pub snippets_already_existed: usize,
+    pub never_learn_pairs_inserted: usize,
+    pub never_learn_pairs_skipped: usize,
 }
 
 // Keys intentionally absent from this list (validated by validate_setting but never exported):
@@ -823,29 +833,36 @@ pub async fn get_dictionary_suggestions(
     .map_err(|e| e.to_string())?
 }
 
+/// Returns true if the suggestion was applied to the dictionary, false if it
+/// conflicted with an existing manual entry. Either way the suggestion is
+/// resolved (removed from the queue) so it never gets permanently stuck.
 #[tauri::command]
 pub async fn approve_dictionary_suggestion(
     app: AppHandle,
     wrong: String,
     correct: String,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let db = app.state::<DbHandle>().inner().clone();
-    tokio::task::spawn_blocking(move || {
+    let applied = tokio::task::spawn_blocking(move || -> Result<bool, String> {
         let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(&wrong), "medium")
             .map_err(|e| e.to_string())?;
-        if !inserted {
-            return Err("Could not approve suggestion because it conflicts with an existing dictionary entry.".to_string());
-        }
         db::delete_dictionary_suggestion(&db, &wrong, &correct).map_err(|e| e.to_string())?;
-        Ok(())
+        if inserted {
+            let _ = db::log_auto_learn_event(&db, "promotion", "approved", "", "", "", 0.0);
+        }
+        Ok(inserted)
     })
     .await
-    .map_err(|e| e.to_string())?
-    .map(|()| {
+    .map_err(|e| e.to_string())??;
+    if applied {
         app.emit("open-flow:dictionary-updated", ()).ok();
-    })
+    }
+    Ok(applied)
 }
 
+/// Soft-dismiss: records the pair in `never_learn_pairs` so it's hidden from
+/// future suggestion queries, but leaves the `dictionary_suggestions` row in
+/// place so `restore_never_learn_pair` can bring it back via undo.
 #[tauri::command]
 pub async fn dismiss_dictionary_suggestion(
     app: AppHandle,
@@ -854,8 +871,21 @@ pub async fn dismiss_dictionary_suggestion(
 ) -> Result<(), String> {
     let db = app.state::<DbHandle>().inner().clone();
     tokio::task::spawn_blocking(move || {
-        db::insert_never_learn_pair(&db, &wrong, &correct).map_err(|e| e.to_string())?;
-        db::delete_dictionary_suggestion(&db, &wrong, &correct).map_err(|e| e.to_string())
+        db::insert_never_learn_pair(&db, &wrong, &correct).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn restore_never_learn_pair(
+    app: AppHandle,
+    wrong: String,
+    correct: String,
+) -> Result<(), String> {
+    let db = app.state::<DbHandle>().inner().clone();
+    tokio::task::spawn_blocking(move || {
+        db::delete_never_learn_pair(&db, &wrong, &correct).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1315,6 +1345,7 @@ pub async fn export_data(
         let stats = db::query_stats(&db).map_err(|e| e.to_string())?;
         let dictionary = db::query_dictionary(&db).map_err(|e| e.to_string())?;
         let snippets = db::query_snippets(&db).map_err(|e| e.to_string())?;
+        let never_learn_pairs = db::query_never_learn_pairs(&db).map_err(|e| e.to_string())?;
 
         let now = chrono::Local::now();
         let payload = ExportPayload {
@@ -1344,6 +1375,13 @@ pub async fn export_data(
                     expansion: s.expansion,
                     instructions: s.instructions,
                     created_at: s.created_at,
+                })
+                .collect(),
+            never_learn_pairs: never_learn_pairs
+                .into_iter()
+                .map(|p| ExportNeverLearnPair {
+                    wrong: p.wrong_word,
+                    correct: p.correct_word,
                 })
                 .collect(),
         };
@@ -1467,11 +1505,28 @@ pub async fn import_data(
             }
         }
 
+        let mut never_learn_pairs_inserted = 0usize;
+        let mut never_learn_pairs_skipped = 0usize;
+        for pair in &payload.never_learn_pairs {
+            if pair.wrong.trim().is_empty() || pair.correct.trim().is_empty() {
+                never_learn_pairs_skipped += 1;
+                continue;
+            }
+            match db::insert_never_learn_pair(&db, &pair.wrong, &pair.correct) {
+                Ok(()) => never_learn_pairs_inserted += 1,
+                Err(e) => {
+                    log::warn!("import_data: never_learn_pair insert error for '{}': {e}", pair.wrong);
+                    never_learn_pairs_skipped += 1;
+                }
+            }
+        }
+
         log::info!(
-            "import_data: settings={}/skip={} dict={}/skip={}/existed={} snip={}/skip={}/existed={}",
+            "import_data: settings={}/skip={} dict={}/skip={}/existed={} snip={}/skip={}/existed={} never_learn={}/skip={}",
             settings_applied, settings_skipped,
             dictionary_inserted, dictionary_skipped, dictionary_already_existed,
             snippets_inserted, snippets_skipped, snippets_already_existed,
+            never_learn_pairs_inserted, never_learn_pairs_skipped,
         );
 
         Ok(ImportSummary {
@@ -1483,6 +1538,8 @@ pub async fn import_data(
             snippets_inserted,
             snippets_skipped,
             snippets_already_existed,
+            never_learn_pairs_inserted,
+            never_learn_pairs_skipped,
         })
     })
     .await

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -844,9 +844,10 @@ pub async fn approve_dictionary_suggestion(
 ) -> Result<bool, String> {
     let db = app.state::<DbHandle>().inner().clone();
     let applied = tokio::task::spawn_blocking(move || -> Result<bool, String> {
-        let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(&wrong), "medium")
+        let wrong_lower = wrong.to_lowercase();
+        let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(&wrong_lower), "medium")
             .map_err(|e| e.to_string())?;
-        db::delete_dictionary_suggestion(&db, &wrong, &correct).map_err(|e| e.to_string())?;
+        db::delete_dictionary_suggestion(&db, &wrong_lower, &correct).map_err(|e| e.to_string())?;
         if inserted {
             let _ = db::log_auto_learn_event(&db, "promotion", "approved", "", "", "", 0.0);
         }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -74,6 +74,7 @@ fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), String> 
         | store::ADVANCED_MODEL_UI
         | store::AUTOSTART_ENABLED => value.is_boolean(),
         store::MIC_GAIN => value.as_f64().is_some_and(|v| (1.0..=8.0).contains(&v)),
+        store::AUTO_LEARN_WINDOW_DAYS => value.as_i64().is_some_and(|v| (1..=30).contains(&v)),
         store::APP_MAPPINGS => serde_json::from_value::<Vec<AppMapping>>(value.clone()).is_ok(),
         store::HOTKEY => value
             .as_array()
@@ -164,6 +165,7 @@ pub struct AllSettings {
     pub autostart_enabled: Option<bool>,
     pub app_context_hint: Option<bool>,
     pub auto_learn_enabled: Option<bool>,
+    pub auto_learn_window_days: Option<i64>,
     pub contextual_caps_enabled: Option<bool>,
     pub auto_spacing_enabled: Option<bool>,
     pub mic_gain: Option<f64>,
@@ -306,6 +308,9 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         autostart_enabled: bool_val(store::AUTOSTART_ENABLED),
         app_context_hint: bool_val(store::APP_CONTEXT_HINT),
         auto_learn_enabled: bool_val(store::AUTO_LEARN_ENABLED),
+        auto_learn_window_days: s
+            .get(store::AUTO_LEARN_WINDOW_DAYS)
+            .and_then(|v| v.as_i64()),
         contextual_caps_enabled: bool_val(store::CONTEXTUAL_CAPS),
         auto_spacing_enabled: bool_val(store::AUTO_SPACING),
         mic_gain: f64_val(store::MIC_GAIN),
@@ -799,6 +804,58 @@ pub async fn get_recent_auto_learn_activity(
     let db = app.state::<DbHandle>().inner().clone();
     tokio::task::spawn_blocking(move || {
         db::get_recent_auto_learn_activity(&db, limit.unwrap_or(20)).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+// ---------- dictionary suggestions ----------
+
+#[tauri::command]
+pub async fn get_dictionary_suggestions(
+    app: AppHandle,
+) -> Result<Vec<db::DictionarySuggestion>, String> {
+    let db = app.state::<DbHandle>().inner().clone();
+    tokio::task::spawn_blocking(move || {
+        db::query_dictionary_suggestions(&db).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn approve_dictionary_suggestion(
+    app: AppHandle,
+    wrong: String,
+    correct: String,
+) -> Result<(), String> {
+    let db = app.state::<DbHandle>().inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let inserted = db::insert_dictionary_entry_auto_learned(&db, &correct, Some(&wrong), "medium")
+            .map_err(|e| e.to_string())?;
+        if !inserted {
+            return Err("Could not approve suggestion because it conflicts with an existing dictionary entry.".to_string());
+        }
+        db::delete_dictionary_suggestion(&db, &wrong, &correct).map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map(|()| {
+        app.emit("open-flow:dictionary-updated", ()).ok();
+    })
+}
+
+#[tauri::command]
+pub async fn dismiss_dictionary_suggestion(
+    app: AppHandle,
+    wrong: String,
+    correct: String,
+) -> Result<(), String> {
+    let db = app.state::<DbHandle>().inner().clone();
+    tokio::task::spawn_blocking(move || {
+        db::insert_never_learn_pair(&db, &wrong, &correct).map_err(|e| e.to_string())?;
+        db::delete_dictionary_suggestion(&db, &wrong, &correct).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1300,9 +1357,11 @@ pub async fn export_data(
             .map_err(|e| format!("Failed to resolve Downloads directory: {e}"))?;
         std::fs::create_dir_all(&downloads)
             .map_err(|e| format!("Failed to create Downloads path: {e}"))?;
-        let path = downloads.join(format!("open-flow-backup-{}.json", now.format("%Y%m%d-%H%M%S")));
-        std::fs::write(&path, json)
-            .map_err(|e| format!("Failed to write backup file: {e}"))?;
+        let path = downloads.join(format!(
+            "open-flow-backup-{}.json",
+            now.format("%Y%m%d-%H%M%S")
+        ));
+        std::fs::write(&path, json).map_err(|e| format!("Failed to write backup file: {e}"))?;
 
         log::info!("export_data: wrote {}", path.display());
         Ok(path.display().to_string())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1461,65 +1461,70 @@ pub async fn import_data(
             crate::apply_runtime_icons(&app, None);
         }
 
-        let mut dictionary_inserted = 0usize;
+        // Pre-filter empty entries, then insert everything else inside a single
+        // transaction (db::import_backup_records) — one INSERT per row would
+        // otherwise force an implicit transaction + disk sync per row.
         let mut dictionary_skipped = 0usize;
-        let mut dictionary_already_existed = 0usize;
-        for entry in &payload.dictionary {
-            if entry.term.trim().is_empty() {
-                dictionary_skipped += 1;
-                continue;
-            }
-            match db::insert_dictionary_entry_from_backup(&db, &entry.term, entry.mistake.as_deref(), entry.auto_learned, &entry.confidence_tier, entry.correction_count) {
-                Ok(()) => dictionary_inserted += 1,
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") {
-                        dictionary_already_existed += 1;
-                    } else {
-                        log::warn!("import_data: dictionary insert error for '{}': {msg}", entry.term);
-                        dictionary_skipped += 1;
-                    }
+        let dictionary_entries: Vec<db::BackupDictionaryEntry> = payload.dictionary.iter()
+            .filter(|entry| {
+                let keep = !entry.term.trim().is_empty();
+                if !keep {
+                    dictionary_skipped += 1;
                 }
-            }
-        }
+                keep
+            })
+            .map(|entry| db::BackupDictionaryEntry {
+                term: &entry.term,
+                mistake: entry.mistake.as_deref(),
+                auto_learned: entry.auto_learned,
+                confidence_tier: &entry.confidence_tier,
+                correction_count: entry.correction_count,
+            })
+            .collect();
 
-        let mut snippets_inserted = 0usize;
         let mut snippets_skipped = 0usize;
-        let mut snippets_already_existed = 0usize;
-        for snippet in &payload.snippets {
-            if snippet.trigger.trim().is_empty() || snippet.expansion.trim().is_empty() {
-                snippets_skipped += 1;
-                continue;
-            }
-            match db::insert_snippet_returning(&db, &snippet.trigger, &snippet.expansion, &snippet.instructions) {
-                Ok(_) => snippets_inserted += 1,
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("UNIQUE constraint failed") {
-                        snippets_already_existed += 1;
-                    } else {
-                        log::warn!("import_data: snippet insert error for '{}': {msg}", snippet.trigger);
-                        snippets_skipped += 1;
-                    }
+        let snippet_entries: Vec<db::BackupSnippet> = payload.snippets.iter()
+            .filter(|snippet| {
+                let keep = !snippet.trigger.trim().is_empty() && !snippet.expansion.trim().is_empty();
+                if !keep {
+                    snippets_skipped += 1;
                 }
-            }
-        }
+                keep
+            })
+            .map(|snippet| db::BackupSnippet {
+                trigger: &snippet.trigger,
+                expansion: &snippet.expansion,
+                instructions: &snippet.instructions,
+            })
+            .collect();
 
-        let mut never_learn_pairs_inserted = 0usize;
         let mut never_learn_pairs_skipped = 0usize;
-        for pair in &payload.never_learn_pairs {
-            if pair.wrong.trim().is_empty() || pair.correct.trim().is_empty() {
-                never_learn_pairs_skipped += 1;
-                continue;
-            }
-            match db::insert_never_learn_pair(&db, &pair.wrong, &pair.correct) {
-                Ok(()) => never_learn_pairs_inserted += 1,
-                Err(e) => {
-                    log::warn!("import_data: never_learn_pair insert error for '{}': {e}", pair.wrong);
+        let never_learn_pair_entries: Vec<db::BackupNeverLearnPair> = payload.never_learn_pairs.iter()
+            .filter(|pair| {
+                let keep = !pair.wrong.trim().is_empty() && !pair.correct.trim().is_empty();
+                if !keep {
                     never_learn_pairs_skipped += 1;
                 }
-            }
-        }
+                keep
+            })
+            .map(|pair| db::BackupNeverLearnPair {
+                wrong: &pair.wrong,
+                correct: &pair.correct,
+            })
+            .collect();
+
+        let import_counts = db::import_backup_records(&db, &dictionary_entries, &snippet_entries, &never_learn_pair_entries)
+            .map_err(|e| e.to_string())?;
+
+        let dictionary_inserted = import_counts.dictionary_inserted;
+        let dictionary_already_existed = import_counts.dictionary_already_existed;
+        dictionary_skipped += import_counts.dictionary_failed;
+
+        let snippets_inserted = import_counts.snippets_inserted;
+        let snippets_already_existed = import_counts.snippets_already_existed;
+        snippets_skipped += import_counts.snippets_failed;
+
+        let never_learn_pairs_inserted = import_counts.never_learn_pairs_inserted;
 
         log::info!(
             "import_data: settings={}/skip={} dict={}/skip={}/existed={} snip={}/skip={}/existed={} never_learn={}/skip={}",

--- a/src-tauri/src/core/context_probe.rs
+++ b/src-tauri/src/core/context_probe.rs
@@ -153,13 +153,13 @@ fn get_monotonic_ms() -> u64 {
 static MACOS_PROBE_START_TIME: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[cfg(target_os = "macos")]
-struct MacosProbeGuard {
+pub(crate) struct MacosProbeGuard {
     start_time: u64,
 }
 
 #[cfg(target_os = "macos")]
 impl MacosProbeGuard {
-    fn acquire() -> Option<Self> {
+    pub(crate) fn acquire() -> Option<Self> {
         use std::sync::atomic::Ordering;
 
         let now = get_monotonic_ms();

--- a/src-tauri/src/core/context_probe_macos.rs
+++ b/src-tauri/src/core/context_probe_macos.rs
@@ -38,6 +38,8 @@ unsafe extern "C" {
         lookbehind_chars: i32,
         out_result: *mut MacosContextProbeResult,
     ) -> i32;
+
+    fn openflow_macos_read_focused_text(buf: *mut c_char, buf_len: usize) -> i32;
 }
 
 fn c_buf_to_string(buf: &[c_char]) -> String {
@@ -66,6 +68,29 @@ fn map_selection_state(selection_state: i32) -> SelectionState {
         SELECTION_NON_COLLAPSED => SelectionState::NonCollapsedSelection,
         SELECTION_UNKNOWN => SelectionState::Unknown,
         _ => SelectionState::Unknown,
+    }
+}
+
+const FULL_TEXT_BUF_LEN: usize = 65536;
+
+/// Read the full kAXValue text of the currently focused UI element.
+/// Returns None if AX is unavailable, permissions are missing, or the element
+/// has no text pattern.
+pub fn read_focused_text_sync() -> Option<String> {
+    let mut buf: Vec<c_char> = vec![0; FULL_TEXT_BUF_LEN];
+    // SAFETY: buf is valid for FULL_TEXT_BUF_LEN bytes; the shim writes at most
+    // buf_len - 1 characters and always null-terminates.
+    let ok = unsafe { openflow_macos_read_focused_text(buf.as_mut_ptr(), FULL_TEXT_BUF_LEN) };
+    if ok == 0 {
+        return None;
+    }
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    let u8_bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
+    let text = String::from_utf8_lossy(u8_bytes).into_owned();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
     }
 }
 

--- a/src-tauri/src/core/context_probe_macos.rs
+++ b/src-tauri/src/core/context_probe_macos.rs
@@ -84,10 +84,7 @@ pub fn read_focused_text_sync() -> Option<String> {
     if ok == 0 {
         return None;
     }
-    // SAFETY: the shim always null-terminates buf within its FULL_TEXT_BUF_LEN bytes.
-    let text = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
-        .to_string_lossy()
-        .into_owned();
+    let text = c_buf_to_string(&buf);
     if text.is_empty() {
         None
     } else {

--- a/src-tauri/src/core/context_probe_macos.rs
+++ b/src-tauri/src/core/context_probe_macos.rs
@@ -84,9 +84,10 @@ pub fn read_focused_text_sync() -> Option<String> {
     if ok == 0 {
         return None;
     }
-    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
-    let u8_bytes = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, len) };
-    let text = String::from_utf8_lossy(u8_bytes).into_owned();
+    // SAFETY: the shim always null-terminates buf within its FULL_TEXT_BUF_LEN bytes.
+    let text = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
     if text.is_empty() {
         None
     } else {

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -435,7 +435,17 @@ pub fn detect_span_corrections(
 /// "Kubernetes" and "Koobernetes" share a similar skeleton while
 /// "running" and "ran" do not.
 pub fn consonant_skeleton(word: &str) -> String {
-    const VOWELS: &[char] = &['a', 'e', 'i', 'o', 'u', 'y'];
+    const VOWELS: &[char] = &[
+        'a', 'e', 'i', 'o', 'u', 'y',
+        // Common accented Latin vowels (e.g. "café", "naïve") so they are
+        // treated as vowels rather than unrelated consonants.
+        'à', 'á', 'â', 'ã', 'ä', 'å', 'ā',
+        'è', 'é', 'ê', 'ë', 'ē',
+        'ì', 'í', 'î', 'ï', 'ī',
+        'ò', 'ó', 'ô', 'õ', 'ö', 'ō', 'ø',
+        'ù', 'ú', 'û', 'ü', 'ū',
+        'ý', 'ÿ',
+    ];
     let mut out = String::new();
     let mut prev: Option<char> = None;
     for ch in word.chars().flat_map(char::to_lowercase) {
@@ -609,6 +619,14 @@ mod tests {
         // "y" acts as a vowel in words like "type"/"rhythm" — treating it as a
         // consonant would make phonetically similar words diverge unnecessarily.
         assert_eq!(consonant_skeleton("typo"), consonant_skeleton("tipo"));
+    }
+
+    #[test]
+    fn consonant_skeleton_treats_accented_vowels_as_vowels() {
+        // Accented vowels (e.g. "café"/"naïve") must not be treated as
+        // consonants, or their skeletons would diverge from the unaccented form.
+        assert_eq!(consonant_skeleton("café"), consonant_skeleton("cafe"));
+        assert_eq!(consonant_skeleton("naïve"), consonant_skeleton("naive"));
     }
 
     #[test]

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -307,12 +307,15 @@ pub fn align_word_ops(
 ) -> Vec<(AlignOp, Option<usize>, Option<usize>)> {
     let m = original.len();
     let n = current.len();
-    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+    // A flat (m+1) x (n+1) table with row stride (n+1) — one allocation
+    // instead of m+1, and better cache locality than Vec<Vec<_>>.
+    let stride = n + 1;
+    let mut dp = vec![0usize; (m + 1) * stride];
 
-    for (i, row) in dp.iter_mut().enumerate().take(m + 1) {
+    for (i, row) in dp.chunks_exact_mut(stride).enumerate().take(m + 1) {
         row[0] = i;
     }
-    for (j, cell) in dp[0].iter_mut().enumerate().take(n + 1) {
+    for (j, cell) in dp[..stride].iter_mut().enumerate() {
         *cell = j;
     }
 
@@ -323,9 +326,10 @@ pub fn align_word_ops(
             } else {
                 1
             };
-            dp[i][j] = (dp[i - 1][j - 1] + replace_cost)
-                .min(dp[i - 1][j] + 1)
-                .min(dp[i][j - 1] + 1);
+            let idx = i * stride + j;
+            dp[idx] = (dp[(i - 1) * stride + (j - 1)] + replace_cost)
+                .min(dp[(i - 1) * stride + j] + 1)
+                .min(dp[i * stride + (j - 1)] + 1);
         }
     }
 
@@ -338,7 +342,7 @@ pub fn align_word_ops(
             } else {
                 1
             };
-            if dp[i][j] == dp[i - 1][j - 1] + replace_cost {
+            if dp[i * stride + j] == dp[(i - 1) * stride + (j - 1)] + replace_cost {
                 let op = if replace_cost == 0 {
                     AlignOp::Equal
                 } else {
@@ -350,7 +354,7 @@ pub fn align_word_ops(
                 continue;
             }
         }
-        if i > 0 && dp[i][j] == dp[i - 1][j] + 1 {
+        if i > 0 && dp[i * stride + j] == dp[(i - 1) * stride + j] + 1 {
             ops.push((AlignOp::Delete, Some(i - 1), None));
             i -= 1;
         } else {

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -6,6 +6,9 @@ pub const MIN_CANDIDATE_NORM_LEN: usize = 2;
 pub const MAX_SPAN_GROWTH_WORDS: usize = 5;
 pub const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
 pub const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
+// align_word_ops runs an O(M*N) DP alignment; cap span lengths so a
+// pathologically long dictation can't blow up CPU/memory.
+pub const MAX_SPAN_TOKENS: usize = 300;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WordToken {
@@ -370,6 +373,9 @@ pub fn detect_span_corrections(
     if original.is_empty() || current.is_empty() {
         return vec![];
     }
+    if original.len() > MAX_SPAN_TOKENS || current.len() > MAX_SPAN_TOKENS {
+        return vec![];
+    }
     if current.len() > original.len() * 2 + MAX_SPAN_GROWTH_WORDS {
         return vec![];
     }
@@ -564,6 +570,16 @@ mod tests {
     fn suffix_completion_rejected() {
         assert!(diff("send the file", "sends the file").is_empty());
         assert!(diff("we should do", "we should doing").is_empty());
+    }
+
+    #[test]
+    fn oversized_spans_rejected_before_alignment() {
+        // align_word_ops is O(M*N); spans longer than MAX_SPAN_TOKENS must be
+        // rejected up front so a pathologically long dictation can't blow up
+        // the alignment matrix.
+        let original = "word ".repeat(MAX_SPAN_TOKENS + 1);
+        let current = "term ".repeat(MAX_SPAN_TOKENS + 1);
+        assert!(diff(original.trim(), current.trim()).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -449,12 +449,45 @@ pub fn consonant_skeleton(word: &str) -> String {
     out
 }
 
+/// Casual contraction → formal-rewrite pairs that the cleanup LLM routinely
+/// applies (e.g. "gonna" → "going"). These are style normalizations, not
+/// transcription mistakes, so they must never be treated as plausible
+/// transcription confusions even though they're phonetically close.
+const COLLOQUIAL_NORMALIZATIONS: &[(&str, &str)] = &[
+    ("gonna", "going"),
+    ("wanna", "want"),
+    ("gotta", "got"),
+    ("kinda", "kind"),
+    ("sorta", "sort"),
+    ("lemme", "let"),
+    ("gimme", "give"),
+    ("dunno", "know"),
+    ("hafta", "have"),
+    ("cuz", "because"),
+    ("cause", "because"),
+    ("til", "until"),
+    ("yall", "you"),
+    ("aint", "isn't"),
+];
+
+fn is_known_colloquial_pair(a: &str, b: &str) -> bool {
+    COLLOQUIAL_NORMALIZATIONS
+        .iter()
+        .any(|&(c, f)| (a == c && b == f) || (a == f && b == c))
+}
+
 /// Returns true when the pair looks like a plausible transcription confusion
 /// (same consonant skeleton, or edit-distance close enough relative to length).
 /// This gates Source A (cleanup divergence) from learning grammar/filler rewrites.
 pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> bool {
     let m_norm: String = mistake.chars().flat_map(char::to_lowercase).collect();
     let c_norm: String = correction.chars().flat_map(char::to_lowercase).collect();
+
+    let m_apos_stripped: String = m_norm.chars().filter(|&c| c != '\'').collect();
+    let c_apos_stripped: String = c_norm.chars().filter(|&c| c != '\'').collect();
+    if is_known_colloquial_pair(&m_apos_stripped, &c_apos_stripped) {
+        return false;
+    }
 
     let skel_m = consonant_skeleton(&m_norm);
     let skel_c = consonant_skeleton(&c_norm);
@@ -475,7 +508,7 @@ pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> 
     let dist = edit_distance(&m_norm, &c_norm);
     let max_len = m_norm.chars().count().max(c_norm.chars().count()).max(1);
     if max_len <= 5 {
-        dist + 1 <= max_len
+        dist < max_len
     } else {
         dist <= max_len / 3 + 1
     }
@@ -550,6 +583,17 @@ mod tests {
     fn phonetic_confusion_rejects_grammar_rewrite() {
         // "running" → "sprint" is not a transcription confusion
         assert!(!is_plausible_transcription_confusion("running", "sprint"));
+    }
+
+    #[test]
+    fn phonetic_confusion_rejects_gonna_going() {
+        // "gonna" → "going" is a cleanup style normalization, not a mistranscription.
+        assert!(!is_plausible_transcription_confusion("gonna", "going"));
+    }
+
+    #[test]
+    fn phonetic_confusion_rejects_wanna_want() {
+        assert!(!is_plausible_transcription_confusion("wanna", "want"));
     }
 
     #[test]

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -435,7 +435,7 @@ pub fn detect_span_corrections(
 /// "Kubernetes" and "Koobernetes" share a similar skeleton while
 /// "running" and "ran" do not.
 pub fn consonant_skeleton(word: &str) -> String {
-    const VOWELS: &[char] = &['a', 'e', 'i', 'o', 'u'];
+    const VOWELS: &[char] = &['a', 'e', 'i', 'o', 'u', 'y'];
     let mut out = String::new();
     let mut prev: Option<char> = None;
     for ch in word.chars().flat_map(char::to_lowercase) {
@@ -600,5 +600,12 @@ mod tests {
     fn consonant_skeleton_basic() {
         assert_eq!(consonant_skeleton("kubernetes"), "kbrnts");
         assert_eq!(consonant_skeleton("koobernetes"), "kbrnts");
+    }
+
+    #[test]
+    fn consonant_skeleton_treats_y_as_vowel() {
+        // "y" acts as a vowel in words like "type"/"rhythm" — treating it as a
+        // consonant would make phonetically similar words diverge unnecessarily.
+        assert_eq!(consonant_skeleton("typo"), consonant_skeleton("tipo"));
     }
 }

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -1,0 +1,560 @@
+// Shared word-diff and candidate-scoring primitives.
+// Used by both the post-injection field monitor (api/auto_learn.rs) and the
+// in-pipeline raw↔clean divergence detector (pipeline.rs).
+
+pub const MIN_CANDIDATE_NORM_LEN: usize = 2;
+pub const MAX_SPAN_GROWTH_WORDS: usize = 5;
+pub const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
+pub const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WordToken {
+    pub raw: String,
+    pub norm: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CandidateCorrection {
+    pub mistake: String,
+    pub correction: String,
+    pub confidence: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CorrectionMetrics {
+    pub a_len: usize,
+    pub b_len: usize,
+    pub max_len: usize,
+    pub distance: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlignOp {
+    Equal,
+    Replace,
+    Insert,
+    Delete,
+}
+
+pub fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    let mut row: Vec<usize> = (0..=n).collect();
+    for i in 1..=m {
+        let mut prev = row[0];
+        row[0] = i;
+        for j in 1..=n {
+            let old = row[j];
+            row[j] = if a[i - 1] == b[j - 1] {
+                prev
+            } else {
+                1 + prev.min(row[j]).min(row[j - 1])
+            };
+            prev = old;
+        }
+    }
+    row[n]
+}
+
+pub fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || matches!(c, '\'' | '-' | '_')
+}
+
+fn normalize_word(word: &str) -> String {
+    word.chars()
+        .filter(|c| is_word_char(*c))
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+pub fn tokenize_words(text: &str) -> Vec<WordToken> {
+    let mut tokens = Vec::new();
+    let mut start = None;
+
+    for (idx, ch) in text.char_indices() {
+        if is_word_char(ch) {
+            if start.is_none() {
+                start = Some(idx);
+            }
+        } else if let Some(s) = start.take() {
+            let raw = &text[s..idx];
+            let norm = normalize_word(raw);
+            if !norm.is_empty() {
+                tokens.push(WordToken {
+                    raw: raw.to_string(),
+                    norm,
+                });
+            }
+        }
+    }
+
+    if let Some(s) = start {
+        let raw = &text[s..];
+        let norm = normalize_word(raw);
+        if !norm.is_empty() {
+            tokens.push(WordToken {
+                raw: raw.to_string(),
+                norm,
+            });
+        }
+    }
+
+    tokens
+}
+
+pub fn has_distinctive_features(token: &str) -> bool {
+    if !token.is_ascii() {
+        return true;
+    }
+    if token.len() >= 4
+        && token
+            .chars()
+            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
+    {
+        return true;
+    }
+    if token
+        .chars()
+        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
+    {
+        return true;
+    }
+
+    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
+    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
+}
+
+pub fn is_common_word(word: &str) -> bool {
+    matches!(
+        word,
+        "a" | "about"
+            | "after"
+            | "all"
+            | "also"
+            | "am"
+            | "an"
+            | "and"
+            | "are"
+            | "as"
+            | "ask"
+            | "at"
+            | "be"
+            | "but"
+            | "by"
+            | "can"
+            | "do"
+            | "for"
+            | "from"
+            | "get"
+            | "go"
+            | "had"
+            | "has"
+            | "have"
+            | "he"
+            | "her"
+            | "him"
+            | "his"
+            | "i"
+            | "if"
+            | "in"
+            | "is"
+            | "it"
+            | "its"
+            | "just"
+            | "me"
+            | "my"
+            | "no"
+            | "not"
+            | "of"
+            | "on"
+            | "or"
+            | "our"
+            | "out"
+            | "so"
+            | "ship"
+            | "shop"
+            | "that"
+            | "the"
+            | "them"
+            | "then"
+            | "there"
+            | "their"
+            | "they"
+            | "this"
+            | "to"
+            | "up"
+            | "us"
+            | "was"
+            | "we"
+            | "what"
+            | "when"
+            | "with"
+            | "you"
+            | "your"
+    )
+}
+
+pub fn compute_correction_metrics(
+    original: &WordToken,
+    corrected: &WordToken,
+) -> CorrectionMetrics {
+    let a_len = original.norm.chars().count();
+    let b_len = corrected.norm.chars().count();
+    let max_len = a_len.max(b_len);
+    let distance = edit_distance(&original.norm, &corrected.norm);
+    CorrectionMetrics {
+        a_len,
+        b_len,
+        max_len,
+        distance,
+    }
+}
+
+fn is_plain_suffix_completion(original: &str, corrected: &str) -> bool {
+    if let Some(suffix) = corrected.strip_prefix(original) {
+        return is_low_signal_suffix(suffix);
+    }
+
+    if let Some(suffix) = original.strip_prefix(corrected) {
+        return is_low_signal_suffix(suffix);
+    }
+
+    false
+}
+
+fn is_low_signal_suffix(suffix: &str) -> bool {
+    matches!(suffix, "s" | "d" | "e" | "g" | "ed" | "er" | "es" | "ing")
+        || suffix
+            .chars()
+            .all(|ch| matches!(ch, 'a' | 'e' | 'i' | 'o' | 'u'))
+}
+
+pub fn is_candidate_correction(
+    original: &WordToken,
+    corrected: &WordToken,
+    metrics: CorrectionMetrics,
+) -> bool {
+    if original.norm.is_empty() || corrected.norm.is_empty() {
+        return false;
+    }
+    if original.norm == corrected.norm {
+        return false;
+    }
+    if metrics.a_len < MIN_CANDIDATE_NORM_LEN || metrics.b_len < MIN_CANDIDATE_NORM_LEN {
+        return false;
+    }
+
+    let original_distinct = has_distinctive_features(&original.raw);
+    let corrected_distinct = has_distinctive_features(&corrected.raw);
+    if metrics.max_len <= 3 && !original_distinct && !corrected_distinct {
+        return false;
+    }
+
+    if is_common_word(&original.norm)
+        && is_common_word(&corrected.norm)
+        && !original_distinct
+        && !corrected_distinct
+    {
+        return false;
+    }
+
+    if is_plain_suffix_completion(&original.norm, &corrected.norm)
+        && !original_distinct
+        && !corrected_distinct
+    {
+        return false;
+    }
+
+    metrics.distance <= 2_usize.max(metrics.max_len / 2)
+        || ((original_distinct || corrected_distinct)
+            && metrics.max_len >= 4
+            && metrics.distance <= 3)
+}
+
+pub fn candidate_confidence(
+    original: &WordToken,
+    corrected: &WordToken,
+    metrics: CorrectionMetrics,
+    changed_ops: usize,
+    replacements_len: usize,
+) -> f64 {
+    let distance = metrics.distance as f64;
+    let max_len = metrics.max_len.max(1) as f64;
+    let ratio_score = 1.0 - (distance / max_len).min(1.0);
+
+    let mut score = ratio_score * 0.55;
+    if has_distinctive_features(&original.raw) || has_distinctive_features(&corrected.raw) {
+        score += 0.25;
+        if metrics.max_len <= 5 && metrics.distance <= 3 {
+            score += 0.10;
+        }
+    }
+    if is_common_word(&original.norm) && is_common_word(&corrected.norm) {
+        score -= 0.2;
+    }
+    score -= (changed_ops.saturating_sub(1) as f64) * 0.07;
+    score -= (replacements_len.saturating_sub(1) as f64) * 0.08;
+    score.clamp(0.0, 1.0)
+}
+
+pub fn align_word_ops(
+    original: &[WordToken],
+    current: &[WordToken],
+) -> Vec<(AlignOp, Option<usize>, Option<usize>)> {
+    let m = original.len();
+    let n = current.len();
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+
+    for (i, row) in dp.iter_mut().enumerate().take(m + 1) {
+        row[0] = i;
+    }
+    for (j, cell) in dp[0].iter_mut().enumerate().take(n + 1) {
+        *cell = j;
+    }
+
+    for i in 1..=m {
+        for j in 1..=n {
+            let replace_cost = if original[i - 1].norm == current[j - 1].norm {
+                0
+            } else {
+                1
+            };
+            dp[i][j] = (dp[i - 1][j - 1] + replace_cost)
+                .min(dp[i - 1][j] + 1)
+                .min(dp[i][j - 1] + 1);
+        }
+    }
+
+    let mut ops = Vec::new();
+    let (mut i, mut j) = (m, n);
+    while i > 0 || j > 0 {
+        if i > 0 && j > 0 {
+            let replace_cost = if original[i - 1].norm == current[j - 1].norm {
+                0
+            } else {
+                1
+            };
+            if dp[i][j] == dp[i - 1][j - 1] + replace_cost {
+                let op = if replace_cost == 0 {
+                    AlignOp::Equal
+                } else {
+                    AlignOp::Replace
+                };
+                ops.push((op, Some(i - 1), Some(j - 1)));
+                i -= 1;
+                j -= 1;
+                continue;
+            }
+        }
+        if i > 0 && dp[i][j] == dp[i - 1][j] + 1 {
+            ops.push((AlignOp::Delete, Some(i - 1), None));
+            i -= 1;
+        } else {
+            ops.push((AlignOp::Insert, None, Some(j - 1)));
+            j -= 1;
+        }
+    }
+
+    ops.reverse();
+    ops
+}
+
+pub fn detect_span_corrections(
+    original_span: &str,
+    current_span: &str,
+) -> Vec<CandidateCorrection> {
+    let original = tokenize_words(original_span);
+    let current = tokenize_words(current_span);
+
+    if original.is_empty() || current.is_empty() {
+        return vec![];
+    }
+    if current.len() > original.len() * 2 + MAX_SPAN_GROWTH_WORDS {
+        return vec![];
+    }
+
+    let ops = align_word_ops(&original, &current);
+    let changed_ops = ops
+        .iter()
+        .filter(|(op, _, _)| *op != AlignOp::Equal)
+        .count();
+    if changed_ops > MAX_CHANGED_OPS_PER_SPAN {
+        log::debug!("correction_diff: rejected span with too many changed word operations");
+        return vec![];
+    }
+
+    let replacements: Vec<_> = ops
+        .iter()
+        .filter_map(|(op, old_idx, new_idx)| {
+            if *op == AlignOp::Replace {
+                Some((old_idx.unwrap(), new_idx.unwrap()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if replacements.len() > MAX_REPLACEMENTS_PER_SPAN {
+        log::debug!("correction_diff: rejected span with too many replacements");
+        return vec![];
+    }
+
+    let replacements_len = replacements.len();
+    replacements
+        .into_iter()
+        .filter_map(|(old_idx, new_idx)| {
+            let old = &original[old_idx];
+            let new = &current[new_idx];
+            if old.norm.is_empty() || new.norm.is_empty() || old.norm == new.norm {
+                return None;
+            }
+            let metrics = compute_correction_metrics(old, new);
+            if is_candidate_correction(old, new, metrics) {
+                Some(CandidateCorrection {
+                    mistake: old.raw.clone(),
+                    correction: new.raw.clone(),
+                    confidence: candidate_confidence(
+                        old,
+                        new,
+                        metrics,
+                        changed_ops,
+                        replacements_len,
+                    ),
+                })
+            } else {
+                log::debug!("correction_diff: rejected low-confidence candidate");
+                None
+            }
+        })
+        .collect()
+}
+
+/// Computes a simple consonant-skeleton for phonetic similarity gating.
+/// Reduces a word to its consonants (minus repeated adjacents) so that
+/// "Kubernetes" and "Koobernetes" share a similar skeleton while
+/// "running" and "ran" do not.
+pub fn consonant_skeleton(word: &str) -> String {
+    const VOWELS: &[char] = &['a', 'e', 'i', 'o', 'u'];
+    let mut out = String::new();
+    let mut prev: Option<char> = None;
+    for ch in word.chars().flat_map(char::to_lowercase) {
+        if !VOWELS.contains(&ch) && ch.is_alphabetic() {
+            if prev != Some(ch) {
+                out.push(ch);
+            }
+            prev = Some(ch);
+        }
+    }
+    out
+}
+
+/// Returns true when the pair looks like a plausible transcription confusion
+/// (same consonant skeleton, or edit-distance close enough relative to length).
+/// This gates Source A (cleanup divergence) from learning grammar/filler rewrites.
+pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> bool {
+    let m_norm: String = mistake.chars().flat_map(char::to_lowercase).collect();
+    let c_norm: String = correction.chars().flat_map(char::to_lowercase).collect();
+
+    let skel_m = consonant_skeleton(&m_norm);
+    let skel_c = consonant_skeleton(&c_norm);
+
+    if skel_m == skel_c {
+        return true;
+    }
+
+    let skel_dist = edit_distance(&skel_m, &skel_c);
+    let skel_max = skel_m.len().max(skel_c.len()).max(1);
+    if skel_dist <= skel_max / 3 + 1 {
+        return true;
+    }
+
+    // Fallback: surface-level ratio.
+    // Short words (≤5 chars) get a lenient threshold because brand names can look
+    // very different phonetically despite sounding identical (e.g. "rock" / "Groq").
+    let dist = edit_distance(&m_norm, &c_norm);
+    let max_len = m_norm.chars().count().max(c_norm.chars().count()).max(1);
+    if max_len <= 5 {
+        dist + 1 <= max_len
+    } else {
+        dist <= max_len / 3 + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diff(original: &str, current: &str) -> Vec<(String, String)> {
+        detect_span_corrections(original, current)
+            .into_iter()
+            .map(|c| (c.mistake, c.correction))
+            .collect()
+    }
+
+    #[test]
+    fn simple_typo_detected() {
+        assert_eq!(
+            diff(
+                "please use Koobernetes today",
+                "please use Kubernetes today"
+            ),
+            vec![("Koobernetes".to_string(), "Kubernetes".to_string())]
+        );
+    }
+
+    #[test]
+    fn casing_only_change_rejected() {
+        assert!(diff("Ask.", "Ask").is_empty());
+        assert!(diff("ask", "Ask").is_empty());
+    }
+
+    #[test]
+    fn suffix_completion_rejected() {
+        assert!(diff("send the file", "sends the file").is_empty());
+        assert!(diff("we should do", "we should doing").is_empty());
+    }
+
+    #[test]
+    fn short_technical_term_detected() {
+        assert_eq!(
+            diff("bran rot hosting", "bran qroq hosting"),
+            vec![("rot".to_string(), "qroq".to_string())]
+        );
+    }
+
+    #[test]
+    fn phonetic_confusion_kubernetes() {
+        assert!(is_plausible_transcription_confusion(
+            "Koobernetes",
+            "Kubernetes"
+        ));
+    }
+
+    #[test]
+    fn phonetic_confusion_groq() {
+        assert!(is_plausible_transcription_confusion("rock", "qroq"));
+    }
+
+    #[test]
+    fn short_brand_confidence_clears_evidence_gate() {
+        let candidates = detect_span_corrections("use rock hosting", "use qroq hosting");
+        assert_eq!(candidates.len(), 1);
+        assert!(
+            candidates[0].confidence >= 0.45,
+            "short brand corrections must be strong enough to record as evidence"
+        );
+    }
+
+    #[test]
+    fn phonetic_confusion_rejects_grammar_rewrite() {
+        // "running" → "sprint" is not a transcription confusion
+        assert!(!is_plausible_transcription_confusion("running", "sprint"));
+    }
+
+    #[test]
+    fn consonant_skeleton_basic() {
+        assert_eq!(consonant_skeleton("kubernetes"), "kbrnts");
+        assert_eq!(consonant_skeleton("koobernetes"), "kbrnts");
+    }
+}

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -439,7 +439,9 @@ pub fn consonant_skeleton(word: &str) -> String {
     let mut out = String::new();
     let mut prev: Option<char> = None;
     for ch in word.chars().flat_map(char::to_lowercase) {
-        if !VOWELS.contains(&ch) && ch.is_alphabetic() {
+        if VOWELS.contains(&ch) {
+            prev = None;
+        } else if ch.is_alphabetic() {
             if prev != Some(ch) {
                 out.push(ch);
             }
@@ -607,5 +609,14 @@ mod tests {
         // "y" acts as a vowel in words like "type"/"rhythm" — treating it as a
         // consonant would make phonetically similar words diverge unnecessarily.
         assert_eq!(consonant_skeleton("typo"), consonant_skeleton("tipo"));
+    }
+
+    #[test]
+    fn consonant_skeleton_keeps_consonants_separated_by_vowels() {
+        // A repeated consonant separated by a vowel (e.g. "state") must not be
+        // collapsed into a single occurrence — only directly-adjacent
+        // duplicates (from the same letter, e.g. "koobernetes") collapse.
+        assert_eq!(consonant_skeleton("state"), "stt");
+        assert_ne!(consonant_skeleton("state"), consonant_skeleton("sat"));
     }
 }

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -489,7 +489,7 @@ const COLLOQUIAL_NORMALIZATIONS: &[(&str, &str)] = &[
     ("cause", "because"),
     ("til", "until"),
     ("yall", "you"),
-    ("aint", "isn't"),
+    ("aint", "isnt"),
 ];
 
 fn is_known_colloquial_pair(a: &str, b: &str) -> bool {

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -502,9 +502,9 @@ fn is_known_colloquial_pair(a: &str, b: &str) -> bool {
 /// (same consonant skeleton, or edit-distance close enough relative to length).
 /// This gates Source A (cleanup divergence) from learning grammar/filler rewrites.
 pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> bool {
-    let m_digits: String = mistake.chars().filter(|c| c.is_ascii_digit()).collect();
-    let c_digits: String = correction.chars().filter(|c| c.is_ascii_digit()).collect();
-    if m_digits != c_digits {
+    let m_digits = mistake.chars().filter(|c| c.is_ascii_digit());
+    let c_digits = correction.chars().filter(|c| c.is_ascii_digit());
+    if !m_digits.eq(c_digits) {
         return false;
     }
 

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -497,7 +497,7 @@ pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> 
     }
 
     let skel_dist = edit_distance(&skel_m, &skel_c);
-    let skel_max = skel_m.len().max(skel_c.len()).max(1);
+    let skel_max = skel_m.chars().count().max(skel_c.chars().count()).max(1);
     if skel_dist <= skel_max / 3 + 1 {
         return true;
     }

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -451,7 +451,7 @@ pub fn consonant_skeleton(word: &str) -> String {
     for ch in word.chars().flat_map(char::to_lowercase) {
         if VOWELS.contains(&ch) {
             prev = None;
-        } else if ch.is_alphabetic() {
+        } else if ch.is_alphanumeric() {
             if prev != Some(ch) {
                 out.push(ch);
             }
@@ -492,6 +492,12 @@ fn is_known_colloquial_pair(a: &str, b: &str) -> bool {
 /// (same consonant skeleton, or edit-distance close enough relative to length).
 /// This gates Source A (cleanup divergence) from learning grammar/filler rewrites.
 pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> bool {
+    let m_digits: String = mistake.chars().filter(|c| c.is_ascii_digit()).collect();
+    let c_digits: String = correction.chars().filter(|c| c.is_ascii_digit()).collect();
+    if m_digits != c_digits {
+        return false;
+    }
+
     let m_norm: String = mistake.chars().flat_map(char::to_lowercase).collect();
     let c_norm: String = correction.chars().flat_map(char::to_lowercase).collect();
 
@@ -609,6 +615,14 @@ mod tests {
     }
 
     #[test]
+    fn phonetic_confusion_rejects_differing_digits() {
+        // "IPv4" vs "IPv6" / "100" vs "200" are distinct values, not
+        // transcription confusions, even though their skeletons match.
+        assert!(!is_plausible_transcription_confusion("IPv4", "IPv6"));
+        assert!(!is_plausible_transcription_confusion("100", "200"));
+    }
+
+    #[test]
     fn consonant_skeleton_basic() {
         assert_eq!(consonant_skeleton("kubernetes"), "kbrnts");
         assert_eq!(consonant_skeleton("koobernetes"), "kbrnts");
@@ -636,5 +650,14 @@ mod tests {
         // duplicates (from the same letter, e.g. "koobernetes") collapse.
         assert_eq!(consonant_skeleton("state"), "stt");
         assert_ne!(consonant_skeleton("state"), consonant_skeleton("sat"));
+    }
+
+    #[test]
+    fn consonant_skeleton_preserves_digits() {
+        // Purely numeric words must not collapse to an empty skeleton, or
+        // distinct numbers (e.g. "100" vs "200") would look identical.
+        assert_eq!(consonant_skeleton("100"), "10");
+        assert_ne!(consonant_skeleton("100"), consonant_skeleton("200"));
+        assert!(!consonant_skeleton("100").is_empty());
     }
 }

--- a/src-tauri/src/core/correction_diff.rs
+++ b/src-tauri/src/core/correction_diff.rs
@@ -535,8 +535,10 @@ pub fn is_plausible_transcription_confusion(mistake: &str, correction: &str) -> 
     // very different phonetically despite sounding identical (e.g. "rock" / "Groq").
     let dist = edit_distance(&m_norm, &c_norm);
     let max_len = m_norm.chars().count().max(c_norm.chars().count()).max(1);
-    if max_len <= 5 {
-        dist < max_len
+    if max_len <= 3 {
+        dist <= 1
+    } else if max_len <= 5 {
+        dist <= 3
     } else {
         dist <= max_len / 3 + 1
     }
@@ -621,6 +623,14 @@ mod tests {
     fn phonetic_confusion_rejects_grammar_rewrite() {
         // "running" → "sprint" is not a transcription confusion
         assert!(!is_plausible_transcription_confusion("running", "sprint"));
+    }
+
+    #[test]
+    fn phonetic_confusion_rejects_unrelated_short_words() {
+        // The fallback ratio for short words must not be so lenient that
+        // unrelated words are treated as transcription confusions.
+        assert!(!is_plausible_transcription_confusion("cat", "map"));
+        assert!(!is_plausible_transcription_confusion("apple", "alien"));
     }
 
     #[test]

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,8 +1,9 @@
 pub mod context_probe;
+pub mod correction_diff;
 pub mod hotkey;
 pub mod injection;
 pub mod text_context;
 pub mod window_context;
 
 #[cfg(target_os = "macos")]
-mod context_probe_macos;
+pub mod context_probe_macos;

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1172,7 +1172,7 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
             params![mistake, term],
         )?;
         tx.execute(
-            "DELETE FROM correction_evidence WHERE wrong_word = ?1 COLLATE NOCASE AND correct_word = ?2 COLLATE NOCASE",
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
             params![mistake, term],
         )?;
     }
@@ -1197,8 +1197,13 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
         let mut del_candidate_stmt = tx.prepare(
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
+        // `mistake`/`term` come from `dictionary` and are stored with the same
+        // casing as `correction_evidence.wrong_word`/`correct_word` (both
+        // lowercased via record_evidence_and_maybe_promote's D1 normalization),
+        // so a binary comparison here lets SQLite use idx_correction_evidence_pair
+        // instead of forcing a full table scan via COLLATE NOCASE.
         let mut del_evidence_stmt = tx.prepare(
-            "DELETE FROM correction_evidence WHERE wrong_word = ?1 COLLATE NOCASE AND correct_word = ?2 COLLATE NOCASE",
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
 
         for chunk in ids.chunks(SQL_BATCH_SIZE) {

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -913,7 +913,7 @@ pub fn compute_evidence_score(
     let mut sources = std::collections::HashSet::new();
 
     for row in &evidence {
-        let decay = (-row.age_days / half_life_days.max(0.1)).exp();
+        let decay = (-row.age_days.max(0.0) / half_life_days.max(0.1)).exp();
         score += row.weight * row.confidence * decay;
         if !row.session_id.is_empty() {
             sessions.insert(row.session_id.clone());
@@ -1133,6 +1133,10 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
             params![mistake, term],
         )?;
+        tx.execute(
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
+            params![mistake, term],
+        )?;
     }
 
     tx.commit()?;
@@ -1154,6 +1158,9 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
         )?;
         let mut del_candidate_stmt = tx.prepare(
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
+        )?;
+        let mut del_evidence_stmt = tx.prepare(
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
 
         for chunk in ids.chunks(SQL_BATCH_SIZE) {
@@ -1177,6 +1184,7 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
             for (term, mistake) in pairs {
                 del_pending_stmt.execute(params![mistake, term])?;
                 del_candidate_stmt.execute(params![mistake, term])?;
+                del_evidence_stmt.execute(params![mistake, term])?;
             }
         }
     }
@@ -1803,6 +1811,28 @@ mod tests {
         // Simulate pending correction records that led to the promotion.
         insert_pending_correction(&db, "Tari", "Tauri").expect("pending 1");
         insert_pending_correction(&db, "Tari", "Tauri").expect("pending 2");
+        insert_correction_evidence(
+            &db,
+            "Tari",
+            "Tauri",
+            "post_edit",
+            1.0,
+            0.9,
+            "sess-a",
+            "test",
+        )
+        .expect("evidence 1");
+        insert_correction_evidence(
+            &db,
+            "Tari",
+            "Tauri",
+            "post_edit",
+            1.0,
+            0.9,
+            "sess-b",
+            "test",
+        )
+        .expect("evidence 2");
         assert_eq!(
             count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count"),
             2
@@ -1817,6 +1847,11 @@ mod tests {
         assert_eq!(
             count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
             0
+        );
+        let evidence_score = compute_evidence_score(&db, "Tari", "Tauri", 7, 1.5).expect("score");
+        assert_eq!(
+            evidence_score.score, 0.0,
+            "rejection must also purge evidence"
         );
     }
 
@@ -1954,6 +1989,17 @@ mod tests {
             .id;
 
         insert_pending_correction(&db, "Tari", "Tauri").expect("pending");
+        insert_correction_evidence(
+            &db,
+            "Tari",
+            "Tauri",
+            "post_edit",
+            1.0,
+            0.9,
+            "sess-a",
+            "test",
+        )
+        .expect("evidence");
         assert_eq!(
             count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count before"),
             1
@@ -1966,6 +2012,11 @@ mod tests {
             count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
             0,
             "pending corrections must be purged when the auto-learned entry is manually deleted"
+        );
+        let evidence_score = compute_evidence_score(&db, "Tari", "Tauri", 7, 1.5).expect("score");
+        assert_eq!(
+            evidence_score.score, 0.0,
+            "manual delete must also purge evidence to prevent immediate re-promotion"
         );
     }
 
@@ -2142,6 +2193,26 @@ mod tests {
         assert!(
             ev14.score > 0.0,
             "evidence inside 14-day window must contribute"
+        );
+    }
+
+    #[test]
+    fn evidence_score_clamps_future_dated_rows() {
+        let db = test_db();
+        {
+            let conn = db.lock().expect("lock");
+            conn.execute(
+                "INSERT INTO correction_evidence (wrong_word, correct_word, source, weight, confidence, session_id, app_context, created_at) \
+                 VALUES ('rock', 'qroq', 'post_edit', 1.0, 0.9, 'future-session', 'test', datetime('now', '+10 days'))",
+                [],
+            )
+            .expect("future insert");
+        }
+
+        let ev = compute_evidence_score(&db, "rock", "qroq", 30, 1.5).expect("score");
+        assert!(
+            (ev.score - 0.9).abs() < 1e-6,
+            "future-dated evidence must not amplify score above its raw weight*confidence"
         );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1332,6 +1332,17 @@ pub struct ImportBackupCounts {
     pub never_learn_pairs_inserted: usize,
 }
 
+/// Returns true if `e` wraps a SQLite UNIQUE/constraint violation, so
+/// import_backup_records can distinguish "row already exists" from real
+/// insert failures without relying on the error message text.
+fn is_unique_constraint_violation(e: &anyhow::Error) -> bool {
+    matches!(
+        e.downcast_ref::<rusqlite::Error>(),
+        Some(rusqlite::Error::SqliteFailure(err, _))
+            if err.code == rusqlite::ErrorCode::ConstraintViolation
+    )
+}
+
 /// Inserts backup records inside a single transaction so a large import
 /// doesn't pay a disk sync per row (one INSERT == one implicit transaction
 /// in SQLite's default autocommit mode).
@@ -1356,7 +1367,7 @@ pub fn import_backup_records(
         ) {
             Ok(()) => counts.dictionary_inserted += 1,
             Err(e) => {
-                if e.to_string().contains("UNIQUE constraint failed") {
+                if is_unique_constraint_violation(&e) {
                     counts.dictionary_already_existed += 1;
                 } else {
                     log::warn!("import_backup_records: dictionary insert error for '{}': {e}", entry.term);
@@ -1370,7 +1381,7 @@ pub fn import_backup_records(
         match insert_snippet_returning_conn(&tx, snippet.trigger, snippet.expansion, snippet.instructions) {
             Ok(_) => counts.snippets_inserted += 1,
             Err(e) => {
-                if e.to_string().contains("UNIQUE constraint failed") {
+                if is_unique_constraint_violation(&e) {
                     counts.snippets_already_existed += 1;
                 } else {
                     log::warn!("import_backup_records: snippet insert error for '{}': {e}", snippet.trigger);

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -705,8 +705,8 @@ pub fn insert_dictionary_entry_returning(
     Ok(CreatedRecordMeta { id, created_at })
 }
 
-pub fn insert_dictionary_entry_from_backup(
-    db: &Db,
+fn insert_dictionary_entry_from_backup_conn(
+    conn: &Connection,
     term: &str,
     mistake: Option<&str>,
     auto_learned: bool,
@@ -719,7 +719,6 @@ pub fn insert_dictionary_entry_from_backup(
     if let Some(m) = normalized_mistake.as_deref() {
         validate_char_limit("Often mistranscribed as", m, DICTIONARY_ENTRY_CHAR_LIMIT)?;
     }
-    let conn = lock_conn(db)?;
     conn.execute(
         "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at) \
          VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
@@ -832,13 +831,17 @@ pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> 
     Ok(count > 0)
 }
 
-pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
-    let conn = lock_conn(db)?;
+fn insert_never_learn_pair_conn(conn: &Connection, wrong: &str, correct: &str) -> Result<()> {
     conn.execute(
         "INSERT OR IGNORE INTO never_learn_pairs (wrong_word, correct_word) VALUES (?1, ?2)",
         params![wrong.to_lowercase(), correct],
     )?;
     Ok(())
+}
+
+pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    insert_never_learn_pair_conn(&conn, wrong, correct)
 }
 
 pub fn delete_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
@@ -1250,8 +1253,8 @@ pub fn insert_snippet(db: &Db, trigger: &str, expansion: &str, instructions: &st
     Ok(())
 }
 
-pub fn insert_snippet_returning(
-    db: &Db,
+fn insert_snippet_returning_conn(
+    conn: &Connection,
     trigger: &str,
     expansion: &str,
     instructions: &str,
@@ -1264,9 +1267,6 @@ pub fn insert_snippet_returning(
     }
     let normalized_instructions = normalize_multiline(instructions);
 
-    // Insert and read last_insert_rowid under a single lock to prevent another
-    // thread's insert racing between the two acquisitions and returning the wrong id.
-    let conn = lock_conn(db)?;
     conn.execute(
         "INSERT INTO snippets (trigger, expansion, instructions) VALUES (?1, ?2, ?3)",
         params![
@@ -1282,6 +1282,105 @@ pub fn insert_snippet_returning(
         |r| r.get(0),
     )?;
     Ok(CreatedRecordMeta { id, created_at })
+}
+
+pub fn insert_snippet_returning(
+    db: &Db,
+    trigger: &str,
+    expansion: &str,
+    instructions: &str,
+) -> Result<CreatedRecordMeta> {
+    // Insert and read last_insert_rowid under a single lock to prevent another
+    // thread's insert racing between the two acquisitions and returning the wrong id.
+    let conn = lock_conn(db)?;
+    insert_snippet_returning_conn(&conn, trigger, expansion, instructions)
+}
+
+pub struct BackupDictionaryEntry<'a> {
+    pub term: &'a str,
+    pub mistake: Option<&'a str>,
+    pub auto_learned: bool,
+    pub confidence_tier: &'a str,
+    pub correction_count: i64,
+}
+
+pub struct BackupSnippet<'a> {
+    pub trigger: &'a str,
+    pub expansion: &'a str,
+    pub instructions: &'a str,
+}
+
+pub struct BackupNeverLearnPair<'a> {
+    pub wrong: &'a str,
+    pub correct: &'a str,
+}
+
+#[derive(Default)]
+pub struct ImportBackupCounts {
+    pub dictionary_inserted: usize,
+    pub dictionary_already_existed: usize,
+    pub dictionary_failed: usize,
+    pub snippets_inserted: usize,
+    pub snippets_already_existed: usize,
+    pub snippets_failed: usize,
+    pub never_learn_pairs_inserted: usize,
+}
+
+/// Inserts backup records inside a single transaction so a large import
+/// doesn't pay a disk sync per row (one INSERT == one implicit transaction
+/// in SQLite's default autocommit mode).
+pub fn import_backup_records(
+    db: &Db,
+    dictionary: &[BackupDictionaryEntry],
+    snippets: &[BackupSnippet],
+    never_learn_pairs: &[BackupNeverLearnPair],
+) -> Result<ImportBackupCounts> {
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let mut counts = ImportBackupCounts::default();
+
+    for entry in dictionary {
+        match insert_dictionary_entry_from_backup_conn(
+            &tx,
+            entry.term,
+            entry.mistake,
+            entry.auto_learned,
+            entry.confidence_tier,
+            entry.correction_count,
+        ) {
+            Ok(()) => counts.dictionary_inserted += 1,
+            Err(e) => {
+                if e.to_string().contains("UNIQUE constraint failed") {
+                    counts.dictionary_already_existed += 1;
+                } else {
+                    log::warn!("import_backup_records: dictionary insert error for '{}': {e}", entry.term);
+                    counts.dictionary_failed += 1;
+                }
+            }
+        }
+    }
+
+    for snippet in snippets {
+        match insert_snippet_returning_conn(&tx, snippet.trigger, snippet.expansion, snippet.instructions) {
+            Ok(_) => counts.snippets_inserted += 1,
+            Err(e) => {
+                if e.to_string().contains("UNIQUE constraint failed") {
+                    counts.snippets_already_existed += 1;
+                } else {
+                    log::warn!("import_backup_records: snippet insert error for '{}': {e}", snippet.trigger);
+                    counts.snippets_failed += 1;
+                }
+            }
+        }
+    }
+
+    for pair in never_learn_pairs {
+        insert_never_learn_pair_conn(&tx, pair.wrong, pair.correct)?;
+        counts.never_learn_pairs_inserted += 1;
+    }
+
+    tx.commit()?;
+    Ok(counts)
 }
 
 pub fn update_snippet(
@@ -2442,5 +2541,61 @@ mod tests {
             (ev.score - 0.9).abs() < 1e-6,
             "future-dated evidence must not amplify score above its raw weight*confidence"
         );
+    }
+
+    #[test]
+    fn import_backup_records_inserts_all_kinds_in_one_transaction() {
+        let db = test_db();
+        let dictionary = vec![BackupDictionaryEntry {
+            term: "Kubernetes",
+            mistake: Some("koobernetes"),
+            auto_learned: true,
+            confidence_tier: "high",
+            correction_count: 3,
+        }];
+        let snippets = vec![BackupSnippet {
+            trigger: "sig",
+            expansion: "Best regards,\nA",
+            instructions: "",
+        }];
+        let never_learn_pairs = vec![BackupNeverLearnPair {
+            wrong: "rock",
+            correct: "qroq",
+        }];
+
+        let counts = import_backup_records(&db, &dictionary, &snippets, &never_learn_pairs)
+            .expect("import");
+        assert_eq!(counts.dictionary_inserted, 1);
+        assert_eq!(counts.dictionary_already_existed, 0);
+        assert_eq!(counts.snippets_inserted, 1);
+        assert_eq!(counts.snippets_already_existed, 0);
+        assert_eq!(counts.never_learn_pairs_inserted, 1);
+        assert!(is_never_learn_pair(&db, "rock", "qroq").expect("check"));
+    }
+
+    #[test]
+    fn import_backup_records_reports_existing_dictionary_and_snippet_conflicts() {
+        let db = test_db();
+        insert_dictionary_entry(&db, "Kubernetes", None).expect("seed dictionary");
+        insert_snippet_returning(&db, "sig", "Best regards,\nA", "").expect("seed snippet");
+
+        let dictionary = vec![BackupDictionaryEntry {
+            term: "Kubernetes",
+            mistake: None,
+            auto_learned: false,
+            confidence_tier: "high",
+            correction_count: 0,
+        }];
+        let snippets = vec![BackupSnippet {
+            trigger: "sig",
+            expansion: "Different expansion",
+            instructions: "",
+        }];
+
+        let counts = import_backup_records(&db, &dictionary, &snippets, &[]).expect("import");
+        assert_eq!(counts.dictionary_inserted, 0);
+        assert_eq!(counts.dictionary_already_existed, 1);
+        assert_eq!(counts.snippets_inserted, 0);
+        assert_eq!(counts.snippets_already_existed, 1);
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -411,7 +411,7 @@ pub fn open(path: &str) -> Result<Db> {
                    ON correction_evidence(wrong_word, correct_word, created_at);
                  INSERT OR IGNORE INTO correction_evidence
                    (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
-                   SELECT wrong_word, correct_word, 'post_edit', 1.0, 0.6, 'legacy-' || id, created_at
+                   SELECT lower(wrong_word), correct_word, 'post_edit', 1.0, 0.6, 'legacy-' || id, created_at
                    FROM pending_corrections;
                  CREATE TABLE IF NOT EXISTS dictionary_suggestions (
                    id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -886,7 +886,7 @@ pub fn compute_evidence_score(
                 (julianday('now') - julianday(created_at)) AS age_days,
                 session_id, source
          FROM correction_evidence
-         WHERE wrong_word=?1 AND correct_word=?2
+         WHERE wrong_word=?1 COLLATE NOCASE AND correct_word=?2
            AND created_at >= datetime('now', ?3)",
     )?;
 
@@ -1561,6 +1561,43 @@ mod tests {
         let conn = lock_conn(&db).expect("lock");
         assert!(table_has_column(&conn, "cleanup_cache", "expires_at_epoch").expect("column"));
         assert!(table_has_column(&conn, "cleanup_cache", "last_hit_at_epoch").expect("column"));
+        drop(conn);
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(path.with_extension("db-shm"));
+    }
+
+    #[test]
+    fn open_migrates_legacy_pending_corrections_with_lowercased_wrong_word() {
+        let path = temp_db_path("legacy_pending_corrections");
+        {
+            let conn = Connection::open(&path).expect("create legacy db");
+            conn.execute_batch(
+                "CREATE TABLE pending_corrections (
+                   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                   wrong_word   TEXT    NOT NULL,
+                   correct_word TEXT    NOT NULL,
+                   created_at   DATETIME NOT NULL DEFAULT (datetime('now'))
+                 );
+                 INSERT INTO pending_corrections (wrong_word, correct_word)
+                   VALUES ('Koobernetes', 'Kubernetes');
+                 PRAGMA user_version = 6;",
+            )
+            .expect("seed legacy db");
+        }
+
+        let db = open(path.to_str().expect("path string")).expect("open migrates legacy db");
+
+        let conn = lock_conn(&db).expect("lock");
+        let wrong_word: String = conn
+            .query_row(
+                "SELECT wrong_word FROM correction_evidence WHERE correct_word = 'Kubernetes'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("migrated evidence row");
+        assert_eq!(wrong_word, "koobernetes");
         drop(conn);
         drop(db);
         let _ = std::fs::remove_file(&path);

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -800,7 +800,7 @@ pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> 
     let conn = lock_conn(db)?;
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
-        params![wrong, correct],
+        params![wrong.to_lowercase(), correct],
         |r| r.get(0),
     )?;
     Ok(count > 0)
@@ -810,7 +810,7 @@ pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()
     let conn = lock_conn(db)?;
     conn.execute(
         "INSERT OR IGNORE INTO never_learn_pairs (wrong_word, correct_word) VALUES (?1, ?2)",
-        params![wrong, correct],
+        params![wrong.to_lowercase(), correct],
     )?;
     Ok(())
 }
@@ -819,7 +819,7 @@ pub fn delete_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()
     let conn = lock_conn(db)?;
     conn.execute(
         "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
-        params![wrong, correct],
+        params![wrong.to_lowercase(), correct],
     )?;
     Ok(())
 }
@@ -2156,6 +2156,18 @@ mod tests {
         // Idempotent.
         insert_never_learn_pair(&db, "rock", "qroq").expect("second insert");
         assert!(is_never_learn_pair(&db, "rock", "qroq").expect("after second insert"));
+    }
+
+    #[test]
+    fn never_learn_pair_lookup_is_case_insensitive_on_wrong_word() {
+        let db = test_db();
+        // A mixed-case `wrong` (e.g. from import_data) must still be normalized
+        // so the lowercase lookup in record_evidence_and_maybe_promote matches.
+        insert_never_learn_pair(&db, "Koobernetes", "Kubernetes").expect("insert");
+        assert!(is_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("lookup"));
+
+        delete_never_learn_pair(&db, "KOOBERNETES", "Kubernetes").expect("delete");
+        assert!(!is_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("after delete"));
     }
 
     #[test]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -971,6 +971,9 @@ pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>
          WHERE NOT EXISTS (
            SELECT 1 FROM never_learn_pairs n
            WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word
+         ) AND NOT EXISTS (
+           SELECT 1 FROM dictionary d
+           WHERE d.term = s.correct_word COLLATE NOCASE AND d.mistake = s.wrong_word COLLATE NOCASE
          )
          ORDER BY s.score DESC, s.updated_at DESC
          LIMIT 50",
@@ -2206,6 +2209,18 @@ mod tests {
         upsert_dictionary_suggestion(&db, "rock", "qroq", 0.9, "x").expect("insert");
         assert_eq!(query_dictionary_suggestions(&db).expect("before").len(), 1);
         delete_dictionary_suggestion(&db, "rock", "qroq").expect("delete");
+        assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
+    }
+
+    #[test]
+    fn dictionary_suggestions_hide_pairs_already_in_dictionary() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.9, "x").expect("insert");
+        assert_eq!(query_dictionary_suggestions(&db).expect("before").len(), 1);
+
+        // Term was added manually (or already auto-learned) — the suggestion
+        // is now redundant and should be hidden, even with mismatched casing.
+        insert_dictionary_entry(&db, "Qroq", Some("Rock")).expect("manual add");
         assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
     }
 

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1376,8 +1376,14 @@ pub fn import_backup_records(
     }
 
     for pair in never_learn_pairs {
-        insert_never_learn_pair_conn(&tx, pair.wrong, pair.correct)?;
-        counts.never_learn_pairs_inserted += 1;
+        match insert_never_learn_pair_conn(&tx, pair.wrong, pair.correct) {
+            Ok(()) => counts.never_learn_pairs_inserted += 1,
+            Err(e) => log::warn!(
+                "import_backup_records: never_learn_pair insert error for '{}' -> '{}': {e}",
+                pair.wrong,
+                pair.correct
+            ),
+        }
     }
 
     tx.commit()?;

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1199,8 +1199,9 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
         // `mistake`/`term` come from `dictionary` and are stored with the same
-        // casing as `correction_evidence.wrong_word`/`correct_word` (both
-        // lowercased via record_evidence_and_maybe_promote's D1 normalization),
+        // casing as `correction_evidence.wrong_word`/`correct_word` (only
+        // `wrong_word`/`mistake` is lowercased via record_evidence_and_maybe_promote's
+        // normalization; `correct_word`/`term` keeps its original casing in both tables),
         // so a binary comparison here lets SQLite use idx_correction_evidence_pair
         // instead of forcing a full table scan via COLLATE NOCASE.
         let mut del_evidence_stmt = tx.prepare(
@@ -1397,7 +1398,11 @@ pub fn import_backup_records(
     )?;
     for pair in never_learn_pairs {
         match never_learn_stmt.execute(params![pair.wrong.to_lowercase(), pair.correct]) {
-            Ok(_) => counts.never_learn_pairs_inserted += 1,
+            Ok(rows) => {
+                if rows > 0 {
+                    counts.never_learn_pairs_inserted += 1;
+                }
+            }
             Err(e) => log::warn!(
                 "import_backup_records: never_learn_pair insert error for '{}' -> '{}': {e}",
                 pair.wrong,
@@ -2606,6 +2611,7 @@ mod tests {
         let db = test_db();
         insert_dictionary_entry(&db, "Kubernetes", None).expect("seed dictionary");
         insert_snippet_returning(&db, "sig", "Best regards,\nA", "").expect("seed snippet");
+        insert_never_learn_pair(&db, "rock", "qroq").expect("seed never-learn pair");
 
         let dictionary = vec![BackupDictionaryEntry {
             term: "Kubernetes",
@@ -2619,11 +2625,19 @@ mod tests {
             expansion: "Different expansion",
             instructions: "",
         }];
+        let never_learn_pairs = vec![BackupNeverLearnPair {
+            wrong: "rock",
+            correct: "qroq",
+        }];
 
-        let counts = import_backup_records(&db, &dictionary, &snippets, &[]).expect("import");
+        let counts = import_backup_records(&db, &dictionary, &snippets, &never_learn_pairs).expect("import");
         assert_eq!(counts.dictionary_inserted, 0);
         assert_eq!(counts.dictionary_already_existed, 1);
         assert_eq!(counts.snippets_inserted, 0);
         assert_eq!(counts.snippets_already_existed, 1);
+        assert_eq!(
+            counts.never_learn_pairs_inserted, 0,
+            "duplicate never-learn pairs ignored by INSERT OR IGNORE must not be counted as inserted"
+        );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -440,19 +440,20 @@ pub fn open(path: &str) -> Result<Db> {
                     .collect::<rusqlite::Result<Vec<_>>>()?;
                 rows
             };
+            let mut insert_stmt = conn.prepare(
+                "INSERT OR IGNORE INTO correction_evidence
+                   (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
+                   VALUES (?1, ?2, 'post_edit', 1.0, 0.6, ?3, ?4)",
+            )?;
             for (id, wrong_word, correct_word, created_at) in legacy_rows {
-                conn.execute(
-                    "INSERT OR IGNORE INTO correction_evidence
-                       (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
-                       VALUES (?1, ?2, 'post_edit', 1.0, 0.6, ?3, ?4)",
-                    params![
-                        wrong_word.to_lowercase(),
-                        correct_word,
-                        format!("legacy-{id}"),
-                        created_at
-                    ],
-                )?;
+                insert_stmt.execute(params![
+                    wrong_word.to_lowercase(),
+                    correct_word,
+                    format!("legacy-{id}"),
+                    created_at
+                ])?;
             }
+            drop(insert_stmt);
 
             conn.execute_batch("PRAGMA user_version = 7;")?;
             Ok(())
@@ -1391,9 +1392,12 @@ pub fn import_backup_records(
         }
     }
 
+    let mut never_learn_stmt = tx.prepare(
+        "INSERT OR IGNORE INTO never_learn_pairs (wrong_word, correct_word) VALUES (?1, ?2)",
+    )?;
     for pair in never_learn_pairs {
-        match insert_never_learn_pair_conn(&tx, pair.wrong, pair.correct) {
-            Ok(()) => counts.never_learn_pairs_inserted += 1,
+        match never_learn_stmt.execute(params![pair.wrong.to_lowercase(), pair.correct]) {
+            Ok(_) => counts.never_learn_pairs_inserted += 1,
             Err(e) => log::warn!(
                 "import_backup_records: never_learn_pair insert error for '{}' -> '{}': {e}",
                 pair.wrong,
@@ -1401,6 +1405,7 @@ pub fn import_backup_records(
             ),
         }
     }
+    drop(never_learn_stmt);
 
     tx.commit()?;
     Ok(counts)

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -201,6 +201,36 @@ CREATE INDEX IF NOT EXISTS idx_cleanup_cache_expires_at
   ON cleanup_cache(expires_at);
 CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
   ON cleanup_cache(last_hit_at);
+CREATE TABLE IF NOT EXISTS correction_evidence (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  wrong_word  TEXT    NOT NULL,
+  correct_word TEXT   NOT NULL,
+  source      TEXT    NOT NULL DEFAULT 'post_edit',
+  weight      REAL    NOT NULL DEFAULT 1.0,
+  confidence  REAL    NOT NULL DEFAULT 0.0,
+  session_id  TEXT    NOT NULL DEFAULT '',
+  app_context TEXT    NOT NULL DEFAULT '',
+  created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_correction_evidence_pair
+  ON correction_evidence(wrong_word, correct_word, created_at);
+CREATE TABLE IF NOT EXISTS dictionary_suggestions (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  wrong_word    TEXT    NOT NULL,
+  correct_word  TEXT    NOT NULL,
+  score         REAL    NOT NULL DEFAULT 0.0,
+  source_summary TEXT   NOT NULL DEFAULT '',
+  created_at    DATETIME NOT NULL DEFAULT (datetime('now')),
+  updated_at    DATETIME NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(wrong_word, correct_word)
+);
+CREATE TABLE IF NOT EXISTS never_learn_pairs (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  wrong_word  TEXT    NOT NULL,
+  correct_word TEXT   NOT NULL,
+  created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(wrong_word, correct_word)
+);
 ";
 
 pub fn open(path: &str) -> Result<Db> {
@@ -355,6 +385,53 @@ pub fn open(path: &str) -> Result<Db> {
         if let Err(err) = (|| -> Result<()> {
             ensure_cleanup_cache_schema(&conn)?;
             conn.execute_batch("PRAGMA user_version = 6;")?;
+            Ok(())
+        })() {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err);
+        }
+        conn.execute_batch("COMMIT;")?;
+    }
+    if user_version < 7 {
+        conn.execute_batch("BEGIN;")?;
+        if let Err(err) = (|| -> Result<()> {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS correction_evidence (
+                   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                   wrong_word   TEXT    NOT NULL,
+                   correct_word TEXT    NOT NULL,
+                   source       TEXT    NOT NULL DEFAULT 'post_edit',
+                   weight       REAL    NOT NULL DEFAULT 1.0,
+                   confidence   REAL    NOT NULL DEFAULT 0.0,
+                   session_id   TEXT    NOT NULL DEFAULT '',
+                   app_context  TEXT    NOT NULL DEFAULT '',
+                   created_at   DATETIME NOT NULL DEFAULT (datetime('now'))
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_correction_evidence_pair
+                   ON correction_evidence(wrong_word, correct_word, created_at);
+                 INSERT OR IGNORE INTO correction_evidence
+                   (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
+                   SELECT wrong_word, correct_word, 'post_edit', 1.0, 0.6, 'legacy-' || id, created_at
+                   FROM pending_corrections;
+                 CREATE TABLE IF NOT EXISTS dictionary_suggestions (
+                   id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                   wrong_word    TEXT    NOT NULL,
+                   correct_word  TEXT    NOT NULL,
+                   score         REAL    NOT NULL DEFAULT 0.0,
+                   source_summary TEXT   NOT NULL DEFAULT '',
+                   created_at    DATETIME NOT NULL DEFAULT (datetime('now')),
+                   updated_at    DATETIME NOT NULL DEFAULT (datetime('now')),
+                   UNIQUE(wrong_word, correct_word)
+                 );
+                 CREATE TABLE IF NOT EXISTS never_learn_pairs (
+                   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                   wrong_word   TEXT    NOT NULL,
+                   correct_word TEXT    NOT NULL,
+                   created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+                   UNIQUE(wrong_word, correct_word)
+                 );
+                 PRAGMA user_version = 7;",
+            )?;
             Ok(())
         })() {
             let _ = conn.execute_batch("ROLLBACK;");
@@ -733,6 +810,189 @@ pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -
     Ok(())
 }
 
+// ---------- correction evidence ledger ----------
+
+pub fn insert_correction_evidence(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    source: &str,
+    weight: f64,
+    confidence: f64,
+    session_id: &str,
+    app_context: &str,
+) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO correction_evidence
+         (wrong_word, correct_word, source, weight, confidence, session_id, app_context)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            wrong,
+            correct,
+            source,
+            weight,
+            confidence,
+            session_id,
+            app_context
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> {
+    let conn = lock_conn(db)?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
+        params![wrong, correct],
+        |r| r.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO never_learn_pairs (wrong_word, correct_word) VALUES (?1, ?2)",
+        params![wrong, correct],
+    )?;
+    Ok(())
+}
+
+/// Promotion score = Σ (weight × confidence × recency_decay) over all evidence in the window.
+/// Decay is exponential: evidence from N days ago scores exp(-N / half_life).
+/// Requires evidence from ≥2 distinct sessions OR ≥2 distinct sources for corroboration.
+pub struct EvidenceScore {
+    pub score: f64,
+    pub distinct_sessions: i64,
+    pub distinct_sources: i64,
+}
+
+pub fn compute_evidence_score(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    window_days: i64,
+    half_life_days: f64,
+) -> Result<EvidenceScore> {
+    let conn = lock_conn(db)?;
+    let window_arg = format!("-{} days", window_days.max(1));
+
+    // Single query that returns weight, confidence, age_days, session_id, source per row.
+    let mut stmt = conn.prepare(
+        "SELECT weight, confidence,
+                (julianday('now') - julianday(created_at)) AS age_days,
+                session_id, source
+         FROM correction_evidence
+         WHERE wrong_word=?1 AND correct_word=?2
+           AND created_at >= datetime('now', ?3)",
+    )?;
+
+    struct Row {
+        weight: f64,
+        confidence: f64,
+        age_days: f64,
+        session_id: String,
+        source: String,
+    }
+
+    let evidence: Vec<Row> = stmt
+        .query_map(params![wrong, correct, window_arg], |r| {
+            Ok(Row {
+                weight: r.get(0)?,
+                confidence: r.get(1)?,
+                age_days: r.get(2)?,
+                session_id: r.get(3)?,
+                source: r.get(4)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut score = 0.0f64;
+    let mut sessions = std::collections::HashSet::new();
+    let mut sources = std::collections::HashSet::new();
+
+    for row in &evidence {
+        let decay = (-row.age_days / half_life_days.max(0.1)).exp();
+        score += row.weight * row.confidence * decay;
+        if !row.session_id.is_empty() {
+            sessions.insert(row.session_id.clone());
+        }
+        sources.insert(row.source.clone());
+    }
+
+    Ok(EvidenceScore {
+        score,
+        distinct_sessions: sessions.len() as i64,
+        distinct_sources: sources.len() as i64,
+    })
+}
+
+// ---------- dictionary suggestions ----------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DictionarySuggestion {
+    pub id: i64,
+    pub wrong_word: String,
+    pub correct_word: String,
+    pub score: f64,
+    pub source_summary: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+pub fn upsert_dictionary_suggestion(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    score: f64,
+    source_summary: &str,
+) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "INSERT INTO dictionary_suggestions (wrong_word, correct_word, score, source_summary)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
+           score = excluded.score,
+           source_summary = excluded.source_summary,
+           updated_at = datetime('now')",
+        params![wrong, correct, score, source_summary],
+    )?;
+    Ok(())
+}
+
+pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>> {
+    let conn = lock_conn(db)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, wrong_word, correct_word, score, source_summary, created_at, updated_at
+         FROM dictionary_suggestions
+         ORDER BY score DESC, updated_at DESC",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(DictionarySuggestion {
+                id: r.get(0)?,
+                wrong_word: r.get(1)?,
+                correct_word: r.get(2)?,
+                score: r.get(3)?,
+                source_summary: r.get(4)?,
+                created_at: r.get(5)?,
+                updated_at: r.get(6)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn delete_dictionary_suggestion(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "DELETE FROM dictionary_suggestions WHERE wrong_word=?1 AND correct_word=?2",
+        params![wrong, correct],
+    )?;
+    Ok(())
+}
+
 pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> {
     let conn = lock_conn(db)?;
     let count_by = |event_type: &str, reason_code: &str| -> Result<i64> {
@@ -749,7 +1009,8 @@ pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> 
         |r| r.get(0),
     )?;
     let promotions: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM auto_learn_events WHERE event_type = 'promotion' AND reason_code = 'promoted'",
+        "SELECT COUNT(*) FROM auto_learn_events
+         WHERE event_type = 'promotion' AND reason_code IN ('promoted', 'auto_promoted')",
         [],
         |r| r.get(0),
     )?;
@@ -1705,6 +1966,182 @@ mod tests {
             count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
             0,
             "pending corrections must be purged when the auto-learned entry is manually deleted"
+        );
+    }
+
+    #[test]
+    fn auto_learn_status_counts_legacy_and_new_promotion_reasons() {
+        let db = test_db();
+        log_auto_learn_event(&db, "promotion", "promoted", "test", "", "", 1.0)
+            .expect("legacy event");
+        log_auto_learn_event(&db, "promotion", "auto_promoted", "test", "", "", 1.0)
+            .expect("new event");
+
+        let summary = get_auto_learn_status_summary(&db).expect("summary");
+        assert_eq!(summary.promotions, 2);
+    }
+
+    // ── evidence scoring engine ──────────────────────────────────────────────
+
+    #[test]
+    fn evidence_score_empty_returns_zero() {
+        let db = test_db();
+        let ev = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("score");
+        assert_eq!(ev.score, 0.0);
+        assert_eq!(ev.distinct_sessions, 0);
+        assert_eq!(ev.distinct_sources, 0);
+    }
+
+    #[test]
+    fn evidence_score_single_observation_accumulates() {
+        let db = test_db();
+        insert_correction_evidence(
+            &db,
+            "rock",
+            "qroq",
+            "post_edit",
+            1.0,
+            0.8,
+            "session-1",
+            "test",
+        )
+        .expect("insert");
+        let ev = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("score");
+        assert!(
+            ev.score > 0.0,
+            "score should be positive after one observation"
+        );
+        assert_eq!(ev.distinct_sessions, 1);
+        assert_eq!(ev.distinct_sources, 1);
+    }
+
+    #[test]
+    fn evidence_score_two_sessions_increases_distinct_sessions() {
+        let db = test_db();
+        insert_correction_evidence(&db, "rock", "qroq", "post_edit", 1.0, 0.9, "sess-a", "test")
+            .expect("1");
+        insert_correction_evidence(&db, "rock", "qroq", "post_edit", 1.0, 0.9, "sess-b", "test")
+            .expect("2");
+        let ev = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("score");
+        assert_eq!(ev.distinct_sessions, 2);
+        assert_eq!(ev.distinct_sources, 1);
+    }
+
+    #[test]
+    fn evidence_score_two_sources_increases_distinct_sources() {
+        let db = test_db();
+        insert_correction_evidence(&db, "rock", "qroq", "post_edit", 1.0, 0.9, "sess-a", "test")
+            .expect("1");
+        insert_correction_evidence(
+            &db,
+            "rock",
+            "qroq",
+            "cleanup_divergence",
+            0.6,
+            0.9,
+            "sess-a",
+            "test",
+        )
+        .expect("2");
+        let ev = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("score");
+        assert_eq!(ev.distinct_sources, 2);
+    }
+
+    #[test]
+    fn evidence_score_same_session_and_source_deduplicated_in_session_count() {
+        let db = test_db();
+        // Same session_id → still counts as 1 distinct session.
+        for _ in 0..5 {
+            insert_correction_evidence(
+                &db,
+                "rock",
+                "qroq",
+                "post_edit",
+                1.0,
+                0.9,
+                "sess-same",
+                "test",
+            )
+            .expect("insert");
+        }
+        let ev = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("score");
+        assert_eq!(ev.distinct_sessions, 1);
+    }
+
+    #[test]
+    fn never_learn_pair_roundtrip() {
+        let db = test_db();
+        assert!(!is_never_learn_pair(&db, "rock", "qroq").expect("check"));
+        insert_never_learn_pair(&db, "rock", "qroq").expect("insert");
+        assert!(is_never_learn_pair(&db, "rock", "qroq").expect("after insert"));
+        // Idempotent.
+        insert_never_learn_pair(&db, "rock", "qroq").expect("second insert");
+        assert!(is_never_learn_pair(&db, "rock", "qroq").expect("after second insert"));
+    }
+
+    #[test]
+    fn never_learn_pair_is_directional() {
+        let db = test_db();
+        insert_never_learn_pair(&db, "rock", "qroq").expect("insert");
+        // Reversed direction is NOT blocked.
+        assert!(!is_never_learn_pair(&db, "qroq", "rock").expect("reverse"));
+    }
+
+    #[test]
+    fn dictionary_suggestions_upsert_and_query() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.8, "sessions=2 sources=1").expect("1");
+        let suggestions = query_dictionary_suggestions(&db).expect("query");
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].wrong_word, "rock");
+        assert_eq!(suggestions[0].correct_word, "qroq");
+        assert!((suggestions[0].score - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dictionary_suggestions_upsert_updates_score() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.8, "v1").expect("1");
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 1.2, "v2").expect("2");
+        let suggestions = query_dictionary_suggestions(&db).expect("query");
+        assert_eq!(suggestions.len(), 1);
+        assert!((suggestions[0].score - 1.2).abs() < 1e-6);
+        assert_eq!(suggestions[0].source_summary, "v2");
+    }
+
+    #[test]
+    fn dictionary_suggestion_delete_removes_entry() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.9, "x").expect("insert");
+        assert_eq!(query_dictionary_suggestions(&db).expect("before").len(), 1);
+        delete_dictionary_suggestion(&db, "rock", "qroq").expect("delete");
+        assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
+    }
+
+    #[test]
+    fn evidence_score_respects_window_days() {
+        let db = test_db();
+        // Insert evidence with a backdated timestamp (simulate old evidence).
+        {
+            let conn = db.lock().expect("lock");
+            conn.execute(
+                "INSERT INTO correction_evidence (wrong_word, correct_word, source, weight, confidence, session_id, app_context, created_at) \
+                 VALUES ('rock', 'qroq', 'post_edit', 1.0, 0.9, 'old-session', 'test', datetime('now', '-10 days'))",
+                [],
+            ).expect("backdated insert");
+        }
+        // Window of 3 days: the 10-day-old evidence is excluded.
+        let ev3 = compute_evidence_score(&db, "rock", "qroq", 3, 1.5).expect("3d score");
+        assert_eq!(
+            ev3.score, 0.0,
+            "10-day-old evidence should be outside the 3-day window"
+        );
+
+        // Window of 14 days: the evidence should now be included.
+        let ev14 = compute_evidence_score(&db, "rock", "qroq", 14, 1.5).expect("14d score");
+        assert!(
+            ev14.score > 0.0,
+            "evidence inside 14-day window must contribute"
         );
     }
 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -999,7 +999,7 @@ pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>
          FROM dictionary_suggestions s
          WHERE NOT EXISTS (
            SELECT 1 FROM never_learn_pairs n
-           WHERE n.wrong_word = s.wrong_word COLLATE NOCASE AND n.correct_word = s.correct_word COLLATE NOCASE
+           WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word COLLATE NOCASE
          ) AND NOT EXISTS (
            SELECT 1 FROM dictionary d
            WHERE d.term = s.correct_word COLLATE NOCASE AND d.mistake = s.wrong_word COLLATE NOCASE

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -409,10 +409,6 @@ pub fn open(path: &str) -> Result<Db> {
                  );
                  CREATE INDEX IF NOT EXISTS idx_correction_evidence_pair
                    ON correction_evidence(wrong_word, correct_word, created_at);
-                 INSERT OR IGNORE INTO correction_evidence
-                   (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
-                   SELECT lower(wrong_word), correct_word, 'post_edit', 1.0, 0.6, 'legacy-' || id, created_at
-                   FROM pending_corrections;
                  CREATE TABLE IF NOT EXISTS dictionary_suggestions (
                    id            INTEGER PRIMARY KEY AUTOINCREMENT,
                    wrong_word    TEXT    NOT NULL,
@@ -429,9 +425,36 @@ pub fn open(path: &str) -> Result<Db> {
                    correct_word TEXT    NOT NULL,
                    created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
                    UNIQUE(wrong_word, correct_word)
-                 );
-                 PRAGMA user_version = 7;",
+                 );",
             )?;
+
+            // Migrate legacy pending_corrections into correction_evidence,
+            // lowercasing wrong_word with Rust's Unicode-aware to_lowercase()
+            // (SQLite's lower() only handles ASCII A-Z).
+            let legacy_rows: Vec<(i64, String, String, String)> = {
+                let mut stmt = conn.prepare(
+                    "SELECT id, wrong_word, correct_word, created_at FROM pending_corrections",
+                )?;
+                let rows = stmt
+                    .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                rows
+            };
+            for (id, wrong_word, correct_word, created_at) in legacy_rows {
+                conn.execute(
+                    "INSERT OR IGNORE INTO correction_evidence
+                       (wrong_word, correct_word, source, weight, confidence, session_id, created_at)
+                       VALUES (?1, ?2, 'post_edit', 1.0, 0.6, ?3, ?4)",
+                    params![
+                        wrong_word.to_lowercase(),
+                        correct_word,
+                        format!("legacy-{id}"),
+                        created_at
+                    ],
+                )?;
+            }
+
+            conn.execute_batch("PRAGMA user_version = 7;")?;
             Ok(())
         })() {
             let _ = conn.execute_batch("ROLLBACK;");
@@ -880,13 +903,16 @@ pub fn compute_evidence_score(
     let conn = lock_conn(db)?;
     let window_arg = format!("-{} days", window_days.max(1));
 
+    // `wrong` is always lowercased by the caller before insertion and lookup
+    // (see record_evidence_and_maybe_promote), so a plain `=` match here uses
+    // idx_correction_evidence_pair instead of forcing a table scan via COLLATE NOCASE.
     // Single query that returns weight, confidence, age_days, session_id, source per row.
     let mut stmt = conn.prepare(
         "SELECT weight, confidence,
                 (julianday('now') - julianday(created_at)) AS age_days,
                 session_id, source
          FROM correction_evidence
-         WHERE wrong_word=?1 COLLATE NOCASE AND correct_word=?2
+         WHERE wrong_word=?1 AND correct_word=?2
            AND created_at >= datetime('now', ?3)",
     )?;
 
@@ -1581,7 +1607,7 @@ mod tests {
                    created_at   DATETIME NOT NULL DEFAULT (datetime('now'))
                  );
                  INSERT INTO pending_corrections (wrong_word, correct_word)
-                   VALUES ('Koobernetes', 'Kubernetes');
+                   VALUES ('Koobernetes', 'Kubernetes'), ('Über', 'Ueber');
                  PRAGMA user_version = 6;",
             )
             .expect("seed legacy db");
@@ -1598,6 +1624,16 @@ mod tests {
             )
             .expect("migrated evidence row");
         assert_eq!(wrong_word, "koobernetes");
+        // SQLite's lower() is ASCII-only and would leave 'Ü' untouched; the
+        // migration must use Rust's Unicode-aware to_lowercase() instead.
+        let wrong_word_unicode: String = conn
+            .query_row(
+                "SELECT wrong_word FROM correction_evidence WHERE correct_word = 'Ueber'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("migrated unicode evidence row");
+        assert_eq!(wrong_word_unicode, "über");
         drop(conn);
         drop(db);
         let _ = std::fs::remove_file(&path);

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1002,7 +1002,7 @@ pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>
            WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word COLLATE NOCASE
          ) AND NOT EXISTS (
            SELECT 1 FROM dictionary d
-           WHERE d.term = s.correct_word COLLATE NOCASE AND d.mistake = s.wrong_word COLLATE NOCASE
+           WHERE d.term = s.correct_word COLLATE NOCASE
          )
          ORDER BY s.score DESC, s.updated_at DESC
          LIMIT 50",
@@ -2307,6 +2307,19 @@ mod tests {
         // Term was added manually (or already auto-learned) — the suggestion
         // is now redundant and should be hidden, even with mismatched casing.
         insert_dictionary_entry(&db, "Qroq", Some("Rock")).expect("manual add");
+        assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
+    }
+
+    #[test]
+    fn dictionary_suggestions_hide_when_term_taken_by_unrelated_entry() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.9, "x").expect("insert");
+        assert_eq!(query_dictionary_suggestions(&db).expect("before").len(), 1);
+
+        // `term` has a UNIQUE constraint, so any suggestion whose correct_word
+        // already exists as a term — even with an unrelated or absent mistake —
+        // would fail approve_dictionary_suggestion and must be hidden.
+        insert_dictionary_entry(&db, "qroq", None).expect("manual add");
         assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
     }
 

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -1136,7 +1136,7 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
             params![mistake, term],
         )?;
         tx.execute(
-            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 COLLATE NOCASE AND correct_word = ?2 COLLATE NOCASE",
             params![mistake, term],
         )?;
     }
@@ -1162,7 +1162,7 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
             "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
         )?;
         let mut del_evidence_stmt = tx.prepare(
-            "DELETE FROM correction_evidence WHERE wrong_word = ?1 AND correct_word = ?2",
+            "DELETE FROM correction_evidence WHERE wrong_word = ?1 COLLATE NOCASE AND correct_word = ?2 COLLATE NOCASE",
         )?;
 
         for chunk in ids.chunks(SQL_BATCH_SIZE) {

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -821,8 +821,11 @@ pub fn insert_correction_evidence(
 
 pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> {
     let conn = lock_conn(db)?;
+    // `wrong_word` is always stored lowercase (see insert_never_learn_pair) and
+    // `wrong` is lowercased above, so a plain `=` match here can use
+    // idx-friendly lookups instead of forcing a per-row COLLATE NOCASE scan.
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 COLLATE NOCASE AND correct_word=?2 COLLATE NOCASE",
+        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2 COLLATE NOCASE",
         params![wrong.to_lowercase(), correct],
         |r| r.get(0),
     )?;

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -818,7 +818,7 @@ pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()
 pub fn delete_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
-        "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
+        "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2 COLLATE NOCASE",
         params![wrong.to_lowercase(), correct],
     )?;
     Ok(())
@@ -2207,6 +2207,16 @@ mod tests {
         assert!(is_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("lookup"));
 
         delete_never_learn_pair(&db, "KOOBERNETES", "Kubernetes").expect("delete");
+        assert!(!is_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("after delete"));
+    }
+
+    #[test]
+    fn delete_never_learn_pair_is_case_insensitive_on_correct_word() {
+        let db = test_db();
+        insert_never_learn_pair(&db, "Koobernetes", "Kubernetes").expect("insert");
+        // A casing mismatch on `correct` (e.g. from a stored suggestion using
+        // different capitalization) must still allow deletion/restore.
+        delete_never_learn_pair(&db, "koobernetes", "kubernetes").expect("delete");
         assert!(!is_never_learn_pair(&db, "koobernetes", "Kubernetes").expect("after delete"));
     }
 

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -227,7 +227,7 @@ CREATE TABLE IF NOT EXISTS dictionary_suggestions (
 CREATE TABLE IF NOT EXISTS never_learn_pairs (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   wrong_word  TEXT    NOT NULL,
-  correct_word TEXT   NOT NULL,
+  correct_word TEXT   NOT NULL COLLATE NOCASE,
   created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
   UNIQUE(wrong_word, correct_word)
 );
@@ -422,7 +422,7 @@ pub fn open(path: &str) -> Result<Db> {
                  CREATE TABLE IF NOT EXISTS never_learn_pairs (
                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
                    wrong_word   TEXT    NOT NULL,
-                   correct_word TEXT    NOT NULL,
+                   correct_word TEXT    NOT NULL COLLATE NOCASE,
                    created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
                    UNIQUE(wrong_word, correct_word)
                  );",
@@ -821,10 +821,11 @@ pub fn insert_correction_evidence(
 pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> {
     let conn = lock_conn(db)?;
     // `wrong_word` is always stored lowercase (see insert_never_learn_pair) and
-    // `wrong` is lowercased above, so a plain `=` match here can use
-    // idx-friendly lookups instead of forcing a per-row COLLATE NOCASE scan.
+    // `wrong` is lowercased above; `correct_word` is COLLATE NOCASE in the
+    // schema, so a plain `=` match here can use idx-friendly lookups instead
+    // of forcing a per-row COLLATE NOCASE scan.
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2 COLLATE NOCASE",
+        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
         params![wrong.to_lowercase(), correct],
         |r| r.get(0),
     )?;
@@ -847,7 +848,7 @@ pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()
 pub fn delete_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
-        "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2 COLLATE NOCASE",
+        "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
         params![wrong.to_lowercase(), correct],
     )?;
     Ok(())
@@ -1002,7 +1003,7 @@ pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>
          FROM dictionary_suggestions s
          WHERE NOT EXISTS (
            SELECT 1 FROM never_learn_pairs n
-           WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word COLLATE NOCASE
+           WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word
          ) AND NOT EXISTS (
            SELECT 1 FROM dictionary d
            WHERE d.term = s.correct_word COLLATE NOCASE

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -763,55 +763,11 @@ pub fn log_auto_learn_event(
     Ok(())
 }
 
-pub fn upsert_auto_learn_candidate(
-    db: &Db,
-    wrong: &str,
-    correct: &str,
-    confidence: f64,
-    cooldown_minutes: i64,
-) -> Result<bool> {
-    let conn = lock_conn(db)?;
-    let blocked: i64 = conn.query_row(
-        "SELECT COUNT(*)
-         FROM auto_learn_candidates
-         WHERE wrong_word = ?1
-           AND correct_word = ?2
-           AND cooldown_until IS NOT NULL
-           AND cooldown_until > datetime('now')",
-        params![wrong, correct],
-        |r| r.get(0),
-    )?;
-    if blocked > 0 {
-        return Ok(false);
-    }
-    conn.execute(
-        "INSERT INTO auto_learn_candidates
-         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at, cooldown_until)
-         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'), datetime('now', ?4))
-         ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
-           confidence_sum = auto_learn_candidates.confidence_sum + excluded.confidence_sum,
-           seen_count = auto_learn_candidates.seen_count + 1,
-           confidence_avg = (auto_learn_candidates.confidence_sum + excluded.confidence_sum) / (auto_learn_candidates.seen_count + 1),
-           last_seen_at = datetime('now'),
-           cooldown_until = datetime('now', ?4)",
-        params![wrong, correct, confidence, format!("+{} minutes", cooldown_minutes.max(0))],
-    )?;
-    Ok(true)
-}
-
-pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -> Result<()> {
-    let conn = lock_conn(db)?;
-    conn.execute(
-        "UPDATE auto_learn_candidates
-         SET promoted_at = datetime('now')
-         WHERE wrong_word = ?1 AND correct_word = ?2",
-        params![wrong, correct],
-    )?;
-    Ok(())
-}
-
 // ---------- correction evidence ledger ----------
 
+// One argument per evidence-observation field (who/what/where/how-confident);
+// grouping into a struct would just move the same fields one layer out.
+#[allow(clippy::too_many_arguments)]
 pub fn insert_correction_evidence(
     db: &Db,
     wrong: &str,
@@ -857,6 +813,52 @@ pub fn insert_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()
         params![wrong, correct],
     )?;
     Ok(())
+}
+
+pub fn delete_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "DELETE FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
+        params![wrong, correct],
+    )?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NeverLearnPair {
+    pub wrong_word: String,
+    pub correct_word: String,
+}
+
+pub fn query_never_learn_pairs(db: &Db) -> Result<Vec<NeverLearnPair>> {
+    let conn = lock_conn(db)?;
+    let mut stmt =
+        conn.prepare("SELECT wrong_word, correct_word FROM never_learn_pairs ORDER BY wrong_word")?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(NeverLearnPair {
+                wrong_word: r.get(0)?,
+                correct_word: r.get(1)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// True if `(term, mistake)` already has an auto-learned dictionary entry —
+/// used to avoid re-emitting promotion events/logs for evidence that arrives
+/// after a pair is already in the dictionary.
+pub fn is_already_auto_learned(db: &Db, term: &str, mistake: &str) -> Result<bool> {
+    let conn = lock_conn(db)?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM dictionary
+         WHERE term = ?1 COLLATE NOCASE
+           AND COALESCE(mistake,'') = ?2 COLLATE NOCASE
+           AND auto_learned = 1",
+        params![term, mistake],
+        |r| r.get(0),
+    )?;
+    Ok(count > 0)
 }
 
 /// Promotion score = Σ (weight × confidence × recency_decay) over all evidence in the window.
@@ -964,9 +966,14 @@ pub fn upsert_dictionary_suggestion(
 pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>> {
     let conn = lock_conn(db)?;
     let mut stmt = conn.prepare(
-        "SELECT id, wrong_word, correct_word, score, source_summary, created_at, updated_at
-         FROM dictionary_suggestions
-         ORDER BY score DESC, updated_at DESC",
+        "SELECT s.id, s.wrong_word, s.correct_word, s.score, s.source_summary, s.created_at, s.updated_at
+         FROM dictionary_suggestions s
+         WHERE NOT EXISTS (
+           SELECT 1 FROM never_learn_pairs n
+           WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word
+         )
+         ORDER BY s.score DESC, s.updated_at DESC
+         LIMIT 50",
     )?;
     let rows = stmt
         .query_map([], |r| {
@@ -993,6 +1000,27 @@ pub fn delete_dictionary_suggestion(db: &Db, wrong: &str, correct: &str) -> Resu
     Ok(())
 }
 
+// Retention windows for the evidence ledger and suggestion queue. Evidence
+// retention exceeds the max `auto_learn_window_days` (30) plus a buffer so a
+// user with a long window doesn't have evidence pruned out from under them.
+const EVIDENCE_RETENTION_DAYS: i64 = 45;
+const SUGGESTION_RETENTION_DAYS: i64 = 14;
+
+/// Prunes stale rows from the append-only evidence ledger and the suggestion
+/// queue. Called once at startup.
+pub fn prune_correction_evidence_and_suggestions(db: &Db) -> Result<()> {
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "DELETE FROM correction_evidence WHERE created_at < datetime('now', ?1)",
+        params![format!("-{EVIDENCE_RETENTION_DAYS} days")],
+    )?;
+    conn.execute(
+        "DELETE FROM dictionary_suggestions WHERE updated_at < datetime('now', ?1)",
+        params![format!("-{SUGGESTION_RETENTION_DAYS} days")],
+    )?;
+    Ok(())
+}
+
 pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> {
     let conn = lock_conn(db)?;
     let count_by = |event_type: &str, reason_code: &str| -> Result<i64> {
@@ -1010,7 +1038,7 @@ pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> 
     )?;
     let promotions: i64 = conn.query_row(
         "SELECT COUNT(*) FROM auto_learn_events
-         WHERE event_type = 'promotion' AND reason_code IN ('promoted', 'auto_promoted')",
+         WHERE event_type = 'promotion' AND reason_code IN ('promoted', 'auto_promoted', 'approved')",
         [],
         |r| r.get(0),
     )?;
@@ -1047,32 +1075,6 @@ pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLea
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
-}
-
-pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<()> {
-    let conn = lock_conn(db)?;
-    conn.execute(
-        "INSERT INTO pending_corrections (wrong_word, correct_word) VALUES (?1, ?2)",
-        params![wrong, correct],
-    )?;
-    Ok(())
-}
-
-pub fn count_pending_corrections_recent(
-    db: &Db,
-    wrong: &str,
-    correct: &str,
-    max_age_days: i64,
-) -> Result<i64> {
-    let conn = lock_conn(db)?;
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM pending_corrections \
-         WHERE wrong_word=?1 AND correct_word=?2 \
-         AND created_at >= datetime('now', ?3)",
-        params![wrong, correct, format!("-{} days", max_age_days.max(1))],
-        |r| r.get(0),
-    )?;
-    Ok(count)
 }
 
 pub fn prune_pending_corrections(db: &Db, max_age_days: i64) -> Result<usize> {
@@ -1491,6 +1493,27 @@ mod tests {
         open(":memory:").expect("test db")
     }
 
+    fn insert_pending_correction_for_test(db: &Db, wrong: &str, correct: &str) {
+        lock_conn(db)
+            .expect("conn")
+            .execute(
+                "INSERT INTO pending_corrections (wrong_word, correct_word) VALUES (?1, ?2)",
+                params![wrong, correct],
+            )
+            .expect("pending insert");
+    }
+
+    fn pending_corrections_count(db: &Db, wrong: &str, correct: &str) -> i64 {
+        lock_conn(db)
+            .expect("conn")
+            .query_row(
+                "SELECT COUNT(*) FROM pending_corrections WHERE wrong_word=?1 AND correct_word=?2",
+                params![wrong, correct],
+                |r| r.get(0),
+            )
+            .expect("count")
+    }
+
     fn temp_db_path(name: &str) -> std::path::PathBuf {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1809,8 +1832,8 @@ mod tests {
             .id;
 
         // Simulate pending correction records that led to the promotion.
-        insert_pending_correction(&db, "Tari", "Tauri").expect("pending 1");
-        insert_pending_correction(&db, "Tari", "Tauri").expect("pending 2");
+        insert_pending_correction_for_test(&db, "Tari", "Tauri");
+        insert_pending_correction_for_test(&db, "Tari", "Tauri");
         insert_correction_evidence(
             &db,
             "Tari",
@@ -1833,21 +1856,15 @@ mod tests {
             "test",
         )
         .expect("evidence 2");
-        assert_eq!(
-            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count"),
-            2
-        );
+        assert_eq!(pending_corrections_count(&db, "Tari", "Tauri"), 2);
 
         // Rejection monitor fires.
         delete_auto_learned_entries_by_ids(&db, &[id]).expect("reject");
 
         // Dictionary entry gone.
         assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
-        // Pending corrections also purged â€” prevents immediate re-promotion.
-        assert_eq!(
-            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
-            0
-        );
+        // Pending corrections also purged — prevents immediate re-promotion.
+        assert_eq!(pending_corrections_count(&db, "Tari", "Tauri"), 0);
         let evidence_score = compute_evidence_score(&db, "Tari", "Tauri", 7, 1.5).expect("score");
         assert_eq!(
             evidence_score.score, 0.0,
@@ -1988,7 +2005,7 @@ mod tests {
             .expect("entry")
             .id;
 
-        insert_pending_correction(&db, "Tari", "Tauri").expect("pending");
+        insert_pending_correction_for_test(&db, "Tari", "Tauri");
         insert_correction_evidence(
             &db,
             "Tari",
@@ -2000,16 +2017,13 @@ mod tests {
             "test",
         )
         .expect("evidence");
-        assert_eq!(
-            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count before"),
-            1
-        );
+        assert_eq!(pending_corrections_count(&db, "Tari", "Tauri"), 1);
 
         delete_dictionary_entry(&db, id).expect("delete");
 
         assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
         assert_eq!(
-            count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
+            pending_corrections_count(&db, "Tari", "Tauri"),
             0,
             "pending corrections must be purged when the auto-learned entry is manually deleted"
         );
@@ -2030,6 +2044,20 @@ mod tests {
 
         let summary = get_auto_learn_status_summary(&db).expect("summary");
         assert_eq!(summary.promotions, 2);
+    }
+
+    #[test]
+    fn auto_learn_status_counts_approved_promotion_reason() {
+        let db = test_db();
+        log_auto_learn_event(&db, "promotion", "promoted", "test", "", "", 1.0)
+            .expect("legacy event");
+        log_auto_learn_event(&db, "promotion", "auto_promoted", "test", "", "", 1.0)
+            .expect("new event");
+        log_auto_learn_event(&db, "promotion", "approved", "test", "", "", 1.0)
+            .expect("approved event");
+
+        let summary = get_auto_learn_status_summary(&db).expect("summary");
+        assert_eq!(summary.promotions, 3);
     }
 
     // ── evidence scoring engine ──────────────────────────────────────────────
@@ -2167,6 +2195,80 @@ mod tests {
         assert_eq!(query_dictionary_suggestions(&db).expect("before").len(), 1);
         delete_dictionary_suggestion(&db, "rock", "qroq").expect("delete");
         assert!(query_dictionary_suggestions(&db).expect("after").is_empty());
+    }
+
+    #[test]
+    fn dictionary_suggestions_hide_never_learn_pairs_until_restored() {
+        let db = test_db();
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.9, "x").expect("insert");
+        assert_eq!(query_dictionary_suggestions(&db).expect("before dismiss").len(), 1);
+
+        // Soft-dismiss: suggestion row stays, but is hidden by the filter.
+        insert_never_learn_pair(&db, "rock", "qroq").expect("dismiss");
+        assert!(query_dictionary_suggestions(&db)
+            .expect("after dismiss")
+            .is_empty());
+
+        // Undo: restoring the pair brings the suggestion back.
+        delete_never_learn_pair(&db, "rock", "qroq").expect("restore");
+        assert_eq!(query_dictionary_suggestions(&db).expect("after restore").len(), 1);
+    }
+
+    #[test]
+    fn query_never_learn_pairs_roundtrip() {
+        let db = test_db();
+        assert!(query_never_learn_pairs(&db).expect("empty").is_empty());
+        insert_never_learn_pair(&db, "rock", "qroq").expect("insert");
+        let pairs = query_never_learn_pairs(&db).expect("query");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].wrong_word, "rock");
+        assert_eq!(pairs[0].correct_word, "qroq");
+    }
+
+    #[test]
+    fn is_already_auto_learned_detects_existing_entry() {
+        let db = test_db();
+        assert!(!is_already_auto_learned(&db, "Tauri", "Tari").expect("before"));
+        insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "medium")
+            .expect("insert");
+        assert!(is_already_auto_learned(&db, "Tauri", "Tari").expect("after"));
+        // Case-insensitive match.
+        assert!(is_already_auto_learned(&db, "tauri", "tari").expect("case-insensitive"));
+    }
+
+    #[test]
+    fn prune_correction_evidence_and_suggestions_removes_stale_rows() {
+        let db = test_db();
+        {
+            let conn = db.lock().expect("lock");
+            conn.execute(
+                "INSERT INTO correction_evidence (wrong_word, correct_word, source, weight, confidence, session_id, app_context, created_at) \
+                 VALUES ('old', 'fresh', 'post_edit', 1.0, 0.9, 'sess', 'test', datetime('now', '-100 days'))",
+                [],
+            ).expect("backdated evidence insert");
+        }
+        insert_correction_evidence(&db, "rock", "qroq", "post_edit", 1.0, 0.9, "sess", "test")
+            .expect("recent evidence insert");
+        upsert_dictionary_suggestion(&db, "old", "fresh", 0.8, "stale").expect("stale suggestion");
+        {
+            let conn = db.lock().expect("lock");
+            conn.execute(
+                "UPDATE dictionary_suggestions SET updated_at = datetime('now', '-30 days') WHERE wrong_word='old'",
+                [],
+            ).expect("backdate suggestion");
+        }
+        upsert_dictionary_suggestion(&db, "rock", "qroq", 0.8, "fresh").expect("fresh suggestion");
+
+        prune_correction_evidence_and_suggestions(&db).expect("prune");
+
+        let recent_score = compute_evidence_score(&db, "rock", "qroq", 365, 1.5).expect("recent score");
+        assert!(recent_score.score > 0.0, "recent evidence must survive pruning");
+        let old_score = compute_evidence_score(&db, "old", "fresh", 365, 1.5).expect("old score");
+        assert_eq!(old_score.score, 0.0, "stale evidence must be pruned");
+
+        let suggestions = query_dictionary_suggestions(&db).expect("suggestions after prune");
+        assert!(suggestions.iter().any(|s| s.wrong_word == "rock"));
+        assert!(!suggestions.iter().any(|s| s.wrong_word == "old"));
     }
 
     #[test]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -799,7 +799,7 @@ pub fn insert_correction_evidence(
 pub fn is_never_learn_pair(db: &Db, wrong: &str, correct: &str) -> Result<bool> {
     let conn = lock_conn(db)?;
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 AND correct_word=?2",
+        "SELECT COUNT(*) FROM never_learn_pairs WHERE wrong_word=?1 COLLATE NOCASE AND correct_word=?2 COLLATE NOCASE",
         params![wrong.to_lowercase(), correct],
         |r| r.get(0),
     )?;
@@ -970,7 +970,7 @@ pub fn query_dictionary_suggestions(db: &Db) -> Result<Vec<DictionarySuggestion>
          FROM dictionary_suggestions s
          WHERE NOT EXISTS (
            SELECT 1 FROM never_learn_pairs n
-           WHERE n.wrong_word = s.wrong_word AND n.correct_word = s.correct_word
+           WHERE n.wrong_word = s.wrong_word COLLATE NOCASE AND n.correct_word = s.correct_word COLLATE NOCASE
          ) AND NOT EXISTS (
            SELECT 1 FROM dictionary d
            WHERE d.term = s.correct_word COLLATE NOCASE AND d.mistake = s.wrong_word COLLATE NOCASE

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -27,6 +27,7 @@ pub const SETUP_COMPLETE: &str = "setup_complete";
 pub const APP_CONTEXT_HINT: &str = "app_context_hint";
 pub const AUTO_LEARN_ENABLED: &str = "auto_learn_enabled";
 pub const AUTO_LEARN_EVENT_MODE: &str = "auto_learn_event_mode";
+pub const AUTO_LEARN_WINDOW_DAYS: &str = "auto_learn_window_days";
 pub const CONTEXTUAL_CAPS: &str = "contextual_caps_enabled";
 pub const AUTO_SPACING: &str = "auto_spacing_enabled";
 pub const APPEARANCE_MODE: &str = "appearance_mode";
@@ -58,6 +59,7 @@ pub struct PipelineConfig {
     pub cleanup_intensity: String,
     pub app_context_hint: bool,
     pub auto_learn_enabled: bool,
+    pub auto_learn_window_days: i64,
     pub contextual_caps_enabled: bool,
     pub auto_spacing_enabled: bool,
     pub macos_clipboard_sniff_enabled: bool,
@@ -275,6 +277,11 @@ pub fn load_pipeline_config(store: &tauri_plugin_store::Store<tauri::Wry>) -> Pi
             .get(AUTO_LEARN_ENABLED)
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
+        auto_learn_window_days: store
+            .get(AUTO_LEARN_WINDOW_DAYS)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(3)
+            .clamp(1, 30),
         contextual_caps_enabled: store
             .get(CONTEXTUAL_CAPS)
             .and_then(|v| v.as_bool())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -129,6 +129,7 @@ fn main() {
     let db_handle: DbHandle =
         db::open(db_dir.join("openflow.db").to_str().unwrap()).expect("failed to open database");
     let _ = db::cleanup_cache_prune_expired(&db_handle);
+    let _ = db::prune_correction_evidence_and_suggestions(&db_handle);
 
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
@@ -274,6 +275,7 @@ fn main() {
             commands::get_dictionary_suggestions,
             commands::approve_dictionary_suggestion,
             commands::dismiss_dictionary_suggestion,
+            commands::restore_never_learn_pair,
             commands::retry_transcription,
             commands::check_for_update,
             commands::install_update,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -203,9 +203,7 @@ fn main() {
                         }
                     }
                     #[cfg(target_os = "macos")]
-                    tauri::WindowEvent::Resized(_)
-                        if window.is_minimized().unwrap_or(false) =>
-                    {
+                    tauri::WindowEvent::Resized(_) if window.is_minimized().unwrap_or(false) => {
                         crate::system::mac_app::set_regular_activation_policy_on_main_thread(
                             window.app_handle(),
                         );
@@ -273,6 +271,9 @@ fn main() {
             commands::remove_dictionary_entry,
             commands::get_auto_learn_status_summary,
             commands::get_recent_auto_learn_activity,
+            commands::get_dictionary_suggestions,
+            commands::approve_dictionary_suggestion,
+            commands::dismiss_dictionary_suggestion,
             commands::retry_transcription,
             commands::check_for_update,
             commands::install_update,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1037,10 +1037,11 @@ async fn run_cleanup_and_snippets_for_db(
     } else {
         None
     };
-    let snippet_active = pure_expansion.is_some() || !snippet_instructions.is_empty();
     let expanded = pure_expansion
         .clone()
         .unwrap_or_else(|| snippets::expand_snippets_from(raw, &mut db_snippets, db_handle));
+    let snippet_active =
+        pure_expansion.is_some() || !snippet_instructions.is_empty() || expanded != raw;
     log::debug!(
         "pipeline: snippets expanded pure_fast_path={} expanded_chars={}",
         pure_expansion.is_some(),
@@ -1284,6 +1285,7 @@ pub struct PipelineTestResult {
     pub history_entry: db::RecentEntry,
     pub recent: Vec<db::RecentEntry>,
     pub stats: db::Stats,
+    pub snippet_active: bool,
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -1359,7 +1361,7 @@ pub async fn run_pipeline_fixture(
         })
     })?;
 
-    let (final_text_before_dictionary, dict_entries, cleanup_cache_key, _snippet_active) =
+    let (final_text_before_dictionary, dict_entries, cleanup_cache_key, snippet_active) =
         run_cleanup_and_snippets_for_db(
             &db_handle,
             &raw_text,
@@ -1400,6 +1402,7 @@ pub async fn run_pipeline_fixture(
         history_entry,
         recent,
         stats,
+        snippet_active,
     })
 }
 
@@ -1768,6 +1771,46 @@ mod tests {
             0
         );
         assert_eq!(take_injections().len(), 1);
+        reset();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pipeline_fixture_marks_snippet_active_for_inline_expansion_without_instructions() {
+        let _guard = harness_test_lock().lock().expect("harness lock");
+        reset();
+        set_enabled(true);
+        register_fixture(FixtureSpec {
+            task: "transcription".into(),
+            provider: "groq".into(),
+            model: "whisper-large-v3-turbo".into(),
+            response: Some("remind them btw to call back".into()),
+            error_kind: None,
+            error_message: None,
+        });
+        register_fixture(FixtureSpec {
+            task: "cleanup".into(),
+            provider: "groq".into(),
+            model: "llama-3.3-70b-versatile".into(),
+            response: Some("remind them by the way to call back".into()),
+            error_kind: None,
+            error_message: None,
+        });
+
+        let mut request = base_request(base_config());
+        request.snippets.push(PipelineTestSnippet {
+            trigger: "btw".into(),
+            expansion: "by the way".into(),
+            instructions: String::new(),
+        });
+
+        let result = run_pipeline_fixture(request)
+            .await
+            .expect("inline snippet expansion should succeed");
+        assert!(result.snippet_active);
+        assert_eq!(
+            result.final_text_before_dictionary,
+            "remind them by the way to call back"
+        );
         reset();
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1494,6 +1494,7 @@ mod tests {
             cleanup_intensity: "medium".into(),
             app_context_hint: false,
             auto_learn_enabled: false,
+            auto_learn_window_days: 3,
             contextual_caps_enabled: true,
             auto_spacing_enabled: true,
             macos_clipboard_sniff_enabled: false,
@@ -2047,7 +2048,8 @@ async fn finalize_pipeline_completion(
         if let Err(e) = injection::copy_to_clipboard(&final_text_substituted).await {
             log::warn!("pipeline: clipboard fallback write failed: {e}");
         }
-        app.emit("open-flow:error", "Text copied — press Ctrl+V to paste").ok();
+        app.emit("open-flow:error", "Text copied — press Ctrl+V to paste")
+            .ok();
         injection::InjectionOutcome {
             text: final_text_substituted.clone(),
             context_state: "self_inject",
@@ -2113,11 +2115,23 @@ async fn finalize_pipeline_completion(
                 app.clone(),
             );
         }
+
+        // Source A: raw↔clean divergence (cross-platform, zero accessibility).
+        auto_learn::record_cleanup_divergence(
+            ctx.raw,
+            ctx.final_text_before_dict,
+            &ctx.process_name,
+            db_handle.inner().clone(),
+            app.clone(),
+            ctx.cfg.auto_learn_window_days,
+        );
+
         auto_learn::start_monitor(
             injected_text,
             ctx.process_name,
             db_handle.inner().clone(),
             app.clone(),
+            ctx.cfg.auto_learn_window_days,
         );
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -725,7 +725,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
     }
 
     let stage_transcribe = std::time::Instant::now();
-    let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key)) =
+    let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key, snippet_active)) =
         run_transcription_and_cleanup(&app, &wav, &cfg, &profile, app_context.as_deref()).await
     else {
         emit_pipeline_failed(&app);
@@ -776,6 +776,7 @@ pub async fn run_pipeline(app: AppHandle, state: SharedState) {
             process_name,
             cleanup_cache_key,
             captured_at: retry_captured_at,
+            snippet_active,
         },
     )
     .await
@@ -948,13 +949,20 @@ async fn run_transcription_and_cleanup(
     cfg: &store::PipelineConfig,
     profile: &str,
     app_context: Option<&str>,
-) -> Option<(String, String, String, Vec<db::DictionaryEntry>, String)> {
+) -> Option<(String, String, String, Vec<db::DictionaryEntry>, String, bool)> {
     let (raw, api_used) = run_transcription(app, wav, cfg).await?;
     let raw = normalize_transcription_math_artifacts(&raw);
 
-    let (final_text, dict_entries, cleanup_cache_key) =
+    let (final_text, dict_entries, cleanup_cache_key, snippet_active) =
         run_cleanup_and_snippets(app, &raw, cfg, profile, app_context).await?;
-    Some((raw, api_used, final_text, dict_entries, cleanup_cache_key))
+    Some((
+        raw,
+        api_used,
+        final_text,
+        dict_entries,
+        cleanup_cache_key,
+        snippet_active,
+    ))
 }
 
 // Handles snippet fast-path, snippet instruction collection, LLM cleanup, and
@@ -966,7 +974,7 @@ async fn run_cleanup_and_snippets(
     cfg: &store::PipelineConfig,
     profile: &str,
     app_context: Option<&str>,
-) -> Option<(String, Vec<db::DictionaryEntry>, String)> {
+) -> Option<(String, Vec<db::DictionaryEntry>, String, bool)> {
     let db_handle = app.state::<DbHandle>();
     match run_cleanup_and_snippets_for_db(db_handle.inner(), raw, cfg, profile, app_context).await {
         Ok(result) => Some(result),
@@ -994,7 +1002,7 @@ async fn run_cleanup_and_snippets_for_db(
     cfg: &store::PipelineConfig,
     profile: &str,
     app_context: Option<&str>,
-) -> anyhow::Result<(String, Vec<db::DictionaryEntry>, String)> {
+) -> anyhow::Result<(String, Vec<db::DictionaryEntry>, String, bool)> {
     let mut db_snippets = db::query_snippets(db_handle).unwrap_or_default();
     let dict_entries = db::query_dictionary(db_handle).unwrap_or_default();
     log::debug!(
@@ -1029,6 +1037,7 @@ async fn run_cleanup_and_snippets_for_db(
     } else {
         None
     };
+    let snippet_active = pure_expansion.is_some() || !snippet_instructions.is_empty();
     let expanded = pure_expansion
         .clone()
         .unwrap_or_else(|| snippets::expand_snippets_from(raw, &mut db_snippets, db_handle));
@@ -1092,7 +1101,7 @@ async fn run_cleanup_and_snippets_for_db(
                     &entry.clean_text,
                     &snippet_instructions,
                 );
-                return Ok((overridden, dict_entries, cache_key));
+                return Ok((overridden, dict_entries, cache_key, snippet_active));
             }
         }
         log::debug!(
@@ -1194,7 +1203,7 @@ async fn run_cleanup_and_snippets_for_db(
         snippets::apply_cleanup_instruction_overrides(&expanded, &snippet_instructions)
     };
 
-    Ok((final_text, dict_entries, used_cache_key))
+    Ok((final_text, dict_entries, used_cache_key, snippet_active))
 }
 
 fn should_run_cleanup_llm(
@@ -1350,7 +1359,7 @@ pub async fn run_pipeline_fixture(
         })
     })?;
 
-    let (final_text_before_dictionary, dict_entries, cleanup_cache_key) =
+    let (final_text_before_dictionary, dict_entries, cleanup_cache_key, _snippet_active) =
         run_cleanup_and_snippets_for_db(
             &db_handle,
             &raw_text,
@@ -1921,7 +1930,7 @@ pub async fn retry_transcription_impl(
         anyhow::bail!("No API key configured");
     }
 
-    let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key)) =
+    let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key, snippet_active)) =
         run_transcription_and_cleanup(
             app,
             &capture.wav,
@@ -1949,6 +1958,7 @@ pub async fn retry_transcription_impl(
             process_name: capture.process_name,
             cleanup_cache_key,
             captured_at: capture.captured_at,
+            snippet_active,
         },
     )
     .await
@@ -1966,6 +1976,7 @@ struct PipelineCompletionContext<'a> {
     process_name: String,
     cleanup_cache_key: String,
     captured_at: std::time::Instant,
+    snippet_active: bool,
 }
 
 async fn finalize_pipeline_completion(
@@ -2117,14 +2128,18 @@ async fn finalize_pipeline_completion(
         }
 
         // Source A: raw↔clean divergence (cross-platform, zero accessibility).
-        auto_learn::record_cleanup_divergence(
-            ctx.raw,
-            ctx.final_text_before_dict,
-            &ctx.process_name,
-            db_handle.inner().clone(),
-            app.clone(),
-            ctx.cfg.auto_learn_window_days,
-        );
+        // Skipped when a snippet fired — the divergence is the snippet expansion,
+        // not a transcription correction.
+        if !ctx.snippet_active {
+            auto_learn::record_cleanup_divergence(
+                ctx.raw.to_string(),
+                ctx.final_text_before_dict.to_string(),
+                ctx.process_name.clone(),
+                db_handle.inner().clone(),
+                app.clone(),
+                ctx.cfg.auto_learn_window_days,
+            );
+        }
 
         auto_learn::start_monitor(
             injected_text,

--- a/src-tauri/src/system/macos_ax_text_marker.m
+++ b/src-tauri/src/system/macos_ax_text_marker.m
@@ -587,3 +587,51 @@ int openflow_macos_read_context_probe(
     CFRelease(system);
     return 1;
 }
+
+// Read the full kAXValue text of the currently focused UI element into buf.
+// buf_len: size of caller-allocated buffer (recommend >= 65536).
+// Returns 1 on success (buf may be empty string if field is empty),
+// 0 if AX is unavailable or the element has no text pattern.
+int openflow_macos_read_focused_text(char *buf, size_t buf_len) {
+    if (buf == NULL || buf_len == 0) {
+        return 0;
+    }
+    buf[0] = '\0';
+
+    if (!AXIsProcessTrusted()) {
+        return 0;
+    }
+
+    AXUIElementRef system = AXUIElementCreateSystemWide();
+    if (system == NULL) {
+        return 0;
+    }
+    of_set_timeout(system);
+
+    AXUIElementRef focused_element = NULL;
+    if (!of_copy_ax_element_attribute(system, kAXFocusedUIElementAttribute, &focused_element)) {
+        CFRelease(system);
+        return 0;
+    }
+    of_set_timeout(focused_element);
+
+    // Try the highest editable ancestor first (catches web areas in browsers).
+    AXUIElementRef target_element = focused_element;
+    AXUIElementRef editable_ancestor = NULL;
+    if (of_copy_ax_element_attribute(focused_element, kOFAXHighestEditableAncestorAttribute, &editable_ancestor)) {
+        if (editable_ancestor != NULL) {
+            target_element = editable_ancestor;
+            of_set_timeout(target_element);
+        }
+    }
+
+    bool ok = of_copy_string_attribute(target_element, kAXValueAttribute, buf, buf_len);
+
+    if (editable_ancestor != NULL) {
+        CFRelease(editable_ancestor);
+    }
+    CFRelease(focused_element);
+    CFRelease(system);
+
+    return ok ? 1 : 0;
+}

--- a/src-tauri/src/system/macos_ax_text_marker.m
+++ b/src-tauri/src/system/macos_ax_text_marker.m
@@ -609,7 +609,7 @@ int openflow_macos_read_focused_text(char *buf, size_t buf_len) {
     of_set_timeout(system);
 
     AXUIElementRef focused_element = NULL;
-    if (!of_copy_ax_element_attribute(system, kAXFocusedUIElementAttribute, &focused_element)) {
+    if (!of_copy_ax_element_attribute(system, kAXFocusedUIElementAttribute, &focused_element) || focused_element == NULL) {
         CFRelease(system);
         return 0;
     }

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from '../../tauri';
-  import { fly, fade } from 'svelte/transition';
+  import { fly, fade, slide } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';
   import { saveSetting, type HistoryRetention } from '../../settings';
@@ -18,6 +18,7 @@
   let historyDropdownOpen = $state(false);
   let appContextHint = $state(false);
   let autoLearn = $state(false);
+  let autoLearnWindowDays = $state(3);
   let cleanupCacheEntries = $state(0);
   let cleanupCacheSpaceConstrained = $state(false);
   let cleanupCacheFreeBytes = $state<number | null>(null);
@@ -34,10 +35,11 @@
 
   async function loadSettings() {
     try {
-      const [retention, hint, learn, cacheStatus, summary, recent] = await Promise.all([
+      const [retention, hint, learn, windowDays, cacheStatus, summary, recent] = await Promise.all([
         invoke<string | null>('get_setting', { key: 'history_retention' }),
         invoke<boolean | null>('get_setting', { key: 'app_context_hint' }),
         invoke<boolean | null>('get_setting', { key: 'auto_learn_enabled' }),
+        invoke<number | null>('get_setting', { key: 'auto_learn_window_days' }),
         invoke<CleanupCacheStatus>('get_cleanup_cache_status'),
         invoke<typeof autoLearnSummary>('get_auto_learn_status_summary'),
         invoke<typeof recentAutoLearn>('get_recent_auto_learn_activity', { limit: 5 }),
@@ -45,6 +47,9 @@
       if (retention) historyRetention = retention;
       appContextHint = hint ?? false;
       autoLearn = learn ?? false;
+      if (windowDays !== null && windowDays !== undefined) {
+        autoLearnWindowDays = Math.max(1, Math.min(30, windowDays));
+      }
       cleanupCacheEntries = cacheStatus?.entry_count ?? 0;
       cleanupCacheSpaceConstrained = cacheStatus?.is_space_constrained ?? false;
       cleanupCacheFreeBytes = cacheStatus?.free_bytes ?? null;
@@ -82,6 +87,14 @@
     } catch (err) {
       autoLearn = !value;
       console.error('save auto_learn_enabled failed:', err);
+    }
+  }
+
+  async function saveAutoLearnWindowDays() {
+    try {
+      await saveSetting('auto_learn_window_days', autoLearnWindowDays);
+    } catch (err) {
+      console.error('saveAutoLearnWindowDays failed:', err);
     }
   }
 
@@ -269,6 +282,26 @@
   </div>
   <Toggle checked={autoLearn} onchange={handleAutoLearn} label="Auto-learn corrections" />
 </div>
+{#if autoLearn}
+  <div class="setting-row window-row" transition:slide={{ duration: motionMs(MOTION_MS.base) }}>
+    <div class="window-header">
+      <div>
+        <div class="label">Learning window</div>
+        <div class="desc">How long evidence is remembered before it stops counting toward a suggestion</div>
+      </div>
+      <span class="window-value">{autoLearnWindowDays} day{autoLearnWindowDays === 1 ? '' : 's'}</span>
+    </div>
+    <input
+      type="range"
+      class="window-slider"
+      min="1" max="30" step="1"
+      bind:value={autoLearnWindowDays}
+      oninput={saveAutoLearnWindowDays}
+      style="--pct: {((autoLearnWindowDays - 1) / 29 * 100).toFixed(1)}%"
+      aria-label="Auto-learn window in days"
+    />
+  </div>
+{/if}
 <div class="setting-row">
   <div>
     <div class="label">Auto-learn activity</div>
@@ -419,4 +452,56 @@
     transition: opacity 0.16s ease, transform 0.16s ease;
   }
   .privacy-eye-wrap:hover .privacy-tooltip { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  .window-row { flex-direction: column; align-items: stretch; gap: 0; }
+  .window-header { display: flex; align-items: center; justify-content: space-between; width: 100%; }
+  .window-value {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--accent);
+    min-width: 52px;
+    text-align: right;
+    flex-shrink: 0;
+  }
+  .window-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 4px;
+    border-radius: 2px;
+    margin-top: 10px;
+    background: linear-gradient(
+      to right,
+      var(--accent) 0%, var(--accent) var(--pct),
+      var(--line-strong) var(--pct), var(--line-strong) 100%
+    );
+    outline: none;
+    cursor: pointer;
+    border: none;
+    display: block;
+  }
+  .window-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--bg-elev);
+    border: 2px solid var(--accent);
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--accent) 35%, transparent);
+    cursor: pointer;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+  }
+  .window-slider::-webkit-slider-thumb:hover { box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 45%, transparent); transform: scale(1.1); }
+  .window-slider::-webkit-slider-thumb:active { box-shadow: 0 2px 10px color-mix(in srgb, var(--accent) 55%, transparent); transform: scale(1.15); }
+  .window-slider::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--bg-elev);
+    border: 2px solid var(--accent);
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--accent) 35%, transparent);
+    cursor: pointer;
+  }
 </style>

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -296,7 +296,7 @@
       class="window-slider"
       min="1" max="30" step="1"
       bind:value={autoLearnWindowDays}
-      oninput={saveAutoLearnWindowDays}
+      onchange={saveAutoLearnWindowDays}
       style="--pct: {((autoLearnWindowDays - 1) / 29 * 100).toFixed(1)}%"
       aria-label="Auto-learn window in days"
     />

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -38,6 +38,7 @@ type SettingsValueMap = {
   force_setup_on_launch: boolean;
   app_context_hint: boolean;
   auto_learn_enabled: boolean;
+  auto_learn_window_days: number;
   contextual_caps_enabled: boolean;
   auto_spacing_enabled: boolean;
   history_retention: HistoryRetention;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -221,9 +221,11 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'set_dev_logging_enabled':
     case 'start_calibration_monitoring':
     case 'stop_calibration_monitoring':
-    case 'approve_dictionary_suggestion':
     case 'dismiss_dictionary_suggestion':
+    case 'restore_never_learn_pair':
       return undefined as T;
+    case 'approve_dictionary_suggestion':
+      return true as T;
     case 'create_snippet': {
       const trigger = assertDevText(args?.trigger, 'Trigger').trim();
       const expansion = assertDevText(args?.expansion, 'Expansion');

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -74,6 +74,7 @@ const defaultSettings: Record<string, unknown> = {
   mic_gain: 3.5,
   app_context_hint: false,
   auto_learn_enabled: false,
+  auto_learn_window_days: 3,
   contextual_caps_enabled: true,
   auto_spacing_enabled: true,
   history_retention: '30 days',
@@ -171,6 +172,7 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return readDevList<DevDictionaryEntry>(DEV_DICTIONARY_KEY) as T;
     case 'get_recent':
     case 'get_recent_auto_learn_activity':
+    case 'get_dictionary_suggestions':
     case 'get_microphones':
     case 'get_recent_logs':
     case 'get_installed_apps':
@@ -219,6 +221,8 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'set_dev_logging_enabled':
     case 'start_calibration_monitoring':
     case 'stop_calibration_monitoring':
+    case 'approve_dictionary_suggestion':
+    case 'dismiss_dictionary_suggestion':
       return undefined as T;
     case 'create_snippet': {
       const trigger = assertDevText(args?.trigger, 'Trigger').trim();

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -44,6 +44,8 @@
   let suggestions     = $state<DictionarySuggestion[]>([]);
   let dismissingKeys  = $state<Set<string>>(new Set());
   let approvingKeys   = $state<Set<string>>(new Set());
+  let lastDismissed   = $state<{ wrong_word: string; correct_word: string } | null>(null);
+  let undoTimer: ReturnType<typeof window.setTimeout> | undefined;
 
   let search        = $state('');
   let debouncedSearch = $state('');
@@ -116,8 +118,8 @@
   async function fetchSuggestions() {
     try {
       suggestions = (await invoke<DictionarySuggestion[] | null>('get_dictionary_suggestions')) ?? [];
-    } catch {
-      // unavailable in browser dev mode — leave suggestions as-is
+    } catch (err) {
+      console.error('fetchSuggestions failed', err);
     }
   }
 
@@ -126,8 +128,11 @@
     if (approvingKeys.has(key)) return;
     approvingKeys = new Set(approvingKeys).add(key);
     try {
-      await invoke('approve_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+      const applied = await invoke<boolean>('approve_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
       suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
+      if (applied === false) {
+        await emit('open-flow:error', `"${s.correct_word}" already has a different dictionary entry — suggestion removed.`);
+      }
     } catch (err) {
       console.error(err);
       await emit('open-flow:error', 'Could not approve suggestion.');
@@ -146,6 +151,7 @@
       try {
         await invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
         suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
+        showUndoBanner(s);
       } catch (err) {
         console.error(err);
         await emit('open-flow:error', 'Could not dismiss suggestion.');
@@ -157,12 +163,38 @@
     }, motionMs(200));
   }
 
+  function showUndoBanner(s: DictionarySuggestion) {
+    if (undoTimer !== undefined) window.clearTimeout(undoTimer);
+    lastDismissed = { wrong_word: s.wrong_word, correct_word: s.correct_word };
+    undoTimer = window.setTimeout(() => {
+      lastDismissed = null;
+      undoTimer = undefined;
+    }, 6000);
+  }
+
+  async function undoDismiss() {
+    const target = lastDismissed;
+    if (!target) return;
+    if (undoTimer !== undefined) {
+      window.clearTimeout(undoTimer);
+      undoTimer = undefined;
+    }
+    lastDismissed = null;
+    try {
+      await invoke('restore_never_learn_pair', { wrong: target.wrong_word, correct: target.correct_word });
+      await fetchSuggestions();
+    } catch (err) {
+      console.error(err);
+      await emit('open-flow:error', 'Could not undo dismissal.');
+    }
+  }
+
   onMount(() => {
     let unlisten: (() => void) | undefined;
     let unlistenSuggestion: (() => void) | undefined;
     fetchDictionary();
     fetchSuggestions();
-    listen('open-flow:dictionary-updated', () => fetchDictionary())
+    listen('open-flow:dictionary-updated', () => { fetchDictionary(); fetchSuggestions(); })
       .then((cleanup) => { unlisten = cleanup; })
       .catch(() => {});
     listen('open-flow:suggestion-added', () => fetchSuggestions())
@@ -171,7 +203,12 @@
     updateSortIndicator();
     const onResize = () => updateSortIndicator();
     window.addEventListener('resize', onResize);
-    return () => { unlisten?.(); unlistenSuggestion?.(); window.removeEventListener('resize', onResize); };
+    return () => {
+      unlisten?.();
+      unlistenSuggestion?.();
+      window.removeEventListener('resize', onResize);
+      if (undoTimer !== undefined) window.clearTimeout(undoTimer);
+    };
   });
 
   function selectRow(e: DictionaryEntry) {
@@ -335,7 +372,7 @@
     <div class="suggested-section" in:fade={{ duration: 180 }}>
       <div class="suggested-header">
         <span class="suggested-label">Suggested corrections</span>
-        <span class="suggested-count">{suggestions.length}</span>
+        <span class="suggested-count">{visibleSuggestions.length}</span>
       </div>
       <div class="suggested-list">
         {#each visibleSuggestions as s (s.id)}
@@ -345,11 +382,16 @@
             animate:flip={{ duration: motionMs(MOTION_MS.panel), easing: expoOut }}
             out:listItemCollapse={{ duration: 200 }}
           >
-            <span class="suggested-pair">
-              <span class="suggested-wrong">"{s.wrong_word}"</span>
-              <svg class="suggested-arrow" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
-              <span class="suggested-correct">{s.correct_word}</span>
-            </span>
+            <div class="suggested-info">
+              <span class="suggested-pair">
+                <span class="suggested-wrong">"{s.wrong_word}"</span>
+                <svg class="suggested-arrow" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+                <span class="suggested-correct">{s.correct_word}</span>
+              </span>
+              {#if s.source_summary}
+                <span class="suggested-meta">{s.source_summary}</span>
+              {/if}
+            </div>
             <div class="suggested-actions">
               <button
                 class="btn-approve"
@@ -364,6 +406,12 @@
           </div>
         {/each}
       </div>
+      {#if lastDismissed}
+        <div class="undo-banner" in:fly={{ y: -6, duration: motionMs(MOTION_MS.fast), easing: expoOut }} out:fade={{ duration: motionMs(MOTION_MS.fast) }}>
+          <span>Won't suggest "{lastDismissed.wrong_word}" → {lastDismissed.correct_word} again.</span>
+          <button class="btn-undo" onclick={undoDismiss}>Undo</button>
+        </div>
+      {/if}
     </div>
   {/if}
 
@@ -730,14 +778,30 @@
     border-bottom: 0;
   }
 
-  .suggested-pair {
+  .suggested-info {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .suggested-pair {
     display: flex;
     align-items: center;
     gap: 7px;
     min-width: 0;
     font-family: var(--sans);
     font-size: 13px;
+  }
+
+  .suggested-meta {
+    font-size: 10.5px;
+    font-family: var(--mono);
+    color: var(--ink-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .suggested-wrong {
@@ -811,6 +875,34 @@
     display: inline-block;
     flex-shrink: 0;
   }
+
+  .undo-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 12px;
+    border-top: 1px solid var(--line);
+    background: var(--bg-elev);
+    font-size: 12px;
+    color: var(--ink-soft);
+  }
+
+  .btn-undo {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: var(--sans);
+    color: var(--accent-ink);
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+  .btn-undo:hover { opacity: 0.8; }
 
   /* ── end suggested section ── */
 

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -11,6 +11,16 @@
   type SortKey = 'newest' | 'oldest' | 'alpha' | 'most_corrected';
   type CreatedRecordMeta = { id: number; created_at: string };
 
+  type DictionarySuggestion = {
+    id: number;
+    wrong_word: string;
+    correct_word: string;
+    score: number;
+    source_summary: string;
+    created_at: string;
+    updated_at: string;
+  };
+
   function fmtDate(iso: string): string {
     try {
       const MS_PER_DAY = 86_400_000;
@@ -30,6 +40,10 @@
     if (tier === 'manual') return 'Manual';
     return 'Unknown confidence';
   }
+
+  let suggestions     = $state<DictionarySuggestion[]>([]);
+  let dismissingKeys  = $state<Set<string>>(new Set());
+  let approvingKeys   = $state<Set<string>>(new Set());
 
   let search        = $state('');
   let debouncedSearch = $state('');
@@ -99,16 +113,65 @@
   });
   const visibleFiltered = $derived(filtered.filter((entry) => !leavingIds.has(entry.id)));
 
+  async function fetchSuggestions() {
+    try {
+      suggestions = (await invoke<DictionarySuggestion[] | null>('get_dictionary_suggestions')) ?? [];
+    } catch {
+      // unavailable in browser dev mode — leave suggestions as-is
+    }
+  }
+
+  async function approveSuggestion(s: DictionarySuggestion) {
+    const key = `${s.wrong_word}:${s.correct_word}`;
+    if (approvingKeys.has(key)) return;
+    approvingKeys = new Set(approvingKeys).add(key);
+    try {
+      await invoke('approve_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+      suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
+    } catch (err) {
+      console.error(err);
+      await emit('open-flow:error', 'Could not approve suggestion.');
+    } finally {
+      const next = new Set(approvingKeys);
+      next.delete(key);
+      approvingKeys = next;
+    }
+  }
+
+  async function dismissSuggestion(s: DictionarySuggestion) {
+    const key = `${s.wrong_word}:${s.correct_word}`;
+    if (dismissingKeys.has(key)) return;
+    dismissingKeys = new Set(dismissingKeys).add(key);
+    window.setTimeout(async () => {
+      try {
+        await invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+        suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
+      } catch (err) {
+        console.error(err);
+        await emit('open-flow:error', 'Could not dismiss suggestion.');
+      } finally {
+        const next = new Set(dismissingKeys);
+        next.delete(key);
+        dismissingKeys = next;
+      }
+    }, motionMs(200));
+  }
+
   onMount(() => {
     let unlisten: (() => void) | undefined;
+    let unlistenSuggestion: (() => void) | undefined;
     fetchDictionary();
+    fetchSuggestions();
     listen('open-flow:dictionary-updated', () => fetchDictionary())
       .then((cleanup) => { unlisten = cleanup; })
+      .catch(() => {});
+    listen('open-flow:suggestion-added', () => fetchSuggestions())
+      .then((cleanup) => { unlistenSuggestion = cleanup; })
       .catch(() => {});
     updateSortIndicator();
     const onResize = () => updateSortIndicator();
     window.addEventListener('resize', onResize);
-    return () => { unlisten?.(); window.removeEventListener('resize', onResize); };
+    return () => { unlisten?.(); unlistenSuggestion?.(); window.removeEventListener('resize', onResize); };
   });
 
   function selectRow(e: DictionaryEntry) {
@@ -264,6 +327,43 @@
     <div class="load-warning" role="alert" aria-live="assertive">
       <span>{appStore.dictionaryFetchError || 'Unable to load dictionary terms.'} Check backend connection and retry.</span>
       <button type="button" class="load-warning-retry" onclick={() => fetchDictionary()}>Retry</button>
+    </div>
+  {/if}
+
+  {#if suggestions != null && suggestions.length > 0}
+    {@const visibleSuggestions = suggestions.filter(s => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`))}
+    <div class="suggested-section" in:fade={{ duration: 180 }}>
+      <div class="suggested-header">
+        <span class="suggested-label">Suggested corrections</span>
+        <span class="suggested-count">{suggestions.length}</span>
+      </div>
+      <div class="suggested-list">
+        {#each visibleSuggestions as s (s.id)}
+          {@const key = `${s.wrong_word}:${s.correct_word}`}
+          <div
+            class="suggested-row"
+            animate:flip={{ duration: motionMs(MOTION_MS.panel), easing: expoOut }}
+            out:listItemCollapse={{ duration: 200 }}
+          >
+            <span class="suggested-pair">
+              <span class="suggested-wrong">"{s.wrong_word}"</span>
+              <svg class="suggested-arrow" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              <span class="suggested-correct">{s.correct_word}</span>
+            </span>
+            <div class="suggested-actions">
+              <button
+                class="btn-approve"
+                disabled={approvingKeys.has(key)}
+                onclick={() => approveSuggestion(s)}
+              >
+                {#if approvingKeys.has(key)}<span class="spinner-sm"></span>{/if}
+                Approve
+              </button>
+              <button class="btn-dismiss" onclick={() => dismissSuggestion(s)}>Dismiss</button>
+            </div>
+          </div>
+        {/each}
+      </div>
     </div>
   {/if}
 
@@ -575,6 +675,144 @@
   }
 
   .page-sub { color: var(--ink-mute); font-size: 12.5px; margin: 0 0 22px; max-width: 560px; line-height: 1.5; }
+
+  /* ── suggested section ── */
+
+  .suggested-section {
+    margin-bottom: 18px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm, 8px);
+    overflow: hidden;
+  }
+
+  .suggested-header {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-elev);
+  }
+
+  .suggested-label {
+    font-size: 11.5px;
+    font-weight: 600;
+    font-family: var(--sans);
+    color: var(--ink-mute);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .suggested-count {
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    font-size: 11px;
+    font-family: var(--sans);
+    font-weight: 600;
+    border-radius: 20px;
+    padding: 1px 7px;
+    line-height: 1.6;
+  }
+
+  .suggested-list {
+    background: var(--bg);
+  }
+
+  .suggested-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .suggested-row:last-child {
+    border-bottom: 0;
+  }
+
+  .suggested-pair {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    font-family: var(--sans);
+    font-size: 13px;
+  }
+
+  .suggested-wrong {
+    color: var(--ink-mute);
+    font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 180px;
+  }
+
+  .suggested-arrow {
+    flex-shrink: 0;
+    color: var(--arm-300);
+  }
+
+  .suggested-correct {
+    color: var(--ink-strong);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .suggested-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .btn-approve {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--ink);
+    color: var(--amber-50);
+    border: 0;
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: var(--sans);
+    cursor: pointer;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+  }
+  .btn-approve:disabled { opacity: 0.4; cursor: default; }
+  .btn-approve:not(:disabled):hover { opacity: 0.82; }
+
+  .btn-dismiss {
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-mute);
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s;
+    white-space: nowrap;
+  }
+  .btn-dismiss:hover { border-color: var(--arm-300); color: var(--ink); }
+
+  .spinner-sm {
+    width: 9px;
+    height: 9px;
+    border: 1.5px solid rgba(255,255,255,0.35);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    display: inline-block;
+    flex-shrink: 0;
+  }
+
+  /* ── end suggested section ── */
 
   .fetch-status {
     margin: 0 0 10px;

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -374,7 +374,7 @@
     </div>
   {/if}
 
-  {#if suggestions != null && suggestions.length > 0}
+  {#if suggestions != null && suggestions.filter(s => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`)).length > 0}
     {@const visibleSuggestions = suggestions.filter(s => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`))}
     <div class="suggested-section" in:fade={{ duration: 180 }}>
       <div class="suggested-header">

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -116,6 +116,9 @@
     return list;
   });
   const visibleFiltered = $derived(filtered.filter((entry) => !leavingIds.has(entry.id)));
+  const visibleSuggestions = $derived(
+    suggestions.filter((s) => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`))
+  );
 
   async function fetchSuggestions() {
     try {
@@ -388,8 +391,7 @@
     </div>
   {/if}
 
-  {#if suggestions != null && suggestions.filter(s => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`)).length > 0}
-    {@const visibleSuggestions = suggestions.filter(s => !dismissingKeys.has(`${s.wrong_word}:${s.correct_word}`))}
+  {#if suggestions != null && visibleSuggestions.length > 0}
     <div class="suggested-section" in:fade={{ duration: 180 }}>
       <div class="suggested-header">
         <span class="suggested-label">Suggested corrections</span>

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -47,6 +47,7 @@
   let lastDismissed   = $state<{ wrong_word: string; correct_word: string } | null>(null);
   let undoTimer: ReturnType<typeof window.setTimeout> | undefined;
   let dismissTimers: ReturnType<typeof window.setTimeout>[] = [];
+  let destroyed = false;
 
   let search        = $state('');
   let debouncedSearch = $state('');
@@ -118,7 +119,9 @@
 
   async function fetchSuggestions() {
     try {
-      suggestions = (await invoke<DictionarySuggestion[] | null>('get_dictionary_suggestions')) ?? [];
+      const result = (await invoke<DictionarySuggestion[] | null>('get_dictionary_suggestions')) ?? [];
+      if (destroyed) return;
+      suggestions = result;
     } catch (err) {
       console.error('fetchSuggestions failed', err);
     }
@@ -130,17 +133,20 @@
     approvingKeys = new Set(approvingKeys).add(key);
     try {
       const applied = await invoke<boolean>('approve_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+      if (destroyed) return;
       suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
       if (applied === false) {
         await emit('open-flow:error', `"${s.correct_word}" already has a different dictionary entry — suggestion removed.`);
       }
     } catch (err) {
       console.error(err);
-      await emit('open-flow:error', 'Could not approve suggestion.');
+      if (!destroyed) await emit('open-flow:error', 'Could not approve suggestion.');
     } finally {
-      const next = new Set(approvingKeys);
-      next.delete(key);
-      approvingKeys = next;
+      if (!destroyed) {
+        const next = new Set(approvingKeys);
+        next.delete(key);
+        approvingKeys = next;
+      }
     }
   }
 
@@ -152,15 +158,18 @@
       dismissTimers = dismissTimers.filter((t) => t !== timer);
       try {
         await invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+        if (destroyed) return;
         suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
         showUndoBanner(s);
       } catch (err) {
         console.error(err);
-        await emit('open-flow:error', 'Could not dismiss suggestion.');
+        if (!destroyed) await emit('open-flow:error', 'Could not dismiss suggestion.');
       } finally {
-        const next = new Set(dismissingKeys);
-        next.delete(key);
-        dismissingKeys = next;
+        if (!destroyed) {
+          const next = new Set(dismissingKeys);
+          next.delete(key);
+          dismissingKeys = next;
+        }
       }
     }, motionMs(200));
     dismissTimers.push(timer);
@@ -185,15 +194,15 @@
     lastDismissed = null;
     try {
       await invoke('restore_never_learn_pair', { wrong: target.wrong_word, correct: target.correct_word });
+      if (destroyed) return;
       await fetchSuggestions();
     } catch (err) {
       console.error(err);
-      await emit('open-flow:error', 'Could not undo dismissal.');
+      if (!destroyed) await emit('open-flow:error', 'Could not undo dismissal.');
     }
   }
 
   onMount(() => {
-    let destroyed = false;
     let unlisten: (() => void) | undefined;
     let unlistenSuggestion: (() => void) | undefined;
     fetchDictionary();

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -227,7 +227,7 @@
       unlistenSuggestion?.();
       window.removeEventListener('resize', onResize);
       if (undoTimer !== undefined) window.clearTimeout(undoTimer);
-      dismissTimers.forEach(window.clearTimeout);
+      dismissTimers.forEach((t) => window.clearTimeout(t));
       dismissTimers = [];
     };
   });

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -155,25 +155,27 @@
     if (dismissingKeys.has(key)) return;
     dismissingKeys = new Set(dismissingKeys).add(key);
     // Start the DB write immediately so it isn't lost if the user navigates
-    // away before the slide/collapse animation timer below fires.
-    const dbWrite = invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+    // away before the slide/collapse animation timer below fires. Attach the
+    // catch handler now so a rejection is never left unhandled if the timer
+    // is cleared (component destroyed) before it settles.
+    let failed = false;
+    const dbWrite = invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word })
+      .catch((err) => {
+        console.error(err);
+        failed = true;
+        if (!destroyed) emit('open-flow:error', 'Could not dismiss suggestion.').catch(() => {});
+      });
     const timer = window.setTimeout(async () => {
       dismissTimers = dismissTimers.filter((t) => t !== timer);
-      try {
-        await dbWrite;
-        if (destroyed) return;
+      await dbWrite;
+      if (destroyed) return;
+      if (!failed) {
         suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
         showUndoBanner(s);
-      } catch (err) {
-        console.error(err);
-        if (!destroyed) await emit('open-flow:error', 'Could not dismiss suggestion.');
-      } finally {
-        if (!destroyed) {
-          const next = new Set(dismissingKeys);
-          next.delete(key);
-          dismissingKeys = next;
-        }
       }
+      const next = new Set(dismissingKeys);
+      next.delete(key);
+      dismissingKeys = next;
     }, motionMs(200));
     dismissTimers.push(timer);
   }

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -154,10 +154,13 @@
     const key = `${s.wrong_word}:${s.correct_word}`;
     if (dismissingKeys.has(key)) return;
     dismissingKeys = new Set(dismissingKeys).add(key);
+    // Start the DB write immediately so it isn't lost if the user navigates
+    // away before the slide/collapse animation timer below fires.
+    const dbWrite = invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
     const timer = window.setTimeout(async () => {
       dismissTimers = dismissTimers.filter((t) => t !== timer);
       try {
-        await invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
+        await dbWrite;
         if (destroyed) return;
         suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
         showUndoBanner(s);

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -193,20 +193,22 @@
   }
 
   onMount(() => {
+    let destroyed = false;
     let unlisten: (() => void) | undefined;
     let unlistenSuggestion: (() => void) | undefined;
     fetchDictionary();
     fetchSuggestions();
     listen('open-flow:dictionary-updated', () => { fetchDictionary(); fetchSuggestions(); })
-      .then((cleanup) => { unlisten = cleanup; })
+      .then((cleanup) => { if (destroyed) cleanup(); else unlisten = cleanup; })
       .catch(() => {});
     listen('open-flow:suggestion-added', () => fetchSuggestions())
-      .then((cleanup) => { unlistenSuggestion = cleanup; })
+      .then((cleanup) => { if (destroyed) cleanup(); else unlistenSuggestion = cleanup; })
       .catch(() => {});
     updateSortIndicator();
     const onResize = () => updateSortIndicator();
     window.addEventListener('resize', onResize);
     return () => {
+      destroyed = true;
       unlisten?.();
       unlistenSuggestion?.();
       window.removeEventListener('resize', onResize);

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -46,6 +46,7 @@
   let approvingKeys   = $state<Set<string>>(new Set());
   let lastDismissed   = $state<{ wrong_word: string; correct_word: string } | null>(null);
   let undoTimer: ReturnType<typeof window.setTimeout> | undefined;
+  let dismissTimers: ReturnType<typeof window.setTimeout>[] = [];
 
   let search        = $state('');
   let debouncedSearch = $state('');
@@ -147,7 +148,8 @@
     const key = `${s.wrong_word}:${s.correct_word}`;
     if (dismissingKeys.has(key)) return;
     dismissingKeys = new Set(dismissingKeys).add(key);
-    window.setTimeout(async () => {
+    const timer = window.setTimeout(async () => {
+      dismissTimers = dismissTimers.filter((t) => t !== timer);
       try {
         await invoke('dismiss_dictionary_suggestion', { wrong: s.wrong_word, correct: s.correct_word });
         suggestions = suggestions.filter(x => !(x.wrong_word === s.wrong_word && x.correct_word === s.correct_word));
@@ -161,6 +163,7 @@
         dismissingKeys = next;
       }
     }, motionMs(200));
+    dismissTimers.push(timer);
   }
 
   function showUndoBanner(s: DictionarySuggestion) {
@@ -208,6 +211,8 @@
       unlistenSuggestion?.();
       window.removeEventListener('resize', onResize);
       if (undoTimer !== undefined) window.clearTimeout(undoTimer);
+      dismissTimers.forEach(window.clearTimeout);
+      dismissTimers = [];
     };
   });
 


### PR DESCRIPTION
## Summary
- Add shared correction-diff and phonetic-confusion primitives for post-edit and cleanup-divergence learning sources
- Replace runtime auto-promotion with evidence scoring, suggestion queue routing, never-learn pairs, and unique per-observation session IDs
- Add macOS focused-text AX path and Dictionary UI controls for suggested corrections
- Fix short brand-name evidence confidence, promotion status counting, legacy backfill session IDs, and manual-entry conflicts during suggestion approval

## Tests
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run check`