### PR TITLE
Subdivide settings into labeled subgroups, add setup wizard toggles

### DIFF
--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -4,6 +4,7 @@
   import { expoOut } from 'svelte/easing';
   import { onDestroy } from 'svelte';
   import Toggle from '../Toggle.svelte';
+  import { isMac } from '../../platform';
   import { saveSetting } from '../../settings';
   import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
   import { getAudioCalibrationCopy } from '../../calibrationCopy';
@@ -21,6 +22,7 @@
   } from '../../calibration';
 
   let noiseReduction = $state(true);
+  let muteAudio = $state(false);
   let micGain = $state(3.5);
   let selectedLanguage = $state<TranscriptionLanguageCode>('en');
   const audioCopy = $derived(getAudioCalibrationCopy(selectedLanguage));
@@ -37,12 +39,14 @@
 
   async function loadSettings() {
     try {
-      const [nr, savedGain, language] = await Promise.all([
+      const [nr, mute, savedGain, language] = await Promise.all([
         invoke<boolean | null>('get_setting', { key: 'noise_reduction' }),
+        invoke<boolean | null>('get_setting', { key: 'mute_audio' }),
         invoke<number | null>('get_setting', { key: 'mic_gain' }),
         invoke<TranscriptionLanguageCode | null>('get_setting', { key: 'transcription_language' }),
       ]);
       noiseReduction = nr ?? true;
+      muteAudio = mute ?? false;
       if (savedGain !== null && savedGain !== undefined) {
         micGain = Math.max(1, Math.min(8, savedGain));
       }
@@ -59,6 +63,16 @@
     } catch (err) {
       noiseReduction = !value;
       console.error('save noise_reduction failed:', err);
+    }
+  }
+
+  async function handleMuteAudio(value: boolean) {
+    muteAudio = value;
+    try {
+      await saveSetting('mute_audio', value);
+    } catch (err) {
+      muteAudio = !value;
+      console.error('save mute_audio failed:', err);
     }
   }
 
@@ -79,6 +93,7 @@
 
 <h2 class="settings-h">Microphone</h2>
 
+<h3 class="settings-subhead first">Gain & calibration</h3>
 <div class="setting-row gain-row">
   <div class="gain-header">
     <div>
@@ -109,11 +124,6 @@
       At high gain, enable <strong>noise reduction</strong> to avoid amplifying background noise.
     </div>
   {/if}
-</div>
-
-<div class="setting-row">
-  <div><div class="label">Noise reduction</div><div class="desc">Suppress background noise before transcription (RNNoise)</div></div>
-  <Toggle checked={noiseReduction} onchange={handleNoiseReduction} label="Noise reduction" />
 </div>
 
 <div class="setting-row cal-row" class:calibrating={$isCalibrating}>
@@ -173,6 +183,16 @@
       </div>
     {/if}
   </div>
+</div>
+
+<h3 class="settings-subhead">Input</h3>
+<div class="setting-row">
+  <div><div class="label">{isMac ? 'Mute System Audio' : 'Mute PC Audio'}</div><div class="desc">{isMac ? 'Mutes system volume while dictating to prevent audio interference' : 'Mutes Windows volume while dictating to prevent audio interference'}</div></div>
+  <Toggle checked={muteAudio} onchange={handleMuteAudio} label={isMac ? 'Mute system audio' : 'Mute PC audio'} />
+</div>
+<div class="setting-row">
+  <div><div class="label">Noise reduction</div><div class="desc">Suppress background noise before transcription (RNNoise)</div></div>
+  <Toggle checked={noiseReduction} onchange={handleNoiseReduction} label="Noise reduction" />
 </div>
 
 <style>

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -25,7 +25,6 @@
     defaultDevice: 'Default Device',
     noDevicesFound: 'No devices found',
   };
-  let muteAudio = $state(false);
   let autostart = $state(false);
   let cleanup = $state(true);
   let contextualCaps = $state(true);
@@ -112,7 +111,6 @@
 
   async function loadSettings() {
     const results = await Promise.allSettled([
-      invoke<boolean | null>('get_setting', { key: 'mute_audio' }),
       invoke<boolean | null>('get_setting', { key: 'autostart_enabled' }),
       invoke<string[] | null>('get_setting', { key: 'hotkey' }),
       invoke<AppearanceMode | null>('get_setting', { key: 'appearance_mode' }),
@@ -127,27 +125,26 @@
     const val = <T>(i: number, fallback: T): T =>
       results[i].status === 'fulfilled' ? (results[i] as PromiseFulfilledResult<T>).value ?? fallback : fallback;
 
-    muteAudio = val<boolean | null>(0, null) ?? false;
-    autostart = val<boolean | null>(1, null) ?? false;
-    cleanup = val<boolean | null>(5, null) ?? true;
-    contextualCaps = val<boolean | null>(6, null) ?? true;
-    autoSpacing = val<boolean | null>(7, null) ?? true;
+    autostart = val<boolean | null>(0, null) ?? false;
+    cleanup = val<boolean | null>(4, null) ?? true;
+    contextualCaps = val<boolean | null>(5, null) ?? true;
+    autoSpacing = val<boolean | null>(6, null) ?? true;
 
-    const hk = val<string[] | null>(2, null);
+    const hk = val<string[] | null>(1, null);
     if (hk && hk.length === 2) hotkey = hk;
 
-    const appearance = val<AppearanceMode | null>(3, null);
+    const appearance = val<AppearanceMode | null>(2, null);
     if (appearance === 'system' || appearance === 'light' || appearance === 'dark') {
       appStore.appearanceMode = appearance;
     }
 
-    const language = val<TranscriptionLanguageCode | null>(4, null);
+    const language = val<TranscriptionLanguageCode | null>(3, null);
     if (!languageTouched && language && transcriptionLanguages.some((option) => option.code === language)) {
       selectedLanguage = language;
     }
 
-    microphones = val<string[]>(8, []);
-    selectedMic = val<string | null>(9, null) ?? '';
+    microphones = val<string[]>(7, []);
+    selectedMic = val<string | null>(8, null) ?? '';
 
     results.forEach((r, i) => {
       if (r.status === 'rejected') console.error(`GeneralSection: invoke[${i}] failed:`, r.reason);
@@ -178,16 +175,6 @@
       await saveSetting('transcription_language', code);
     } catch (err) {
       console.error('save transcription_language failed:', err);
-    }
-  }
-
-  async function handleMuteAudio(value: boolean) {
-    muteAudio = value;
-    try {
-      await saveSetting('mute_audio', value);
-    } catch (err) {
-      muteAudio = !value;
-      console.error('save mute_audio failed:', err);
     }
   }
 
@@ -327,6 +314,7 @@
 <svelte:window onclick={handleWindowClick} />
 
 <h2 class="settings-h">General</h2>
+<h3 class="settings-subhead first">Dictation</h3>
 <div class="setting-row">
   <div><div class="label">Hotkey</div><div class="desc">Hold to record, release to transcribe</div></div>
   <button
@@ -430,10 +418,7 @@
     {/if}
   </div>
 </div>
-<div class="setting-row">
-  <div><div class="label">{isMac ? 'Mute System Audio' : 'Mute PC Audio'}</div><div class="desc">{isMac ? 'Mutes system volume while dictating to prevent audio interference' : 'Mutes Windows volume while dictating to prevent audio interference'}</div></div>
-  <Toggle checked={muteAudio} onchange={handleMuteAudio} label={isMac ? 'Mute system audio' : 'Mute PC audio'} />
-</div>
+<h3 class="settings-subhead">Appearance & System</h3>
 <div class="setting-row">
   <div><div class="label">Appearance</div><div class="desc">{isMac ? 'Follow macOS or force a specific theme' : 'Follow Windows or force a specific theme'}</div></div>
   <div class="appearance-segment" role="radiogroup" aria-label="Appearance" bind:this={segmentEl}>
@@ -455,6 +440,7 @@
   <div><div class="label">Start on Boot</div><div class="desc">{isMac ? 'Launch Verenu when macOS starts' : 'Launch Verenu when Windows starts'}</div></div>
   <Toggle checked={autostart} onchange={handleAutostart} label="Start on boot" />
 </div>
+<h3 class="settings-subhead">Text processing</h3>
 <div class="setting-row">
   <div><div class="label">Auto-cleanup</div><div class="desc">Run LLM cleanup on every transcription</div></div>
   <Toggle checked={cleanup} onchange={handleCleanup} label="Auto-cleanup" />

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -232,6 +232,45 @@
 <svelte:window onkeydown={handleRetentionModalKeydown} />
 
 <h2 class="settings-h">Privacy</h2>
+
+<h3 class="settings-subhead first">Context</h3>
+<div class="setting-row">
+  <div><div class="label">App context hint</div><div class="desc">Passes the active app to the cleanup model to tailor formatting</div></div>
+  <Toggle checked={appContextHint} onchange={handleAppContextHint} label="App context hint" />
+</div>
+
+<h3 class="settings-subhead">On-device learning</h3>
+<div class="setting-row">
+  <div>
+    <div class="label" style="display:flex;align-items:center;gap:7px;">
+      Auto-learn corrections
+      <span class="privacy-eye-wrap">
+        <svg class="privacy-eye" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>
+        <span class="privacy-tooltip">Entirely on-device — no text is sent to any API.</span>
+      </span>
+    </div>
+    <div class="desc">Add confirmed corrections to dictionary automatically</div>
+  </div>
+  <Toggle checked={autoLearn} onchange={handleAutoLearn} label="Auto-learn corrections" />
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Auto-learn activity</div>
+    <div class="desc">
+      Promoted: {autoLearnSummary.promotions} | Low-confidence blocked: {autoLearnSummary.low_confidence_rejections} | Anchor misses: {autoLearnSummary.anchor_misses}
+    </div>
+    {#if recentAutoLearn.length > 0}
+      <div class="desc" style="margin-top:4px;">
+        Latest: {recentAutoLearn[0].event_type} ({recentAutoLearn[0].reason_code})
+      </div>
+    {/if}
+  </div>
+</div>
+
+<h3 class="settings-subhead">History & storage</h3>
 <div class="setting-row">
   <div><div class="label">Transcription history</div><div class="desc">How long to keep past dictations</div></div>
   <div class="history-dropdown">
@@ -279,39 +318,6 @@
   </div>
 </div>
 <div class="setting-row">
-  <div><div class="label">App context hint</div><div class="desc">Passes the active app to the cleanup model to tailor formatting</div></div>
-  <Toggle checked={appContextHint} onchange={handleAppContextHint} label="App context hint" />
-</div>
-<div class="setting-row">
-  <div>
-    <div class="label" style="display:flex;align-items:center;gap:7px;">
-      Auto-learn corrections
-      <span class="privacy-eye-wrap">
-        <svg class="privacy-eye" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-          <circle cx="12" cy="12" r="3"/>
-        </svg>
-        <span class="privacy-tooltip">Entirely on-device — no text is sent to any API.</span>
-      </span>
-    </div>
-    <div class="desc">Add confirmed corrections to dictionary automatically</div>
-  </div>
-  <Toggle checked={autoLearn} onchange={handleAutoLearn} label="Auto-learn corrections" />
-</div>
-<div class="setting-row">
-  <div>
-    <div class="label">Auto-learn activity</div>
-    <div class="desc">
-      Promoted: {autoLearnSummary.promotions} | Low-confidence blocked: {autoLearnSummary.low_confidence_rejections} | Anchor misses: {autoLearnSummary.anchor_misses}
-    </div>
-    {#if recentAutoLearn.length > 0}
-      <div class="desc" style="margin-top:4px;">
-        Latest: {recentAutoLearn[0].event_type} ({recentAutoLearn[0].reason_code})
-      </div>
-    {/if}
-  </div>
-</div>
-<div class="setting-row">
   <div>
     <div class="label">Cleanup cache</div>
     <div class="desc">
@@ -335,7 +341,7 @@
   </button>
 </div>
 
-<h2 class="settings-h data-h">Data</h2>
+<h3 class="settings-subhead">Backup</h3>
 <div class="setting-row">
   <div>
     <div class="label">Export Backup</div>
@@ -403,8 +409,6 @@
 {/if}
 
 <style>
-  .data-h { --settings-h-mb: 2px; margin-top: 52px; }
-
   .data-ok { color: var(--success); }
   .data-err { color: var(--accent); }
   .data-status {

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -333,6 +333,17 @@
     color: var(--ink);
   }
 
+  .settings-body :global(.settings-subhead) {
+    font-family: var(--serif);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    letter-spacing: -0.01em;
+    margin: 30px 0 4px;
+  }
+
+  .settings-body :global(.settings-subhead.first) { margin-top: 4px; }
+
   .settings-body :global(.setting-row) {
     display: flex;
     align-items: center;

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -89,6 +89,8 @@
     cleanup: true,
     noise: true,
     caps: true,
+    autoSpacing: true,
+    appContextHint: false,
     autoLearn: false,
     autostart: false,
     muteAudio: false,
@@ -385,6 +387,8 @@
       await saveSetting('cleanup_enabled', quickPrefs.cleanup);
       await saveSetting('noise_reduction', quickPrefs.noise);
       await saveSetting('contextual_caps_enabled', quickPrefs.caps);
+      await saveSetting('auto_spacing_enabled', quickPrefs.autoSpacing);
+      await saveSetting('app_context_hint', quickPrefs.appContextHint);
       await saveSetting('auto_learn_enabled', quickPrefs.autoLearn);
       await saveSetting('mute_audio', quickPrefs.muteAudio);
       if (quickPrefs.autostart) await invoke('set_autostart', { enabled: true });
@@ -1027,6 +1031,28 @@
                   onclick={() => toggleQuickPref('caps')}
                   onkeydown={handleQuickSwitchKeydown}
                   onkeyup={(e) => handleQuickSwitchKeyup(e, 'caps')}
+                ></div>
+              </div>
+              <div class="qs-toggle-row">
+                <div>
+                  <div class="qs-toggle-label">Automatic spacing</div>
+                  <div class="qs-toggle-desc">Add a space before injected text when joining after existing text</div>
+                </div>
+                <div class="qs-toggle" class:on={quickPrefs.autoSpacing} role="switch" aria-checked={quickPrefs.autoSpacing} aria-label="Automatic spacing" tabindex="0"
+                  onclick={() => toggleQuickPref('autoSpacing')}
+                  onkeydown={handleQuickSwitchKeydown}
+                  onkeyup={(e) => handleQuickSwitchKeyup(e, 'autoSpacing')}
+                ></div>
+              </div>
+              <div class="qs-toggle-row">
+                <div>
+                  <div class="qs-toggle-label">App context hint</div>
+                  <div class="qs-toggle-desc">Pass the active app to the cleanup model to tailor formatting</div>
+                </div>
+                <div class="qs-toggle" class:on={quickPrefs.appContextHint} role="switch" aria-checked={quickPrefs.appContextHint} aria-label="App context hint" tabindex="0"
+                  onclick={() => toggleQuickPref('appContextHint')}
+                  onkeydown={handleQuickSwitchKeydown}
+                  onkeyup={(e) => handleQuickSwitchKeyup(e, 'appContextHint')}
                 ></div>
               </div>
               <div class="qs-toggle-row">

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -2494,7 +2494,7 @@
   }
 
   /* ── Quick Settings step ───────────────────────────────────────────── */
-  .qs-step { max-width: 920px; }
+  .qs-step { max-width: 920px; gap: 18px; }
 
   .qs-cards {
     display: grid;
@@ -2507,7 +2507,7 @@
     background: var(--bg-elev);
     border: 1.5px solid var(--line);
     border-radius: var(--r-md);
-    padding: 14px 14px;
+    padding: 11px 14px;
     opacity: 0;
     transform: translateY(12px);
     transition: opacity 0.3s ease, transform 0.3s ease, border-color 0.15s;
@@ -2534,7 +2534,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .qs-card-icon {
@@ -2573,7 +2573,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 10px 0;
+    padding: 7px 0;
     border-top: 1px solid var(--line);
     gap: 16px;
   }
@@ -2582,13 +2582,13 @@
     font-size: 13px;
     font-weight: 500;
     color: var(--ink-strong);
-    margin-bottom: 2px;
+    margin-bottom: 1px;
   }
 
   .qs-toggle-desc {
     font-size: 11.5px;
     color: var(--ink-mute);
-    line-height: 1.4;
+    line-height: 1.3;
   }
 
   .qs-toggle {


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows/macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: Settings UI (General, Microphone, Privacy tabs) and the first-run Setup wizard
> - The General tab in particular was a flat, unstructured list mixing hotkey, language, mic device, mute, appearance, autostart, and text-processing toggles with no visual grouping, making it hard to scan. The Setup wizard's Smart Processing card was also missing two toggles (`auto_spacing_enabled`, `app_context_hint`) that already exist everywhere else in the app.
> - This needed addressing now because the settings surface keeps growing and was becoming harder to navigate; doing the subdivision now (while sections are still small) is cheaper than after more settings accumulate.
> - This pull request subdivides General, Microphone, and Privacy into labeled subgroups, moves "Mute audio" out of General into the Microphone tab (next to the other audio controls), surfaces the two missing toggles during onboarding, and tightens the onboarding step's spacing so adding those toggles doesn't push the footer off-screen at the app's default window size.
> - The benefit is a settings modal that reads as organized categories instead of a grab-bag list, and an onboarding flow that no longer silently relies on defaults for settings the user might want to opt out of up front - without requiring the user to scroll or resize the window to reach the Next button.

## What Changed

- Added a shared `.settings-subhead` style in `Settings.svelte` for subgroup headers (distinct from the frozen `h2.settings-h` section titles the smoke tests assert on).
- **General tab**: subdivided into `Dictation` (hotkey, language, input device), `Appearance & System` (appearance, start on boot), `Text processing` (auto-cleanup, contextual caps, automatic spacing); removed the `Mute audio` row.
- **Microphone tab**: added `Mute audio` (moved from General), subdivided into `Gain & calibration` (mic gain, auto calibration) at top and `Input` (mute audio, noise reduction) at the bottom.
- **Privacy tab**: subdivided into `Context` (app context hint), `On-device learning` (auto-learn + activity), `History & storage` (retention, cleanup cache), `Backup` (export/import, renamed from "Data").
- **Setup wizard**: added `Automatic spacing` and `App context hint` toggles to the Smart Processing card, persisted in `finish()`. No new setting keys or backend changes were needed — both already existed in `SettingsValueMap` and `store.rs`.
- **Setup wizard layout fix**: the two new toggles brought Smart Processing to 6 rows, pushing the step footer ~30px below the visible area at the default 1100x720 window size. Tightened row padding, description line-height, and card padding/header spacing (scoped to the Quick Settings step only, not the shared step styles used elsewhere in the wizard) so the footer fits with ~40px of margin again.
- Kept the `Microphone` tab name and the `Input device` control's location in `General` unchanged, since `tests/smoke/playwright-test-ui.cjs` and `tests/smoke/test-all-dropdown-animations.cjs` pin both.

## Verification

- `npm run check` - 0 errors, 0 warnings (118 files)
- `npm run lint` - frontend + `cargo clippy -D warnings` clean
- `npm run test:rust` - 203 passed, 0 failed
- `npm test` (fast profile) - 14/16 passed; the 2 failures (`Frontend typecheck`, `Frontend build`) are a pre-existing `Executable not found: npm` harness/PATH issue, reproduced identically on the unmodified `dev` baseline before this change, so unrelated to this PR
- Layout fix verified with a Playwright measurement against the running Vite dev server at 1100x720 (the app's default window size): before the fix the Quick Settings step footer bottom was at 749px (29px past the 720px viewport); after, it's at 680px (40px of margin). Confirmed visually via screenshot that the three cards still render cleanly, not cramped.
- Manual: opened Settings in `npm run tauri dev`, confirmed subgroup headers render correctly in General/Microphone/Privacy and that Mute audio now lives in the Microphone tab; walked the Setup wizard via "Force Setup On Launch", toggled the two new Smart Processing switches, finished setup, and confirmed `auto_spacing_enabled` / `app_context_hint` persisted with the chosen values

## Risks

- Low risk. Purely a UI reorganization - no new setting keys, no backend/store changes, no changes to default values. The riskiest part (moving `Mute audio` across tabs) was checked against the frozen `tests/smoke/` contracts first to confirm no test asserts its location in General.
- The Quick Settings step still overflows at a smaller, user-resized 900x600 window (~71px past viewport) - this was not the reported issue (which was specifically about the app's default size) and is left as a known follow-up rather than over-compacting the default case to chase a less common window size.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Anthropic Claude (Opus 4.8 for planning/research, Sonnet 4.6 for implementation), via Claude Code, with extended tool use (file edits, codebase search, Playwright-based layout measurement, test execution)

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work (roadmap's "Models and Settings Redesign" item is scoped to `ModelsSection.svelte`/`ApiKeysSection.svelte` provider/key validation, not this tab subdivision)
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above