### PR TITLE
Per-app cleanup intensity override in App Mappings

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -560,7 +560,7 @@ fn resolve_app_mapping(
     store.and_then(|s| {
         s.get(store::APP_MAPPINGS)
             .and_then(|v| serde_json::from_value::<Vec<AppMapping>>(v).ok())
-            .and_then(|list| list.into_iter().find(|m| m.exe.to_lowercase() == process_name))
+            .and_then(|list| list.into_iter().find(|m| m.exe.eq_ignore_ascii_case(process_name)))
     })
 }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1919,7 +1919,7 @@ pub async fn retry_transcription_impl(
         show_error_pill(app, "Retry window expired").await;
         anyhow::bail!("Retry window expired");
     }
-    let Some(capture) = capture else {
+    let Some(mut capture) = capture else {
         hide_pill(app);
         anyhow::bail!("No retry available");
     };
@@ -1933,7 +1933,7 @@ pub async fn retry_transcription_impl(
     }
 
     let mapping = resolve_app_mapping(Some(&settings_store), &capture.process_name);
-    apply_app_style_overrides(&mut cfg, mapping.as_ref());
+    capture.profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
 
     let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key)) =
         run_transcription_and_cleanup(

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -553,20 +553,31 @@ fn reject_with_pill(app: &AppHandle, msg: &str) {
     });
 }
 
