### PR TITLE
fix: correct macOS Intel DMG source filename in build-installers

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -45,7 +45,7 @@ jobs:
             npm run tauri build -- --target aarch64-apple-darwin
             mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Apple_Silicon.dmg"
             npm run tauri build -- --target x86_64-apple-darwin
-            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_x86_64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Intel.dmg"
+            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_x64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Open Flow_0.12.1_Intel.dmg"
           else
             npm run tauri build
           fi


### PR DESCRIPTION
## Summary
- Tauri's bundler names the x86_64-apple-darwin DMG `Open Flow_<version>_x64.dmg`, not `_x86_64.dmg`. The macOS build job's rename-to-`Intel.dmg` step expected the latter and failed (run [27375720880](https://github.com/MONKE2525E/Open-Flow/actions/runs/27375720880)), so the macOS Apple Silicon DMG built fine but the Intel DMG was never produced/uploaded.
- Fixes the source filename in the rename step so both macOS DMGs build successfully.

## Test plan
- [x] Re-run the `Build Installers` workflow on master after merge and confirm both `Open Flow_0.12.1_Apple_Silicon.dmg` and `Open Flow_0.12.1_Intel.dmg` are produced and uploaded as artifacts.