### PR TITLE
Release 0.13.0

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           if [ "${{ matrix.os-name }}" = "macos" ]; then
             npm run tauri build -- --target aarch64-apple-darwin
-            mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_Apple_Silicon.dmg"
+            mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_Apple_Silicon.dmg"
             npm run tauri build -- --target x86_64-apple-darwin
-            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_x64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_Intel.dmg"
+            mv "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_x64.dmg" "src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_Intel.dmg"
           else
             npm run tauri build
           fi
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Verenu-macOS-Apple-Silicon-dmg
-          path: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_Apple_Silicon.dmg
+          path: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_Apple_Silicon.dmg
           if-no-files-found: error
 
       - name: Upload macOS Intel DMG (.dmg)
@@ -80,5 +80,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Verenu-macOS-Intel-dmg
-          path: src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.12.1_Intel.dmg
+          path: src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Verenu_0.13.0_Intel.dmg
           if-no-files-found: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,9 +233,11 @@ Cleanup instruction keywords are applied mechanically to LLM output *after* the 
 
 ## Auto-Learn System (`api/auto_learn.rs`)
 
-After injection, monitors the focused text field for 30 seconds using Windows UI Automation. Each dictation session spawns its own monitor; concurrent monitors are intentional and necessary so corrections from separate dictations can each count toward the 2-session promotion threshold. Detects user corrections via Levenshtein edit distance (`edit_distance`, `is_spelling_correction`) — pairs must differ by ≤2 chars or ≤50% of max length. A `StableTextGate` requires two consecutive identical UIA reads before evaluating corrections, preventing mid-typing noise. A (wrong → correct) pair must be seen in 2 separate sessions within 2 days before being promoted to the dictionary. Within a session, `recorded_this_session` deduplicates so one noisy edit can't count twice.
+After injection, monitors the focused text field for 60 seconds using Windows UI Automation. Each dictation session spawns its own monitor; concurrent monitors are intentional and necessary so corrections from separate dictations can each count toward the promotion threshold. Detects user corrections via Levenshtein edit distance (`edit_distance`, `is_candidate_correction`) — pairs must differ by ≤2 chars or ≤50% of max length. A `StableTextGate` requires two consecutive identical UIA reads before evaluating corrections, preventing mid-typing noise. Promotion is confidence-tiered: a (wrong → correct) pair whose accumulated `confidence_avg` reaches `FAST_PROMOTION_CONFIDENCE` (0.70 — reachable only by distinctive corrections, e.g. brand/technical terms with a small edit distance) promotes after a single session; all other pairs need 2 separate sessions within 2 days. Within a session, `recorded_this_session` deduplicates so one noisy edit can't count twice.
 
 Requires COM initialization (`CoInitializeEx`) per thread via a `ComGuard` — UI Automation will fail silently without it.
+
+Auto-learned dictionary entries whose `mistake` is a plain, non-distinctive word (per `has_distinctive_features` in `system/text.rs`) are excluded from the mechanical find/replace in `apply_substitutions_from` — they're corrected contextually via the cleanup LLM prompt instead, so a mis-learned pair (e.g. "rock" → "Groq") can't clobber legitimate uses of the common word. Manual dictionary entries are never gated.
 
 ## Key Design Constraints
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verenu",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Verenu - An open-source AI dictation app for Windows",
   "main": "index.js",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5132,7 +5132,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "verenu"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "accessibility-sys",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verenu"
-version = "0.12.1"
+version = "0.13.0"
 description = "Verenu — local-first AI dictation"
 authors = ["Verenu Team"]
 edition = "2021"

--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -17,6 +17,7 @@ use crate::core::text_context::is_invisible_prefix_char as is_invisible_probe_ch
 #[cfg(any(windows, test))]
 use crate::core::text_context::SentenceContext;
 use crate::data::{db, store};
+use crate::system::text::has_distinctive_features;
 use crate::DbHandle;
 
 const MONITOR_WINDOW_SECS: u64 = 60;
@@ -28,14 +29,19 @@ const REJECTION_WINDOW_SECS: u64 = 8;
 const REJECTION_POLL_MS: u64 = 500;
 const CACHE_REJECTION_WINDOW_SECS: u64 = 10;
 const PENDING_RETENTION_DAYS: i64 = 2;
-const PROMOTION_THRESHOLD: i64 = 2;
+const PROMOTION_THRESHOLD_DEFAULT: i64 = 2;
+const PROMOTION_THRESHOLD_FAST: i64 = 1;
+// candidate_confidence() tops out around 0.80; this is reachable only by
+// distinctive corrections (brand/technical terms) with a small edit distance.
+const FAST_PROMOTION_CONFIDENCE: f64 = 0.70;
+const HIGH_CONFIDENCE_TIER: f64 = 0.70;
+const MEDIUM_CONFIDENCE_TIER: f64 = 0.55;
 const STABLE_TEXT_OBSERVATIONS_REQUIRED: usize = 2;
 const MIN_CANDIDATE_NORM_LEN: usize = 2;
 const MAX_SPAN_GROWTH_WORDS: usize = 5;
 const MAX_REPLACEMENTS_PER_SPAN: usize = 2;
 const MAX_CHANGED_OPS_PER_SPAN: usize = 4;
 const MIN_CANDIDATE_CONFIDENCE: f64 = 0.45;