-fn resolve_profile(
+fn resolve_app_mapping(
     store: Option<&tauri_plugin_store::Store<tauri::Wry>>,
     process_name: &str,
-    default_tone: &str,
-) -> String {
-    let mapped = store.and_then(|s| {
+) -> Option<AppMapping> {
+    store.and_then(|s| {
         s.get(store::APP_MAPPINGS)
             .and_then(|v| serde_json::from_value::<Vec<AppMapping>>(v).ok())
-            .and_then(|list| {
-                list.into_iter()
-                    .find_map(|m| (m.exe.to_lowercase() == process_name).then_some(m.profile))
-            })
-    });
-    mapped.unwrap_or_else(|| default_tone.to_owned())
+            .and_then(|list| list.into_iter().find(|m| m.exe.to_lowercase() == process_name))
+    })
+}
+
+/// Resolves the effective tone profile for `mapping`, falling back to the
+/// global `default_tone` when the app has no override, and applies the
+/// app's `cleanup_intensity` override (if any) onto `cfg` in place.
+fn apply_app_style_overrides(cfg: &mut store::PipelineConfig, mapping: Option<&AppMapping>) -> String {
+    if let Some(intensity) = mapping
+        .and_then(|m| m.cleanup_intensity.as_deref())
+        .filter(|i| !i.is_empty())
+    {
+        cfg.cleanup_intensity = intensity.to_owned();
+    }
+    mapping
+        .map(|m| m.profile.clone())
+        .filter(|p| !p.is_empty())
+        .unwrap_or_else(|| cfg.default_tone.clone())
 }
 
 pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow::Result<String> {
@@ -852,7 +863,7 @@ async fn open_config_and_context(
             return None;
         }
     };
-    let cfg = store::load_pipeline_config(&settings_store);
+    let mut cfg = store::load_pipeline_config(&settings_store);
     if !has_transcription_key_in_chain(&cfg) {
         show_error_pill(
             app,
@@ -861,7 +872,8 @@ async fn open_config_and_context(
         .await;
         return None;
     }
-    let profile = resolve_profile(Some(&settings_store), process_name, &cfg.default_tone);
+    let mapping = resolve_app_mapping(Some(&settings_store), process_name);
+    let profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
     let app_context = if cfg.app_context_hint {
         window_context::get_app_context_hint(process_name)
     } else {
@@ -1913,12 +1925,15 @@ pub async fn retry_transcription_impl(
     };
 
     let settings_store = app.store("settings.json")?;
-    let cfg = store::load_pipeline_config(&settings_store);
+    let mut cfg = store::load_pipeline_config(&settings_store);
 
     if !has_transcription_key_in_chain(&cfg) {
         show_error_pill(app, "No API key configured").await;
         anyhow::bail!("No API key configured");
     }
+
+    let mapping = resolve_app_mapping(Some(&settings_store), &capture.process_name);
+    apply_app_style_overrides(&mut cfg, mapping.as_ref());
 
     let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key)) =
         run_transcription_and_cleanup(

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -12,6 +12,10 @@ pub struct AppMapping {
     pub profile: String,
     #[serde(default)]
     pub name: String,
+    /// Per-app override for `cleanup_intensity`. `None` (or empty) falls back
+    /// to the global setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_intensity: Option<String>,
 }
 
 /// Combines registry-discovered and currently-running apps into a single deduplicated list.

--- a/src/lib/appMappings.ts
+++ b/src/lib/appMappings.ts
@@ -7,6 +7,7 @@ export interface AppMapping {
   exe: string;
   profile: string;
   name?: string;
+  cleanup_intensity?: string;
 }
 
 export const profileOptions = [
@@ -15,12 +16,26 @@ export const profileOptions = [
   { id: 'very_casual', label: 'Very Casual' },
 ] as const;
 
+export const cleanupIntensityOptions = [
+  { id: 'none', label: 'Verbatim' },
+  { id: 'light', label: 'Light' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'Direct' },
+] as const;
+
+export const DEFAULT_CLEANUP_INTENSITY_LABEL = 'Default';
+
 export function normalizeExe(exe: string) {
   return exe.trim().toLowerCase();
 }
 
 export function getProfileLabel(profile: string) {
   return profileOptions.find((option) => option.id === profile)?.label ?? titleize(profile);
+}
+
+export function getCleanupIntensityLabel(intensity: string | undefined | null) {
+  if (!intensity) return DEFAULT_CLEANUP_INTENSITY_LABEL;
+  return cleanupIntensityOptions.find((option) => option.id === intensity)?.label ?? titleize(intensity);
 }
 
 export function getAppDisplayName(

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -154,10 +154,14 @@
   }
 
   async function setMappingField(exe: string, patch: Partial<AppMapping>) {
+    const previousMappings = mappings;
     const updated = mappings.map((mapping) =>
       mapping.exe === exe ? normalizeMapping({ ...mapping, ...patch }) : mapping,
     );
-    await saveMappings(updated);
+    const saved = await saveMappings(updated);
+    if (!saved) {
+      mappings = normalizeMappings(previousMappings);
+    }
     openRowDropdown = null;
     rowDropdownPos = null;
   }

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -53,6 +53,7 @@
   const activeRowDropdown = $derived.by(() => {
     if (!openRowDropdown) return null;
     const sep = openRowDropdown.lastIndexOf(':');
+    if (sep === -1) return null;
     const exe = openRowDropdown.slice(0, sep);
     const field = openRowDropdown.slice(sep + 1) as 'profile' | 'cleanup';
     const mapping = mappings.find((m) => m.exe === exe);

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -6,7 +6,9 @@
   import { expoOut } from 'svelte/easing';
   import {
     cleanAppName,
+    cleanupIntensityOptions,
     getAppDisplayName,
+    getCleanupIntensityLabel,
     getProfileLabel,
     normalizeExe,
     profileOptions,
@@ -33,11 +35,19 @@
   let addExe = $state('');
   let addName = $state('');
   let addProfile = $state('casual');
+  let addCleanupIntensity = $state('');
   let appSearch = $state('');
   let appPickerOpen = $state(false);
   let profileDropdownOpen = $state(false);
+  let cleanupDropdownOpen = $state(false);
+  let openRowDropdown = $state<string | null>(null);
   let mappingError = $state('');
   let leavingExes = $state<Set<string>>(new Set());
+
+  const cleanupIntensityChoices = [
+    { id: '', label: 'Default' },
+    ...cleanupIntensityOptions,
+  ] as const;
 
   const pendingExe = $derived(addExe || (appSearch.trim() ? customExeFromSearch(appSearch) : ''));
   const pendingName = $derived(cleanAppName(addName || appSearch || pendingExe));
@@ -121,13 +131,23 @@
       exe: rawExe,
       profile: addProfile,
       name: addName || appSearch || rawExe,
+      cleanup_intensity: addCleanupIntensity || undefined,
     });
     await saveMappings([...mappings.filter((mapping) => mapping.exe !== entry.exe), entry]);
     addExe = '';
     addName = '';
     addProfile = 'casual';
+    addCleanupIntensity = '';
     appSearch = '';
     appPickerOpen = false;
+  }
+
+  async function setMappingField(exe: string, patch: Partial<AppMapping>) {
+    const updated = mappings.map((mapping) =>
+      mapping.exe === exe ? normalizeMapping({ ...mapping, ...patch }) : mapping,
+    );
+    await saveMappings(updated);
+    openRowDropdown = null;
   }
 
   function pickApp(app: InstalledApp) {
@@ -158,6 +178,38 @@
     }
   }
 
+  function closeCleanupDropdown(e: MouseEvent | PointerEvent) {
+    const target = e.target;
+    if (target instanceof Element && !target.closest('.cleanup-drop-wrap')) {
+      cleanupDropdownOpen = false;
+    }
+  }
+
+  function handleCleanupButtonKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && cleanupDropdownOpen) {
+      cleanupDropdownOpen = false;
+      e.stopPropagation();
+    }
+  }
+
+  function toggleRowDropdown(key: string) {
+    openRowDropdown = openRowDropdown === key ? null : key;
+  }
+
+  function closeRowDropdown(e: MouseEvent | PointerEvent) {
+    const target = e.target;
+    if (target instanceof Element && !target.closest('.row-drop-wrap')) {
+      openRowDropdown = null;
+    }
+  }
+
+  function handleRowDropdownKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && openRowDropdown) {
+      openRowDropdown = null;
+      e.stopPropagation();
+    }
+  }
+
   function normalizeMappings(entries: AppMapping[]) {
     const seen = new Set<string>();
     return entries
@@ -171,11 +223,15 @@
 
   function normalizeMapping(entry: AppMapping): AppMapping {
     const exe = normalizeExe(entry.exe);
-    return {
+    const mapping: AppMapping = {
       exe,
       profile: entry.profile || 'casual',
       name: getAppDisplayName({ exe, name: entry.name }, installedApps),
     };
+    if (entry.cleanup_intensity) {
+      mapping.cleanup_intensity = entry.cleanup_intensity;
+    }
+    return mapping;
   }
 
   function matchesAppSearch(app: InstalledApp, search: string) {
@@ -218,6 +274,32 @@
       window.removeEventListener('pointerdown', closeProfileDropdown);
     };
   });
