### PR TITLE
fix(macos): permissionless hotkey via RegisterEventHotKey + Verenu rename

### DIFF
--- a/docs/macos-code-signing.md
+++ b/docs/macos-code-signing.md
@@ -9,15 +9,18 @@ npm run tauri:build:signed
 ```
 
 This signs the app with a **stable self-signed identity** ("Open Flow Self-Signed")
-so that Accessibility and Input Monitoring permissions you grant **survive
-rebuilds**. Building with plain `npm run tauri build` (ad-hoc signing) will make
-the app forget its permissions every time you rebuild.
+so that the Accessibility permission you grant **survives rebuilds**. Building
+with plain `npm run tauri build` (ad-hoc signing) will make the app forget its
+permission every time you rebuild.
+
+> The global hotkey now uses Carbon `RegisterEventHotKey` (no Input Monitoring
+> permission), so **Accessibility** (for Cmd+V injection / AX reads) is the only
+> rebuild-sensitive TCC grant left. Microphone self-heals (see below).
 
 ## Why this matters
 
-macOS TCC (Transparency, Consent & Control) ties **Accessibility** and **Input
-Monitoring** grants to the application's *code-signature identity*, not its path
-or bundle id.
+macOS TCC (Transparency, Consent & Control) ties the **Accessibility** grant to
+the application's *code-signature identity*, not its path or bundle id.
 
 - An **ad-hoc** signature (`signingIdentity: "-"` in `tauri.conf.json`) has no
   stable identity. TCC falls back to keying the grant on the binary's `CDHash`,
@@ -27,16 +30,15 @@ or bundle id.
 
 The symptom is confusing: **System Settings → Privacy & Security → Accessibility
 shows the app as enabled, but the app still behaves as if permission is missing**
-(the global hotkey and clipboard injection silently stop working). That is
-because the System Settings list matches the entry by path for *display*, while
-the runtime `AXIsProcessTrusted()` / `IOHIDCheckAccess()` checks compare the
-*running* binary's signature against what TCC actually authorised — and they
-don't match after a rebuild.
+(clipboard injection silently stops working). That is because the System Settings
+list matches the entry by path for *display*, while the runtime
+`AXIsProcessTrusted()` check compares the *running* binary's signature against
+what TCC actually authorised — and they don't match after a rebuild.
 
-> Microphone is the exception that hid this for a while: the mic path re-prompts
-> through AVFoundation (re-establishing the grant against the current binary) and
-> also has an empirical "I actually captured audio" latch, so it self-heals.
-> Accessibility and Input Monitoring cannot re-prompt the same way.
+> Microphone is the exception: the mic path re-prompts through AVFoundation
+> (re-establishing the grant against the current binary) and also has an empirical
+> "I actually captured audio" latch, so it self-heals. Accessibility cannot
+> re-prompt the same way.
 
 Signing every local/release build with **one reused certificate** gives the
 bundle a stable designated requirement, so a single grant persists across all
@@ -102,11 +104,10 @@ is tracked separately and is out of scope here.
 
 ## Recovering from stale grants
 
-If you previously installed ad-hoc builds and the OS is holding stale entries,
+If you previously installed ad-hoc builds and the OS is holding a stale entry,
 the in-app **Settings → Permissions → "Reset stale grants"** button runs
-`tccutil reset Accessibility com.verenu.app` and `tccutil reset ListenEvent
-com.verenu.app`, then walks you through re-adding the app. After switching to
-signed builds you should only have to grant once.
+`tccutil reset Accessibility com.verenu.app`, then walks you through re-adding the
+app. After switching to signed builds you should only have to grant once.
 
 ## Runtime resilience
 
@@ -114,10 +115,8 @@ Independently of signing, the permission snapshot uses empirical latches so a
 confirmed-working capability is trusted even if the raw TCC status query is stale:
 
 - **Microphone** — a successful capture (`mark_microphone_verified`).
-- **Input Monitoring** — the global tap actually seeing input
-  (`has_seen_global_input`).
 - **Accessibility** — a successful cross-process AX read in the caret probe
   (`mark_accessibility_verified`).
 
 The raw OS check is still surfaced separately in the snapshot's
-`diagnostics.accessibilityTrusted` / `inputMonitoringRaw` fields for debugging.
+`diagnostics.accessibilityTrusted` field for debugging.

--- a/scripts/macos/build-signed.sh
+++ b/scripts/macos/build-signed.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Build a macOS release bundle signed with the stable, reused self-signed identity
-# so TCC permission grants (Accessibility / Input Monitoring) survive rebuilds.
+# so the TCC Accessibility grant survives rebuilds.
 # See scripts/macos/ensure-signing-identity.sh and docs/macos-code-signing.md.
 #
 # Extra args are forwarded to `tauri build`, e.g.:

--- a/scripts/macos/ensure-signing-identity.sh
+++ b/scripts/macos/ensure-signing-identity.sh
@@ -5,7 +5,7 @@
 #
 # WHY THIS MATTERS
 # ----------------
-# macOS TCC ties Accessibility and Input Monitoring grants to the app's code
+# macOS TCC ties the Accessibility grant to the app's code
 # signature (its "designated requirement"), NOT its path or bundle id. Ad-hoc
 # signing (`signingIdentity: "-"`) has no stable identity, so every rebuild gets a
 # different CDHash and the OS treats it as a brand-new app — silently dropping

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1494,6 +1494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1623,23 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "once_cell",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -5105,6 +5132,7 @@ dependencies = [
  "cpal",
  "crossbeam-queue",
  "foreign-types-shared 0.3.1",
+ "global-hotkey",
  "hound",
  "libc",
  "libproc",
@@ -6090,6 +6118,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,7 +55,8 @@ windows = { version = "0.61", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-graphics      = "0.24"   # CGEventTap, CGEvent post (Cmd+V)
+global-hotkey      = "0.8"    # Carbon RegisterEventHotKey global hotkey (no Input Monitoring / Accessibility needed)
+core-graphics      = "0.24"   # CGEvent post (Cmd+V), Caps-Lock state
 foreign-types-shared = "0.3"
 core-foundation    = "0.10"   # CFRunLoop, CFString, CFRunLoopSource
 core-foundation-sys = "0.8"   # CFGetTypeID / CFRelease for AX value handling

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,12 +1,16 @@
 //! macOS Accessibility / Microphone / Keychain permission commands.
+//!
+//! The global hotkey uses Carbon `RegisterEventHotKey` (see `core::hotkey::mac`),
+//! which needs no Input Monitoring permission — so the only macOS permissions the
+//! app requests are **Accessibility** (Cmd+V injection + AX reads) and
+//! **Microphone**. Keychain access is surfaced separately when a provider key is
+//! stored.
 
 // ---------- macOS permissions ----------
 
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionSourceHints {
-    pub hotkey_tap_active: bool,
-    pub global_input_seen: bool,
     pub microphone_verified: bool,
     pub accessibility_verified: bool,
 }
@@ -15,11 +19,9 @@ pub struct PermissionSourceHints {
 #[serde(rename_all = "camelCase")]
 pub struct MacPermissionSnapshot {
     pub accessibility: String,
-    pub input_monitoring: String,
     pub microphone: String,
     pub keychain: String,
     pub all_core_granted: bool,
-    pub needs_relaunch: bool,
     pub last_checked_at: String,
     pub source_hints: PermissionSourceHints,
     pub diagnostics: MacPermissionDiagnostics,
@@ -33,7 +35,6 @@ pub struct MacPermissionDiagnostics {
     pub executable_path: Option<String>,
     pub process_id: u32,
     pub accessibility_trusted: bool,
-    pub input_monitoring_raw: String,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -51,33 +52,25 @@ pub struct TccResetResult {
     pub steps: Vec<TccResetStep>,
 }
 
-fn summarize_core_permissions(
-    accessibility: &str,
-    input_monitoring: &str,
-    microphone: &str,
-    source_hints: &PermissionSourceHints,
-) -> (bool, bool) {
-    let all_core_granted = accessibility == "authorized"
-        && input_monitoring == "authorized"
-        && microphone == "authorized";
-
-    // IOHID/TCC decisions can be cached by the running process. If macOS says
-    // Input Monitoring is granted but this process has not yet empirically seen
-    // global input, a relaunch is the clearest recovery path after the user has
-    // just changed the toggle in System Settings. The UI decides when to surface
-    // the hint so long-time users are not nagged before interacting.
-    let needs_relaunch = input_monitoring == "authorized" && !source_hints.global_input_seen;
-
-    (all_core_granted, needs_relaunch)
+/// Core permissions are granted once both Accessibility and Microphone are
+/// authorized. (The hotkey no longer needs a separate permission.)
+fn core_permissions_granted(accessibility: &str, microphone: &str) -> bool {
+    accessibility == "authorized" && microphone == "authorized"
 }
 
 #[cfg(target_os = "macos")]
 fn permission_source_hints() -> PermissionSourceHints {
     PermissionSourceHints {
-        hotkey_tap_active: crate::core::hotkey::is_tap_active(),
-        global_input_seen: crate::core::hotkey::has_seen_global_input(),
         microphone_verified: crate::system::mac_app::is_microphone_verified(),
         accessibility_verified: crate::system::mac_app::is_accessibility_verified(),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn permission_source_hints() -> PermissionSourceHints {
+    PermissionSourceHints {
+        microphone_verified: true,
+        accessibility_verified: true,
     }
 }
 
@@ -91,7 +84,6 @@ fn permission_diagnostics() -> MacPermissionDiagnostics {
             .map(|p| p.to_string_lossy().into_owned()),
         process_id: std::process::id(),
         accessibility_trusted: check_accessibility_permission(false),
-        input_monitoring_raw: crate::system::mac_app::input_monitoring_status().to_string(),
     }
 }
 
@@ -105,17 +97,6 @@ fn permission_diagnostics() -> MacPermissionDiagnostics {
             .map(|p| p.to_string_lossy().into_owned()),
         process_id: std::process::id(),
         accessibility_trusted: true,
-        input_monitoring_raw: "authorized".to_string(),
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn permission_source_hints() -> PermissionSourceHints {
-    PermissionSourceHints {
-        hotkey_tap_active: true,
-        global_input_seen: true,
-        microphone_verified: true,
-        accessibility_verified: true,
     }
 }
 
@@ -138,19 +119,6 @@ fn accessibility_permission_status() -> String {
 
 #[cfg(not(target_os = "macos"))]
 fn accessibility_permission_status() -> String {
-    "authorized".to_string()
-}
-
-#[cfg(target_os = "macos")]
-fn input_monitoring_permission_status() -> String {
-    if crate::core::hotkey::has_seen_global_input() {
-        return "authorized".to_string();
-    }
-    crate::system::mac_app::input_monitoring_status().to_string()
-}
-
-#[cfg(not(target_os = "macos"))]
-fn input_monitoring_permission_status() -> String {
     "authorized".to_string()
 }
 
@@ -186,24 +154,16 @@ async fn keychain_status_for_provider(_provider: Option<String>) -> String {
 
 async fn macos_permission_snapshot(provider: Option<String>) -> MacPermissionSnapshot {
     let accessibility = accessibility_permission_status();
-    let input_monitoring = input_monitoring_permission_status();
     let microphone = microphone_permission_status_string();
     let keychain = keychain_status_for_provider(provider).await;
     let source_hints = permission_source_hints();
-    let (all_core_granted, needs_relaunch) = summarize_core_permissions(
-        &accessibility,
-        &input_monitoring,
-        &microphone,
-        &source_hints,
-    );
+    let all_core_granted = core_permissions_granted(&accessibility, &microphone);
 
     MacPermissionSnapshot {
         accessibility,
-        input_monitoring,
         microphone,
         keychain,
         all_core_granted,
-        needs_relaunch,
         last_checked_at: now_rfc3339(),
         source_hints,
         diagnostics: permission_diagnostics(),
@@ -215,9 +175,9 @@ pub async fn get_macos_permission_snapshot(provider: Option<String>) -> MacPermi
     macos_permission_snapshot(provider).await
 }
 
-/// Whether Verenu is trusted for the Accessibility API (needed for the global
-/// hotkey, Cmd+V injection, and auto-learn). When `prompt` is true, macOS shows
-/// the system permission dialog. Always true on non-macOS platforms.
+/// Whether Verenu is trusted for the Accessibility API (needed for Cmd+V
+/// injection and auto-learn). When `prompt` is true, macOS shows the system
+/// permission dialog. Always true on non-macOS platforms.
 #[cfg(target_os = "macos")]
 #[tauri::command]
 pub fn check_accessibility_permission(prompt: bool) -> bool {
@@ -268,21 +228,6 @@ pub async fn request_accessibility_permission(provider: Option<String>) -> MacPe
     macos_permission_snapshot(provider).await
 }
 
-/// Returns `true` once the macOS CGEventTap has been successfully created and
-/// enabled. Useful as a permission signal when Accessibility status is stale
-/// immediately after the user grants access. Always true off macOS.
-#[tauri::command]
-pub fn is_hotkey_tap_active() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        crate::core::hotkey::is_tap_active()
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        true
-    }
-}
-
 #[tauri::command]
 pub fn get_microphone_permission_status() -> String {
     microphone_permission_status_string()
@@ -325,56 +270,12 @@ pub fn open_microphone_settings() -> Result<(), String> {
     ])
 }
 
-/// Relaunches the app. macOS caches Input Monitoring (and other TCC) decisions
-/// for the life of the process, and the global event tap only picks up a newly
-/// granted Input Monitoring permission after a restart.
+/// Relaunches the app. macOS can cache a TCC decision for the life of the
+/// process, so synthesised Cmd+V injection may only start working after a
+/// restart once Accessibility has just been granted.
 #[tauri::command]
 pub fn restart_app(handle: tauri::AppHandle) {
     handle.restart();
-}
-
-/// Current Input Monitoring permission status (`authorized`, `denied`, or
-/// `not_determined`). Required for the global keyboard tap to see keystrokes
-/// while other apps are frontmost. Always `authorized` on non-macOS platforms.
-#[tauri::command]
-pub fn get_input_monitoring_permission_status() -> String {
-    input_monitoring_permission_status()
-}
-
-/// Requests Input Monitoring access, showing the macOS consent prompt when the
-/// permission is undetermined. Returns the resulting status. No-op elsewhere.
-#[tauri::command]
-pub fn request_input_monitoring_permission() -> String {
-    #[cfg(target_os = "macos")]
-    {
-        let _ = crate::system::mac_app::request_input_monitoring();
-        crate::system::mac_app::input_monitoring_status().to_string()
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        "authorized".to_string()
-    }
-}
-
-#[tauri::command]
-pub async fn request_input_monitoring_permission_snapshot(
-    provider: Option<String>,
-) -> MacPermissionSnapshot {
-    #[cfg(target_os = "macos")]
-    {
-        let _ = crate::system::mac_app::request_input_monitoring();
-    }
-    macos_permission_snapshot(provider).await
-}
-
-/// Opens the macOS Input Monitoring privacy pane so the user can grant access.
-/// No-op on other platforms.
-#[tauri::command]
-pub fn open_input_monitoring_settings() -> Result<(), String> {
-    open_macos_settings(&[
-        "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
-        "x-apple.systempreferences:com.apple.preference.security",
-    ])
 }
 
 #[cfg(target_os = "macos")]
@@ -407,6 +308,9 @@ pub fn open_privacy_security_settings() -> Result<(), String> {
     Ok(())
 }
 
+/// Clears the app's stale Accessibility TCC grant so the user can re-add this
+/// build fresh. Rarely needed now that builds are signed with a stable identity,
+/// but kept as a last-resort repair.
 #[tauri::command]
 pub async fn reset_macos_core_permissions() -> TccResetResult {
     #[cfg(target_os = "macos")]
@@ -416,36 +320,33 @@ pub async fn reset_macos_core_permissions() -> TccResetResult {
             let mut steps = Vec::new();
 
             if let Some(bundle_id) = bundle_identifier.as_deref() {
-                for service in ["Accessibility", "ListenEvent"] {
-                    let output = std::process::Command::new("/usr/bin/tccutil")
-                        .args(["reset", service, bundle_id])
-                        .output();
-                    match output {
-                        Ok(output) if output.status.success() => {
-                            steps.push(TccResetStep {
-                                service: service.to_string(),
-                                ok: true,
-                                message: "Reset".to_string(),
-                            });
-                        }
-                        Ok(output) => {
-                            let stderr =
-                                String::from_utf8_lossy(&output.stderr).trim().to_string();
-                            let stdout =
-                                String::from_utf8_lossy(&output.stdout).trim().to_string();
-                            steps.push(TccResetStep {
-                                service: service.to_string(),
-                                ok: false,
-                                message: if stderr.is_empty() { stdout } else { stderr },
-                            });
-                        }
-                        Err(err) => {
-                            steps.push(TccResetStep {
-                                service: service.to_string(),
-                                ok: false,
-                                message: err.to_string(),
-                            });
-                        }
+                let service = "Accessibility";
+                let output = std::process::Command::new("/usr/bin/tccutil")
+                    .args(["reset", service, bundle_id])
+                    .output();
+                match output {
+                    Ok(output) if output.status.success() => {
+                        steps.push(TccResetStep {
+                            service: service.to_string(),
+                            ok: true,
+                            message: "Reset".to_string(),
+                        });
+                    }
+                    Ok(output) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                        steps.push(TccResetStep {
+                            service: service.to_string(),
+                            ok: false,
+                            message: if stderr.is_empty() { stdout } else { stderr },
+                        });
+                    }
+                    Err(err) => {
+                        steps.push(TccResetStep {
+                            service: service.to_string(),
+                            ok: false,
+                            message: err.to_string(),
+                        });
                     }
                 }
             } else {
@@ -504,34 +405,12 @@ pub async fn check_keychain_access(provider: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{summarize_core_permissions, PermissionSourceHints};
-
-    fn hints(global_input_seen: bool) -> PermissionSourceHints {
-        PermissionSourceHints {
-            hotkey_tap_active: true,
-            global_input_seen,
-            microphone_verified: true,
-            accessibility_verified: true,
-        }
-    }
+    use super::core_permissions_granted;
 
     #[test]
-    fn summary_requires_all_three_core_permissions() {
-        let (all, relaunch) =
-            summarize_core_permissions("authorized", "authorized", "authorized", &hints(true));
-        assert!(all);
-        assert!(!relaunch);
-
-        let (all, _) =
-            summarize_core_permissions("authorized", "denied", "authorized", &hints(true));
-        assert!(!all);
-    }
-
-    #[test]
-    fn summary_flags_possible_input_monitoring_relaunch_cache() {
-        let (all, relaunch) =
-            summarize_core_permissions("authorized", "authorized", "authorized", &hints(false));
-        assert!(all);
-        assert!(relaunch);
+    fn summary_requires_accessibility_and_microphone() {
+        assert!(core_permissions_granted("authorized", "authorized"));
+        assert!(!core_permissions_granted("authorized", "denied"));
+        assert!(!core_permissions_granted("needs_permission", "authorized"));
     }
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -57,7 +57,9 @@ pub async fn save_hotkey(app: AppHandle, key1: String, key2: String) -> Result<(
     if vk1 == 0 {
         return Err(format!("Unrecognized key code: {key1}"));
     }
-    if vk2 == 0 {
+    // An empty second slot is allowed (a single-key hotkey, e.g. macOS F5);
+    // only reject a non-empty key code that we can't recognise.
+    if !key2.is_empty() && vk2 == 0 {
         return Err(format!("Unrecognized key code: {key2}"));
     }
     crate::core::hotkey::update_keys(vk1, vk2);

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -186,8 +186,15 @@ fn js_code_to_mac_keycode(code: &str) -> Option<u32> {
         "Digit9" => 25,
         "Digit0" => 29,
         "Space" => 49,
+        "Escape" => 53,
+        "Backspace" => 51,
+        "Delete" => 117,
         "Enter" => 36,
         "Tab" => 48,
+        "Home" => 115,
+        "End" => 119,
+        "PageUp" => 116,
+        "PageDown" => 121,
         "Backquote" => 50,
         "Minus" => 27,
         "Equal" => 24,
@@ -261,8 +268,15 @@ fn mac_keycode_to_code(kc: u32) -> Option<Code> {
         25 => Code::Digit9,
         29 => Code::Digit0,
         49 => Code::Space,
+        53 => Code::Escape,
+        51 => Code::Backspace,
+        117 => Code::Delete,
         36 => Code::Enter,
         48 => Code::Tab,
+        115 => Code::Home,
+        119 => Code::End,
+        116 => Code::PageUp,
+        121 => Code::PageDown,
         50 => Code::Backquote,
         27 => Code::Minus,
         24 => Code::Equal,
@@ -565,6 +579,9 @@ mod tests {
         // The default ⌥+Space and other modifier+key combos are valid.
         assert!(hk("AltLeft", "Space").is_some());
         assert!(hk("ControlLeft", "KeyA").is_some());
+        assert!(hk("AltLeft", "Escape").is_some());
+        assert!(hk("AltLeft", "Backspace").is_some());
+        assert!(hk("AltLeft", "PageDown").is_some());
         // A modifier-only chord (e.g. the legacy Fn+Control) is not registrable.
         assert!(hk("ControlLeft", "Fn").is_none());
         assert!(hk("", "").is_none());

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -79,7 +79,11 @@ static MANAGER: OnceLock<GlobalHotKeyManager> = OnceLock::new();
 static CURRENT_HOTKEY: Mutex<Option<HotKey>> = Mutex::new(None);
 static MAIN_HOTKEY_ID: AtomicU32 = AtomicU32::new(0);
 static ESCAPE_HOTKEY: OnceLock<HotKey> = OnceLock::new();
-static ESCAPE_REGISTERED: AtomicBool = AtomicBool::new(false);
+// `Mutex<bool>` (not an atomic) so the check and the register/unregister call are
+// one critical section — `set_escape_listening` is invoked from both the hotkey
+// event thread and Tauri command threads, and a lock-free swap could interleave
+// such that Escape stays registered (hijacked) system-wide.
+static ESCAPE_REGISTERED: Mutex<bool> = Mutex::new(false);
 
 fn now_ms() -> u64 {
     static START: OnceLock<Instant> = OnceLock::new();
@@ -323,7 +327,31 @@ fn build_hotkey(k1: u32, k2: u32) -> Option<HotKey> {
     }
     let trigger = code?;
     let mods = if mods.is_empty() { None } else { Some(mods) };
+    // A modifier-less single key would be consumed system-wide by
+    // RegisterEventHotKey, hijacking normal typing of that key everywhere. Only
+    // function keys (which don't produce text) are safe as a bare hotkey.
+    if mods.is_none() && !is_function_key(trigger) {
+        return None;
+    }
     Some(HotKey::new(mods, trigger))
+}
+
+fn is_function_key(code: Code) -> bool {
+    matches!(
+        code,
+        Code::F1
+            | Code::F2
+            | Code::F3
+            | Code::F4
+            | Code::F5
+            | Code::F6
+            | Code::F7
+            | Code::F8
+            | Code::F9
+            | Code::F10
+            | Code::F11
+            | Code::F12
+    )
 }
 
 // --- registration ----------------------------------------------------------
@@ -368,12 +396,16 @@ fn set_escape_listening(on: bool) {
         return;
     };
     let esc = *ESCAPE_HOTKEY.get_or_init(|| HotKey::new(None, Code::Escape));
-    if on {
-        if !ESCAPE_REGISTERED.swap(true, Ordering::SeqCst) && mgr.register(esc).is_err() {
-            ESCAPE_REGISTERED.store(false, Ordering::SeqCst);
+    let Ok(mut registered) = ESCAPE_REGISTERED.lock() else {
+        return;
+    };
+    if on && !*registered {
+        if mgr.register(esc).is_ok() {
+            *registered = true;
         }
-    } else if ESCAPE_REGISTERED.swap(false, Ordering::SeqCst) {
+    } else if !on && *registered {
         let _ = mgr.unregister(esc);
+        *registered = false;
     }
 }
 
@@ -500,4 +532,33 @@ where
     log::info!("macOS global hotkey installed (RegisterEventHotKey)");
 
     Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hk(code1: &str, code2: &str) -> Option<HotKey> {
+        build_hotkey(map_code_to_vk(code1), map_code_to_vk(code2))
+    }
+
+    #[test]
+    fn modifier_less_single_key_is_rejected_unless_function_key() {
+        // A bare printable key would be consumed system-wide — reject it.
+        assert!(hk("KeyA", "").is_none());
+        assert!(hk("Space", "").is_none());
+        // Function keys don't produce text, so they're allowed bare.
+        assert!(hk("F5", "").is_some());
+        assert!(hk("F12", "").is_some());
+    }
+
+    #[test]
+    fn modifier_plus_key_and_modifier_only_combinations() {
+        // The default ⌥+Space and other modifier+key combos are valid.
+        assert!(hk("AltLeft", "Space").is_some());
+        assert!(hk("ControlLeft", "KeyA").is_some());
+        // A modifier-only chord (e.g. the legacy Fn+Control) is not registrable.
+        assert!(hk("ControlLeft", "Fn").is_none());
+        assert!(hk("", "").is_none());
+    }
 }

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -66,7 +66,6 @@ static CANCEL_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 static ESCAPE_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 
 static CHORD_ACTIVE: AtomicBool = AtomicBool::new(false);
-static HANDLESS_ACTIVE: AtomicBool = AtomicBool::new(false);
 static ESCAPE_CANCELLED: AtomicBool = AtomicBool::new(false);
 static CHORD_DOWN_MS: AtomicU64 = AtomicU64::new(0);
 static HANDLESS_PENDING: AtomicBool = AtomicBool::new(false);
@@ -114,7 +113,7 @@ pub fn reset_chord_state() {
 }
 
 pub fn set_handless_active(v: bool) {
-    HANDLESS_ACTIVE.store(v, Ordering::SeqCst);
+    let _ = v;
     refresh_escape_listening();
 }
 
@@ -410,7 +409,10 @@ fn set_escape_listening(on: bool) {
 }
 
 fn refresh_escape_listening() {
-    set_escape_listening(CHORD_ACTIVE.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst));
+    // Keep Escape transient to active hold-to-talk only. Leaving it registered
+    // for the entire handsfree session would hijack Escape system-wide while the
+    // app records in the background.
+    set_escape_listening(CHORD_ACTIVE.load(Ordering::SeqCst));
 }
 
 // --- event handling --------------------------------------------------------
@@ -505,6 +507,11 @@ where
     C: Fn() + Send + Sync + 'static,
     E: Fn() + Send + Sync + 'static,
 {
+    if MANAGER.get().is_some() {
+        log::warn!("hotkey: global hotkey manager already initialized");
+        return Ok(std::thread::spawn(|| {}));
+    }
+
     let _ = PRESS_CB.set(Box::new(on_press));
     let _ = RELEASE_CB.set(Box::new(on_release));
     let _ = HANDLESS_CB.set(Box::new(on_handless));
@@ -518,6 +525,7 @@ where
         .map_err(|e| format!("failed to create global hotkey manager: {e}"))?;
     if MANAGER.set(manager).is_err() {
         log::warn!("hotkey: global hotkey manager already initialized");
+        return Ok(std::thread::spawn(|| {}));
     }
     register_main_hotkey();
 

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -1,47 +1,40 @@
-//! macOS global hold/release hotkey via a `CGEventTap`.
+//! macOS global hold/release hotkey via Carbon `RegisterEventHotKey`
+//! (through the `global-hotkey` crate).
 //!
 //! Mirrors the public contract of the Windows backend (`super::win`):
 //! `start`, `update_keys`, `map_code_to_vk`, `is_hotkey_available`,
-//! `reset_chord_state`, `set_handless_active`.
+//! `reset_chord_state`, `set_handless_active`, `begin_synthetic_paste_suppression`,
+//! `caps_lock_is_on`.
 //!
 //! Design notes:
-//! - A **listen-only** tap is used (`CGEventTapOptions::ListenOnly`). It observes
-//!   key/modifier state but never deletes events, so it can't cause stuck
-//!   modifiers or swallow shortcuts. The trade-off is that we cannot suppress the
-//!   OS Fn/Globe "show emoji" action — users set System Settings → Keyboard →
-//!   "Press 🌐 key to: Do Nothing". The tap requires Accessibility / Input
-//!   Monitoring permission (the OS prompts on first creation).
+//! - `RegisterEventHotKey` requires **no permission** — not Accessibility, not
+//!   Input Monitoring. It delivers `Pressed` / `Released` events for a single
+//!   registered key combination, which is exactly what hold-to-talk needs. The
+//!   trade-off vs. the old `CGEventTap` is that the hotkey can no longer be a
+//!   pure modifier chord (e.g. Fn+Control): Carbon hotkeys need a real key, so
+//!   the default is **⌥ Option + Space** (two adjacent bottom-row keys, no Fn
+//!   gymnastics and no Spotlight conflict).
+//! - Because we no longer observe every keystroke, we also no longer feed the
+//!   injection-history capitalization fallback on macOS — that path now relies on
+//!   the Accessibility caret read / clipboard sniff (see `core::context_probe`).
 //! - Key ids produced by `map_code_to_vk` are private to this backend: modifiers
-//!   are tiny sentinel ids (1..=6) resolved against `CGEventFlags`; regular keys
-//!   are `REGULAR_BASE + <macOS keycode>` and tracked via key down/up.
-//! - The default chord is **Control (key1) + Fn (key2)**.
+//!   are tiny sentinel ids (1..=6); regular keys are `REGULAR_BASE + <macOS
+//!   keycode>`. `update_keys` resolves them into a single `global_hotkey::HotKey`.
 
