### PR TITLE
fix: enforce transcription history retention and confirm before deleting

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -133,9 +133,11 @@ pub async fn save_setting(
     value: serde_json::Value,
 ) -> Result<(), String> {
     validate_setting(&key, &value)?;
-    let history_prune_days = (key == store::HISTORY_RETENTION)
-        .then(|| value.as_str().and_then(store::history_retention_days))
-        .flatten();
+    let history_prune_days = if key == store::HISTORY_RETENTION {
+        value.as_str().and_then(store::history_retention_days)
+    } else {
+        None
+    };
     let store = app.store("settings.json").map_err(|e| e.to_string())?;
     store.set(key.clone(), value);
     store.save().map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -133,12 +133,26 @@ pub async fn save_setting(
     value: serde_json::Value,
 ) -> Result<(), String> {
     validate_setting(&key, &value)?;
+    let history_prune_days = (key == store::HISTORY_RETENTION)
+        .then(|| value.as_str().and_then(store::history_retention_days))
+        .flatten();
     let store = app.store("settings.json").map_err(|e| e.to_string())?;
     store.set(key.clone(), value);
     store.save().map_err(|e| e.to_string())?;
 
     if key == store::APPEARANCE_MODE {
         crate::apply_runtime_icons(&app, None);
+    }
+
+    if let Some(days) = history_prune_days {
+        let db = app.state::<DbHandle>().inner().clone();
+        let deleted = tokio::task::spawn_blocking(move || db::prune_transcriptions_older_than(&db, days))
+            .await
+            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?;
+        if deleted > 0 {
+            let _ = app.emit("verenu:history-pruned", ());
+        }
     }
 
     Ok(())
@@ -376,6 +390,19 @@ pub async fn get_stats(app: AppHandle) -> Result<db::Stats, String> {
     tokio::task::spawn_blocking(move || db::query_stats(&db).map_err(|e| e.to_string()))
         .await
         .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn count_old_transcriptions(app: AppHandle, retention: String) -> Result<i64, String> {
+    let Some(days) = store::history_retention_days(&retention) else {
+        return Ok(0);
+    };
+    let db = app.state::<DbHandle>().inner().clone();
+    tokio::task::spawn_blocking(move || {
+        db::count_transcriptions_older_than(&db, days).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -181,6 +181,10 @@ CREATE TABLE IF NOT EXISTS transcriptions (
 );
 CREATE INDEX IF NOT EXISTS idx_transcriptions_created_at
   ON transcriptions(created_at);
+CREATE TABLE IF NOT EXISTS lifetime_stats (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  total_words INTEGER NOT NULL DEFAULT 0
+);
 CREATE TABLE IF NOT EXISTS dictionary (
   id               INTEGER PRIMARY KEY AUTOINCREMENT,
   term             TEXT    NOT NULL UNIQUE,
@@ -441,6 +445,23 @@ pub fn open(path: &str) -> Result<Db> {
             return Err(err.into());
         }
     }
+    if user_version < 9 {
+        // Seed the lifetime word counter from existing history so upgrading
+        // users don't see it reset to zero. From here on it's only ever
+        // incremented on insert, never recomputed from transcriptions, so
+        // history retention pruning can't shrink it.
+        let res = conn.execute_batch(
+            "BEGIN;
+             INSERT OR IGNORE INTO lifetime_stats (id, total_words)
+               SELECT 1, COALESCE(SUM(words), 0) FROM transcriptions;
+             PRAGMA user_version = 9;
+             COMMIT;",
+        );
+        if let Err(err) = res {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err.into());
+        }
+    }
     ensure_cleanup_cache_schema(&conn)?;
 
     // Self-heal: some databases ended up with user_version >= 7 without the
@@ -527,7 +548,7 @@ pub fn insert_transcription_returning(
 ) -> Result<RecentEntry> {
     let conn = lock_conn(db)?;
     let spoken_words = compute_spoken_words(&conn, raw)?;
-    Ok(conn.query_row(
+    let entry = conn.query_row(
         "INSERT INTO transcriptions (raw_text, clean_text, words, spoken_words, duration_ms, api_used) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
          RETURNING id, clean_text, words, created_at",
@@ -540,7 +561,14 @@ pub fn insert_transcription_returning(
                 created_at: r.get(3)?,
             })
         },
-    )?)
+    )?;
+    // Lifetime counter is intentionally separate from the transcriptions
+    // table so history retention pruning never shrinks it.
+    conn.execute(
+        "UPDATE lifetime_stats SET total_words = total_words + ?1 WHERE id = 1",
+        params![words],
+    )?;
+    Ok(entry)
 }
 
 pub fn query_recent(db: &Db) -> Result<Vec<RecentEntry>> {
@@ -570,7 +598,7 @@ pub fn query_stats(db: &Db) -> Result<Stats> {
     let conn = lock_conn(db)?;
 
     let total_words: i64 = conn.query_row(
-        "SELECT COALESCE(SUM(words),0) FROM transcriptions",
+        "SELECT total_words FROM lifetime_stats WHERE id = 1",
         [],
         |r| r.get(0),
     )?;
@@ -1798,6 +1826,68 @@ mod tests {
 
         assert_eq!(stats.total_words, 1500);
         assert!(stats.avg_wpm > 0.0);
+    }
+
+    #[test]
+    fn prune_transcriptions_older_than_deletes_only_old_rows() {
+        let db = test_db();
+        insert_transcription_returning(&db, "old one", "old one", 2, 1000, "test")
+            .expect("old transcription");
+        insert_transcription_returning(&db, "recent one", "recent one", 2, 1000, "test")
+            .expect("recent transcription");
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "UPDATE transcriptions SET created_at = datetime('now', '-30 days') WHERE clean_text = 'old one'",
+                [],
+            )
+            .expect("backdate old row");
+        }
+
+        assert_eq!(
+            count_transcriptions_older_than(&db, 7).expect("count"),
+            1
+        );
+        assert_eq!(
+            prune_transcriptions_older_than(&db, 7).expect("prune"),
+            1
+        );
+
+        let conn = lock_conn(&db).expect("lock");
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM transcriptions", [], |r| r.get(0))
+            .expect("remaining count");
+        assert_eq!(remaining, 1);
+        let remaining_text: String = conn
+            .query_row("SELECT clean_text FROM transcriptions", [], |r| r.get(0))
+            .expect("remaining text");
+        assert_eq!(remaining_text, "recent one");
+    }
+
+    #[test]
+    fn pruning_old_transcriptions_does_not_reduce_lifetime_word_total() {
+        let db = test_db();
+        insert_transcription_returning(&db, "old one", "old one", 5, 1000, "test")
+            .expect("old transcription");
+        insert_transcription_returning(&db, "recent one", "recent one", 3, 1000, "test")
+            .expect("recent transcription");
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "UPDATE transcriptions SET created_at = datetime('now', '-30 days') WHERE clean_text = 'old one'",
+                [],
+            )
+            .expect("backdate old row");
+        }
+
+        let before = query_stats(&db).expect("stats before prune").total_words;
+        assert_eq!(before, 8);
+
+        let deleted = prune_transcriptions_older_than(&db, 7).expect("prune");
+        assert_eq!(deleted, 1);
+
+        let after = query_stats(&db).expect("stats after prune").total_words;
+        assert_eq!(after, 8, "lifetime word counter must not shrink when old history is pruned");
     }
 
     #[test]

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -546,9 +546,10 @@ pub fn insert_transcription_returning(
     duration_ms: i64,
     api_used: &str,
 ) -> Result<RecentEntry> {
-    let conn = lock_conn(db)?;
+    let mut conn = lock_conn(db)?;
     let spoken_words = compute_spoken_words(&conn, raw)?;
-    let entry = conn.query_row(
+    let tx = conn.transaction()?;
+    let entry = tx.query_row(
         "INSERT INTO transcriptions (raw_text, clean_text, words, spoken_words, duration_ms, api_used) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
          RETURNING id, clean_text, words, created_at",
@@ -563,11 +564,14 @@ pub fn insert_transcription_returning(
         },
     )?;
     // Lifetime counter is intentionally separate from the transcriptions
-    // table so history retention pruning never shrinks it.
-    conn.execute(
+    // table so history retention pruning never shrinks it. Committed in the
+    // same transaction as the insert so a crash between the two can't leave
+    // total_words permanently undercounted.
+    tx.execute(
         "UPDATE lifetime_stats SET total_words = total_words + ?1 WHERE id = 1",
         params![words],
     )?;
+    tx.commit()?;
     Ok(entry)
 }
 

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -179,6 +179,8 @@ CREATE TABLE IF NOT EXISTS transcriptions (
   api_used    TEXT    NOT NULL DEFAULT '',
   created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
 );
+CREATE INDEX IF NOT EXISTS idx_transcriptions_created_at
+  ON transcriptions(created_at);
 CREATE TABLE IF NOT EXISTS dictionary (
   id               INTEGER PRIMARY KEY AUTOINCREMENT,
   term             TEXT    NOT NULL UNIQUE,
@@ -425,6 +427,19 @@ pub fn open(path: &str) -> Result<Db> {
             return Err(err);
         }
         conn.execute_batch("COMMIT;")?;
+    }
+    if user_version < 8 {
+        let res = conn.execute_batch(
+            "BEGIN;
+             CREATE INDEX IF NOT EXISTS idx_transcriptions_created_at
+               ON transcriptions(created_at);
+             PRAGMA user_version = 8;
+             COMMIT;",
+        );
+        if let Err(err) = res {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err.into());
+        }
     }
     ensure_cleanup_cache_schema(&conn)?;
 

--- a/src-tauri/src/data/db.rs
+++ b/src-tauri/src/data/db.rs
@@ -907,6 +907,25 @@ pub fn prune_pending_corrections(db: &Db, max_age_days: i64) -> Result<usize> {
     Ok(changed)
 }
 
+pub fn count_transcriptions_older_than(db: &Db, max_age_days: i64) -> Result<i64> {
+    let conn = lock_conn(db)?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM transcriptions WHERE created_at < datetime('now', ?1)",
+        params![format!("-{} days", max_age_days.max(1))],
+        |r| r.get(0),
+    )?;
+    Ok(count)
+}
+
+pub fn prune_transcriptions_older_than(db: &Db, max_age_days: i64) -> Result<usize> {
+    let conn = lock_conn(db)?;
+    let changed = conn.execute(
+        "DELETE FROM transcriptions WHERE created_at < datetime('now', ?1)",
+        params![format!("-{} days", max_age_days.max(1))],
+    )?;
+    Ok(changed)
+}
+
 pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&str>) -> Result<()> {
     let normalized_term = require_nonempty_trimmed("Term", term)?;
     let normalized_mistake = normalize_optional_trimmed(mistake);

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -39,6 +39,17 @@ pub const UPDATE_DISMISSED_VERSION: &str = "update_dismissed_version";
 pub const HISTORY_RETENTION: &str = "history_retention";
 pub const AUTOSTART_ENABLED: &str = "autostart_enabled";
 
+/// Maps a `history_retention` setting value to a day count. `None` means
+/// "Forever" (or an unrecognized value) — never prune.
+pub fn history_retention_days(value: &str) -> Option<i64> {
+    match value {
+        "7 days" => Some(7),
+        "30 days" => Some(30),
+        "90 days" => Some(90),
+        _ => None,
+    }
+}
+
 // ---------- pipeline config ----------
 
 /// All settings values needed by run_pipeline, loaded in one place.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -161,10 +161,12 @@ fn main() {
                     .and_then(|v| v.as_str().map(str::to_string))
                     .and_then(|v| crate::data::store::history_retention_days(&v))
                 {
-                    let _ = db::prune_transcriptions_older_than(
-                        app.state::<DbHandle>().inner(),
-                        days,
-                    );
+                    let db = app.state::<DbHandle>().inner().clone();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        if let Err(e) = db::prune_transcriptions_older_than(&db, days) {
+                            log::warn!("Failed to prune old transcriptions during startup: {e:?}");
+                        }
+                    });
                 }
                 !store
                     .get("setup_complete")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -156,10 +156,12 @@ fn main() {
                         }
                     }
                 }
