### PR TITLE
feat: dual Open-Flow/Verenu repo check for updates and Source link (v0.12.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-flow",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Open Flow - An open-source AI dictation app for Windows",
   "main": "index.js",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "open-flow"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "accessibility-sys",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-flow"
-version = "0.12.0"
+version = "0.12.1"
 description = "Open Flow — local-first AI dictation"
 authors = ["Open Flow Team"]
 edition = "2021"

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::sync::OnceLock;
 
 #[derive(Deserialize)]
 struct GhRelease {
@@ -17,14 +18,50 @@ pub struct UpdateInfo {
     pub download_url: String,
 }
 
+/// Repos to check for releases, in priority order. MONKE2525E/Verenu is the
+/// planned future home of this project's GitHub repo; MONKE2525E/Open-Flow
+/// is the current one. Checking both lets releases published under either
+/// name be picked up without another code change once the rename happens.
+const RELEASE_REPOS: &[&str] = &["MONKE2525E/Verenu", "MONKE2525E/Open-Flow"];
+
+/// Check all configured repos for a release newer than the current version,
+/// returning the highest version found. A 404 (repo has no releases yet, or
+/// doesn't exist) or other request error from a single repo is treated as "no
+/// release" rather than failing the whole check.
 pub async fn check() -> anyhow::Result<Option<UpdateInfo>> {
-    let url = "https://api.github.com/repos/MONKE2525E/Open-Flow/releases/latest";
+    let mut best: Option<UpdateInfo> = None;
+
+    for repo in RELEASE_REPOS {
+        match check_repo(repo).await {
+            Ok(Some(info)) => {
+                let is_better = match &best {
+                    Some(current_best) => is_newer(&info.version, &current_best.version),
+                    None => true,
+                };
+                if is_better {
+                    best = Some(info);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("Update check against {repo} failed: {e}"),
+        }
+    }
+
+    Ok(best)
+}
+
+async fn check_repo(repo: &str) -> anyhow::Result<Option<UpdateInfo>> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/latest");
     let resp = super::client::get()
-        .get(url)
+        .get(&url)
         .header("User-Agent", "open-flow")
         .send()
-        .await?
-        .error_for_status()?;
+        .await?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let resp = resp.error_for_status()?;
 
     let release: GhRelease = resp.json().await?;
     let display_version = normalize_version(&release.tag_name);
@@ -43,6 +80,56 @@ pub async fn check() -> anyhow::Result<Option<UpdateInfo>> {
         version: display_version,
         download_url: asset.browser_download_url.clone(),
     }))
+}
+
+/// Repos to check, in priority order, for the About page "Source" link.
+const SOURCE_REPO_CANDIDATES: &[&str] = &["MONKE2525E/Verenu", "MONKE2525E/Open-Flow"];
+
+/// Cache for `resolve_source_repo()` so the About page only queries the
+/// GitHub API once per app run, regardless of how many times it mounts.
+static RESOLVED_SOURCE_REPO: OnceLock<String> = OnceLock::new();
+
+/// Resolve which repo to display/link as the project's "Source" by checking
+/// each candidate in order and returning the first that doesn't 404. Falls
+/// back to the last candidate (the current default) if every check fails.
+/// A successful resolution is cached for the lifetime of the process; a
+/// transient failure (network error or non-404 API error, e.g. rate limit)
+/// is not cached so it can be retried on the next call.
+pub async fn resolve_source_repo() -> String {
+    if let Some(repo) = RESOLVED_SOURCE_REPO.get() {
+        return repo.clone();
+    }
+
+    if let Some(resolved) = resolve_source_repo_uncached().await {
+        let _ = RESOLVED_SOURCE_REPO.set(resolved.clone());
+        resolved
+    } else {
+        SOURCE_REPO_CANDIDATES.last().unwrap().to_string()
+    }
+}
+
+async fn resolve_source_repo_uncached() -> Option<String> {
+    for repo in SOURCE_REPO_CANDIDATES {
+        let url = format!("https://api.github.com/repos/{repo}");
+        match super::client::get()
+            .get(&url)
+            .header("User-Agent", "open-flow")
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    return Some((*repo).to_string());
+                } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                    continue;
+                } else {
+                    return None;
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    Some(SOURCE_REPO_CANDIDATES.last().unwrap().to_string())
 }
 
 /// Extract the first three numeric groups from any version string, return as "major.minor.patch".

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1134,6 +1134,11 @@ pub async fn check_for_update() -> Result<Option<serde_json::Value>, String> {
 }
 
 #[tauri::command]
+pub async fn get_source_repo() -> String {
+    crate::api::updater::resolve_source_repo().await
+}
+
+#[tauri::command]
 pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), String> {
     #[cfg(not(windows))]
     {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -276,6 +276,7 @@ fn main() {
             commands::retry_transcription,
             commands::check_for_update,
             commands::install_update,
+            commands::get_source_repo,
             commands::check_connectivity,
             commands::get_recent_logs,
             commands::download_logs,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "Open Flow",
   "mainBinaryName": "Open Flow",
   "identifier": "com.openflow.app",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -12,16 +12,29 @@
   let versionTapTimer: ReturnType<typeof setTimeout> | null = null;
   let devModeHintVisible = $state(false);
 
+  // Defaults to the current Open-Flow repo and is replaced with
+  // "MONKE2525E/Verenu" once the backend confirms that repo exists.
+  let sourceRepo = $state('MONKE2525E/Open-Flow');
+
   $effect(() => {
     if (appStore.updateInfo) updateCheckState = 'available';
   });
 
+  $effect(() => {
+    invoke<string>('get_source_repo')
+      .then((repo) => {
+        if (repo) sourceRepo = repo;
+      })
+      .catch(() => {});
+  });
+
   async function openRepo() {
+    const url = `https://github.com/${sourceRepo}`;
     try {
       const { open } = await import('@tauri-apps/plugin-shell');
-      await open('https://github.com/MONKE2525E/Open-Flow');
+      await open(url);
     } catch {
-      window.open('https://github.com/MONKE2525E/Open-Flow', '_blank');
+      window.open(url, '_blank');
     }
   }
 
@@ -92,7 +105,7 @@
 </div>
 <div class="setting-row">
   <div><div class="label">Source</div></div>
-  <button class="btn-ghost" onclick={openRepo}>github.com/MONKE2525E/Open-Flow</button>
+  <button class="btn-ghost" onclick={openRepo}>github.com/{sourceRepo}</button>
 </div>
 <div class="setting-row">
   <div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -187,6 +187,8 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return String(getDevSetting('microphone_permission_status') ?? 'authorized') as T;
     case 'check_for_update':
       return null as T;
+    case 'get_source_repo':
+      return 'MONKE2525E/Open-Flow' as T;
     case 'check_connectivity':
       return (typeof navigator === 'undefined' ? true : navigator.onLine) as T;
     case 'get_cleanup_cache_status':


### PR DESCRIPTION
## Summary
- Update checker (`updater.rs`) now checks both `MONKE2525E/Verenu` and `MONKE2525E/Open-Flow` for releases, picking the newer one. A 404 from either repo is treated as "no release" rather than an error.
- About page "Source" link now resolves dynamically via a new `get_source_repo` command, preferring `MONKE2525E/Verenu` once it exists and falling back to `MONKE2525E/Open-Flow`.
- Bumped version to 0.12.1 across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `Cargo.lock`.

This is groundwork for the planned rename to Verenu — no identifier renames, branding changes, or migration shims are included here.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -D warnings` passes
- [x] `npm run check` passes (0 errors/warnings)
- [ ] Manual: confirm About page "Source" link/button still shows `github.com/MONKE2525E/Open-Flow` in dev mode