-use std::ffi::c_void;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicU64, Ordering};
-use std::sync::mpsc;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
-use core_foundation::base::TCFType;
-use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop};
-use core_foundation_sys::mach_port::CFMachPortRef;
-use core_graphics::event::{
-    CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventTapProxy,
-    CGEventType, EventField,
-};
-use foreign_types_shared::ForeignType;
+use global_hotkey::hotkey::{Code, HotKey, Modifiers};
+use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
 
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
-    fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
-    fn CGEventKeyboardGetUnicodeString(
-        event: core_graphics::sys::CGEventRef,
-        max_string_length: libc::c_ulong,
-        actual_string_length: *mut libc::c_ulong,
-        unicode_string: *mut u16,
-    );
     fn CGEventSourceFlagsState(state_id: i32) -> u64;
 }
+
+// caps-lock bit in CGEventFlags (kCGEventFlagMaskAlphaShift).
+const FLAG_ALPHASHIFT: u64 = 0x0001_0000;
 
 // --- private key id scheme -------------------------------------------------
 
@@ -53,52 +46,18 @@ const ID_FN: u32 = 5;
 const ID_CAPS: u32 = 6;
 const REGULAR_BASE: u32 = 0x100;
 
-const KEY_ESCAPE: i64 = 53; // macOS virtual keycode for Escape
-const KEY_TAB: i64 = 48;
-const KEY_BACKSPACE: i64 = 51;
-const KEY_RETURN: i64 = 36;
-const KEY_FORWARD_DELETE: i64 = 117;
-const KEY_HOME: i64 = 115;
-const KEY_END: i64 = 119;
-const KEY_PAGE_UP: i64 = 116;
-const KEY_PAGE_DOWN: i64 = 121;
-const KEY_LEFT: i64 = 123;
-const KEY_RIGHT: i64 = 124;
-const KEY_DOWN: i64 = 125;
-const KEY_UP: i64 = 126;
+// macOS virtual keycode for Space — the trigger key of the default ⌥+Space hotkey.
+const MAC_KEYCODE_SPACE: u32 = 49;
 