-                if let Some(days) = store
-                    .get(crate::data::store::HISTORY_RETENTION)
-                    .and_then(|v| v.as_str().and_then(crate::data::store::history_retention_days))
-                {
+                let retention_value = store.get(crate::data::store::HISTORY_RETENTION);
+                let retention = retention_value
+                    .as_ref()
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("30 days");
+                if let Some(days) = crate::data::store::history_retention_days(retention) {
                     let db = app.state::<DbHandle>().inner().clone();
                     tauri::async_runtime::spawn_blocking(move || {
                         if let Err(e) = db::prune_transcriptions_older_than(&db, days) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -156,6 +156,16 @@ fn main() {
                         }
                     }
                 }
+                if let Some(days) = store
+                    .get(crate::data::store::HISTORY_RETENTION)
+                    .and_then(|v| v.as_str().map(str::to_string))
+                    .and_then(|v| crate::data::store::history_retention_days(&v))
+                {
+                    let _ = db::prune_transcriptions_older_than(
+                        app.state::<DbHandle>().inner(),
+                        days,
+                    );
+                }
                 !store
                     .get("setup_complete")
                     .and_then(|v| v.as_bool())
@@ -248,6 +258,7 @@ fn main() {
             commands::hide_main,
             commands::get_recent,
             commands::get_stats,
+            commands::count_old_transcriptions,
             commands::get_cleanup_cache_status,
             commands::clear_cleanup_cache,
             commands::get_default_cleanup_prompt,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -163,9 +163,18 @@ fn main() {
                     .unwrap_or("30 days");
                 if let Some(days) = crate::data::store::history_retention_days(retention) {
                     let db = app.state::<DbHandle>().inner().clone();
+                    let app_handle = app.handle().clone();
                     tauri::async_runtime::spawn_blocking(move || {
-                        if let Err(e) = db::prune_transcriptions_older_than(&db, days) {
-                            log::warn!("Failed to prune old transcriptions during startup: {e:?}");
+                        match db::prune_transcriptions_older_than(&db, days) {
+                            Ok(deleted) if deleted > 0 => {
+                                let _ = app_handle.emit("verenu:history-pruned", ());
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                log::warn!(
+                                    "Failed to prune old transcriptions during startup: {e:?}"
+                                );
+                            }
                         }
                     });
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -158,8 +158,7 @@ fn main() {
                 }
                 if let Some(days) = store
                     .get(crate::data::store::HISTORY_RETENTION)
-                    .and_then(|v| v.as_str().map(str::to_string))
-                    .and_then(|v| crate::data::store::history_retention_days(&v))
+                    .and_then(|v| v.as_str().and_then(crate::data::store::history_retention_days))
                 {
                     let db = app.state::<DbHandle>().inner().clone();
                     tauri::async_runtime::spawn_blocking(move || {

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -88,6 +88,10 @@
     await saveHistoryRetention(value);
   }
 
+  function handleRetentionModalKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && confirmRetention) confirmRetention = null;
+  }
+
   async function handleAppContextHint(value: boolean) {
     appContextHint = value;
     try {
@@ -224,6 +228,8 @@
     }
   }
 </script>
+
+<svelte:window onkeydown={handleRetentionModalKeydown} />
 
 <h2 class="settings-h">Privacy</h2>
 <div class="setting-row">

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -4,10 +4,11 @@
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';
   import { saveSetting, type HistoryRetention } from '../../settings';
-  import { animateWidth, MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
+  import { animateWidth, modalBackdrop, modalCard, MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
 
   const historyOptions = ['7 days', '30 days', '90 days', 'Forever'];
   const HISTORY_MENU_ID = 'history-retention-menu';
+  let confirmRetention = $state<{ value: string; count: number } | null>(null);
   type CleanupCacheStatus = {
     entry_count: number;
     is_space_constrained: boolean;
@@ -63,6 +64,28 @@
     } catch (err) {
       console.error('saveHistoryRetention failed:', err);
     }
+  }
+
+  async function requestHistoryRetention(value: string) {
+    historyDropdownOpen = false;
+    if (value === historyRetention) return;
+    try {
+      const count = await invoke<number>('count_old_transcriptions', { retention: value });
+      if (count > 0) {
+        confirmRetention = { value, count };
+      } else {
+        await saveHistoryRetention(value);
+      }
+    } catch (err) {
+      console.error('count_old_transcriptions failed:', err);
+    }
+  }
+
+  async function confirmHistoryRetention() {
+    if (!confirmRetention) return;
+    const { value } = confirmRetention;
+    confirmRetention = null;
+    await saveHistoryRetention(value);
   }
 
   async function handleAppContextHint(value: boolean) {
@@ -237,7 +260,7 @@
           <button
             class="mic-item"
             class:active={historyRetention === opt}
-            onclick={() => saveHistoryRetention(opt)}
+            onclick={() => requestHistoryRetention(opt)}
             onkeydown={handleHistoryButtonKeydown}
             role="option"
             aria-selected={historyRetention === opt}
@@ -345,6 +368,34 @@
   onchange={handleFileSelected}
 />
 
+{#if confirmRetention}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <button class="modal-backdrop" aria-label="Close dialog" onclick={() => (confirmRetention = null)} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></button>
+  <div
+    class="modal-card"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="retention-confirm-title"
+    in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
+    out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
+  >
+    <div class="modal-header">
+      <h2 id="retention-confirm-title" class="modal-title">Delete older history?</h2>
+    </div>
+    <div class="modal-body">
+      <p class="confirm-copy">
+        Looks like you have {confirmRetention.count} transcription{confirmRetention.count === 1 ? '' : 's'} before this point. Changing this will delete that data. Are you sure?
+      </p>
+    </div>
+    <div class="modal-footer">
+      <div class="footer-actions">
+        <button class="btn-ghost" onclick={() => (confirmRetention = null)}>Cancel</button>
+        <button class="btn-danger" onclick={confirmHistoryRetention}>Delete history</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
 <style>
   .data-h { --settings-h-mb: 2px; margin-top: 52px; }
 
@@ -419,4 +470,73 @@
     transition: opacity 0.16s ease, transform 0.16s ease;
   }
   .privacy-eye-wrap:hover .privacy-tooltip { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  /* ── retention confirm modal ── */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    appearance: none;
+    background: var(--overlay);
+    z-index: 50;
+    outline: none;
+  }
+  .modal-card {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    translate: -50% -50%;
+    z-index: 51;
+    isolation: isolate;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-lg);
+    width: min(420px, calc(100vw - 40px));
+    box-shadow: var(--shadow-elev);
+    overflow: hidden;
+  }
+  .modal-header {
+    padding: 20px 20px 0;
+  }
+  .modal-title {
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 500;
+    letter-spacing: -0.015em;
+    color: var(--ink);
+    margin: 0;
+  }
+  .modal-body { padding: 10px 20px 18px; }
+  .confirm-copy {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink-soft);
+  }
+  .modal-footer {
+    padding: 0 20px 20px;
+  }
+  .footer-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .btn-danger {
+    background: var(--danger-bg);
+    color: var(--danger);
+    border: 1px solid var(--danger-line);
+    border-radius: 6px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-family: var(--sans);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+  .btn-danger:hover {
+    background: var(--danger);
+    color: var(--on-accent);
+    border-color: var(--danger);
+  }
 </style>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -179,6 +179,8 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return { total_words: 0, avg_wpm: 0, day_streak: 0 } as T;
     case 'get_memory_mb':
       return 0 as T;
+    case 'count_old_transcriptions':
+      return 0 as T;
     case 'get_api_key_status':
       return { groq: false, openai: false, google: false } as T;
     case 'get_accessibility_permission_status':

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -429,6 +429,8 @@
       load();
     }));
 
+    trackListener(listen('verenu:history-pruned', () => load()));
+
     trackListener(listen<string>('verenu:pipeline-failed', (ev) => {
       failedEntry = { created_at: ev.payload };
       if (failedTimer) clearTimeout(failedTimer);


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: Privacy settings / data layer - the "Transcription history" retention control
> - The retention dropdown only ever persisted its value; nothing read it back to prune the `transcriptions` table, so a user with "7 days" selected still had a month+ of history sitting in SQLite
> - This needs fixing now because it's a correctness bug in a privacy-facing control - the setting silently does nothing, and any future deletion path needs a confirmation step before it touches real data
> - This pull request wires `history_retention` to a real prune (on save, and on every app startup so existing backlogs clear without the user re-touching the dropdown) and adds a confirm dialog with an accurate count before any deletion happens
> - The benefit is the Privacy setting actually does what its label says, with a safety check before irreversible data loss, and the homepage word counter no longer shrinks as a side effect of that pruning

## What Changed

- `store.rs`: add `history_retention_days()` mapping `"7 days"/"30 days"/"90 days"` to a day count (`None` for `Forever`/unknown, meaning never prune)
- `db.rs`: add `count_transcriptions_older_than()` and `prune_transcriptions_older_than()`, mirroring the existing `prune_pending_corrections` pattern; add an index on `transcriptions(created_at)` (base schema + version-9 migration) since both now run on every startup; add a `lifetime_stats` table that's incremented on insert and never recomputed from `transcriptions`, so the homepage "total words" counter no longer shrinks when retention prunes old rows (version-9 migration backfills it from existing data for upgrading installs)
- `commands/mod.rs`: add `count_old_transcriptions` command for the frontend pre-check; `save_setting` now prunes whenever `history_retention` changes and emits `verenu:history-pruned` if rows were deleted
- `main.rs`: register the new command; prune on app startup based on the persisted setting (off the main thread, via `tauri::async_runtime::spawn_blocking`) so existing backlogs clear without the user re-touching the dropdown; falls back to the "30 days" default when the setting hasn't been saved yet (fresh installs, or any install that never opened this dropdown)
- `PrivacySection.svelte`: switching the retention dropdown now checks for older history first; if any exists, shows a confirm dialog (exact count, Cancel / red "Delete history") before applying the change, dismissible with Escape; styled to match the app's existing muted danger palette (`--danger-bg`/`--danger`/`--danger-line`), no header/footer divider lines
- `Home.svelte`: listens for `verenu:history-pruned` to refresh the visible list live if Settings prunes while Home is open underneath it
- `tauri.ts`: mock `count_old_transcriptions` in browser dev mode (caught by the integration smoke test - without this, retention changes silently no-op'd outside the real Tauri runtime)

This PR went through several rounds of `@gemini-code-assist` review - see inline thread replies for what was fixed vs. flagged-but-already-covered vs. corrected (one of its suggested diffs didn't actually compile in this Svelte/Rust setup; replied with the working equivalent in each case).

## Verification

- `npm run check` - clean (0 errors)
- `npm run lint` (svelte-check + `cargo clippy -D warnings`) - clean
- `npm run test:rust` - 203 tests pass (201 existing + 2 new: `prune_transcriptions_older_than_deletes_only_old_rows`, `pruning_old_transcriptions_does_not_reduce_lifetime_word_total`)
- `python tests/OnePyFone.py` - 14/16 pass; the 2 failures (`Frontend typecheck` / `Frontend build`) are a pre-existing harness issue in this environment ("Executable not found: npm" from the Python subprocess call, unrelated to this diff) - independently confirmed via direct `npm run check`/`npm run lint` above
- Validated the count/prune SQL, the `created_at` index migration, and the `lifetime_stats` backfill directly against copies of real production data (3,043 of 3,432 rows correctly identified as older than 7 days, matching the reported bug; index migration verified via `EXPLAIN QUERY PLAN` switching from a table scan to a covering-index search; lifetime counter backfilled to the correct pre-existing total)
- Drove the actual running app (Tauri dev build, WebView2 remote debugging + Playwright over CDP) end-to-end: confirm dialog shows the correct count, Cancel preserves data and the setting, confirming deletes and Home refreshes live without a manual reload; separately confirmed the startup-prune path by relaunching with a real stale backlog present
- Confirm dialog screenshots were captured in both light and dark mode during manual testing (not embedded in this PR; available on request)

## Risks

- Deleting transcriptions older than the selected retention is irreversible (no undo) - mitigated by the new confirm dialog, which shows the exact row count before anything is deleted
- Startup pruning now runs automatically whenever a finite retention is configured (defaulting to "30 days" if unset). This is the intended behavior, but existing installs with old data will see it removed on first launch after upgrading
- `lifetime_stats.total_words` is now a running counter rather than a derived sum; if a future code path inserts into `transcriptions` directly without going through `insert_transcription_returning`, it would silently skip incrementing this counter (currently there's only one production insertion path, so this is low risk today)

## Model Used

- Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Claude Code - agentic tool use (file edits, Bash, Playwright driven over CDP against the real running app for manual verification, GitHub CLI for iterative review handling)

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above