### PR TITLE
Confidence-tiered auto-learn promotion and substitution safety gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,9 +233,11 @@ Cleanup instruction keywords are applied mechanically to LLM output *after* the 
 
 ## Auto-Learn System (`api/auto_learn.rs`)
 
-After injection, monitors the focused text field for 30 seconds using Windows UI Automation. Each dictation session spawns its own monitor; concurrent monitors are intentional and necessary so corrections from separate dictations can each count toward the 2-session promotion threshold. Detects user corrections via Levenshtein edit distance (`edit_distance`, `is_spelling_correction`) — pairs must differ by ≤2 chars or ≤50% of max length. A `StableTextGate` requires two consecutive identical UIA reads before evaluating corrections, preventing mid-typing noise. A (wrong → correct) pair must be seen in 2 separate sessions within 2 days before being promoted to the dictionary. Within a session, `recorded_this_session` deduplicates so one noisy edit can't count twice.
+After injection, monitors the focused text field for 60 seconds using Windows UI Automation. Each dictation session spawns its own monitor; concurrent monitors are intentional and necessary so corrections from separate dictations can each count toward the promotion threshold. Detects user corrections via Levenshtein edit distance (`edit_distance`, `is_candidate_correction`) — pairs must differ by ≤2 chars or ≤50% of max length. A `StableTextGate` requires two consecutive identical UIA reads before evaluating corrections, preventing mid-typing noise. Promotion is confidence-tiered: a (wrong → correct) pair whose accumulated `confidence_avg` reaches `FAST_PROMOTION_CONFIDENCE` (0.70 — reachable only by distinctive corrections, e.g. brand/technical terms with a small edit distance) promotes after a single session; all other pairs need 2 separate sessions within 2 days. Within a session, `recorded_this_session` deduplicates so one noisy edit can't count twice.
 
 Requires COM initialization (`CoInitializeEx`) per thread via a `ComGuard` — UI Automation will fail silently without it.
+
+Auto-learned dictionary entries whose `mistake` is a plain, non-distinctive word (per `has_distinctive_features` in `system/text.rs`) are excluded from the mechanical find/replace in `apply_substitutions_from` — they're corrected contextually via the cleanup LLM prompt instead, so a mis-learned pair (e.g. "rock" → "Groq") can't clobber legitimate uses of the common word. Manual dictionary entries are never gated.
 
 ## Key Design Constraints
 

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -17,6 +17,7 @@ use crate::core::text_context::is_invisible_prefix_char as is_invisible_probe_ch
 #[cfg(any(windows, test))]
 use crate::core::text_context::SentenceContext;
 use crate::data::{db, store};
+use crate::system::text::has_distinctive_features;
 use crate::DbHandle;
 
 const MONITOR_WINDOW_SECS: u64 = 60;
@@ -28,14 +29,19 @@ const REJECTION_WINDOW_SECS: u64 = 8;
 const REJECTION_POLL_MS: u64 = 500;
 const CACHE_REJECTION_WINDOW_SECS: u64 = 10;
 const PENDING_RETENTION_DAYS: i64 = 2;
-const PROMOTION_THRESHOLD: i64 = 2;
+const PROMOTION_THRESHOLD_DEFAULT: i64 = 2;
+const PROMOTION_THRESHOLD_FAST: i64 = 1;
+// candidate_confidence() tops out around 0.80; this is reachable only by
+// distinctive corrections (brand/technical terms) with a small edit distance.
+const FAST_PROMOTION_CONFIDENCE: f64 = 0.70;
+const HIGH_CONFIDENCE_TIER: f64 = 0.70;
+const MEDIUM_CONFIDENCE_TIER: f64 = 0.55;
 const STABLE_TEXT_OBSERVATIONS_REQUIRED: usize = 2;
 const MIN_CANDIDATE_NORM_LEN: usize = 2;
 const MAX_SPAN_GROWTH_WORDS: usize = 5;
 const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
 const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
 const MIN_CANDIDATE_CONFIDENCE: f64 = 0.45;
