### PR TITLE
chore(release): update build-installers DMG names for 0.12.1

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           if [ "${{ matrix.os-name }}" = "macos" ]; then
             npm run tauri build -- --target aarch64-apple-darwin
-            mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_Apple_Silicon.dmg"
+            mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Apple_Silicon.dmg"
             npm run tauri build -- --target x86_64-apple-darwin
-            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_x86_64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_Intel.dmg"
+            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_x86_64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Intel.dmg"
           else
             npm run tauri build
           fi
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Open-Flow-macOS-Apple-Silicon-dmg
-          path: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_Apple_Silicon.dmg
+          path: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Apple_Silicon.dmg
           if-no-files-found: error
 
       - name: Upload macOS Intel DMG (.dmg)
@@ -80,5 +80,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Open-Flow-macOS-Intel-dmg
-          path: src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.0_Intel.dmg
+          path: src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Intel.dmg
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- Update the hardcoded macOS DMG rename/upload paths in build-installers.yml from 0.12.0 to 0.12.1, matching the version bump in PR #111.

## Test plan
- [ ] Trigger Build Installers workflow and confirm macOS DMGs are produced/renamed correctly for 0.12.1