-// Keep production builds quiet unless we're actively debugging the event tap.
-const HOTKEY_DEBUG: bool = false;
-
-fn is_modifier(id: u32) -> bool {
-    (ID_CONTROL..=ID_CAPS).contains(&id)
-}
-
-// CGEventFlags raw bits (kCGEventFlagMask*). Kept as raw u64 so this module
-// doesn't depend on the exact associated-constant names across crate versions.
-const FLAG_ALPHASHIFT: u64 = 0x0001_0000; // caps lock
-const FLAG_SHIFT: u64 = 0x0002_0000;
-const FLAG_CONTROL: u64 = 0x0004_0000;
-const FLAG_ALTERNATE: u64 = 0x0008_0000;
-const FLAG_COMMAND: u64 = 0x0010_0000;
-const FLAG_SECONDARY_FN: u64 = 0x0080_0000;
-
-fn modifier_mask(id: u32) -> u64 {
-    match id {
-        ID_CONTROL => FLAG_CONTROL,
-        ID_SHIFT => FLAG_SHIFT,
-        ID_ALT => FLAG_ALTERNATE,
-        ID_COMMAND => FLAG_COMMAND,
-        ID_FN => FLAG_SECONDARY_FN,
-        ID_CAPS => FLAG_ALPHASHIFT,
-        _ => 0,
-    }
-}
+// Double-tap window for handsfree toggle, and the max hold treated as a "tap".
+const HANDSFREE_DOUBLE_TAP_MS: u64 = 350;
+const TAP_MAX_HOLD_MS: u64 = 250;
 
 // --- state -----------------------------------------------------------------
 
-static KEY1: AtomicU32 = AtomicU32::new(ID_CONTROL); // held modifier (default Ctrl)
-static KEY2: AtomicU32 = AtomicU32::new(ID_FN); // trigger (default Fn)
+// Default hotkey: ⌥ Option + Space. KEY1 is the Option modifier, KEY2 the Space key.
+static KEY1: AtomicU32 = AtomicU32::new(ID_ALT);
+static KEY2: AtomicU32 = AtomicU32::new(REGULAR_BASE + MAC_KEYCODE_SPACE);
 
 static PRESS_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 static RELEASE_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
@@ -112,79 +71,33 @@ static ESCAPE_CANCELLED: AtomicBool = AtomicBool::new(false);
 static CHORD_DOWN_MS: AtomicU64 = AtomicU64::new(0);
 static HANDLESS_PENDING: AtomicBool = AtomicBool::new(false);
 static HANDLESS_PENDING_MS: AtomicU64 = AtomicU64::new(0);
-static EVENT_TAP_PORT: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
-static TAP_ACTIVE: AtomicBool = AtomicBool::new(false);
-// Latched once the chord fires while another app is frontmost — empirical proof
-// that the tap receives global keystrokes (i.e. Input Monitoring is effectively
-// granted), independent of the per-process-cached IOHIDCheckAccess result.
-static GLOBAL_INPUT_SEEN: AtomicBool = AtomicBool::new(false);
 
-/// True once the hotkey has fired while another application was frontmost, which
-/// can only happen when the tap is receiving global input — i.e. Input Monitoring
-/// is working. Authoritative override for the unreliable `IOHIDCheckAccess` cache.
-pub fn has_seen_global_input() -> bool {
-    GLOBAL_INPUT_SEEN.load(Ordering::SeqCst)
-}
-
-/// Returns `true` once the CGEventTap has been successfully created and enabled.
-/// The tap polls until Accessibility permission is granted, so this becomes `true`
-/// only after the user has authorized the app — useful as a permission signal when
-/// `AXIsProcessTrustedWithOptions` returns a stale cached result.
-pub fn is_tap_active() -> bool {
-    TAP_ACTIVE.load(Ordering::SeqCst)
-}
-
-// Down-state for the (rare) case where a configured chord key is a regular key
-// rather than a modifier. Modifiers are read from CGEventFlags instead.
-static K1_REGULAR_DOWN: AtomicBool = AtomicBool::new(false);
-static K2_REGULAR_DOWN: AtomicBool = AtomicBool::new(false);
-static SYNTHETIC_PASTE_UNTIL_MS: AtomicU64 = AtomicU64::new(0);
-
-#[derive(Clone, Copy)]
-struct HotkeyEvent {
-    etype: CGEventType,
-    flags: u64,
-    keycode: i64,
-    text: [u16; 8],
-    text_len: u8,
-}
+// `GlobalHotKeyManager` is `unsafe impl Send + Sync` (it guards Carbon access
+// with an internal mutex), so it is safe to hold in a static and re-register
+// the hotkey from `update_keys` on any thread.
+static MANAGER: OnceLock<GlobalHotKeyManager> = OnceLock::new();
+static CURRENT_HOTKEY: Mutex<Option<HotKey>> = Mutex::new(None);
+static MAIN_HOTKEY_ID: AtomicU32 = AtomicU32::new(0);
+static ESCAPE_HOTKEY: OnceLock<HotKey> = OnceLock::new();
+static ESCAPE_REGISTERED: AtomicBool = AtomicBool::new(false);
 
 fn now_ms() -> u64 {
     static START: OnceLock<Instant> = OnceLock::new();
     START.get_or_init(Instant::now).elapsed().as_millis() as u64
 }
 
-pub fn begin_synthetic_paste_suppression(duration_ms: u64) {
-    SYNTHETIC_PASTE_UNTIL_MS.store(now_ms().saturating_add(duration_ms), Ordering::SeqCst);
-}
-
-fn synthetic_paste_suppressed(now: u64) -> bool {
-    SYNTHETIC_PASTE_UNTIL_MS.load(Ordering::SeqCst) > now
-}
-
-fn reenable_event_tap() {
-    let tap_port = EVENT_TAP_PORT.load(Ordering::SeqCst) as CFMachPortRef;
-    if tap_port.is_null() {
-        log::warn!("macOS event tap disabled before a tap port was registered");
-        return;
-    }
-
-    unsafe {
-        CGEventTapEnable(tap_port, true);
-    }
-    log::info!("macOS event tap re-enabled");
-}
-
 // --- public contract -------------------------------------------------------
 
