### PR TITLE
fix: stop pill window flicker on hands-free state transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,11 +283,11 @@ The `WH_KEYBOARD_LL` callback in `core/hotkey/win.rs` must return within ~300ms 
 Hiding the pill window suspends the WebView2 renderer. The next state event emitted while it is hidden will be silently dropped, leaving the pill stuck. Keep it always-visible but click-through + transparent in idle state. Emit state events *after* showing the window, not before. The pill uses `SW_SHOWNOACTIVATE` so it appears without stealing focus from the target app. In idle/passive states the pill is click-through; only in "handsfree" state does it accept real cursor events for buttons.
 
 ### Recording quality gates
-`run_pipeline()` silently rejects recordings below two thresholds before calling any API:
+`run_pipeline()` rejects recordings below two thresholds before calling any API:
 - `duration_ms < 700` — avoids Whisper hallucinations on short clips
 - `rms < 0.008` — near-silence, likely accidental activation
 
-No user-facing feedback is shown when rejected. These are currently magic numbers in `pipeline.rs`.
+Rejection shows an error message on the pill (`reject_with_pill()` in `pipeline.rs`, distinguishing "Recording too short" vs "Audio too quiet — check your mic"); the in-app mic button (`transcribe_input_only()` / `MicInputButton.svelte`) shows the equivalent message inline. These thresholds are currently magic numbers in `pipeline.rs`.
 
 ### Injection — contextual capitalization and timing
 Capitalization decisions come from a layered `InjectionContextProbe` (`core/context_probe.rs` + `core/text_context.rs`), not a single trick. It tries, in order: a caret-local read via the platform accessibility API (UI Automation on Windows, AX on macOS, `ContextProbeSource::CaretLocal`) → a clipboard-sniff fallback (select one char back with Shift+Left/Cmd+Shift+Left, copy, inspect, then restore the selection — `ContextProbeSource::ClipboardSniff`) → a history-based guess (`HistoryFallback`) when the control is unsupported or permission is missing. The result classifies into `SentenceContext` (`NewSentence`/`MidSentence`/`Unknown`); if not `NewSentence`, the first letter of the injected text is lowercased (mid-sentence join). Timing constants in `injection.rs`: `MODIFIER_GAP_MS` = 30ms between releasing modifier keys and sending Ctrl+V/Cmd+V (without this gap, some apps miss the Ctrl key in the same message-pump cycle), and ~30ms waits between the sniff's key-down/key-up stages for the clipboard to populate.

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -16,8 +16,7 @@ use chrono::{DateTime, Duration, NaiveDateTime, SecondsFormat, Utc};
 const MIN_RECORDING_MS: u64 = 700;
 const MIN_RECORDING_RMS: f32 = 0.008;
 const RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
-const PILL_WIDTH_POINTS: f64 = 140.0;
-const PILL_ERROR_WIDTH_POINTS: f64 = 380.0;
+const PILL_WIDTH_POINTS: f64 = 380.0;
 const PILL_HEIGHT_POINTS: f64 = 44.0;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const PILL_BOTTOM_GAP_POINTS: f64 = 16.0;
@@ -207,11 +206,14 @@ pub fn show_pill(app: &AppHandle, state: &str) {
 }
 
 /// Shows the pill window in the given state, optionally carrying an error