-const PAIR_COOLDOWN_MINUTES: i64 = 0;
 
 static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -223,28 +229,6 @@ fn tokenize_words(text: &str) -> Vec<WordToken> {
     }
 
     tokens
-}
-
-fn has_distinctive_features(token: &str) -> bool {
-    if !token.is_ascii() {
-        return true;
-    }
-    if token.len() >= 4
-        && token
-            .chars()
-            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
-    {
-        return true;
-    }
-    if token
-        .chars()
-        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
-    {
-        return true;
-    }
-
-    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
-    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
 }
 
 fn is_common_word(word: &str) -> bool {
@@ -747,26 +731,22 @@ fn record_candidate(
         return false;
     }
 
-    if !db::upsert_auto_learn_candidate(
-        db,
-        &mistake,
-        &correction,
-        confidence,
-        PAIR_COOLDOWN_MINUTES,
-    )
-    .unwrap_or(false)
-    {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "cooldown_skip",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
+    let confidence_avg = match db::upsert_auto_learn_candidate(db, &mistake, &correction, confidence) {
+        Ok(confidence_avg) => confidence_avg,
+        Err(e) => {
+            log::warn!("auto-learn candidate upsert failed: {e}");
+            let _ = db::log_auto_learn_event(
+                db,
+                "candidate",
+                "candidate_upsert_failed",
+                app_context,
+                &mistake_hash,
+                &correction_hash,
+                confidence,
+            );
+            return false;
+        }
+    };
 
     if let Err(e) = db::insert_pending_correction(db, &mistake, &correction) {
         log::warn!("auto-learn pending insert failed: {e}");
@@ -786,7 +766,13 @@ fn record_candidate(
         db::count_pending_corrections_recent(db, &mistake, &correction, PENDING_RETENTION_DAYS)
             .unwrap_or(0);
 
-    if count < PROMOTION_THRESHOLD {
+    let threshold = if confidence_avg >= FAST_PROMOTION_CONFIDENCE {
+        PROMOTION_THRESHOLD_FAST
+    } else {
+        PROMOTION_THRESHOLD_DEFAULT
+    };
+
+    if count < threshold {
         let _ = db::log_auto_learn_event(
             db,
             "candidate",
@@ -799,9 +785,9 @@ fn record_candidate(
         return false;
     }
 
-    let tier = if confidence >= 0.85 {
+    let tier = if confidence_avg >= HIGH_CONFIDENCE_TIER {
         "high"
-    } else if confidence >= 0.72 {
+    } else if confidence_avg >= MEDIUM_CONFIDENCE_TIER {
         "medium"
     } else {
         "low"
@@ -1824,7 +1810,12 @@ mod tests {
         original: String,
         corrected: String,
         expect: Vec<[String; 2]>,
-        promotes_after_two_sessions: bool,
+        /// Number of sessions needed to promote this pair, or `null` if the
+        /// case isn't expected to promote at all. 1 exercises the
+        /// fast-promotion path (confidence >= FAST_PROMOTION_CONFIDENCE);
+        /// 2 exercises the default path.
+        #[serde(default)]
+        promotion_sessions: Option<u8>,
     }
 
     #[test]
@@ -1929,7 +1920,7 @@ mod tests {
             "test-app",
             "Koobernetes".to_string(),
             "Kubernetes".to_string(),
-            0.9,
+            0.6,
         ));
         assert!(!record_candidate(
             &db,
@@ -1937,7 +1928,7 @@ mod tests {
             "test-app",
             "Koobernetes".to_string(),
             "Kubernetes".to_string(),
-            0.9,
+            0.6,
         ));
 
         let count = db::count_pending_corrections_recent(
@@ -1963,7 +1954,7 @@ mod tests {
                     "test-app",
                     "Koobernetes".to_string(),
                     "Kubernetes".to_string(),
-                    0.9,
+                    0.6,
                 ),
                 expected
             );
@@ -1989,7 +1980,7 @@ mod tests {
                     "test-app",
                     "rock".to_string(),
                     "qroq".to_string(),
-                    0.9,
+                    0.6,
                 ),
                 expected
             );
@@ -2000,6 +1991,28 @@ mod tests {
         assert_eq!(entries[0].term, "qroq");
         assert_eq!(entries[0].mistake.as_deref(), Some("rock"));
         assert!(entries[0].auto_learned);
+    }
+
+    #[test]
+    fn high_confidence_candidate_promotes_after_one_session() {
+        let db = db::open(":memory:").expect("test db");
+        let mut recorded = HashSet::new();
+
+        assert!(record_candidate(
+            &db,
+            &mut recorded,
+            "test-app",
+            "vsc0de".to_string(),
+            "vscode".to_string(),
+            0.75,
+        ));
+
+        let entries = db::query_dictionary(&db).expect("dictionary");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].term, "vscode");
+        assert_eq!(entries[0].mistake.as_deref(), Some("vsc0de"));
+        assert!(entries[0].auto_learned);
+        assert_eq!(entries[0].confidence_tier, "high");
     }
 
     #[test]
@@ -2108,7 +2121,7 @@ mod tests {
                 .collect();
             assert_eq!(actual, expected, "case {}", case.name);
 
-            if case.promotes_after_two_sessions {
+            if let Some(sessions) = case.promotion_sessions {
                 assert!(
                     !expected.is_empty(),
                     "case {} marked promotable without expected pair",
@@ -2117,19 +2130,28 @@ mod tests {
                 let db = db::open(":memory:").expect("test db");
                 let (mistake, correction) = expected[0].clone();
 
-                for expected_promoted in [false, true] {
+                // 1 session exercises the fast-promotion path (confidence >=
+                // FAST_PROMOTION_CONFIDENCE); 2 exercises the default path.
+                let confidence = if sessions == 1 {
+                    FAST_PROMOTION_CONFIDENCE + 0.05
+                } else {
+                    FAST_PROMOTION_CONFIDENCE - 0.1
+                };
+
+                for session in 1..=sessions {
                     let mut recorded = HashSet::new();
+                    let promoted = record_candidate(
+                        &db,
+                        &mut recorded,
+                        "test-app",
+                        mistake.clone(),
+                        correction.clone(),
+                        confidence,
+                    );
                     assert_eq!(
-                        record_candidate(
-                            &db,
-                            &mut recorded,
-                            "test-app",
-                            mistake.clone(),
-                            correction.clone(),
-                            0.9,
-                        ),
-                        expected_promoted,
-                        "case {} promotion threshold",
+                        promoted,
+                        session == sessions,
+                        "case {} promotion threshold (session {session}/{sessions})",
                         case.name
                     );
                 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -737,8 +737,8 @@ pub fn insert_dictionary_entry_auto_learned(
 
     let conn = lock_conn(db)?;
     let changed = conn.execute(
-        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count) \
-         VALUES (?1, ?2, 1, 1) \
+        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier) \
+         VALUES (?1, ?2, 1, 1, ?3) \
          ON CONFLICT(term) DO UPDATE SET \
            correction_count = correction_count + 1, \
            confidence_tier = ?3, \
@@ -776,40 +776,29 @@ pub fn log_auto_learn_event(
     Ok(())
 }
 
+/// Records a confidence observation for a (wrong, correct) pair and returns
+/// the running average confidence across all observations of that pair.
 pub fn upsert_auto_learn_candidate(
     db: &Db,
     wrong: &str,
     correct: &str,
     confidence: f64,
-    cooldown_minutes: i64,
-) -> Result<bool> {
+) -> Result<f64> {
     let conn = lock_conn(db)?;
-    let blocked: i64 = conn.query_row(
-        "SELECT COUNT(*)
-         FROM auto_learn_candidates
-         WHERE wrong_word = ?1
-           AND correct_word = ?2
-           AND cooldown_until IS NOT NULL
-           AND cooldown_until > datetime('now')",
-        params![wrong, correct],
-        |r| r.get(0),
-    )?;
-    if blocked > 0 {
-        return Ok(false);
-    }
-    conn.execute(
+    conn.query_row(
         "INSERT INTO auto_learn_candidates
-         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at, cooldown_until)
-         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'), datetime('now', ?4))
+         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at)
+         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'))
          ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
            confidence_sum = auto_learn_candidates.confidence_sum + excluded.confidence_sum,
            seen_count = auto_learn_candidates.seen_count + 1,
            confidence_avg = (auto_learn_candidates.confidence_sum + excluded.confidence_sum) / (auto_learn_candidates.seen_count + 1),
-           last_seen_at = datetime('now'),
-           cooldown_until = datetime('now', ?4)",
-        params![wrong, correct, confidence, format!("+{} minutes", cooldown_minutes.max(0))],
-    )?;
-    Ok(true)
+           last_seen_at = datetime('now')
+         RETURNING confidence_avg",
+        params![wrong, correct, confidence],
+        |r| r.get(0),
+    )
+    .map_err(Into::into)
 }
 
 pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -> Result<()> {

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -1,5 +1,5 @@
 use crate::data::db;
-use crate::system::text::tokenize_lower_alnum;
+use crate::system::text::{has_distinctive_features, tokenize_lower_alnum};
 
 const MAX_PROMPT_ENTRIES: usize = 48;
 const MAX_PROMPT_CHARS: usize = 5_000;
@@ -173,9 +173,19 @@ fn format_dictionary_entry(entry: &db::DictionaryEntry) -> String {
 }
 
 pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> (String, Vec<i64>) {
+    // Auto-learned mistakes that look like plain common words (no distinctive
+    // features) are left to the cleanup LLM's contextual judgment instead of
+    // a blunt mechanical replace, so a mis-learned pair like "rock" -> "Groq"
+    // can't clobber every legitimate use of "rock".
     let mut replaceable: Vec<(i64, &str, &str)> = entries
         .iter()
-        .filter_map(|e| e.mistake.as_deref().map(|m| (e.id, m, e.term.as_str())))
+        .filter_map(|e| {
+            let mistake = e.mistake.as_deref()?;
+            if e.auto_learned && !has_distinctive_features(mistake) {
+                return None;
+            }
+            Some((e.id, mistake, e.term.as_str()))
+        })
         .collect();
     replaceable.sort_by_key(|(_, mistake, _)| std::cmp::Reverse(mistake.len()));
 
@@ -260,6 +270,14 @@ mod tests {
         }
     }
 
+    fn auto_learned_entry(id: i64, term: &str, mistake: &str) -> DictionaryEntry {
+        DictionaryEntry {
+            auto_learned: true,
+            confidence_tier: "medium".to_string(),
+            ..entry(id, term, Some(mistake))
+        }
+    }
+
     #[test]
     fn relevant_prompt_prefers_matching_entries() {
         let entries = vec![
@@ -312,6 +330,30 @@ mod tests {
         let entries = vec![entry(1, "cliche", Some("cliché"))];
         let (out, applied) = apply_substitutions_from("Use cliché in this line.", &entries);
         assert_eq!(out, "Use cliche in this line.");
+        assert_eq!(applied, vec![1]);
+    }
+
+    #[test]
+    fn auto_learned_common_word_mistake_is_not_mechanically_substituted() {
+        let entries = vec![auto_learned_entry(1, "Groq", "rock")];
+        let (out, applied) = apply_substitutions_from("I love rock music", &entries);
+        assert_eq!(out, "I love rock music");
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn auto_learned_distinctive_mistake_is_still_substituted() {
+        let entries = vec![auto_learned_entry(1, "vscode", "vsc0de")];
+        let (out, applied) = apply_substitutions_from("please open vsc0de now", &entries);
+        assert_eq!(out, "please open vscode now");
+        assert_eq!(applied, vec![1]);
+    }
+
+    #[test]
+    fn manual_common_word_mistake_is_still_mechanically_substituted() {
+        let entries = vec![entry(1, "Groq", Some("rock"))];
+        let (out, applied) = apply_substitutions_from("I love rock music", &entries);
+        assert_eq!(out, "I love Groq music");
         assert_eq!(applied, vec![1]);
     }
 }

--- a/src-tauri/src/system/text.rs
+++ b/src-tauri/src/system/text.rs
@@ -1,3 +1,28 @@
+/// True if `token` contains a feature (non-ASCII, q/x/z, digit/apostrophe/hyphen/underscore,
+/// or internal capitalization) that makes it unlikely to be a plain mis-transcribed
+/// common word — i.e. likely a brand/technical term or proper noun.
+pub fn has_distinctive_features(token: &str) -> bool {
+    if !token.is_ascii() {
+        return true;
+    }
+    if token.len() >= 4
+        && token
+            .chars()
+            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
+    {
+        return true;
+    }
+    if token
+        .chars()
+        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
+    {
+        return true;
+    }
+
+    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
+    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
+}
+
 pub fn tokenize_lower_alnum(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut buf = String::new();

--- a/src-tauri/testdata/auto_learn_cases.json
+++ b/src-tauri/testdata/auto_learn_cases.json
@@ -4,90 +4,90 @@
     "original": "bran rock hosting",
     "corrected": "bran qroq hosting",
     "expect": [["rock", "qroq"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "technical brand qroq from rot",
     "original": "bran rot hosting",
     "corrected": "bran qroq hosting",
     "expect": [["rot", "qroq"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "kubernetes misspelling",
     "original": "please use Koobernetes today",
     "corrected": "please use Kubernetes today",
     "expect": [["Koobernetes", "Kubernetes"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "suffix completion noise",
     "original": "bran rot hostin",
     "corrected": "bran rot hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "repeated vowel typing noise",
     "original": "say nugga",
     "corrected": "say nuggaaaa",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "common word swap",
     "original": "the thing is good",
     "corrected": "is thing is good",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "one letter source junk",
     "original": "use x hosting",
     "corrected": "use qroq hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "one letter target junk",
     "original": "use rock hosting",
     "corrected": "use q hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "case only change",
     "original": "ask me later",
     "corrected": "Ask me later",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "sentence rewrite",
     "original": "please use Koobernetes in the deployment tomorrow",
     "corrected": "rewrite this whole sentence into something else",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "near homophone should not promote",
     "original": "their deployment passed",
     "corrected": "there deployment passed",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "ambiguous short common swap rejected",
     "original": "we can ship this now",
     "corrected": "we can shop this now",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "brand typo with numbers promotes",
     "original": "please open vsc0de now",
     "corrected": "please open vscode now",
     "expect": [["vsc0de", "vscode"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 1
   }
 ]


### PR DESCRIPTION
## Summary
- Auto-learn promotion now uses the accumulated `confidence_avg` as the single source of truth: distinctive corrections (brand/technical terms) that reach `confidence_avg >= 0.70` promote after a single session, while everything else keeps the existing 2-session requirement.
- Confidence tiers (`high`/`medium`/`low`) are recalibrated to the formula's real 0-0.80 range, fixing a previously unreachable "high" tier.
- Removed the dead `PAIR_COOLDOWN_MINUTES` cooldown path (it was a no-op).
- Gated mechanical dictionary substitution: auto-learned entries whose `mistake` is a plain non-distinctive word now rely on contextual LLM correction instead of a blunt find/replace that could clobber legitimate uses of the word (e.g. "rock" -> "Groq"). Manual entries are unaffected.
- Fixed a latent bug where first-time auto-learn promotions always stored `confidence_tier = 'low'` regardless of the computed tier.

## Test plan
- [x] `cargo test --bin verenu` (184 passed, including `auto_learn_regression_matrix`)
- [x] `npm run lint` (svelte-check + cargo clippy, clean)
- [x] `npm test` (fast profile) - unchanged baseline vs. clean tree