### PR TITLE
fix: prevent text ellipsis on history retention dropdown during animation

### DIFF
--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -362,7 +362,7 @@
   .mic-btn { display: flex; align-items: center; gap: 6px; max-width: 180px; }
   .mic-btn svg { transition: transform 150ms; }
   .mic-btn svg.open { transform: rotate(180deg); }
-  .mic-btn span { white-space: nowrap; }
+  .mic-btn span { overflow: hidden; white-space: nowrap; }
   .mic-menu {
     position: absolute;
     right: 0;

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -362,7 +362,7 @@
   .mic-btn { display: flex; align-items: center; gap: 6px; max-width: 180px; }
   .mic-btn svg { transition: transform 150ms; }
   .mic-btn svg.open { transform: rotate(180deg); }
-  .mic-btn span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
+  .mic-btn span { white-space: nowrap; }
   .mic-menu {
     position: absolute;
     right: 0;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - Subsystem: Settings UI — Privacy section, history retention dropdown
> - The `animateWidth` Svelte action animates the button width when the selected option changes; during the transition the containing `<span>` was constrained by `max-width: 140px` + `overflow: hidden` + `text-overflow: ellipsis`
> - A mid-transition width smaller than the label's natural width caused labels like "7 days" to flash an ellipsis for a frame before the animation completed
> - This PR removes the overflow/truncation constraints from `.mic-btn span` since all four option strings are short fixed values that never need truncation
> - The benefit is a stable, non-flickering dropdown label at all times

## What Changed

- Removed `overflow: hidden`, `text-overflow: ellipsis`, and `max-width: 140px` from `.mic-btn span` in `PrivacySection.svelte`; replaced with just `white-space: nowrap`

## Verification

- Open Settings → Privacy
- Change the "Transcription history" dropdown between options (e.g. "7 days" ↔ "30 days") and observe that no ellipsis appears during or after the transition

## Risks

Low risk — style-only, one-line change affecting only the Privacy section's history retention dropdown label span.

## Model Used

- Anthropic Claude Sonnet 4.6 (claude-sonnet-4-6), tool use mode

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable (style-only, no tests needed)
- [x] UI changes include before/after screenshots (screenshot in issue — ellipsis "7 da…" vs clean "7 days")
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (no version bump)
- [x] Relevant documentation updated to reflect changes (none required)
- [x] Risks documented above