+
+  $effect(() => {
+    if (!cleanupDropdownOpen) return;
+
+    const timeout = window.setTimeout(() => {
+      window.addEventListener('pointerdown', closeCleanupDropdown);
+    });
+
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('pointerdown', closeCleanupDropdown);
+    };
+  });
+
+  $effect(() => {
+    if (!openRowDropdown) return;
+
+    const timeout = window.setTimeout(() => {
+      window.addEventListener('pointerdown', closeRowDropdown);
+    });
+
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('pointerdown', closeRowDropdown);
+    };
+  });
 </script>
 
 {#if showHeading}
@@ -239,7 +321,73 @@
             <span class="mapping-app-name">{getAppDisplayName(mapping, installedApps)}</span>
             <span class="mapping-exe-pill" aria-hidden="true">{mapping.exe}</span>
           </div>
-          <span class="mapping-profile-badge">{getProfileLabel(mapping.profile)}</span>
+          <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
+            <button
+              class="mapping-badge-btn"
+              onclick={() => toggleRowDropdown(`${mapping.exe}:profile`)}
+              onkeydown={handleRowDropdownKeydown}
+              title="Tone for {getAppDisplayName(mapping, installedApps)}"
+            >
+              {getProfileLabel(mapping.profile)}
+              <svg class:open={openRowDropdown === `${mapping.exe}:profile`} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m6 9 6 6 6-6"/>
+              </svg>
+            </button>
+            {#if openRowDropdown === `${mapping.exe}:profile`}
+              <div
+                class="row-drop-menu scroll-styled"
+                role="presentation"
+                onclick={(e) => e.stopPropagation()}
+                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+                out:fade={{ duration: motionMs(100) }}
+              >
+                {#each profileOptions as profile}
+                  <button
+                    class="row-drop-item"
+                    class:active={mapping.profile === profile.id}
+                    onclick={() => setMappingField(mapping.exe, { profile: profile.id })}
+                    onkeydown={handleRowDropdownKeydown}
+                  >
+                    {profile.label}
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
+          <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
+            <button
+              class="mapping-badge-btn"
+              class:is-default={!mapping.cleanup_intensity}
+              onclick={() => toggleRowDropdown(`${mapping.exe}:cleanup`)}
+              onkeydown={handleRowDropdownKeydown}
+              title="Auto-cleanup style for {getAppDisplayName(mapping, installedApps)}"
+            >
+              {getCleanupIntensityLabel(mapping.cleanup_intensity)}
+              <svg class:open={openRowDropdown === `${mapping.exe}:cleanup`} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m6 9 6 6 6-6"/>
+              </svg>
+            </button>
+            {#if openRowDropdown === `${mapping.exe}:cleanup`}
+              <div
+                class="row-drop-menu scroll-styled"
+                role="presentation"
+                onclick={(e) => e.stopPropagation()}
+                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+                out:fade={{ duration: motionMs(100) }}
+              >
+                {#each cleanupIntensityChoices as choice}
+                  <button
+                    class="row-drop-item"
+                    class:active={(mapping.cleanup_intensity || '') === choice.id}
+                    onclick={() => setMappingField(mapping.exe, { cleanup_intensity: choice.id || undefined })}
+                    onkeydown={handleRowDropdownKeydown}
+                  >
+                    {choice.label}
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
           <button class="mapping-delete-btn" onclick={() => deleteMapping(mapping.exe)} title="Remove {getAppDisplayName(mapping, installedApps)}">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
               <path d="M18 6 6 18M6 6l12 12"/>
@@ -347,6 +495,48 @@
         </div>
       {/if}
     </div>
+    <div
+      class="cleanup-drop-wrap"
+      role="presentation"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <select class="cleanup-select cleanup-select-hidden" bind:value={addCleanupIntensity} tabindex="-1" aria-hidden="true">
+        {#each cleanupIntensityChoices as choice}
+          <option value={choice.id}>{choice.label}</option>
+        {/each}
+      </select>
+      <button
+        class="cleanup-drop-btn"
+        use:animateWidth={{ text: getCleanupIntensityLabel(addCleanupIntensity) }}
+        onclick={() => (cleanupDropdownOpen = !cleanupDropdownOpen)}
+        onkeydown={handleCleanupButtonKeydown}
+      >
+        <span>{getCleanupIntensityLabel(addCleanupIntensity)}</span>
+        <svg class:open={cleanupDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+      </button>
+      {#if cleanupDropdownOpen}
+        <div
+          class="cleanup-drop-menu scroll-styled"
+          role="presentation"
+          onclick={(e) => e.stopPropagation()}
+          in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+          out:fade={{ duration: motionMs(100) }}
+        >
+          {#each cleanupIntensityChoices as choice}
+            <button
+              class="cleanup-drop-item"
+              class:active={addCleanupIntensity === choice.id}
+              onclick={() => { addCleanupIntensity = choice.id; cleanupDropdownOpen = false; }}
+              onkeydown={handleCleanupButtonKeydown}
+            >
+              {choice.label}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
     <button type="button" class="btn-primary add-btn" onclick={addMapping} disabled={!addExe && !appSearch.trim()}>Add</button>
   </div>
   {#if pendingExe}
@@ -354,6 +544,8 @@
       <span>{pendingName}</span>
       <span class="preview-dot"></span>
       <span>{getProfileLabel(addProfile)}</span>
+      <span class="preview-dot"></span>
+      <span>{getCleanupIntensityLabel(addCleanupIntensity)} cleanup</span>
     </div>
   {/if}
 </div>
@@ -421,16 +613,72 @@
     text-overflow: ellipsis;
   }
 
-  .mapping-profile-badge {
+  .row-drop-wrap {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .mapping-badge-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 12px;
     font-weight: 500;
+    font-family: var(--sans);
     color: var(--accent-ink);
     background: var(--accent-soft);
     border: 1px solid color-mix(in oklab, var(--accent) 28%, transparent);
     border-radius: 4px;
     padding: 2px 8px;
-    flex-shrink: 0;
+    cursor: pointer;
+    white-space: nowrap;
   }
+
+  .mapping-badge-btn:hover { background: color-mix(in oklab, var(--accent-soft) 80%, var(--accent) 20%); }
+
+  .mapping-badge-btn.is-default {
+    color: var(--ink-mute);
+    background: transparent;
+    border-color: var(--line-strong);
+  }
+
+  .mapping-badge-btn.is-default:hover { background: var(--control-hover); }
+
+  .mapping-badge-btn svg { transition: transform 150ms; flex-shrink: 0; }
+  .mapping-badge-btn svg.open { transform: rotate(180deg); }
+
+  .row-drop-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    box-shadow: var(--shadow-popover);
+    min-width: 120px;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 20;
+  }
+
+  .row-drop-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 7px 10px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .row-drop-item:last-child { border-bottom: none; }
+  .row-drop-item:hover { background: var(--control-hover); }
+  .row-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
 
   .mapping-exe-pill {
     position: absolute;
@@ -649,6 +897,87 @@
   .profile-drop-item:last-child { border-bottom: none; }
   .profile-drop-item:hover { background: var(--control-hover); }
   .profile-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
+
+  .cleanup-drop-wrap {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .cleanup-select-hidden {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    clip-path: inset(50%);
+    border: 0;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .cleanup-drop-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid var(--line-strong);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .cleanup-drop-btn:hover { background: var(--control-hover); }
+  .cleanup-drop-btn svg { transition: transform 150ms; }
+  .cleanup-drop-btn svg.open { transform: rotate(180deg); }
+
+  .cleanup-drop-btn span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 140px;
+  }
+
+  .cleanup-drop-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    box-shadow: var(--shadow-popover);
+    min-width: 120px;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 20;
+  }
+
+  .cleanup-drop-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .cleanup-drop-item:last-child { border-bottom: none; }
+  .cleanup-drop-item:hover { background: var(--control-hover); }
+  .cleanup-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
 
   .add-btn { flex-shrink: 0; }
 

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -41,6 +41,7 @@
   let profileDropdownOpen = $state(false);
   let cleanupDropdownOpen = $state(false);
   let openRowDropdown = $state<string | null>(null);
+  let rowDropdownPos = $state<{ top: number; right: number } | null>(null);
   let mappingError = $state('');
   let leavingExes = $state<Set<string>>(new Set());
 
@@ -48,6 +49,16 @@
     { id: '', label: 'Default' },
     ...cleanupIntensityOptions,
   ] as const;
+
+  const activeRowDropdown = $derived.by(() => {
+    if (!openRowDropdown) return null;
+    const sep = openRowDropdown.lastIndexOf(':');
+    const exe = openRowDropdown.slice(0, sep);
+    const field = openRowDropdown.slice(sep + 1) as 'profile' | 'cleanup';
+    const mapping = mappings.find((m) => m.exe === exe);
+    if (!mapping) return null;
+    return { exe, field, mapping };
+  });
 
   const pendingExe = $derived(addExe || (appSearch.trim() ? customExeFromSearch(appSearch) : ''));
   const pendingName = $derived(cleanAppName(addName || appSearch || pendingExe));
@@ -148,6 +159,7 @@
     );
     await saveMappings(updated);
     openRowDropdown = null;
+    rowDropdownPos = null;
   }
 
   function pickApp(app: InstalledApp) {
@@ -192,14 +204,22 @@
     }
   }
 
-  function toggleRowDropdown(key: string) {
-    openRowDropdown = openRowDropdown === key ? null : key;
+  function toggleRowDropdown(key: string, e: MouseEvent) {
+    if (openRowDropdown === key) {
+      openRowDropdown = null;
+      rowDropdownPos = null;
+      return;
+    }
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    rowDropdownPos = { top: rect.bottom + 4, right: window.innerWidth - rect.right };
+    openRowDropdown = key;
   }
 
   function closeRowDropdown(e: MouseEvent | PointerEvent) {
     const target = e.target;
-    if (target instanceof Element && !target.closest('.row-drop-wrap')) {
+    if (target instanceof Element && !target.closest('.row-drop-wrap') && !target.closest('.row-drop-menu')) {
       openRowDropdown = null;
+      rowDropdownPos = null;
     }
   }
 
@@ -324,7 +344,7 @@
           <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
             <button
               class="mapping-badge-btn"
-              onclick={() => toggleRowDropdown(`${mapping.exe}:profile`)}
+              onclick={(e) => toggleRowDropdown(`${mapping.exe}:profile`, e)}
               onkeydown={handleRowDropdownKeydown}
               title="Tone for {getAppDisplayName(mapping, installedApps)}"
             >
@@ -333,32 +353,12 @@
                 <path d="m6 9 6 6 6-6"/>
               </svg>
             </button>
-            {#if openRowDropdown === `${mapping.exe}:profile`}
-              <div
-                class="row-drop-menu scroll-styled"
-                role="presentation"
-                onclick={(e) => e.stopPropagation()}
-                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
-                out:fade={{ duration: motionMs(100) }}
-              >
-                {#each profileOptions as profile}
-                  <button
-                    class="row-drop-item"
-                    class:active={mapping.profile === profile.id}
-                    onclick={() => setMappingField(mapping.exe, { profile: profile.id })}
-                    onkeydown={handleRowDropdownKeydown}
-                  >
-                    {profile.label}
-                  </button>
-                {/each}
-              </div>
-            {/if}
           </div>
           <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
             <button
               class="mapping-badge-btn"
               class:is-default={!mapping.cleanup_intensity}
-              onclick={() => toggleRowDropdown(`${mapping.exe}:cleanup`)}
+              onclick={(e) => toggleRowDropdown(`${mapping.exe}:cleanup`, e)}
               onkeydown={handleRowDropdownKeydown}
               title="Auto-cleanup style for {getAppDisplayName(mapping, installedApps)}"
             >
@@ -367,26 +367,6 @@
                 <path d="m6 9 6 6 6-6"/>
               </svg>
             </button>
-            {#if openRowDropdown === `${mapping.exe}:cleanup`}
-              <div
-                class="row-drop-menu scroll-styled"
-                role="presentation"
-                onclick={(e) => e.stopPropagation()}
-                in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
-                out:fade={{ duration: motionMs(100) }}
-              >
-                {#each cleanupIntensityChoices as choice}
-                  <button
-                    class="row-drop-item"
-                    class:active={(mapping.cleanup_intensity || '') === choice.id}
-                    onclick={() => setMappingField(mapping.exe, { cleanup_intensity: choice.id || undefined })}
-                    onkeydown={handleRowDropdownKeydown}
-                  >
-                    {choice.label}
-                  </button>
-                {/each}
-              </div>
-            {/if}
           </div>
           <button class="mapping-delete-btn" onclick={() => deleteMapping(mapping.exe)} title="Remove {getAppDisplayName(mapping, installedApps)}">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
@@ -400,6 +380,41 @@
     <div class="mapping-empty" in:fade={{ duration: motionMs(MOTION_MS.fast) }} out:fade={{ duration: motionMs(MOTION_MS.fast) }}>{emptyText}</div>
   {/if}
 </div>
+
+{#if activeRowDropdown && rowDropdownPos}
+  <div
+    class="row-drop-menu scroll-styled"
+    role="presentation"
+    style="top: {rowDropdownPos.top}px; right: {rowDropdownPos.right}px;"
+    onclick={(e) => e.stopPropagation()}
+    in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+    out:fade={{ duration: motionMs(100) }}
+  >
+    {#if activeRowDropdown.field === 'profile'}
+      {#each profileOptions as profile}
+        <button
+          class="row-drop-item"
+          class:active={activeRowDropdown.mapping.profile === profile.id}
+          onclick={() => setMappingField(activeRowDropdown.exe, { profile: profile.id })}
+          onkeydown={handleRowDropdownKeydown}
+        >
+          {profile.label}
+        </button>
+      {/each}
+    {:else}
+      {#each cleanupIntensityChoices as choice}
+        <button
+          class="row-drop-item"
+          class:active={(activeRowDropdown.mapping.cleanup_intensity || '') === choice.id}
+          onclick={() => setMappingField(activeRowDropdown.exe, { cleanup_intensity: choice.id || undefined })}
+          onkeydown={handleRowDropdownKeydown}
+        >
+          {choice.label}
+        </button>
+      {/each}
+    {/if}
+  </div>
+{/if}
 
 {#if mappingError}
   <div class="mapping-error">{mappingError}</div>
@@ -648,9 +663,7 @@
   .mapping-badge-btn svg.open { transform: rotate(180deg); }
 
   .row-drop-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
+    position: fixed;
     background: var(--bg-elev);
     border: 1px solid var(--line);
     border-radius: var(--r-sm);
@@ -658,7 +671,7 @@
     min-width: 120px;
     max-height: 200px;
     overflow-y: auto;
-    z-index: 20;
+    z-index: 50;
   }
 
   .row-drop-item {

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -316,13 +316,20 @@
   $effect(() => {
     if (!openRowDropdown) return;
 
+    const handleScroll = () => {
+      openRowDropdown = null;
+      rowDropdownPos = null;
+    };
+
     const timeout = window.setTimeout(() => {
       window.addEventListener('pointerdown', closeRowDropdown);
+      window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
     });
 
     return () => {
       window.clearTimeout(timeout);
       window.removeEventListener('pointerdown', closeRowDropdown);
+      window.removeEventListener('scroll', handleScroll, { capture: true });
     };
   });
 </script>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -13,6 +13,7 @@ export interface AppMapping {
   exe: string;
   profile: string;
   name?: string;
+  cleanup_intensity?: CleanupIntensity;
 }
 
 type SettingsValueMap = {


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows/macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: settings / App Mappings (Style page) + pipeline cleanup stage
> - App Mappings previously only let a per-app override change the *tone* (personal style) applied during cleanup; the auto-cleanup *intensity* (Verbatim/Light/Medium/Direct) was always global
> - Users want, e.g., "Verbatim" cleanup in a code editor but "Direct" in Slack, alongside their existing per-app tone
> - This pull request adds an optional per-app `cleanup_intensity` override to `AppMapping`, resolved alongside the tone at pipeline time (and on retry), with a "Default" option that falls back to the global Style setting
> - The benefit is per-app tone *and* cleanup style can now both be customized from one place, with inline editing of existing mappings

## What Changed

- `src-tauri/src/system/apps.rs`: added optional `cleanup_intensity: Option<String>` field to `AppMapping`
- `src-tauri/src/pipeline.rs`: replaced `resolve_profile` with `resolve_app_mapping` + `apply_app_style_overrides`, which resolves the per-app tone and applies the per-app `cleanup_intensity` override onto the loaded config (both in `run_pipeline` and `retry_transcription_impl`)
- `src/lib/appMappings.ts` / `src/lib/settings.ts`: added `cleanup_intensity` to the `AppMapping` type, plus `cleanupIntensityOptions` and `getCleanupIntensityLabel` helpers
- `src/lib/components/AppMappingsEditor.svelte`: added a second "auto-cleanup style" dropdown (Default/Verbatim/Light/Medium/Direct) to the add-app row, and made existing mapping rows show two clickable badges (tone + cleanup style) that open inline dropdowns for editing without delete-and-re-add

## Verification

- `cargo check` and `cargo clippy -- -D warnings` (clean)
- `npm run check` (svelte-check, 0 errors)
- `cargo test pipeline` - all 21 pipeline tests pass, including cache-key/intensity tests
- `python tests/OnePyFone.py --suite ui` and `--suite animation` - all smoke tests pass (App mappings flow, dropdown animations)
- Manual Playwright pass through Settings > Style > App Mappings: added chrome.exe with Formal tone + Direct cleanup, confirmed badges show correctly, then edited inline to Very Casual tone and Default cleanup, confirmed persisted mapping (`cleanup_intensity` omitted when set to Default)

## Risks

- Low risk. New field is `Option<String>` with `#[serde(default)]`, so existing saved `app_mappings` (without the field) deserialize unchanged
- Existing `.profile-select`, `.mapping-row`, `.mapping-exe-pill`, `.profile-drop-*` smoke-test selectors are unchanged; new selectors (`.mapping-badge-btn`, `.row-drop-*`, `.cleanup-drop-*`, `.cleanup-select`) are additive

> Checked `docs/ROADMAP.md` - no overlapping planned work for App Mappings or cleanup intensity.

## Model Used

- Claude Sonnet 4.6 (claude-sonnet-4-6), via Claude Code

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (no screenshots attached - verified via Playwright assertions on `.mapping-badge-btn` text/state, see Verification)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above