-/// message. The window stays at the wide (transparent, click-through) error
-/// width for all passive states so the in-pill error text has room to
-/// expand into without a resize/reposition jump; only "handsfree" narrows
-/// the window, since that's the one state where the click-capture zone
-/// must stay tight.
+/// message. The window is always kept at the same width regardless of state
+/// (room enough for the error text to expand into) so it never needs to
+/// resize or reposition after its first appearance — resizing a WebView2
+/// window causes a visible repaint-lag flicker even when the native resize
+/// itself is atomic, so the fix is to avoid triggering one at all rather
+/// than to make it faster. Handsfree's click-capture zone is therefore wider
+/// than the visible pill; clicks in the empty space around it are swallowed
+/// instead of passing through while handsfree is active.
 fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     create_pill_if_needed(app);
     if let Some(pill) = app.get_webview_window("pill") {
@@ -221,11 +223,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
 
         // Size and position while still hidden, so the window appears already
         // in place instead of flashing at its previous geometry and jumping.
-        let width = if state == "handsfree" {
-            PILL_WIDTH_POINTS
-        } else {
-            PILL_ERROR_WIDTH_POINTS
-        };
+        let width = PILL_WIDTH_POINTS;
 
         // Resize and reposition are checked independently: primary_monitor()
         // can return None on some platforms (e.g. macOS) while the window is
@@ -246,11 +244,8 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
             .map(|cur| (cur.width as f64 - width * scale_factor).abs() > 1.0)
             .unwrap_or(true);
 
-        if needs_resize {
-            pill.set_size(tauri::LogicalSize::new(width, PILL_HEIGHT_POINTS)).ok();
-        }
-
-        if let Some(m) = monitor {
+        // Target position (physical pixels) on the current monitor, if known.
+        let target_pos = monitor.as_ref().map(|m| {
             let sz = m.size();
             let sf = m.scale_factor();
             let pos = m.position();
@@ -258,14 +253,57 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
             let bottom_offset_points = pill_bottom_offset_points();
             let target_y = pos.y
                 + (sz.height as f64 - (PILL_HEIGHT_POINTS + bottom_offset_points) * sf) as i32;
+            (target_x, target_y)
+        });
 
-            let needs_reposition = pill
+        let needs_reposition = match target_pos {
+            Some((target_x, target_y)) => pill
                 .outer_position()
                 .map(|cur| (cur.x - target_x).abs() > 1 || (cur.y - target_y).abs() > 1)
-                .unwrap_or(true);
+                .unwrap_or(true),
+            None => false,
+        };
 
-            if needs_reposition {
-                pill.set_position(tauri::PhysicalPosition::new(target_x, target_y)).ok();
+        // On Windows, resize and reposition are merged into a single
+        // SetWindowPos call so the two are atomic if both are ever needed at
+        // once (e.g. a monitor/DPI change). With a constant width this only
+        // actually fires on the very first show, while still hidden.
+        #[cfg(target_os = "windows")]
+        {
+            use windows::Win32::UI::WindowsAndMessaging::{
+                SetWindowPos, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
+            };
+
+            if needs_resize || needs_reposition {
+                if let Ok(hwnd) = pill.hwnd() {
+                    let cx = (width * scale_factor).round() as i32;
+                    let cy = (PILL_HEIGHT_POINTS * scale_factor).round() as i32;
+                    let (x, y) = target_pos.unwrap_or((0, 0));
+
+                    let mut flags = SWP_NOZORDER | SWP_NOACTIVATE;
+                    if !needs_resize {
+                        flags |= SWP_NOSIZE;
+                    }
+                    if !needs_reposition {
+                        flags |= SWP_NOMOVE;
+                    }
+
+                    unsafe {
+                        let _ = SetWindowPos(hwnd, None, x, y, cx, cy, flags);
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            if needs_resize {
+                pill.set_size(tauri::LogicalSize::new(width, PILL_HEIGHT_POINTS)).ok();
+            }
+            if let Some((target_x, target_y)) = target_pos {
+                if needs_reposition {
+                    pill.set_position(tauri::PhysicalPosition::new(target_x, target_y)).ok();
+                }
             }
         }
 
@@ -747,7 +785,10 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
 
     if duration_ms < MIN_RECORDING_MS || rms < min_rms {
         hide_pill(&app);
-        anyhow::bail!("Recording too short");
+        if duration_ms < MIN_RECORDING_MS {
+            anyhow::bail!("Recording too short");
+        }
+        anyhow::bail!("Audio too quiet — check your mic");
     }
     let wav = bytes::Bytes::from(wav);
 

--- a/src/lib/components/MicInputButton.svelte
+++ b/src/lib/components/MicInputButton.svelte
@@ -29,6 +29,7 @@
       } catch (e) {
         const msg = String(e);
         error = msg.includes('too short') ? 'Too short — try again'
+              : msg.includes('too quiet') ? 'Too quiet — try again'
               : msg.includes('No API key') ? 'No API key configured'
               : msg.includes('Microphone access is blocked') ? 'Enable microphone permission in System Settings'
               : msg.includes('Accessibility permission is required') ? 'Enable Accessibility permission in System Settings'


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: pipeline (pill window state/geometry management) and UI
> - The floating pill window visibly jumped left and snapped back to center right after stopping a hands-free dictation, confirmed via screen-recording screenshots
> - It needs fixing now because it's a visible, reproducible polish regression on the hands-free flow, and a likely contributor to a related "transcription seems to disappear" complaint (misclicks on the confirm/cancel buttons while their position is jumping)
> - This pull request removes the only state-dependent width difference in the pill window so it never needs to resize after first appearing, eliminating the flicker at its source
> - The benefit is a visually stable pill across all states, plus two small consistency fixes uncovered while investigating (a mislabeled quality-gate message, and a stale doc comment)

## What Changed

- Removed the handsfree-only narrow (140pt) pill window width; the pill now uses one constant width (380pt) for every state, so the window never resizes/repositions after its first appearance. (An earlier attempt made the resize+reposition atomic via a single `SetWindowPos` call, which worked correctly at the OS level — confirmed with diagnostic logging — but WebView2's own repaint still lagged visibly behind any native resize, so the real fix is avoiding the resize trigger entirely rather than making it faster.)
- `transcribe_input_only()` (in-app mic button path) now distinguishes "Audio too quiet — check your mic" from "Recording too short", matching the main pipeline's existing message; `MicInputButton.svelte` surfaces the new "too quiet" case.
- Corrected a stale `CLAUDE.md` comment claiming rejected recordings get no user feedback — they do, via `reject_with_pill()` / `show_error_pill()`.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `cargo clippy -- -D warnings` — clean
- `npm run test:rust` — 203 passed, 0 failed
- Manual repro on Windows: held the hotkey, double-tapped into hands-free, spoke, then stopped hands-free (both via the on-screen confirm button and the keyboard double-tap) — pill stays visually fixed in place through the transition to "processing", no jump. Verified with diagnostic logging that the previous atomic-`SetWindowPos` attempt was in fact resizing/repositioning correctly at the OS level (before this change), which is what pointed to WebView2 repaint lag rather than a Win32 ordering race as the actual cause.

## Risks

- Trade-off, not a regression: while hands-free is active, the pill's click-capture zone is now the full 380pt width instead of a tight 140pt, since the window no longer narrows. Clicks in the empty space around the visible pill are swallowed instead of passing through to whatever's underneath (e.g. a taskbar icon) for the duration of that hands-free session.
- Low risk otherwise — no schema/migration changes, no API/network behavior changes, no smoke-test-contract elements touched.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Claude Sonnet 4.6 (claude-sonnet-4-6), via Claude Code, in the VSCode extension. Standard tool-use mode (no extended thinking); included live diagnostic-logging-driven debugging against a running `npm run tauri dev` instance to disprove an initial hypothesis and find the real root cause.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (none attached — this is a native-window timing/flicker fix; a screen recording would represent it better than a static screenshot, and none was captured for this PR)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above