-const PAIR_COOLDOWN_MINUTES: i64 = 0;
 
 static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -223,28 +229,6 @@ fn tokenize_words(text: &str) -> Vec<WordToken> {
     }
 
     tokens
-}
-
-fn has_distinctive_features(token: &str) -> bool {
-    if !token.is_ascii() {
-        return true;
-    }
-    if token.len() >= 4
-        && token
-            .chars()
-            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
-    {
-        return true;
-    }
-    if token
-        .chars()
-        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
-    {
-        return true;
-    }
-
-    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
-    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
 }
 
 fn is_common_word(word: &str) -> bool {
@@ -747,26 +731,22 @@ fn record_candidate(
         return false;
     }
 
-    if !db::upsert_auto_learn_candidate(
-        db,
-        &mistake,
-        &correction,
-        confidence,
-        PAIR_COOLDOWN_MINUTES,
-    )
-    .unwrap_or(false)
-    {
-        let _ = db::log_auto_learn_event(
-            db,
-            "candidate",
-            "cooldown_skip",
-            app_context,
-            &mistake_hash,
-            &correction_hash,
-            confidence,
-        );
-        return false;
-    }
+    let confidence_avg = match db::upsert_auto_learn_candidate(db, &mistake, &correction, confidence) {
+        Ok(confidence_avg) => confidence_avg,
+        Err(e) => {
+            log::warn!("auto-learn candidate upsert failed: {e}");
+            let _ = db::log_auto_learn_event(
+                db,
+                "candidate",
+                "candidate_upsert_failed",
+                app_context,
+                &mistake_hash,
+                &correction_hash,
+                confidence,
+            );
+            return false;
+        }
+    };
 
     if let Err(e) = db::insert_pending_correction(db, &mistake, &correction) {
         log::warn!("auto-learn pending insert failed: {e}");
@@ -786,7 +766,13 @@ fn record_candidate(
         db::count_pending_corrections_recent(db, &mistake, &correction, PENDING_RETENTION_DAYS)
             .unwrap_or(0);
 
-    if count < PROMOTION_THRESHOLD {
+    let threshold = if confidence_avg >= FAST_PROMOTION_CONFIDENCE {
+        PROMOTION_THRESHOLD_FAST
+    } else {
+        PROMOTION_THRESHOLD_DEFAULT
+    };
+
+    if count < threshold {
         let _ = db::log_auto_learn_event(
             db,
             "candidate",
@@ -799,9 +785,9 @@ fn record_candidate(
         return false;
     }
 
-    let tier = if confidence >= 0.85 {
+    let tier = if confidence_avg >= HIGH_CONFIDENCE_TIER {
         "high"
-    } else if confidence >= 0.72 {
+    } else if confidence_avg >= MEDIUM_CONFIDENCE_TIER {
         "medium"
     } else {
         "low"
@@ -1824,7 +1810,12 @@ mod tests {
         original: String,
         corrected: String,
         expect: Vec<[String; 2]>,
-        promotes_after_two_sessions: bool,
+        /// Number of sessions needed to promote this pair, or `null` if the
+        /// case isn't expected to promote at all. 1 exercises the
+        /// fast-promotion path (confidence >= FAST_PROMOTION_CONFIDENCE);
+        /// 2 exercises the default path.
+        #[serde(default)]
+        promotion_sessions: Option<u8>,
     }
 
     #[test]
@@ -1929,7 +1920,7 @@ mod tests {
             "test-app",
             "Koobernetes".to_string(),
             "Kubernetes".to_string(),
-            0.9,
+            0.6,
         ));
         assert!(!record_candidate(
             &db,
@@ -1937,7 +1928,7 @@ mod tests {
             "test-app",
             "Koobernetes".to_string(),
             "Kubernetes".to_string(),
-            0.9,
+            0.6,
         ));
 
         let count = db::count_pending_corrections_recent(
@@ -1963,7 +1954,7 @@ mod tests {
                     "test-app",
                     "Koobernetes".to_string(),
                     "Kubernetes".to_string(),
-                    0.9,
+                    0.6,
                 ),
                 expected
             );
@@ -1989,7 +1980,7 @@ mod tests {
                     "test-app",
                     "rock".to_string(),
                     "qroq".to_string(),
-                    0.9,
+                    0.6,
                 ),
                 expected
             );
@@ -2000,6 +1991,28 @@ mod tests {
         assert_eq!(entries[0].term, "qroq");
         assert_eq!(entries[0].mistake.as_deref(), Some("rock"));
         assert!(entries[0].auto_learned);
+    }
+
+    #[test]
+    fn high_confidence_candidate_promotes_after_one_session() {
+        let db = db::open(":memory:").expect("test db");
+        let mut recorded = HashSet::new();
+
+        assert!(record_candidate(
+            &db,
+            &mut recorded,
+            "test-app",
+            "vsc0de".to_string(),
+            "vscode".to_string(),
+            0.75,
+        ));
+
+        let entries = db::query_dictionary(&db).expect("dictionary");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].term, "vscode");
+        assert_eq!(entries[0].mistake.as_deref(), Some("vsc0de"));
+        assert!(entries[0].auto_learned);
+        assert_eq!(entries[0].confidence_tier, "high");
     }
 
     #[test]
@@ -2108,7 +2121,7 @@ mod tests {
                 .collect();
             assert_eq!(actual, expected, "case {}", case.name);
 
-            if case.promotes_after_two_sessions {
+            if let Some(sessions) = case.promotion_sessions {
                 assert!(
                     !expected.is_empty(),
                     "case {} marked promotable without expected pair",
@@ -2117,19 +2130,28 @@ mod tests {
                 let db = db::open(":memory:").expect("test db");
                 let (mistake, correction) = expected[0].clone();
 
-                for expected_promoted in [false, true] {
+                // 1 session exercises the fast-promotion path (confidence >=
+                // FAST_PROMOTION_CONFIDENCE); 2 exercises the default path.
+                let confidence = if sessions == 1 {
+                    FAST_PROMOTION_CONFIDENCE + 0.05
+                } else {
+                    FAST_PROMOTION_CONFIDENCE - 0.1
+                };
+
+                for session in 1..=sessions {
                     let mut recorded = HashSet::new();
+                    let promoted = record_candidate(
+                        &db,
+                        &mut recorded,
+                        "test-app",
+                        mistake.clone(),
+                        correction.clone(),
+                        confidence,
+                    );
                     assert_eq!(
-                        record_candidate(
-                            &db,
-                            &mut recorded,
-                            "test-app",
-                            mistake.clone(),
-                            correction.clone(),
-                            0.9,
-                        ),
-                        expected_promoted,
-                        "case {} promotion threshold",
+                        promoted,
+                        session == sessions,
+                        "case {} promotion threshold (session {session}/{sessions})",
                         case.name
                     );
                 }

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -737,8 +737,8 @@ pub fn insert_dictionary_entry_auto_learned(
 
     let conn = lock_conn(db)?;
     let changed = conn.execute(
-        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count) \
-         VALUES (?1, ?2, 1, 1) \
+        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier) \
+         VALUES (?1, ?2, 1, 1, ?3) \
          ON CONFLICT(term) DO UPDATE SET \
            correction_count = correction_count + 1, \
            confidence_tier = ?3, \
@@ -776,40 +776,29 @@ pub fn log_auto_learn_event(
     Ok(())
 }
 
+/// Records a confidence observation for a (wrong, correct) pair and returns
+/// the running average confidence across all observations of that pair.
 pub fn upsert_auto_learn_candidate(
     db: &Db,
     wrong: &str,
     correct: &str,
     confidence: f64,
-    cooldown_minutes: i64,
-) -> Result<bool> {
+) -> Result<f64> {
     let conn = lock_conn(db)?;
-    let blocked: i64 = conn.query_row(
-        "SELECT COUNT(*)
-         FROM auto_learn_candidates
-         WHERE wrong_word = ?1
-           AND correct_word = ?2
-           AND cooldown_until IS NOT NULL
-           AND cooldown_until > datetime('now')",
-        params![wrong, correct],
-        |r| r.get(0),
-    )?;
-    if blocked > 0 {
-        return Ok(false);
-    }
-    conn.execute(
+    conn.query_row(
         "INSERT INTO auto_learn_candidates
-         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at, cooldown_until)
-         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'), datetime('now', ?4))
+         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at)
+         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'))
          ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
            confidence_sum = auto_learn_candidates.confidence_sum + excluded.confidence_sum,
            seen_count = auto_learn_candidates.seen_count + 1,
            confidence_avg = (auto_learn_candidates.confidence_sum + excluded.confidence_sum) / (auto_learn_candidates.seen_count + 1),
-           last_seen_at = datetime('now'),
-           cooldown_until = datetime('now', ?4)",
-        params![wrong, correct, confidence, format!("+{} minutes", cooldown_minutes.max(0))],
-    )?;
-    Ok(true)
+           last_seen_at = datetime('now')
+         RETURNING confidence_avg",
+        params![wrong, correct, confidence],
+        |r| r.get(0),
+    )
+    .map_err(Into::into)
 }
 
 pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -> Result<()> {

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -1,5 +1,5 @@
 use crate::data::db;
-use crate::system::text::tokenize_lower_alnum;
+use crate::system::text::{has_distinctive_features, tokenize_lower_alnum};
 
 const MAX_PROMPT_ENTRIES: usize = 48;
 const MAX_PROMPT_CHARS: usize = 5_000;
@@ -173,9 +173,19 @@ fn format_dictionary_entry(entry: &db::DictionaryEntry) -> String {
 }
 
 pub fn apply_substitutions_from(text: &str, entries: &[db::DictionaryEntry]) -> (String, Vec<i64>) {
+    // Auto-learned mistakes that look like plain common words (no distinctive
+    // features) are left to the cleanup LLM's contextual judgment instead of
+    // a blunt mechanical replace, so a mis-learned pair like "rock" -> "Groq"
+    // can't clobber every legitimate use of "rock".
     let mut replaceable: Vec<(i64, &str, &str)> = entries
         .iter()
-        .filter_map(|e| e.mistake.as_deref().map(|m| (e.id, m, e.term.as_str())))
+        .filter_map(|e| {
+            let mistake = e.mistake.as_deref()?;
+            if e.auto_learned && !has_distinctive_features(mistake) {
+                return None;
+            }
+            Some((e.id, mistake, e.term.as_str()))
+        })
         .collect();
     replaceable.sort_by_key(|(_, mistake, _)| std::cmp::Reverse(mistake.len()));
 
@@ -260,6 +270,14 @@ mod tests {
         }
     }
 
+    fn auto_learned_entry(id: i64, term: &str, mistake: &str) -> DictionaryEntry {
+        DictionaryEntry {
+            auto_learned: true,
+            confidence_tier: "medium".to_string(),
+            ..entry(id, term, Some(mistake))
+        }
+    }
+
     #[test]
     fn relevant_prompt_prefers_matching_entries() {
         let entries = vec![
@@ -312,6 +330,30 @@ mod tests {
         let entries = vec![entry(1, "cliche", Some("cliché"))];
         let (out, applied) = apply_substitutions_from("Use cliché in this line.", &entries);
         assert_eq!(out, "Use cliche in this line.");
+        assert_eq!(applied, vec![1]);
+    }
+
+    #[test]
+    fn auto_learned_common_word_mistake_is_not_mechanically_substituted() {
+        let entries = vec![auto_learned_entry(1, "Groq", "rock")];
+        let (out, applied) = apply_substitutions_from("I love rock music", &entries);
+        assert_eq!(out, "I love rock music");
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn auto_learned_distinctive_mistake_is_still_substituted() {
+        let entries = vec![auto_learned_entry(1, "vscode", "vsc0de")];
+        let (out, applied) = apply_substitutions_from("please open vsc0de now", &entries);
+        assert_eq!(out, "please open vscode now");
+        assert_eq!(applied, vec![1]);
+    }
+
+    #[test]
+    fn manual_common_word_mistake_is_still_mechanically_substituted() {
+        let entries = vec![entry(1, "Groq", Some("rock"))];
+        let (out, applied) = apply_substitutions_from("I love rock music", &entries);
+        assert_eq!(out, "I love Groq music");
         assert_eq!(applied, vec![1]);
     }
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -553,20 +553,31 @@ fn reject_with_pill(app: &AppHandle, msg: &str) {
     });
 }
 
-fn resolve_profile(
+fn resolve_app_mapping(
     store: Option<&tauri_plugin_store::Store<tauri::Wry>>,
     process_name: &str,
-    default_tone: &str,
-) -> String {
-    let mapped = store.and_then(|s| {
+) -> Option<AppMapping> {
+    store.and_then(|s| {
         s.get(store::APP_MAPPINGS)
             .and_then(|v| serde_json::from_value::<Vec<AppMapping>>(v).ok())
-            .and_then(|list| {
-                list.into_iter()
-                    .find_map(|m| (m.exe.to_lowercase() == process_name).then_some(m.profile))
-            })
-    });
-    mapped.unwrap_or_else(|| default_tone.to_owned())
+            .and_then(|list| list.into_iter().find(|m| m.exe.eq_ignore_ascii_case(process_name)))
+    })
+}
+
+/// Resolves the effective tone profile for `mapping`, falling back to the
+/// global `default_tone` when the app has no override, and applies the
+/// app's `cleanup_intensity` override (if any) onto `cfg` in place.
+fn apply_app_style_overrides(cfg: &mut store::PipelineConfig, mapping: Option<&AppMapping>) -> String {
+    if let Some(intensity) = mapping
+        .and_then(|m| m.cleanup_intensity.as_deref())
+        .filter(|i| !i.is_empty())
+    {
+        cfg.cleanup_intensity = intensity.to_owned();
+    }
+    mapping
+        .map(|m| m.profile.clone())
+        .filter(|p| !p.is_empty())
+        .unwrap_or_else(|| cfg.default_tone.clone())
 }
 
 pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow::Result<String> {
@@ -852,7 +863,7 @@ async fn open_config_and_context(
             return None;
         }
     };
-    let cfg = store::load_pipeline_config(&settings_store);
+    let mut cfg = store::load_pipeline_config(&settings_store);
     if !has_transcription_key_in_chain(&cfg) {
         show_error_pill(
             app,
@@ -861,7 +872,8 @@ async fn open_config_and_context(
         .await;
         return None;
     }
-    let profile = resolve_profile(Some(&settings_store), process_name, &cfg.default_tone);
+    let mapping = resolve_app_mapping(Some(&settings_store), process_name);
+    let profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
     let app_context = if cfg.app_context_hint {
         window_context::get_app_context_hint(process_name)
     } else {
@@ -1907,18 +1919,21 @@ pub async fn retry_transcription_impl(
         show_error_pill(app, "Retry window expired").await;
         anyhow::bail!("Retry window expired");
     }
-    let Some(capture) = capture else {
+    let Some(mut capture) = capture else {
         hide_pill(app);
         anyhow::bail!("No retry available");
     };
 
     let settings_store = app.store("settings.json")?;
-    let cfg = store::load_pipeline_config(&settings_store);
+    let mut cfg = store::load_pipeline_config(&settings_store);
 
     if !has_transcription_key_in_chain(&cfg) {
         show_error_pill(app, "No API key configured").await;
         anyhow::bail!("No API key configured");
     }
+
+    let mapping = resolve_app_mapping(Some(&settings_store), &capture.process_name);
+    capture.profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
 
     let Some((raw, api_used, final_text, dict_entries, cleanup_cache_key)) =
         run_transcription_and_cleanup(

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -12,6 +12,10 @@ pub struct AppMapping {
     pub profile: String,
     #[serde(default)]
     pub name: String,
+    /// Per-app override for `cleanup_intensity`. `None` (or empty) falls back
+    /// to the global setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_intensity: Option<String>,
 }
 
 /// Combines registry-discovered and currently-running apps into a single deduplicated list.

--- a/src-tauri/src/system/text.rs
+++ b/src-tauri/src/system/text.rs
@@ -1,3 +1,28 @@
+/// True if `token` contains a feature (non-ASCII, q/x/z, digit/apostrophe/hyphen/underscore,
+/// or internal capitalization) that makes it unlikely to be a plain mis-transcribed
+/// common word — i.e. likely a brand/technical term or proper noun.
+pub fn has_distinctive_features(token: &str) -> bool {
+    if !token.is_ascii() {
+        return true;
+    }
+    if token.len() >= 4
+        && token
+            .chars()
+            .any(|c| matches!(c.to_ascii_lowercase(), 'q' | 'x' | 'z'))
+    {
+        return true;
+    }
+    if token
+        .chars()
+        .any(|c| c.is_ascii_digit() || matches!(c, '\'' | '-' | '_'))
+    {
+        return true;
+    }
+
+    let uppercase_count = token.chars().filter(|c| c.is_uppercase()).count();
+    uppercase_count > 1 || token.chars().skip(1).any(|c| c.is_uppercase())
+}
+
 pub fn tokenize_lower_alnum(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut buf = String::new();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "Verenu",
   "mainBinaryName": "Verenu",
   "identifier": "com.verenu.app",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/testdata/auto_learn_cases.json
+++ b/src-tauri/testdata/auto_learn_cases.json
@@ -4,90 +4,90 @@
     "original": "bran rock hosting",
     "corrected": "bran qroq hosting",
     "expect": [["rock", "qroq"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "technical brand qroq from rot",
     "original": "bran rot hosting",
     "corrected": "bran qroq hosting",
     "expect": [["rot", "qroq"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "kubernetes misspelling",
     "original": "please use Koobernetes today",
     "corrected": "please use Kubernetes today",
     "expect": [["Koobernetes", "Kubernetes"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 2
   },
   {
     "name": "suffix completion noise",
     "original": "bran rot hostin",
     "corrected": "bran rot hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "repeated vowel typing noise",
     "original": "say nugga",
     "corrected": "say nuggaaaa",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "common word swap",
     "original": "the thing is good",
     "corrected": "is thing is good",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "one letter source junk",
     "original": "use x hosting",
     "corrected": "use qroq hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "one letter target junk",
     "original": "use rock hosting",
     "corrected": "use q hosting",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "case only change",
     "original": "ask me later",
     "corrected": "Ask me later",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "sentence rewrite",
     "original": "please use Koobernetes in the deployment tomorrow",
     "corrected": "rewrite this whole sentence into something else",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "near homophone should not promote",
     "original": "their deployment passed",
     "corrected": "there deployment passed",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "ambiguous short common swap rejected",
     "original": "we can ship this now",
     "corrected": "we can shop this now",
     "expect": [],
-    "promotes_after_two_sessions": false
+    "promotion_sessions": null
   },
   {
     "name": "brand typo with numbers promotes",
     "original": "please open vsc0de now",
     "corrected": "please open vscode now",
     "expect": [["vsc0de", "vscode"]],
-    "promotes_after_two_sessions": true
+    "promotion_sessions": 1
   }
 ]

--- a/src/lib/appMappings.ts
+++ b/src/lib/appMappings.ts
@@ -7,6 +7,7 @@ export interface AppMapping {
   exe: string;
   profile: string;
   name?: string;
+  cleanup_intensity?: string;
 }
 
 export const profileOptions = [
@@ -15,12 +16,26 @@ export const profileOptions = [
   { id: 'very_casual', label: 'Very Casual' },
 ] as const;
 
+export const cleanupIntensityOptions = [
+  { id: 'none', label: 'Verbatim' },
+  { id: 'light', label: 'Light' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'Direct' },
+] as const;
+
+export const DEFAULT_CLEANUP_INTENSITY_LABEL = 'Default';
+
 export function normalizeExe(exe: string) {
   return exe.trim().toLowerCase();
 }
 
 export function getProfileLabel(profile: string) {
   return profileOptions.find((option) => option.id === profile)?.label ?? titleize(profile);
+}
+
+export function getCleanupIntensityLabel(intensity: string | undefined | null) {
+  if (!intensity) return DEFAULT_CLEANUP_INTENSITY_LABEL;
+  return cleanupIntensityOptions.find((option) => option.id === intensity)?.label ?? titleize(intensity);
 }
 
 export function getAppDisplayName(

--- a/src/lib/components/AppMappingsEditor.svelte
+++ b/src/lib/components/AppMappingsEditor.svelte
@@ -6,7 +6,9 @@
   import { expoOut } from 'svelte/easing';
   import {
     cleanAppName,
+    cleanupIntensityOptions,
     getAppDisplayName,
+    getCleanupIntensityLabel,
     getProfileLabel,
     normalizeExe,
     profileOptions,
@@ -33,11 +35,31 @@
   let addExe = $state('');
   let addName = $state('');
   let addProfile = $state('casual');
+  let addCleanupIntensity = $state('');
   let appSearch = $state('');
   let appPickerOpen = $state(false);
   let profileDropdownOpen = $state(false);
+  let cleanupDropdownOpen = $state(false);
+  let openRowDropdown = $state<string | null>(null);
+  let rowDropdownPos = $state<{ top: number; right: number } | null>(null);
   let mappingError = $state('');
   let leavingExes = $state<Set<string>>(new Set());
+
+  const cleanupIntensityChoices = [
+    { id: '', label: 'Default' },
+    ...cleanupIntensityOptions,
+  ] as const;
+
+  const activeRowDropdown = $derived.by(() => {
+    if (!openRowDropdown) return null;
+    const sep = openRowDropdown.lastIndexOf(':');
+    if (sep === -1) return null;
+    const exe = openRowDropdown.slice(0, sep);
+    const field = openRowDropdown.slice(sep + 1) as 'profile' | 'cleanup';
+    const mapping = mappings.find((m) => m.exe === exe);
+    if (!mapping) return null;
+    return { exe, field, mapping };
+  });
 
   const pendingExe = $derived(addExe || (appSearch.trim() ? customExeFromSearch(appSearch) : ''));
   const pendingName = $derived(cleanAppName(addName || appSearch || pendingExe));
@@ -121,13 +143,28 @@
       exe: rawExe,
       profile: addProfile,
       name: addName || appSearch || rawExe,
+      cleanup_intensity: addCleanupIntensity || undefined,
     });
     await saveMappings([...mappings.filter((mapping) => mapping.exe !== entry.exe), entry]);
     addExe = '';
     addName = '';
     addProfile = 'casual';
+    addCleanupIntensity = '';
     appSearch = '';
     appPickerOpen = false;
+  }
+
+  async function setMappingField(exe: string, patch: Partial<AppMapping>) {
+    const previousMappings = mappings;
+    const updated = mappings.map((mapping) =>
+      mapping.exe === exe ? normalizeMapping({ ...mapping, ...patch }) : mapping,
+    );
+    const saved = await saveMappings(updated);
+    if (!saved) {
+      mappings = normalizeMappings(previousMappings);
+    }
+    openRowDropdown = null;
+    rowDropdownPos = null;
   }
 
   function pickApp(app: InstalledApp) {
@@ -158,6 +195,46 @@
     }
   }
 
+  function closeCleanupDropdown(e: MouseEvent | PointerEvent) {
+    const target = e.target;
+    if (target instanceof Element && !target.closest('.cleanup-drop-wrap')) {
+      cleanupDropdownOpen = false;
+    }
+  }
+
+  function handleCleanupButtonKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && cleanupDropdownOpen) {
+      cleanupDropdownOpen = false;
+      e.stopPropagation();
+    }
+  }
+
+  function toggleRowDropdown(key: string, e: MouseEvent) {
+    if (openRowDropdown === key) {
+      openRowDropdown = null;
+      rowDropdownPos = null;
+      return;
+    }
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    rowDropdownPos = { top: rect.bottom + 4, right: window.innerWidth - rect.right };
+    openRowDropdown = key;
+  }
+
+  function closeRowDropdown(e: MouseEvent | PointerEvent) {
+    const target = e.target;
+    if (target instanceof Element && !target.closest('.row-drop-wrap') && !target.closest('.row-drop-menu')) {
+      openRowDropdown = null;
+      rowDropdownPos = null;
+    }
+  }
+
+  function handleRowDropdownKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && openRowDropdown) {
+      openRowDropdown = null;
+      e.stopPropagation();
+    }
+  }
+
   function normalizeMappings(entries: AppMapping[]) {
     const seen = new Set<string>();
     return entries
@@ -171,11 +248,15 @@
 
   function normalizeMapping(entry: AppMapping): AppMapping {
     const exe = normalizeExe(entry.exe);
-    return {
+    const mapping: AppMapping = {
       exe,
       profile: entry.profile || 'casual',
       name: getAppDisplayName({ exe, name: entry.name }, installedApps),
     };
+    if (entry.cleanup_intensity) {
+      mapping.cleanup_intensity = entry.cleanup_intensity;
+    }
+    return mapping;
   }
 
   function matchesAppSearch(app: InstalledApp, search: string) {
@@ -218,6 +299,39 @@
       window.removeEventListener('pointerdown', closeProfileDropdown);
     };
   });
+
+  $effect(() => {
+    if (!cleanupDropdownOpen) return;
+
+    const timeout = window.setTimeout(() => {
+      window.addEventListener('pointerdown', closeCleanupDropdown);
+    });
+
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('pointerdown', closeCleanupDropdown);
+    };
+  });
+
+  $effect(() => {
+    if (!openRowDropdown) return;
+
+    const handleScroll = () => {
+      openRowDropdown = null;
+      rowDropdownPos = null;
+    };
+
+    const timeout = window.setTimeout(() => {
+      window.addEventListener('pointerdown', closeRowDropdown);
+      window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+    });
+
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('pointerdown', closeRowDropdown);
+      window.removeEventListener('scroll', handleScroll, { capture: true });
+    };
+  });
 </script>
 
 {#if showHeading}
@@ -239,7 +353,33 @@
             <span class="mapping-app-name">{getAppDisplayName(mapping, installedApps)}</span>
             <span class="mapping-exe-pill" aria-hidden="true">{mapping.exe}</span>
           </div>
-          <span class="mapping-profile-badge">{getProfileLabel(mapping.profile)}</span>
+          <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
+            <button
+              class="mapping-badge-btn"
+              onclick={(e) => toggleRowDropdown(`${mapping.exe}:profile`, e)}
+              onkeydown={handleRowDropdownKeydown}
+              title="Tone for {getAppDisplayName(mapping, installedApps)}"
+            >
+              {getProfileLabel(mapping.profile)}
+              <svg class:open={openRowDropdown === `${mapping.exe}:profile`} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m6 9 6 6 6-6"/>
+              </svg>
+            </button>
+          </div>
+          <div class="row-drop-wrap" role="presentation" onclick={(e) => e.stopPropagation()}>
+            <button
+              class="mapping-badge-btn"
+              class:is-default={!mapping.cleanup_intensity}
+              onclick={(e) => toggleRowDropdown(`${mapping.exe}:cleanup`, e)}
+              onkeydown={handleRowDropdownKeydown}
+              title="Auto-cleanup style for {getAppDisplayName(mapping, installedApps)}"
+            >
+              {getCleanupIntensityLabel(mapping.cleanup_intensity)}
+              <svg class:open={openRowDropdown === `${mapping.exe}:cleanup`} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m6 9 6 6 6-6"/>
+              </svg>
+            </button>
+          </div>
           <button class="mapping-delete-btn" onclick={() => deleteMapping(mapping.exe)} title="Remove {getAppDisplayName(mapping, installedApps)}">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
               <path d="M18 6 6 18M6 6l12 12"/>
@@ -252,6 +392,41 @@
     <div class="mapping-empty" in:fade={{ duration: motionMs(MOTION_MS.fast) }} out:fade={{ duration: motionMs(MOTION_MS.fast) }}>{emptyText}</div>
   {/if}
 </div>
+
+{#if activeRowDropdown && rowDropdownPos}
+  <div
+    class="row-drop-menu scroll-styled"
+    role="presentation"
+    style="top: {rowDropdownPos.top}px; right: {rowDropdownPos.right}px;"
+    onclick={(e) => e.stopPropagation()}
+    in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+    out:fade={{ duration: motionMs(100) }}
+  >
+    {#if activeRowDropdown.field === 'profile'}
+      {#each profileOptions as profile}
+        <button
+          class="row-drop-item"
+          class:active={activeRowDropdown.mapping.profile === profile.id}
+          onclick={() => setMappingField(activeRowDropdown.exe, { profile: profile.id })}
+          onkeydown={handleRowDropdownKeydown}
+        >
+          {profile.label}
+        </button>
+      {/each}
+    {:else}
+      {#each cleanupIntensityChoices as choice}
+        <button
+          class="row-drop-item"
+          class:active={(activeRowDropdown.mapping.cleanup_intensity || '') === choice.id}
+          onclick={() => setMappingField(activeRowDropdown.exe, { cleanup_intensity: choice.id || undefined })}
+          onkeydown={handleRowDropdownKeydown}
+        >
+          {choice.label}
+        </button>
+      {/each}
+    {/if}
+  </div>
+{/if}
 
 {#if mappingError}
   <div class="mapping-error">{mappingError}</div>
@@ -347,6 +522,48 @@
         </div>
       {/if}
     </div>
+    <div
+      class="cleanup-drop-wrap"
+      role="presentation"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <select class="cleanup-select cleanup-select-hidden" bind:value={addCleanupIntensity} tabindex="-1" aria-hidden="true">
+        {#each cleanupIntensityChoices as choice}
+          <option value={choice.id}>{choice.label}</option>
+        {/each}
+      </select>
+      <button
+        class="cleanup-drop-btn"
+        use:animateWidth={{ text: getCleanupIntensityLabel(addCleanupIntensity) }}
+        onclick={() => (cleanupDropdownOpen = !cleanupDropdownOpen)}
+        onkeydown={handleCleanupButtonKeydown}
+      >
+        <span>{getCleanupIntensityLabel(addCleanupIntensity)}</span>
+        <svg class:open={cleanupDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+      </button>
+      {#if cleanupDropdownOpen}
+        <div
+          class="cleanup-drop-menu scroll-styled"
+          role="presentation"
+          onclick={(e) => e.stopPropagation()}
+          in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+          out:fade={{ duration: motionMs(100) }}
+        >
+          {#each cleanupIntensityChoices as choice}
+            <button
+              class="cleanup-drop-item"
+              class:active={addCleanupIntensity === choice.id}
+              onclick={() => { addCleanupIntensity = choice.id; cleanupDropdownOpen = false; }}
+              onkeydown={handleCleanupButtonKeydown}
+            >
+              {choice.label}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
     <button type="button" class="btn-primary add-btn" onclick={addMapping} disabled={!addExe && !appSearch.trim()}>Add</button>
   </div>
   {#if pendingExe}
@@ -354,6 +571,8 @@
       <span>{pendingName}</span>
       <span class="preview-dot"></span>
       <span>{getProfileLabel(addProfile)}</span>
+      <span class="preview-dot"></span>
+      <span>{getCleanupIntensityLabel(addCleanupIntensity)} cleanup</span>
     </div>
   {/if}
 </div>
@@ -421,16 +640,70 @@
     text-overflow: ellipsis;
   }
 
-  .mapping-profile-badge {
+  .row-drop-wrap {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .mapping-badge-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 12px;
     font-weight: 500;
+    font-family: var(--sans);
     color: var(--accent-ink);
     background: var(--accent-soft);
     border: 1px solid color-mix(in oklab, var(--accent) 28%, transparent);
     border-radius: 4px;
     padding: 2px 8px;
-    flex-shrink: 0;
+    cursor: pointer;
+    white-space: nowrap;
   }
+
+  .mapping-badge-btn:hover { background: color-mix(in oklab, var(--accent-soft) 80%, var(--accent) 20%); }
+
+  .mapping-badge-btn.is-default {
+    color: var(--ink-mute);
+    background: transparent;
+    border-color: var(--line-strong);
+  }
+
+  .mapping-badge-btn.is-default:hover { background: var(--control-hover); }
+
+  .mapping-badge-btn svg { transition: transform 150ms; flex-shrink: 0; }
+  .mapping-badge-btn svg.open { transform: rotate(180deg); }
+
+  .row-drop-menu {
+    position: fixed;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    box-shadow: var(--shadow-popover);
+    min-width: 120px;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 50;
+  }
+
+  .row-drop-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 7px 10px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .row-drop-item:last-child { border-bottom: none; }
+  .row-drop-item:hover { background: var(--control-hover); }
+  .row-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
 
   .mapping-exe-pill {
     position: absolute;
@@ -649,6 +922,87 @@
   .profile-drop-item:last-child { border-bottom: none; }
   .profile-drop-item:hover { background: var(--control-hover); }
   .profile-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
+
+  .cleanup-drop-wrap {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .cleanup-select-hidden {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    clip-path: inset(50%);
+    border: 0;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .cleanup-drop-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid var(--line-strong);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .cleanup-drop-btn:hover { background: var(--control-hover); }
+  .cleanup-drop-btn svg { transition: transform 150ms; }
+  .cleanup-drop-btn svg.open { transform: rotate(180deg); }
+
+  .cleanup-drop-btn span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 140px;
+  }
+
+  .cleanup-drop-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    box-shadow: var(--shadow-popover);
+    min-width: 120px;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 20;
+  }
+
+  .cleanup-drop-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-family: var(--sans);
+    color: var(--ink-strong);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .cleanup-drop-item:last-child { border-bottom: none; }
+  .cleanup-drop-item:hover { background: var(--control-hover); }
+  .cleanup-drop-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
 
   .add-btn { flex-shrink: 0; }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -13,6 +13,7 @@ export interface AppMapping {
   exe: string;
   profile: string;
   name?: string;
+  cleanup_intensity?: CleanupIntensity;
 }
 
 type SettingsValueMap = {


### PR DESCRIPTION
This pull request merges the release/0.13.0 branch (dev + version bump) into master to release Verenu version 0.13.0.

### What's New in 0.13.0
- **Confidence-Tiered Auto-Learn Promotion**: Distinctive corrections (brand/technical terms) reaching 0.70 confidence promote after a single session; recalibrated confidence tiers and a substitution safety gate prevent auto-learned entries from clobbering common words (#117).
- **Per-App Cleanup Intensity**: App Mappings now support an optional per-app cleanup intensity override (Verbatim/Light/Medium/Direct) alongside the existing per-app tone (#116).
- **Database Self-Heal & Docs Overhaul**: Self-heals a missing `spoken_words` column from interrupted migrations, overhauls README/CONTRIBUTING/release docs, adds `docs/DATA_AND_PRIVACY.md`, and removes leftover OpenFlow -> Verenu rebrand transition code (#115).
- **Verenu Rename Follow-ups**: Completes remaining Open Flow -> Verenu renames across release packaging, updater/source links, and snippet stats (#114).