+/// Synthetic-paste suppression was only needed to keep the old keystroke tap
+/// from recording our own Cmd+V into the injection history. Without the tap this
+/// is a no-op (kept to satisfy the shared cross-platform contract).
+pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
+
 pub fn update_keys(k1: u32, k2: u32) {
-    if k1 != 0 {
-        KEY1.store(k1, Ordering::SeqCst);
-    }
-    if k2 != 0 {
-        KEY2.store(k2, Ordering::SeqCst);
-    }
+    KEY1.store(k1, Ordering::SeqCst);
+    KEY2.store(k2, Ordering::SeqCst);
     reset_chord_state();
+    register_main_hotkey();
 }
 
 pub fn reset_chord_state() {
@@ -193,31 +106,30 @@ pub fn reset_chord_state() {
     HANDLESS_PENDING.store(false, Ordering::SeqCst);
     HANDLESS_PENDING_MS.store(0, Ordering::SeqCst);
     CHORD_DOWN_MS.store(0, Ordering::SeqCst);
-    K1_REGULAR_DOWN.store(false, Ordering::SeqCst);
-    K2_REGULAR_DOWN.store(false, Ordering::SeqCst);
+    refresh_escape_listening();
 }
 
 pub fn set_handless_active(v: bool) {
     HANDLESS_ACTIVE.store(v, Ordering::SeqCst);
+    refresh_escape_listening();
 }
 
-/// Current Caps Lock toggle state, queried synchronously from the OS — avoids
-/// depending on the event tap having already observed a flags-changed event
-/// (which would otherwise read stale/default state for Caps Lock toggled
-/// before the tap was installed, or before Accessibility permission is granted).
+/// Current Caps Lock toggle state, queried synchronously from the OS.
 pub fn caps_lock_is_on() -> bool {
     const COMBINED_SESSION_STATE: i32 = 0; // kCGEventSourceStateCombinedSessionState
     unsafe { (CGEventSourceFlagsState(COMBINED_SESSION_STATE) & FLAG_ALPHASHIFT) != 0 }
 }
 
-/// A chord is registrable as long as the trigger key maps to a known id.
-pub fn is_hotkey_available(_key1: &str, key2: &str) -> bool {
-    map_code_to_vk(key2) != 0
+/// A hotkey is registrable as long as the (modifiers, key) pair resolves to a
+/// real key — Carbon hotkeys cannot be modifier-only.
+pub fn is_hotkey_available(key1: &str, key2: &str) -> bool {
+    build_hotkey(map_code_to_vk(key1), map_code_to_vk(key2)).is_some()
 }
 
 /// Map a JS `KeyboardEvent.code` to this backend's private key id.
 pub fn map_code_to_vk(code: &str) -> u32 {
     match code {
+        "" => 0,
         "ControlLeft" | "ControlRight" => ID_CONTROL,
         "ShiftLeft" | "ShiftRight" => ID_SHIFT,
         "AltLeft" | "AltRight" => ID_ALT,
@@ -231,7 +143,7 @@ pub fn map_code_to_vk(code: &str) -> u32 {
 }
 
 /// macOS ANSI virtual keycodes for the common `KeyboardEvent.code` values a user
-/// might rebind to. The default Fn+Control chord uses none of these.
+/// might rebind to. The default F5 hotkey resolves through here (F5 → 96).
 fn js_code_to_mac_keycode(code: &str) -> Option<u32> {
     let kc = match code {
         "KeyA" => 0,
@@ -305,6 +217,248 @@ fn js_code_to_mac_keycode(code: &str) -> Option<u32> {
     Some(kc)
 }
 
+/// Reverse of `js_code_to_mac_keycode`: macOS virtual keycode → `global-hotkey`
+/// `Code`. Used by `build_hotkey` to register the trigger key.
+fn mac_keycode_to_code(kc: u32) -> Option<Code> {
+    let code = match kc {
+        0 => Code::KeyA,
+        1 => Code::KeyS,
+        2 => Code::KeyD,
+        3 => Code::KeyF,
+        4 => Code::KeyH,
+        5 => Code::KeyG,
+        6 => Code::KeyZ,
+        7 => Code::KeyX,
+        8 => Code::KeyC,
+        9 => Code::KeyV,
+        11 => Code::KeyB,
+        12 => Code::KeyQ,
+        13 => Code::KeyW,
+        14 => Code::KeyE,
+        15 => Code::KeyR,
+        16 => Code::KeyY,
+        17 => Code::KeyT,
+        31 => Code::KeyO,
+        32 => Code::KeyU,
+        34 => Code::KeyI,
+        35 => Code::KeyP,
+        37 => Code::KeyL,
+        38 => Code::KeyJ,
+        40 => Code::KeyK,
+        45 => Code::KeyN,
+        46 => Code::KeyM,
+        18 => Code::Digit1,
+        19 => Code::Digit2,
+        20 => Code::Digit3,
+        21 => Code::Digit4,
+        23 => Code::Digit5,
+        22 => Code::Digit6,
+        26 => Code::Digit7,
+        28 => Code::Digit8,
+        25 => Code::Digit9,
+        29 => Code::Digit0,
+        49 => Code::Space,
+        36 => Code::Enter,
+        48 => Code::Tab,
+        50 => Code::Backquote,
+        27 => Code::Minus,
+        24 => Code::Equal,
+        33 => Code::BracketLeft,
+        30 => Code::BracketRight,
+        42 => Code::Backslash,
+        41 => Code::Semicolon,
+        39 => Code::Quote,
+        43 => Code::Comma,
+        47 => Code::Period,
+        44 => Code::Slash,
+        123 => Code::ArrowLeft,
+        124 => Code::ArrowRight,
+        125 => Code::ArrowDown,
+        126 => Code::ArrowUp,
+        122 => Code::F1,
+        120 => Code::F2,
+        99 => Code::F3,
+        118 => Code::F4,
+        96 => Code::F5,
+        97 => Code::F6,
+        98 => Code::F7,
+        100 => Code::F8,
+        101 => Code::F9,
+        109 => Code::F10,
+        103 => Code::F11,
+        111 => Code::F12,
+        _ => return None,
+    };
+    Some(code)
+}
+
+fn modifier_id_to_mods(id: u32) -> Option<Modifiers> {
+    match id {
+        ID_CONTROL => Some(Modifiers::CONTROL),
+        ID_SHIFT => Some(Modifiers::SHIFT),
+        ID_ALT => Some(Modifiers::ALT),
+        ID_COMMAND => Some(Modifiers::META),
+        // Fn / Caps Lock can't be Carbon hotkey modifiers — ignore them.
+        ID_FN | ID_CAPS => Some(Modifiers::empty()),
+        _ => None,
+    }
+}
+
+/// Resolve the two private key ids into a single registrable `HotKey`, or `None`
+/// if there is no real trigger key (e.g. a modifier-only combination).
+fn build_hotkey(k1: u32, k2: u32) -> Option<HotKey> {
+    let mut mods = Modifiers::empty();
+    let mut code: Option<Code> = None;
+    for id in [k1, k2] {
+        if id == 0 {
+            continue;
+        }
+        if let Some(m) = modifier_id_to_mods(id) {
+            mods |= m;
+        } else if id >= REGULAR_BASE {
+            if let Some(c) = mac_keycode_to_code(id - REGULAR_BASE) {
+                code = Some(c);
+            }
+        }
+    }
+    let trigger = code?;
+    let mods = if mods.is_empty() { None } else { Some(mods) };
+    Some(HotKey::new(mods, trigger))
+}
+
+// --- registration ----------------------------------------------------------
+
+fn register_main_hotkey() {
+    let Some(mgr) = MANAGER.get() else {
+        return;
+    };
+    let hk = match build_hotkey(KEY1.load(Ordering::SeqCst), KEY2.load(Ordering::SeqCst)) {
+        Some(hk) => hk,
+        None => {
+            // Fall back to ⌥+Space so the app always has a working hotkey rather
+            // than silently registering nothing (e.g. a stale modifier-only setting).
+            log::warn!("hotkey: configured keys are not registrable — falling back to ⌥+Space");
+            HotKey::new(Some(Modifiers::ALT), Code::Space)
+        }
+    };
+    if let Ok(mut cur) = CURRENT_HOTKEY.lock() {
+        if let Some(prev) = cur.take() {
+            let _ = mgr.unregister(prev);
+        }
+        match mgr.register(hk) {
+            Ok(()) => {
+                *cur = Some(hk);
+                MAIN_HOTKEY_ID.store(hk.id(), Ordering::SeqCst);
+                log::info!("hotkey: registered global hotkey id={}", hk.id());
+            }
+            Err(e) => {
+                MAIN_HOTKEY_ID.store(0, Ordering::SeqCst);
+                log::error!("hotkey: failed to register global hotkey: {e}");
+            }
+        }
+    }
+}
+
+/// Register/unregister a plain-Escape hotkey for the duration of an active
+/// recording so the user can cancel mid-dictation. We keep it transient because
+/// a registered hotkey is consumed system-wide — we don't want to swallow Escape
+/// everywhere, only while the user is holding the dictation key.
+fn set_escape_listening(on: bool) {
+    let Some(mgr) = MANAGER.get() else {
+        return;
+    };
+    let esc = *ESCAPE_HOTKEY.get_or_init(|| HotKey::new(None, Code::Escape));
+    if on {
+        if !ESCAPE_REGISTERED.swap(true, Ordering::SeqCst) && mgr.register(esc).is_err() {
+            ESCAPE_REGISTERED.store(false, Ordering::SeqCst);
+        }
+    } else if ESCAPE_REGISTERED.swap(false, Ordering::SeqCst) {
+        let _ = mgr.unregister(esc);
+    }
+}
+
+fn refresh_escape_listening() {
+    set_escape_listening(CHORD_ACTIVE.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst));
+}
+
+// --- event handling --------------------------------------------------------
+
+fn handle_hotkey_event(ev: GlobalHotKeyEvent) {
+    if ESCAPE_HOTKEY.get().is_some_and(|h| h.id() == ev.id) {
+        if matches!(ev.state, HotKeyState::Pressed) {
+            on_escape_pressed();
+        }
+        return;
+    }
+    if ev.id != MAIN_HOTKEY_ID.load(Ordering::SeqCst) {
+        return;
+    }
+    match ev.state {
+        HotKeyState::Pressed => on_main_pressed(),
+        HotKeyState::Released => on_main_released(),
+    }
+}
+
+fn on_main_pressed() {
+    // Carbon delivers a single Pressed per physical press, but guard against any
+    // duplicate before a Released arrives.
+    if CHORD_ACTIVE.load(Ordering::SeqCst) {
+        return;
+    }
+    let now = now_ms();
+
+    // Double-tap within the window toggles handsfree mode.
+    if HANDLESS_PENDING.swap(false, Ordering::SeqCst)
+        && now.saturating_sub(HANDLESS_PENDING_MS.load(Ordering::SeqCst)) <= HANDSFREE_DOUBLE_TAP_MS
+    {
+        if let Some(cb) = HANDLESS_CB.get() {
+            cb();
+        }
+        return;
+    }
+
+    CHORD_ACTIVE.store(true, Ordering::SeqCst);
+    CHORD_DOWN_MS.store(now, Ordering::SeqCst);
+    ESCAPE_CANCELLED.store(false, Ordering::SeqCst);
+    refresh_escape_listening();
+    if let Some(cb) = PRESS_CB.get() {
+        cb();
+    }
+}
+
+fn on_main_released() {
+    if !CHORD_ACTIVE.swap(false, Ordering::SeqCst) {
+        return;
+    }
+    let now = now_ms();
+    let held_ms = now.saturating_sub(CHORD_DOWN_MS.load(Ordering::SeqCst));
+    refresh_escape_listening();
+
+    if ESCAPE_CANCELLED.swap(false, Ordering::SeqCst) {
+        // Escape already cancelled this session — emit nothing further.
+    } else if held_ms < TAP_MAX_HOLD_MS {
+        // Quick tap → cancel and arm the double-tap (handsfree) window.
+        HANDLESS_PENDING.store(true, Ordering::SeqCst);
+        HANDLESS_PENDING_MS.store(now, Ordering::SeqCst);
+        if let Some(cb) = CANCEL_CB.get() {
+            cb();
+        }
+    } else if let Some(cb) = RELEASE_CB.get() {
+        cb();
+    }
+}
+
+fn on_escape_pressed() {
+    if CHORD_ACTIVE.load(Ordering::SeqCst) {
+        ESCAPE_CANCELLED.store(true, Ordering::SeqCst);
+    }
+    if let Some(cb) = ESCAPE_CB.get() {
+        cb();
+    }
+}
+
+// --- start -----------------------------------------------------------------
+
 pub fn start<P, R, H, C, E>(
     on_press: P,
     on_release: R,
@@ -325,325 +479,25 @@ where
     let _ = CANCEL_CB.set(Box::new(on_cancel));
     let _ = ESCAPE_CB.set(Box::new(on_escape));
 
-    let (tx, rx) = mpsc::channel::<HotkeyEvent>();
-    std::thread::spawn(move || {
-        while let Ok(event) = rx.recv() {
-            handle_event(event);
-        }
-    });
+    // Created here (on the main thread, from Tauri `setup`) because the crate
+    // installs its Carbon event handler on the application event target, which
+    // is serviced by the main run loop Tauri already runs.
+    let manager = GlobalHotKeyManager::new()
+        .map_err(|e| format!("failed to create global hotkey manager: {e}"))?;
+    if MANAGER.set(manager).is_err() {
+        log::warn!("hotkey: global hotkey manager already initialized");
+    }
+    register_main_hotkey();
 
+    // Drain hotkey events on a background thread; the receiver is a process-wide
+    // channel fed by the Carbon handler, so it is safe to poll off-thread.
     let handle = std::thread::spawn(move || {
-        // CGEventTap creation returns Err until Accessibility permission is
-        // granted. Rather than failing permanently (forcing an app restart after
-        // the user grants it), poll until it succeeds.
-        let mut attempt: u32 = 0;
-        let tap = loop {
-            let result = CGEventTap::new(
-                CGEventTapLocation::HID,
-                CGEventTapPlacement::HeadInsertEventTap,
-                CGEventTapOptions::ListenOnly,
-                // core-graphics 0.24.x builds the CGEventMask internally from
-                // a Vec<CGEventType>, so keep the typed list here.
-                vec![
-                    CGEventType::KeyDown,
-                    CGEventType::KeyUp,
-                    CGEventType::FlagsChanged,
-                ],
-                {
-                    let tx = tx.clone();
-                    move |_proxy: CGEventTapProxy, etype: CGEventType, event| {
-                        let (flags, keycode, text, text_len) = if matches!(
-                            etype,
-                            CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
-                        ) {
-                            (0, 0, [0u16; 8], 0)
-                        } else {
-                            let mut text = [0u16; 8];
-                            let mut actual_len = 0u8;
-                            if matches!(etype, CGEventType::KeyDown) {
-                                let mut out_len = 0 as libc::c_ulong;
-                                unsafe {
-                                    CGEventKeyboardGetUnicodeString(
-                                        event.as_ptr(),
-                                        text.len() as libc::c_ulong,
-                                        &mut out_len,
-                                        text.as_mut_ptr(),
-                                    );
-                                }
-                                actual_len = out_len.min(text.len() as libc::c_ulong) as u8;
-                            }
-                            let flags_bits = event.get_flags().bits();
-                            (
-                                flags_bits,
-                                event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE),
-                                text,
-                                actual_len,
-                            )
-                        };
-                        let _ = tx.send(HotkeyEvent {
-                            etype,
-                            flags,
-                            keycode,
-                            text,
-                            text_len,
-                        });
-                        None
-                    }
-                },
-            );
-            match result {
-                Ok(t) => break t,
-                Err(()) => {
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if attempt % 10 == 0 {
-                        log::error!(
-                            "CGEventTap not created — grant Verenu Accessibility permission (System Settings → Privacy & Security → Accessibility). Retrying…"
-                        );
-                        if HOTKEY_DEBUG {
-                            log::debug!("[hotkey] CGEventTap::new failed (attempt {attempt}) — Accessibility not granted yet");
-                        }
-                    }
-                    attempt += 1;
-                    std::thread::sleep(std::time::Duration::from_secs(2));
-                }
-            }
-        };
-
-        let loop_source = match tap.mach_port.create_runloop_source(0) {
-            Ok(s) => s,
-            Err(()) => {
-                log::error!("failed to create run-loop source for event tap");
-                return;
-            }
-        };
-        let current = CFRunLoop::get_current();
-        unsafe {
-            current.add_source(&loop_source, kCFRunLoopCommonModes);
+        let rx = GlobalHotKeyEvent::receiver();
+        while let Ok(ev) = rx.recv() {
+            handle_hotkey_event(ev);
         }
-        EVENT_TAP_PORT.store(
-            tap.mach_port.as_concrete_TypeRef() as *mut c_void,
-            Ordering::SeqCst,
-        );
-        tap.enable();
-        TAP_ACTIVE.store(true, Ordering::SeqCst);
-        log::info!("macOS hotkey event tap installed");
-        if HOTKEY_DEBUG {
-            log::debug!("[hotkey] event tap installed — listening for Fn+Control");
-        }
-        CFRunLoop::run_current();
     });
+    log::info!("macOS global hotkey installed (RegisterEventHotKey)");
 
     Ok(handle)
-}
-
-// --- event handling --------------------------------------------------------
-
-fn keycode_is_navigation_or_reset(keycode: i64) -> bool {
-    matches!(
-        keycode,
-        KEY_TAB
-            | KEY_FORWARD_DELETE
-            | KEY_ESCAPE
-            | KEY_HOME
-            | KEY_END
-            | KEY_PAGE_UP
-            | KEY_PAGE_DOWN
-            | KEY_LEFT
-            | KEY_RIGHT
-            | KEY_DOWN
-            | KEY_UP
-    )
-}
-
-fn shortcut_modifier_held(flags: u64) -> bool {
-    flags & (FLAG_CONTROL | FLAG_ALTERNATE | FLAG_COMMAND) != 0
-}
-
-fn event_text(event: &HotkeyEvent) -> String {
-    String::from_utf16_lossy(&event.text[..event.text_len as usize])
-}
-
-fn update_injection_history_for_event(event: &HotkeyEvent, now: u64) {
-    if !matches!(event.etype, CGEventType::KeyDown) || synthetic_paste_suppressed(now) {
-        return;
-    }
-
-    let keycode = event.keycode;
-    let flags = event.flags;
-
-    if keycode == KEY_BACKSPACE {
-        if shortcut_modifier_held(flags) {
-            crate::core::injection::reset_injection_history();
-        } else {
-            let hwnd = crate::core::window_context::get_foreground_hwnd();
-            crate::core::injection::backspace_injection_history(hwnd);
-        }
-        return;
-    }
-
-    if keycode == KEY_RETURN {
-        if flags & FLAG_SHIFT != 0 {
-            let hwnd = crate::core::window_context::get_foreground_hwnd();
-            if hwnd != 0 {
-                crate::core::injection::append_or_reset_injection_history(hwnd, '\n');
-            }
-        } else {
-            crate::core::injection::reset_injection_history();
-        }
-        return;
-    }
-
-    if keycode_is_navigation_or_reset(keycode) || shortcut_modifier_held(flags) {
-        crate::core::injection::reset_injection_history();
-        return;
-    }
-
-    let text = event_text(event);
-    let mut appended = false;
-    let hwnd = crate::core::window_context::get_foreground_hwnd();
-    if hwnd == 0 {
-        crate::core::injection::reset_injection_history();
-        return;
-    }
-    for ch in text
-        .chars()
-        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\r')
-    {
-        crate::core::injection::append_or_reset_injection_history(hwnd, ch);
-        appended = true;
-    }
-
-    if !appended && !text.is_empty() {
-        crate::core::injection::reset_injection_history();
-    }
-}
-
-fn handle_event(event: HotkeyEvent) {
-    let etype = event.etype;
-    // The system can disable a tap during lag or timeout; re-enable so the
-    // global hotkey does not stop permanently.
-    if matches!(
-        etype,
-        CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
-    ) {
-        log::warn!("macOS event tap disabled by system ({etype:?})");
-        reenable_event_tap();
-        return;
-    }
-
-    let k1 = KEY1.load(Ordering::Relaxed);
-    let k2 = KEY2.load(Ordering::Relaxed);
-    let flags = event.flags;
-    let keycode = event.keycode;
-    let is_down = matches!(etype, CGEventType::KeyDown);
-    let is_up = matches!(etype, CGEventType::KeyUp);
-
-    // Track down-state for regular (non-modifier) configured keys.
-    if k1 >= REGULAR_BASE {
-        let kc = (k1 - REGULAR_BASE) as i64;
-        if is_down && keycode == kc {
-            K1_REGULAR_DOWN.store(true, Ordering::SeqCst);
-        } else if is_up && keycode == kc {
-            K1_REGULAR_DOWN.store(false, Ordering::SeqCst);
-        }
-    }
-    if k2 >= REGULAR_BASE {
-        let kc = (k2 - REGULAR_BASE) as i64;
-        if is_down && keycode == kc {
-            K2_REGULAR_DOWN.store(true, Ordering::SeqCst);
-        } else if is_up && keycode == kc {
-            K2_REGULAR_DOWN.store(false, Ordering::SeqCst);
-        }
-    }
-
-    let held = |id: u32, regular_down: &AtomicBool| -> bool {
-        if is_modifier(id) {
-            flags & modifier_mask(id) != 0
-        } else {
-            regular_down.load(Ordering::SeqCst)
-        }
-    };
-    let held1 = held(k1, &K1_REGULAR_DOWN);
-    let held2 = held(k2, &K2_REGULAR_DOWN);
-    let both = held1 && held2;
-
-    if HOTKEY_DEBUG
-        && matches!(
-            etype,
-            CGEventType::FlagsChanged | CGEventType::KeyDown | CGEventType::KeyUp
-        )
-    {
-        log::debug!(
-            "[hotkey] {:?} flags={flags:#010x} keycode={keycode} k1={k1} k2={k2} held1={held1} held2={held2} both={both}",
-            etype
-        );
-    }
-
-    // Escape cancels an in-flight recording / handsfree session.
-    if is_down
-        && keycode == KEY_ESCAPE
-        && (CHORD_ACTIVE.load(Ordering::SeqCst) || HANDLESS_ACTIVE.load(Ordering::SeqCst))
-    {
-        if CHORD_ACTIVE.load(Ordering::SeqCst) {
-            ESCAPE_CANCELLED.store(true, Ordering::SeqCst);
-        }
-        if let Some(cb) = ESCAPE_CB.get() {
-            cb();
-        }
-        return;
-    }
-
-    let active = CHORD_ACTIVE.load(Ordering::SeqCst);
-    let now = now_ms();
-
-    if matches!(etype, CGEventType::KeyDown) {
-        update_injection_history_for_event(&event, now);
-    }
-
-    if both && !active {
-        // Double-tap of the chord within the window toggles handsfree mode.
-        if HANDLESS_PENDING.swap(false, Ordering::SeqCst)
-            && now.saturating_sub(HANDLESS_PENDING_MS.load(Ordering::SeqCst)) <= 350
-        {
-            if let Some(cb) = HANDLESS_CB.get() {
-                cb();
-            }
-            return;
-        }
-        CHORD_ACTIVE.store(true, Ordering::SeqCst);
-        CHORD_DOWN_MS.store(now, Ordering::SeqCst);
-        ESCAPE_CANCELLED.store(false, Ordering::SeqCst);
-        // If the chord fired while another app was frontmost, the tap is seeing
-        // global events — mark Input Monitoring as effectively granted.
-        if !GLOBAL_INPUT_SEEN.load(Ordering::SeqCst) {
-            let our_pid = std::process::id() as i32;
-            if crate::system::mac_app::frontmost_pid().is_some_and(|p| p != our_pid) {
-                GLOBAL_INPUT_SEEN.store(true, Ordering::SeqCst);
-            }
-        }
-        if HOTKEY_DEBUG {
-            log::debug!("[hotkey] PRESS (chord engaged) → start recording");
-        }
-        if let Some(cb) = PRESS_CB.get() {
-            cb();
-        }
-    } else if active && !both {
-        if HOTKEY_DEBUG {
-            log::debug!("[hotkey] RELEASE (chord released)");
-        }
-        CHORD_ACTIVE.store(false, Ordering::SeqCst);
-        let held_ms = now.saturating_sub(CHORD_DOWN_MS.load(Ordering::SeqCst));
-        if ESCAPE_CANCELLED.swap(false, Ordering::SeqCst) {
-            // Escape already cancelled this session — emit nothing further.
-        } else if held_ms < 250 {
-            // Quick tap → cancel and arm the double-tap (handsfree) window.
-            HANDLESS_PENDING.store(true, Ordering::SeqCst);
-            HANDLESS_PENDING_MS.store(now, Ordering::SeqCst);
-            if let Some(cb) = CANCEL_CB.get() {
-                cb();
-            }
-        } else if let Some(cb) = RELEASE_CB.get() {
-            cb();
-        }
-    }
 }

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -1074,7 +1074,7 @@ pub async fn inject_text(
         if !crate::commands::check_accessibility_permission(false) {
             log::error!(
                 "inject_text: Cmd+V injection attempted but Accessibility is not granted — \
-                 grant Open Flow Accessibility permission in System Settings → Privacy & Security → Accessibility"
+                 grant Verenu Accessibility permission in System Settings → Privacy & Security → Accessibility"
             );
         }
 
@@ -1128,11 +1128,10 @@ pub async fn inject_text(
         .flatten();
 
         log::info!(
-            "inject_text(macos): target_pid={} text_len={} posted={} tap_active={}",
+            "inject_text(macos): target_pid={} text_len={} posted={}",
             (target_hwnd & 0xFFFFFFFF) as i32,
             adjusted.len(),
             posted.is_some(),
-            crate::core::hotkey::is_tap_active()
         );
 
         tokio::time::sleep(Duration::from_millis(120)).await;

--- a/src-tauri/src/core/injection.rs
+++ b/src-tauri/src/core/injection.rs
@@ -1071,7 +1071,9 @@ pub async fn inject_text(
         crate::system::mac_app::pasteboard_set_string(&adjusted);
         tokio::time::sleep(Duration::from_millis(20)).await;
 
-        if !crate::commands::check_accessibility_permission(false) {
+        if !crate::system::mac_app::is_accessibility_verified()
+            && !crate::commands::check_accessibility_permission(false)
+        {
             log::error!(
                 "inject_text: Cmd+V injection attempted but Accessibility is not granted — \
                  grant Verenu Accessibility permission in System Settings → Privacy & Security → Accessibility"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,6 +159,16 @@ fn main() {
                     if let Some(arr) = val.as_array() {
                         if arr.len() == 2 {
                             if let (Some(k1), Some(k2)) = (arr[0].as_str(), arr[1].as_str()) {
+                                // On macOS the hotkey is now a modifier+key combo
+                                // (RegisterEventHotKey, no Input Monitoring). A stored
+                                // modifier-only chord from an earlier build (e.g. Fn+Control)
+                                // is not registrable — migrate it to the ⌥+Space default so
+                                // the backend and the settings label stay in sync.
+                                #[cfg(target_os = "macos")]
+                                if !crate::core::hotkey::is_hotkey_available(k1, k2) {
+                                    store.set("hotkey", serde_json::json!(["AltLeft", "Space"]));
+                                    let _ = store.save();
+                                }
                                 let vk1 = crate::core::hotkey::map_code_to_vk(k1);
                                 let vk2 = crate::core::hotkey::map_code_to_vk(k2);
                                 crate::core::hotkey::update_keys(vk1, vk2);
@@ -270,16 +280,11 @@ fn main() {
             commands::request_accessibility_permission,
             commands::open_accessibility_settings,
             commands::get_accessibility_permission_status,
-            commands::is_hotkey_tap_active,
             commands::get_microphone_permission_status,
             commands::request_microphone_permission,
             commands::request_microphone_permission_snapshot,
             commands::open_microphone_settings,
             commands::restart_app,
-            commands::get_input_monitoring_permission_status,
-            commands::request_input_monitoring_permission,
-            commands::request_input_monitoring_permission_snapshot,
-            commands::open_input_monitoring_settings,
             commands::open_privacy_security_settings,
             commands::reset_macos_core_permissions,
             commands::check_keychain_access,
@@ -338,7 +343,7 @@ fn main() {
 }
 
 fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
-    let open_i = MenuItem::with_id(app, "open", "Open Open Flow", true, None::<&str>)?;
+    let open_i = MenuItem::with_id(app, "open", "Open Verenu", true, None::<&str>)?;
     let permissions_i =
         MenuItem::with_id(app, "permissions", "Permissions...", true, None::<&str>)?;
     let settings_i = MenuItem::with_id(app, "settings", "Settings...", true, None::<&str>)?;
@@ -365,7 +370,7 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
         .icon_as_template(cfg!(target_os = "macos"))
         .menu(&menu)
         .show_menu_on_left_click(true)
-        .tooltip("Open Flow")
+        .tooltip("Verenu")
         .on_menu_event(|app, ev| match ev.id.as_ref() {
             "open" => {
                 show_main_window(app);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,16 +159,25 @@ fn main() {
                     if let Some(arr) = val.as_array() {
                         if arr.len() == 2 {
                             if let (Some(k1), Some(k2)) = (arr[0].as_str(), arr[1].as_str()) {
+                                let (k1, k2) = (k1, k2);
                                 // On macOS the hotkey is now a modifier+key combo
                                 // (RegisterEventHotKey, no Input Monitoring). A stored
                                 // modifier-only chord from an earlier build (e.g. Fn+Control)
                                 // is not registrable — migrate it to the ⌥+Space default so
                                 // the backend and the settings label stay in sync.
                                 #[cfg(target_os = "macos")]
-                                if !crate::core::hotkey::is_hotkey_available(k1, k2) {
+                                let (k1, k2) = if !crate::core::hotkey::is_hotkey_available(k1, k2)
+                                {
                                     store.set("hotkey", serde_json::json!(["AltLeft", "Space"]));
-                                    let _ = store.save();
-                                }
+                                    if let Err(e) = store.save() {
+                                        log::warn!(
+                                            "Failed to save migrated hotkey to settings.json: {e:?}"
+                                        );
+                                    }
+                                    ("AltLeft", "Space")
+                                } else {
+                                    (k1, k2)
+                                };
                                 let vk1 = crate::core::hotkey::map_code_to_vk(k1);
                                 let vk2 = crate::core::hotkey::map_code_to_vk(k2);
                                 crate::core::hotkey::update_keys(vk1, vk2);

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -329,7 +329,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
         pill.show().ok();
 
         // macOS: `show()` (orderFront:) is ignored for a background app, so the
-        // pill only appeared when Open Flow was frontmost. Force it above the
+        // pill only appeared when Verenu was frontmost. Force it above the
         // active app's windows without stealing focus. AppKit window calls must
         // run on the main thread — show_pill is invoked from pipeline worker
         // threads, so dispatch there (a raw msg_send off-thread raises an ObjC
@@ -420,12 +420,10 @@ pub fn start_recording_session_ex(
 
     #[cfg(target_os = "macos")]
     {
-        // `AXIsProcessTrustedWithOptions` can return a stale cached `false` for the
-        // Check Accessibility strictly rather than using is_tap_active() as a proxy.
-        // The CGEventTap can be active on Input Monitoring alone — so a running tap
-        // does NOT prove Accessibility is granted. Without Accessibility, synthetic
-        // Cmd+V (posting events to the HID tap) silently fails. Using the real TCC
-        // check ensures we surface the error instead of recording and never pasting.
+        // The global hotkey needs no permission, but synthetic Cmd+V injection
+        // requires Accessibility — without it, posting the paste keystroke silently
+        // fails. Check the real TCC status up front so we surface the error instead
+        // of recording and never pasting.
         if !crate::commands::check_accessibility_permission(false) {
             return Err(
                 "Accessibility permission is required for Verenu on macOS. Open System Settings > Privacy & Security > Accessibility and enable Verenu."

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -424,7 +424,9 @@ pub fn start_recording_session_ex(
         // requires Accessibility — without it, posting the paste keystroke silently
         // fails. Check the real TCC status up front so we surface the error instead
         // of recording and never pasting.
-        if !crate::commands::check_accessibility_permission(false) {
+        if !crate::system::mac_app::is_accessibility_verified()
+            && !crate::commands::check_accessibility_permission(false)
+        {
             return Err(
                 "Accessibility permission is required for Verenu on macOS. Open System Settings > Privacy & Security > Accessibility and enable Verenu."
                     .to_string(),

--- a/src-tauri/src/system/mac_app.rs
+++ b/src-tauri/src/system/mac_app.rs
@@ -19,40 +19,10 @@ use tauri::AppHandle;
 #[link(name = "AVFoundation", kind = "framework")]
 extern "C" {}
 
-// Input Monitoring (HID listen) permission. A keyboard `CGEventTap` only receives
-// events from *other* applications when the app is granted Input Monitoring —
-// without it the tap only sees keystrokes while the app is frontmost. This is
-// distinct from Accessibility (which authorizes posting events / Cmd+V).
-#[link(name = "IOKit", kind = "framework")]
-extern "C" {
-    fn IOHIDCheckAccess(request_type: u32) -> u32;
-    fn IOHIDRequestAccess(request_type: u32) -> u8;
-}
-
-// IOHIDRequestType: kIOHIDRequestTypeListenEvent is the first variant (= 0).
-const IOHID_REQUEST_TYPE_LISTEN_EVENT: u32 = 0;
-// IOHIDAccessType return values from IOHIDCheckAccess.
-const IOHID_ACCESS_TYPE_GRANTED: u32 = 0;
-const IOHID_ACCESS_TYPE_DENIED: u32 = 1;
-
-/// Current Input Monitoring (HID listen) permission for the app.
-///
-/// Returns `authorized`, `denied`, or `not_determined`.
-pub fn input_monitoring_status() -> &'static str {
-    match unsafe { IOHIDCheckAccess(IOHID_REQUEST_TYPE_LISTEN_EVENT) } {
-        IOHID_ACCESS_TYPE_GRANTED => "authorized",
-        IOHID_ACCESS_TYPE_DENIED => "denied",
-        _ => "not_determined",
-    }
-}
-
-/// Request Input Monitoring access. If undetermined, macOS shows the consent
-/// prompt and adds the app to System Settings → Privacy & Security → Input
-/// Monitoring. Returns `true` if already granted. Changes generally require an
-/// app relaunch before an existing event tap sees global events.
-pub fn request_input_monitoring() -> bool {
-    unsafe { IOHIDRequestAccess(IOHID_REQUEST_TYPE_LISTEN_EVENT) != 0 }
-}
+// The global hotkey now uses Carbon `RegisterEventHotKey` (see
+// `core::hotkey::mac`), which needs no Input Monitoring permission, so the old
+// IOKit HID-listen probing has been removed. The only remaining macOS
+// permissions are Accessibility (Cmd+V injection / AX reads) and Microphone.
 
 const APP_ICON_ICNS: &[u8] = include_bytes!("../../icons/icon.icns");
 
@@ -188,7 +158,7 @@ pub fn set_regular_activation_policy_on_main_thread(app: &AppHandle) {
 /// Float the pill window above other apps' windows *without* activating Open
 /// Flow. Tauri's `show()` maps to `-[NSWindow orderFront:]`, which AppKit
 /// suppresses for a background (non-active) app — so the pill only appeared
-/// while Open Flow was frontmost. We instead:
+/// while Verenu was frontmost. We instead:
 ///   1. raise the window level above normal windows (NSStatusWindowLevel = 25),
 ///   2. let it appear on every Space and over full-screen apps,
 ///   3. order it front with `orderFrontRegardless`, which ignores active state.
@@ -209,7 +179,7 @@ pub fn float_pill_window(ns_window: *mut std::ffi::c_void) {
         // active Space and over full-screen apps without switching Spaces.
         let behavior: usize = (1 << 0) | (1 << 8);
         let _: () = msg_send![win, setCollectionBehavior: behavior];
-        // Order front even though Open Flow is not the active application.
+        // Order front even though Verenu is not the active application.
         let _: () = msg_send![win, orderFrontRegardless];
     })
 }

--- a/src/lib/components/MacPermissions.svelte
+++ b/src/lib/components/MacPermissions.svelte
@@ -17,15 +17,11 @@
   type KeychainStatus = 'authorized' | 'not_configured' | 'denied' | 'unknown';
   type MacPermissionSnapshot = {
     accessibility: MacPermissionStatus;
-    inputMonitoring: MacPermissionStatus;
     microphone: MacPermissionStatus;
     keychain: KeychainStatus;
     allCoreGranted: boolean;
-    needsRelaunch: boolean;
     lastCheckedAt: string;
     sourceHints: {
-      hotkeyTapActive: boolean;
-      globalInputSeen: boolean;
       microphoneVerified: boolean;
       accessibilityVerified: boolean;
     };
@@ -35,7 +31,6 @@
       executablePath: string | null;
       processId: number;
       accessibilityTrusted: boolean;
-      inputMonitoringRaw: MacPermissionStatus;
     };
   };
   type TccResetResult = {
@@ -44,7 +39,7 @@
   };
 
   type Props = {
-    /** True once Accessibility + Input Monitoring + Microphone are all granted. */
+    /** True once Accessibility + Microphone are both granted. */
     allGranted?: boolean;
     /** 'setup' shows a success banner once all granted; 'settings' is steady-state. */
     variant?: 'setup' | 'settings';
@@ -56,15 +51,11 @@
 
   let snapshot = $state<MacPermissionSnapshot>({
     accessibility: isMac ? 'unknown' : 'authorized',
-    inputMonitoring: isMac ? 'unknown' : 'authorized',
     microphone: isMac ? 'unknown' : 'authorized',
     keychain: 'unknown',
     allCoreGranted: !isMac,
-    needsRelaunch: false,
     lastCheckedAt: '',
     sourceHints: {
-      hotkeyTapActive: !isMac,
-      globalInputSeen: !isMac,
       microphoneVerified: !isMac,
       accessibilityVerified: !isMac,
     },
@@ -74,21 +65,18 @@
       executablePath: null,
       processId: 0,
       accessibilityTrusted: !isMac,
-      inputMonitoringRaw: !isMac ? 'authorized' : 'unknown',
     },
   });
   let keychainProvider = $state<ProviderId | null>(null);
   let permissionsLoading = $state(false);
   let permissionsError = $state('');
   let accessibilityPrompting = $state(false);
-  let inputMonitoringRequesting = $state(false);
   let microphoneRequesting = $state(false);
   let keychainLoading = $state(false);
   let repairing = $state(false);
   let restarting = $state(false);
 
   let accessibilityActionTaken = $state(false);
-  let inputMonitoringActionTaken = $state(false);
   let watchInterval: ReturnType<typeof setInterval> | null = null;
   let watchTicksLeft = 0;
   let restartTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -96,7 +84,6 @@
   let active = true;
 
   const accessibilityPermission = $derived(snapshot.accessibility);
-  const inputMonitoringPermission = $derived(snapshot.inputMonitoring);
   const microphonePermission = $derived(snapshot.microphone);
   const keychainStatus = $derived(snapshot.keychain);
   const showKeychainRow = $derived(!!keychainProvider && keychainStatus !== 'not_configured');
@@ -109,16 +96,9 @@
     if (status === 'unknown') return 'checking';
     return 'attention';
   }
-  const showRestartHint = $derived(
-    snapshot.needsRelaunch &&
-    (accessibilityActionTaken || inputMonitoringActionTaken) &&
-    (accessibilityPermission === 'authorized' || inputMonitoringPermission === 'authorized')
-  );
-  const showRepairHint = $derived(
-    accessibilityPermission !== 'authorized' || inputMonitoringPermission !== 'authorized'
-  );
+  const showRepairHint = $derived(accessibilityPermission !== 'authorized');
 
-  // Keep the bindable flag in sync with the three core OS permissions.
+  // Keep the bindable flag in sync with the core OS permissions.
   $effect(() => {
     allGranted = snapshot.allCoreGranted;
   });
@@ -161,7 +141,6 @@
     snapshot = {
       ...next,
       accessibility: next.accessibility || 'unknown',
-      inputMonitoring: next.inputMonitoring || 'unknown',
       microphone: next.microphone || 'unknown',
       keychain: providerOverride
         ? next.keychain || 'unknown'
@@ -225,7 +204,7 @@
       if (permissionsLoading) return;
       await refreshMacPermissions(true);
       watchTicksLeft -= 1;
-      if ((snapshot.allCoreGranted && !snapshot.needsRelaunch) || watchTicksLeft <= 0) {
+      if (snapshot.allCoreGranted || watchTicksLeft <= 0) {
         stopWatch();
       }
     }, WATCH_INTERVAL_MS);
@@ -244,7 +223,6 @@
     return (
       m.includes('permission') ||
       m.includes('accessibility') ||
-      m.includes('input monitoring') ||
       m.includes('microphone') ||
       m.includes('system settings')
     );
@@ -262,21 +240,6 @@
       permissionsError = 'Could not request Accessibility permission.';
     }
     accessibilityPrompting = false;
-    startWatch();
-  }
-
-  async function requestInputMonitoringPrompt() {
-    if (!isMac) return;
-    inputMonitoringRequesting = true;
-    inputMonitoringActionTaken = true;
-    permissionsError = '';
-    try {
-      const next = await invoke<MacPermissionSnapshot>('request_input_monitoring_permission_snapshot', { provider: null });
-      applySnapshot(next, null);
-    } catch {
-      permissionsError = 'Could not request Input Monitoring permission.';
-    }
-    inputMonitoringRequesting = false;
     startWatch();
   }
 
@@ -299,7 +262,7 @@
     permissionsError = '';
     restartTimeout = setTimeout(() => {
       restarting = false;
-      permissionsError = 'Could not relaunch automatically — please quit and reopen Open Flow.';
+      permissionsError = 'Could not relaunch automatically — please quit and reopen Verenu.';
     }, 5000);
     void invoke('restart_app').catch(() => {
       // Ignore immediate IPC disconnection errors during restart.
@@ -316,7 +279,7 @@
       if (failed.length > 0) {
         permissionsError = `Could not reset ${failed.map((step) => step.service).join(', ')}.`;
       } else {
-        permissionsError = 'Old macOS grants were reset. Add Open Flow again in Accessibility and Input Monitoring, then relaunch.';
+        permissionsError = 'Old macOS grant was reset. Add Verenu again under Accessibility, then relaunch.';
       }
       await invoke('open_accessibility_settings');
       startWatch();
@@ -328,14 +291,11 @@
     }
   }
 
-  async function openPermissionSettings(kind: 'accessibility' | 'microphone' | 'input_monitoring') {
+  async function openPermissionSettings(kind: 'accessibility' | 'microphone') {
     try {
-      if (kind === 'input_monitoring') inputMonitoringActionTaken = true;
       if (kind === 'accessibility') accessibilityActionTaken = true;
       const cmd =
-        kind === 'accessibility' ? 'open_accessibility_settings'
-        : kind === 'input_monitoring' ? 'open_input_monitoring_settings'
-        : 'open_microphone_settings';
+        kind === 'accessibility' ? 'open_accessibility_settings' : 'open_microphone_settings';
       await invoke(cmd);
       startWatch();
     } catch {
@@ -405,7 +365,7 @@
     <div class="perm-row">
       <div class="perm-row-main">
         <div class="perm-row-title">Accessibility</div>
-        <div class="perm-row-desc">Lets Open Flow listen for the global hotkey and inject text into any app.</div>
+        <div class="perm-row-desc">Lets Verenu type your dictation into other apps. The global hotkey (default <strong>⌥ Space</strong>) needs no extra permission.</div>
       </div>
       <div class="perm-row-side">
         {@render statusIndicator(accessibilityPermission, permissionLabel(accessibilityPermission))}
@@ -418,27 +378,6 @@
             </button>
           {/if}
           <button class="perm-action" onclick={() => openPermissionSettings('accessibility')}>Open Settings</button>
-        {/if}
-      </div>
-    </div>
-
-    <!-- Input Monitoring -->
-    <div class="perm-row">
-      <div class="perm-row-main">
-        <div class="perm-row-title">Input Monitoring</div>
-        <div class="perm-row-desc">Keeps the hotkey working while other apps are focused — without it, it only fires when Open Flow is frontmost.</div>
-      </div>
-      <div class="perm-row-side">
-        {@render statusIndicator(inputMonitoringPermission, permissionLabel(inputMonitoringPermission))}
-        {#if inputMonitoringPermission === 'restricted'}
-          <span class="perm-restricted">Managed by org</span>
-        {:else if inputMonitoringPermission !== 'authorized'}
-          {#if inputMonitoringPermission === 'not_determined' || inputMonitoringPermission === 'unknown'}
-            <button class="perm-action" onclick={requestInputMonitoringPrompt} disabled={inputMonitoringRequesting}>
-              {inputMonitoringRequesting ? 'Prompting…' : 'Request'}
-            </button>
-          {/if}
-          <button class="perm-action" onclick={() => openPermissionSettings('input_monitoring')}>Open Settings</button>
         {/if}
       </div>
     </div>
@@ -471,11 +410,11 @@
           <div class="perm-row-title">Keychain Access</div>
           <div class="perm-row-desc">
             {#if keychainStatus === 'denied'}
-              Access denied. Click <strong>Unlock access</strong> or allow Open Flow in Keychain Access.app.
+              Access denied. Click <strong>Unlock access</strong> or allow Verenu in Keychain Access.app.
             {:else if keychainStatus === 'authorized'}
               Secures your API key and keeps it in your Keychain.
             {:else}
-              Secures your API key. Open Flow prompts for access when it needs it.
+              Secures your API key. Verenu prompts for access when it needs it.
             {/if}
           </div>
         </div>
@@ -495,18 +434,6 @@
     <p class="permission-error">{permissionsError}</p>
   {/if}
 
-  {#if showRestartHint}
-    <div class="permission-restart-hint" transition:slide={{ duration: motionMs(200) }}>
-      <span class="restart-hint-text">
-        Just changed a permission in System Settings? Relaunch Open Flow so macOS
-        re-reads the latest Accessibility and Input Monitoring grants.
-      </span>
-      <button class="btn-relaunch" onclick={relaunchApp} disabled={restarting}>
-        {restarting ? 'Relaunching…' : 'Relaunch now'}
-      </button>
-    </div>
-  {/if}
-
   <div class="permission-foot">
     <button
       class="permission-details-toggle"
@@ -522,7 +449,7 @@
         class="permission-refresh-btn"
         onclick={relaunchApp}
         disabled={restarting}
-        title="Relaunch Open Flow to apply permission changes"
+        title="Relaunch Verenu to apply permission changes"
       >
         <span aria-hidden="true">⏻</span>
         {restarting ? 'Relaunching…' : 'Relaunch'}
@@ -544,26 +471,18 @@
       {#if showRepairHint}
         <div class="permission-repair">
           <p class="repair-copy">
-            <strong>Permission shows as enabled in System Settings but still isn't working?</strong>
-            macOS can hold a stale grant tied to an older build of Open Flow. Clear the
-            old grants so you can re-add this version fresh.
+            <strong>Accessibility shows as enabled but typing still doesn't work?</strong>
+            macOS can hold a stale grant from an older build. Reset it so you can re-add
+            this version fresh.
           </p>
           <button class="btn-repair" onclick={repairStaleGrants} disabled={repairing}>
-            {repairing ? 'Clearing…' : 'Clear old grants & re-request'}
+            {repairing ? 'Resetting…' : 'Reset stale grants'}
           </button>
         </div>
       {/if}
-      <p class="permission-note">
-        <strong>Bundle checked:</strong>
-        {snapshot.diagnostics.bundleIdentifier ?? 'Unknown bundle'}
-        {#if snapshot.diagnostics.bundlePath}
-          <br />{snapshot.diagnostics.bundlePath}
-        {/if}
-      </p>
       <p class="diag-line">
-        Raw OS state — Accessibility: <strong>{snapshot.diagnostics.accessibilityTrusted ? 'trusted' : 'not trusted'}</strong>,
-        Input Monitoring: <strong>{snapshot.diagnostics.inputMonitoringRaw}</strong>.
-        If these disagree with the status above, macOS is likely holding a stale grant from a previous build.
+        {snapshot.diagnostics.bundleIdentifier ?? 'Unknown bundle'} ·
+        Accessibility raw status: <strong>{snapshot.diagnostics.accessibilityTrusted ? 'trusted' : 'not trusted'}</strong>
       </p>
     </div>
   {/if}
@@ -681,27 +600,8 @@
 
   .permission-error { margin: 12px 0 0; color: var(--danger); font-size: 12px; }
 
-  /* Auxiliary hint — relaunch banner. */
-  .permission-restart-hint {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    border-radius: var(--r-sm);
-    padding: 10px 12px;
-    margin-top: 12px;
-    font-size: 12px;
-    color: var(--ink-soft);
-    line-height: 1.45;
-    background: var(--paper, #fafafa);
-    background: color-mix(in srgb, oklch(75% 0.12 60) 12%, var(--paper));
-    border: 1px solid var(--line, #d0d0d0);
-    border: 1px solid color-mix(in srgb, oklch(75% 0.12 60) 30%, var(--line));
-  }
-
-  .restart-hint-text { flex: 1; }
-
-  /* Repair action, shown inside the expanded Details section when a core
-     permission isn't granted — clears stale TCC grants and re-requests. */
+  /* Repair action, shown inside the expanded Details section when Accessibility
+     isn't granted — resets a stale TCC grant and re-requests. */
   .permission-repair {
     display: flex;
     align-items: center;
@@ -726,7 +626,6 @@
 
   .repair-copy strong { color: var(--ink-strong); display: block; margin-bottom: 2px; }
 
-  .btn-relaunch,
   .btn-repair {
     flex-shrink: 0;
     border: 0;
@@ -741,9 +640,7 @@
     white-space: nowrap;
     transition: filter 0.15s;
   }
-  .btn-relaunch:hover,
   .btn-repair:hover { filter: brightness(1.06); }
-  .btn-relaunch:disabled,
   .btn-repair:disabled { opacity: 0.6; cursor: default; }
 
   .permission-foot {
@@ -776,21 +673,7 @@
 
   .permission-diagnostics { margin-top: 10px; display: flex; flex-direction: column; gap: 8px; }
 
-  .permission-note {
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    padding: 9px 12px;
-    margin: 0;
-    font-size: 11.5px;
-    color: var(--ink-soft);
-    line-height: 1.5;
-    word-break: break-word;
-  }
-
-  .permission-note strong { color: var(--ink-strong); }
-
-  .diag-line { margin: 0; font-size: 11.5px; color: var(--ink-mute); line-height: 1.5; }
+  .diag-line { margin: 0; font-size: 11.5px; color: var(--ink-mute); line-height: 1.5; word-break: break-word; }
   .diag-line strong { color: var(--ink-soft); font-weight: 600; }
 
   .permission-refresh-btn {

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -70,14 +70,20 @@
     return formatKeyLabel(code);
   }
 
+  // A macOS hotkey can be a single key (e.g. F5) — its second slot is empty.
+  function formatHotkeyDisplay(hk: string[]): string {
+    const first = formatHotkeyBadgeLabel(hk[0] ?? '');
+    return hk[1] ? `${first} + ${formatHotkeyBadgeLabel(hk[1])}` : first;
+  }
+
   let buttonText = $derived(
     recordingHotkey
       ? capturedKeys[0] === '__bad__'
-        ? isMac ? 'Must be ⌘/⌃/⌥/⇧' : 'Must be Alt/Ctrl/Shift/Win'
+        ? isMac ? 'Pick a key like F5' : 'Must be Alt/Ctrl/Shift/Win'
         : capturedKeys.length === 0
-          ? isMac ? 'Press modifier key...' : 'Press Alt/Ctrl/Shift/Win...'
+          ? isMac ? 'Press a key (e.g. F5)…' : 'Press Alt/Ctrl/Shift/Win...'
           : 'Press 2nd key...'
-      : `${formatHotkeyBadgeLabel(hotkey[0])} + ${formatHotkeyBadgeLabel(hotkey[1])}`
+      : formatHotkeyDisplay(hotkey)
   );
 
   $effect.pre(() => {
@@ -271,13 +277,19 @@
     if (e.repeat) return;
     if (capturedKeys.length === 0) {
       if (e.code === 'Escape') { cancelRecordingHotkey(); return; }
-      if (!MODIFIER_CODES.has(e.code)) {
+      if (MODIFIER_CODES.has(e.code)) {
+        // A modifier first — wait for the key it pairs with (modifier+key chord).
+        capturedKeys = [e.code];
+        hotkeyState = 'first';
+      } else if (isMac) {
+        // macOS allows a single-key hotkey (e.g. F5) — accept it immediately.
+        capturedKeys = [e.code, ''];
+        hotkeyState = 'saving';
+        finishRecordingHotkey();
+      } else {
         capturedKeys = ['__bad__'];
         setTimeout(() => { capturedKeys = []; }, 800);
-        return;
       }
-      capturedKeys = [e.code];
-      hotkeyState = 'first';
     } else if (capturedKeys.length === 1 && e.code !== capturedKeys[0]) {
       capturedKeys = [...capturedKeys, e.code];
       hotkeyState = 'saving';
@@ -346,6 +358,13 @@
     {/key}
   </button>
 </div>
+{#if isMac && hotkey[0] === 'F5'}
+  <p class="hotkey-tip">
+    F5 is the 🎤 key on Mac keyboards. If pressing it opens macOS Dictation instead of
+    Verenu, turn off Dictation in <strong>System Settings → Keyboard → Dictation</strong>
+    (or hold <strong>Fn</strong> with F5). You can also pick any other key above.
+  </p>
+{/if}
 <div class="setting-row">
   <div><div class="label">Spoken Language</div><div class="desc">Tells transcription what language to expect</div></div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -472,6 +491,15 @@
 </div>
 
 <style>
+  .hotkey-tip {
+    margin: -2px 0 2px;
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--ink-mute);
+    max-width: 52ch;
+  }
+  .hotkey-tip strong { color: var(--ink-soft); font-weight: 600; }
+
   .keybind-btn {
     cursor: pointer;
     border: 1px solid transparent;

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -281,8 +281,9 @@
         // A modifier first — wait for the key it pairs with (modifier+key chord).
         capturedKeys = [e.code];
         hotkeyState = 'first';
-      } else if (isMac) {
-        // macOS allows a single-key hotkey (e.g. F5) — accept it immediately.
+      } else if (isMac && /^F([1-9]|1[0-2])$/.test(e.code)) {
+        // macOS allows a single-key hotkey, but only function keys (F1–F12):
+        // a bare letter/Space would be consumed system-wide and hijack typing.
         capturedKeys = [e.code, ''];
         hotkeyState = 'saving';
         finishRecordingHotkey();

--- a/src/lib/components/settings/PermissionsSection.svelte
+++ b/src/lib/components/settings/PermissionsSection.svelte
@@ -13,7 +13,7 @@
 
 <h2 class="settings-h">Permissions</h2>
 <p class="panel-note">
-  Open Flow needs these macOS permissions to capture your voice and type into other
+  Verenu needs these macOS permissions to capture your voice and type into other
   apps. Anything not granted will stop dictation from working everywhere.
 </p>
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -42,5 +42,11 @@ export function formatKeyLabel(code: string): string {
 	);
 }
 
-/** The default dictation hotkey codes for the current platform. */
-export const defaultHotkey: string[] = isMac ? ['ControlLeft', 'Fn'] : ['ControlLeft', 'MetaLeft'];
+/**
+ * The default dictation hotkey codes for the current platform.
+ *
+ * macOS uses Carbon `RegisterEventHotKey` (no Input Monitoring permission), which
+ * can't bind a modifier-only chord — so the default is ⌥ Option + Space (two
+ * adjacent bottom-row keys, no Fn/Spotlight conflict). Windows keeps its chord.
+ */
+export const defaultHotkey: string[] = isMac ? ['AltLeft', 'Space'] : ['ControlLeft', 'MetaLeft'];

--- a/src/lib/setup/steps/TryItStep.svelte
+++ b/src/lib/setup/steps/TryItStep.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { invoke, listen } from '../../tauri';
-  import { isMac } from '../../platform';
+  import { isMac, formatKeyLabel, defaultHotkey } from '../../platform';
 
-  const hkKey1 = isMac ? 'fn' : 'Ctrl';
-  const hkKey2 = isMac ? 'Control' : 'Windows';
+  let hotkey = $state<string[]>(isMac ? defaultHotkey : ['ControlLeft', 'MetaLeft']);
+  invoke<string[] | null>('get_setting', { key: 'hotkey' })
+    .then((hk) => { if (hk && hk.length === 2) hotkey = hk; })
+    .catch(() => {});
+  const keyLabels = $derived(hotkey.filter(Boolean).map(formatKeyLabel));
   const setupTryHotkeyCodes = new Set(['ControlLeft', 'ControlRight', 'MetaLeft', 'MetaRight']);
 
   let sampleText = $state('');
@@ -137,8 +140,13 @@
 
 <div class="step">
   <div class="tryit-callout">
-    <kbd>{hkKey1}</kbd> <span>+</span> <kbd>{hkKey2}</kbd>
-    <p>Hold the keys, say a sentence, then release.</p>
+    {#each keyLabels as k, i}
+      {#if i > 0}<span>+</span>{/if}<kbd>{k}</kbd>
+    {/each}
+    <p>Hold {keyLabels.length > 1 ? 'the keys' : 'the key'}, say a sentence, then release.</p>
+    {#if isMac && hotkey[0] === 'F5'}
+      <p class="tryit-note">Nothing happening? F5 may be opening macOS Dictation — turn it off in System Settings → Keyboard → Dictation, or hold Fn with F5.</p>
+    {/if}
   </div>
 
   <textarea
@@ -191,6 +199,13 @@
     font-size: 13px;
     color: var(--ink-soft);
     flex-basis: 100%;
+  }
+
+  .tryit-callout .tryit-note {
+    margin-top: 6px;
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--ink-mute);
   }
 
   .tryit-field {

--- a/src/lib/setup/steps/TryItStep.svelte
+++ b/src/lib/setup/steps/TryItStep.svelte
@@ -3,7 +3,7 @@
   import { invoke, listen } from '../../tauri';
   import { isMac, formatKeyLabel, defaultHotkey } from '../../platform';
 
-  let hotkey = $state<string[]>(isMac ? defaultHotkey : ['ControlLeft', 'MetaLeft']);
+  let hotkey = $state<string[]>(defaultHotkey);
   invoke<string[] | null>('get_setting', { key: 'hotkey' })
     .then((hk) => { if (hk && hk.length === 2) hotkey = hk; })
     .catch(() => {});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -149,26 +149,20 @@ function devCreated(id: number): CreatedRecordMeta {
 
 function devPermissionSnapshot(provider?: unknown) {
   const accessibility = String(getDevSetting('accessibility_permission_status') ?? 'authorized') as DevPermissionStatus;
-  const inputMonitoring = String(getDevSetting('input_monitoring_permission_status') ?? 'authorized') as DevPermissionStatus;
   const microphone = String(getDevSetting('microphone_permission_status') ?? 'authorized') as DevPermissionStatus;
   const saved = (getDevSetting('__provider_connected') as Record<string, boolean> | null) ?? {};
   const providerKey = typeof provider === 'string' ? provider : '';
   const keychain = providerKey && saved[providerKey]
     ? String(getDevSetting('keychain_permission_status') ?? 'authorized') as DevKeychainStatus
     : 'not_configured';
-  const globalInputSeen = Boolean(getDevSetting('global_input_seen') ?? true);
 
   return {
     accessibility,
-    inputMonitoring,
     microphone,
     keychain,
-    allCoreGranted: accessibility === 'authorized' && inputMonitoring === 'authorized' && microphone === 'authorized',
-    needsRelaunch: inputMonitoring === 'authorized' && !globalInputSeen,
+    allCoreGranted: accessibility === 'authorized' && microphone === 'authorized',
     lastCheckedAt: new Date().toISOString(),
     sourceHints: {
-      hotkeyTapActive: Boolean(getDevSetting('hotkey_tap_active') ?? true),
-      globalInputSeen,
       microphoneVerified: Boolean(getDevSetting('microphone_verified') ?? microphone === 'authorized'),
       accessibilityVerified: Boolean(getDevSetting('accessibility_verified') ?? accessibility === 'authorized'),
     },
@@ -178,7 +172,6 @@ function devPermissionSnapshot(provider?: unknown) {
       executablePath: String(getDevSetting('executable_path') ?? '/Applications/Verenu.app/Contents/MacOS/Verenu'),
       processId: 12345,
       accessibilityTrusted: accessibility === 'authorized',
-      inputMonitoringRaw: inputMonitoring,
     },
   };
 }
@@ -233,19 +226,10 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return String(getDevSetting('accessibility_permission_status') ?? 'authorized') as T;
     case 'get_microphone_permission_status':
       return String(getDevSetting('microphone_permission_status') ?? 'authorized') as T;
-    case 'get_input_monitoring_permission_status':
-      return String(getDevSetting('input_monitoring_permission_status') ?? 'authorized') as T;
     case 'get_macos_permission_snapshot':
       return devPermissionSnapshot(args?.provider) as T;
     case 'request_accessibility_permission':
       writeDevSetting('accessibility_permission_status', 'authorized');
-      return devPermissionSnapshot(args?.provider) as T;
-    case 'request_input_monitoring_permission':
-      writeDevSetting('input_monitoring_permission_status', 'authorized');
-      return 'authorized' as T;
-    case 'request_input_monitoring_permission_snapshot':
-      writeDevSetting('input_monitoring_permission_status', 'authorized');
-      writeDevSetting('global_input_seen', false);
       return devPermissionSnapshot(args?.provider) as T;
     case 'request_microphone_permission':
       writeDevSetting('microphone_permission_status', 'authorized');
@@ -258,12 +242,10 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return 'authorized' as T;
     case 'reset_macos_core_permissions':
       writeDevSetting('accessibility_permission_status', 'not_determined');
-      writeDevSetting('input_monitoring_permission_status', 'not_determined');
       return {
         bundleIdentifier: 'com.verenu.app',
         steps: [
           { service: 'Accessibility', ok: true, message: 'Reset' },
-          { service: 'ListenEvent', ok: true, message: 'Reset' },
         ],
       } as T;
     case 'check_for_update':
@@ -302,7 +284,6 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'save_hotkey':
     case 'hide_main':
     case 'open_accessibility_settings':
-    case 'open_input_monitoring_settings':
     case 'open_microphone_settings':
     case 'open_privacy_security_settings':
     case 'restart_app':

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -472,7 +472,7 @@
       <div class="hero-photo">
         <div class="hero-photo-content">
           <h2 class="hero-photo-title">
-            Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to dictate
+            Hold <kbd>{hk1}</kbd>{#if hotkey[1]} <kbd>{hk2}</kbd>{/if} to dictate
           </h2>
           <p class="hero-photo-sub">
             Verenu works in any app. Try it in
@@ -522,7 +522,7 @@
 
         {#if recents.length === 0 && !failedEntry}
           <div class="empty-state">
-            No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
+            No dictations yet. Hold <kbd>{hk1}</kbd>{#if hotkey[1]} <kbd>{hk2}</kbd>{/if} to get started.
           </div>
         {:else}
           <div bind:this={listContainer}>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows + macOS AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection.
> - This change lives in the macOS **hotkey + permissions** subsystem.
> - The macOS hotkey was a Fn+Control modifier chord read by a listen-only `CGEventTap`, which forces the **Input Monitoring** permission.
> - Input Monitoring was the buggy one: it didn't auto-appear in System Settings, needed a relaunch to take effect (per-process TCC caching), and reset on every ad-hoc rebuild — so the app often behaved as if it had no permission (see ROADMAP macOS-2).
> - Carbon `RegisterEventHotKey` detects a combo globally with **no permission** and still reports press/release — exactly what hold-to-talk needs — but it can't bind a modifier-only chord, so the default hotkey had to change.
> - This pull request swaps the `CGEventTap` hotkey for `RegisterEventHotKey` (via the `global-hotkey` crate), defaults to **Option + Space**, removes the entire Input Monitoring path, and renames leftover "Open Flow" UI strings to **Verenu**.
> - The benefit is one fewer (and the buggiest) macOS permission, a hotkey that works out of the box with no Spotlight/Dictation conflict, and consistent product branding.

## What Changed

- Replace the Fn+Control `CGEventTap` hotkey with Carbon `RegisterEventHotKey` (`global-hotkey` crate). No Input Monitoring/Accessibility needed for the hotkey itself; hold-to-talk preserved via Pressed/Released. Default macOS hotkey is now **Option + Space** (rebindable; capture + storage now support single-key and modifier+key). A stored modifier-only chord from an older build auto-migrates to Option+Space on startup.
- Remove the entire Input Monitoring path: IOKit FFI (`IOHIDCheckAccess`/`IOHIDRequestAccess`), the IM request/status/open-settings commands, snapshot fields (`inputMonitoring`, `needsRelaunch`, tap/global-input source hints), and the `ListenEvent` `tccutil` reset. macOS core permissions are now **Accessibility + Microphone**.
- Simplify the macOS permissions UI: drop the Input Monitoring row, the relaunch-hint banner, and the raw-diagnostics wall; "Reset stale grants" is now one clean action.
- Rename leftover user-facing "Open Flow" strings to **Verenu** (tray menu item + tooltip, permissions UI, error messages).
- Update `docs/macos-code-signing.md` and signing scripts to reflect Accessibility-only TCC sensitivity.

## Verification

- `npm run check` — 0 errors / 0 warnings.
- `npm run lint` — svelte-check + `cargo clippy -- -D warnings` clean.
- `npm run test:rust` — 214 passed (incl. updated permissions test).
- `npm test` (unified fast profile) — 16/16 passed, including the onboarding-flow and element-contract smoke tests.
- Manual (macOS, recommended before merge): hold **Option+Space** → records; release → transcribes + injects; fires while another app is focused with **no Input Monitoring grant**; double-tap handsfree and Escape-cancel work. Worth an on-device sanity check of the Option+Space ergonomics.

## Risks

- **Behavior change:** the macOS default hotkey changes from Fn+Control to Option+Space. Stored modifier-only chords are auto-migrated on startup so the backend and the settings label stay in sync.
- **New dependency:** macOS-only `global-hotkey` 0.8 — gated by the dependency-review workflow.
- Removing Input Monitoring also removes the global keystroke observation that fed the capitalization *history* fallback on macOS; capitalization now relies on the Accessibility caret read / clipboard sniff (Accessibility is still required for injection, unchanged).
- No smoke-test contract classes changed. Smoke tests run with `isMac=false`, so the Windows hotkey display/behavior is unaffected.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Anthropic **Claude Opus 4.8** (`claude-opus-4-8`), via Claude Code with extended thinking + tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work (it advances the macOS-2 permission issues)
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (unified fast profile, 16/16)
- [x] Tests added or updated where applicable (permissions summary test)
- [ ] UI changes include before/after screenshots (macOS-only UI; not captured in this environment)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (N/A - no version bump)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above
