### PR TITLE
[codex] Add native update notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource-variable/fraunces": "^5.2.9",
         "@fontsource-variable/inter-tight": "^5.2.7",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-shell": "^2.3.5"
       },
       "devDependencies": {
@@ -1414,6 +1415,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
     "test:smoke": "node tests/smoke/test.cjs && node tests/smoke/test-app.cjs && node tests/smoke/playwright-test-ui.cjs && node tests/smoke/playwright-test-fixes.cjs",
     "test:smoke:state": "node tests/smoke/playwright-test-state.cjs",
-    "tauri": "node scripts/tauri-cli.mjs",
-    "macos:signing-identity": "bash scripts/macos/ensure-signing-identity.sh",
-    "tauri:build:signed": "bash scripts/macos/build-signed.sh"
+    "tauri": "node scripts/tauri-cli.mjs"
   },
   "keywords": [],
   "author": "",
@@ -43,6 +41,7 @@
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/inter-tight": "^5.2.7",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-shell": "^2.3.5"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2380,6 +2380,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2601,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -2806,6 +2834,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3138,7 +3167,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.3",
  "serde",
  "time",
 ]
@@ -3197,6 +3226,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -3293,6 +3331,15 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
@@ -3320,6 +3367,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -4367,6 +4443,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4516,6 +4611,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -5094,7 +5201,6 @@ dependencies = [
  "accessibility-sys",
  "anyhow",
  "base64 0.22.1",
- "block2 0.5.1",
  "bytes",
  "cc",
  "chrono",
@@ -5119,6 +5225,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-ico", "macos-private-api"] }
+tauri-plugin-notification = "2.3.3"
 tauri-plugin-store       = "2"
 tauri-plugin-shell       = "2"
 tauri-plugin-single-instance = "2"
@@ -61,7 +62,6 @@ core-foundation    = "0.10"   # CFRunLoop, CFString, CFRunLoopSource
 core-foundation-sys = "0.8"   # CFGetTypeID / CFRelease for AX value handling
 objc2              = "0.5"     # msg_send! for AppKit (NSWorkspace, NSPasteboard)
 objc2-foundation   = { version = "0.2", features = ["NSData", "NSString"] }  # NSData/NSString conversions
-block2             = "0.5"     # ObjC completion blocks (AVCaptureDevice mic request)
 accessibility-sys  = "0.1"     # AXUIElement (auto-learn focused text + AX prompt)
 libproc            = "0.14"    # process RSS for memory monitor
 libc               = "0.2"     # statvfs (free disk space)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ core-foundation    = "0.10"   # CFRunLoop, CFString, CFRunLoopSource
 core-foundation-sys = "0.8"   # CFGetTypeID / CFRelease for AX value handling
 objc2              = "0.5"     # msg_send! for AppKit (NSWorkspace, NSPasteboard)
 objc2-foundation   = { version = "0.2", features = ["NSData", "NSString"] }  # NSData/NSString conversions
+block2             = "0.5"     # ObjC completion blocks (AVCaptureDevice mic request)
 accessibility-sys  = "0.1"     # AXUIElement (auto-learn focused text + AX prompt)
 libproc            = "0.14"    # process RSS for memory monitor
 libc               = "0.2"     # statvfs (free disk space)

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-show",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
+    "notification:default",
     "shell:allow-open",
     "store:allow-get",
     "store:allow-set",

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -59,8 +59,18 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
     if parsed.scheme() != "https" || parsed.host_str() != Some("github.com") {
         return false;
     }
+    let path = parsed.path();
+    // `Url::parse` normalizes literal `..` segments but leaves *percent-encoded*
+    // dots/slashes (`%2e`, `%2f`) untouched, so a path like
+    // `/MONKE2525E/Verenu/releases/download/%2e%2e/attacker/...` would still pass
+    // the prefix check yet be decoded into a traversal by the server. Real
+    // release-asset paths never contain encoded dots/slashes, so reject them.
+    let path_lower = path.to_ascii_lowercase();
+    if path_lower.contains("%2e") || path_lower.contains("%2f") {
+        return false;
+    }
     let expected_path = format!("/{RELEASE_REPO}/releases/download/");
-    parsed.path().starts_with(&expected_path)
+    path.starts_with(&expected_path)
 }
 
 /// Check the configured repo for a release newer than the current version. A

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -43,11 +43,24 @@ const RELEASE_REPO: &str = "MONKE2525E/Verenu";
 /// Returns true only for URLs that point at an official release asset for
 /// [`RELEASE_REPO`]. GitHub serves release assets from
 /// `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`, so any
-/// legitimate `download_url` we hand to the installer starts with this prefix.
+/// legitimate `download_url` we hand to the installer lives under this path.
 /// Used by the `install_update` command to reject arbitrary URLs.
+///
+/// The URL is fully parsed (not string-prefix matched) so dot-segment path
+/// traversal can't smuggle a different repo past the check: a raw
+/// `starts_with` would accept
+/// `https://github.com/MONKE2525E/Verenu/releases/download/../../attacker/repo/...`,
+/// but `Url::parse` normalizes the `..` segments before we inspect the host
+/// and path.
 pub fn is_authorized_release_asset_url(url: &str) -> bool {
-    let prefix = format!("https://github.com/{RELEASE_REPO}/releases/download/");
-    url.starts_with(&prefix)
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    if parsed.scheme() != "https" || parsed.host_str() != Some("github.com") {
+        return false;
+    }
+    let expected_path = format!("/{RELEASE_REPO}/releases/download/");
+    parsed.path().starts_with(&expected_path)
 }
 
 /// Check the configured repo for a release newer than the current version. A

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -42,16 +42,16 @@ const RELEASE_REPO: &str = "MONKE2525E/Verenu";
 
 /// Returns true only for URLs that point at an official release asset for
 /// [`RELEASE_REPO`]. GitHub serves release assets from
-/// `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`, so any
-/// legitimate `download_url` we hand to the installer lives under this path.
-/// Used by the `install_update` command to reject arbitrary URLs.
+/// `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>` — exactly
+/// six path segments. Used by the `install_update` command to reject arbitrary
+/// URLs before we open/download/execute them.
 ///
-/// The URL is fully parsed (not string-prefix matched) so dot-segment path
-/// traversal can't smuggle a different repo past the check: a raw
-/// `starts_with` would accept
-/// `https://github.com/MONKE2525E/Verenu/releases/download/../../attacker/repo/...`,
-/// but `Url::parse` normalizes the `..` segments before we inspect the host
-/// and path.
+/// Validation is done segment-by-segment rather than by prefix-matching the raw
+/// path, because `Url::parse` only normalizes *literal* `..` segments — it
+/// leaves percent-encoded traversal sequences (`%2e`, `%2f`, `%5c`) intact,
+/// which a server or proxy could later decode into a traversal to a different
+/// repo. Requiring exactly six segments, pinning the fixed ones, and rejecting
+/// dot/encoded-traversal segments closes every such bypass.
 pub fn is_authorized_release_asset_url(url: &str) -> bool {
     let Ok(parsed) = reqwest::Url::parse(url) else {
         return false;
@@ -59,21 +59,41 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
     if parsed.scheme() != "https" || parsed.host_str() != Some("github.com") {
         return false;
     }
-    let path = parsed.path();
-    // `Url::parse` normalizes literal `..` segments but leaves *percent-encoded*
-    // dots/slashes (`%2e`, `%2f`) untouched, so a path like
-    // `/MONKE2525E/Verenu/releases/download/%2e%2e/attacker/...` would still pass
-    // the prefix check yet be decoded into a traversal by the server. Real
-    // release-asset paths never contain encoded dots/slashes, so reject them.
-    let path_lower = path.to_ascii_lowercase();
-    if path_lower.contains("%2e") || path_lower.contains("%2f") {
+
+    let Some(segments) = parsed.path_segments() else {
+        return false;
+    };
+    let segments: Vec<&str> = segments.collect();
+    // `/<owner>/<repo>/releases/download/<tag>/<asset>` — no more, no fewer.
+    let [owner, repo, releases, download, tag, asset] = segments.as_slice() else {
+        return false;
+    };
+
+    // GitHub owner/repo names are case-insensitive, so match them that way.
+    let mut expected = RELEASE_REPO.split('/');
+    let expected_owner = expected.next().unwrap_or_default();
+    let expected_repo = expected.next().unwrap_or_default();
+    if !owner.eq_ignore_ascii_case(expected_owner)
+        || !repo.eq_ignore_ascii_case(expected_repo)
+        || !releases.eq_ignore_ascii_case("releases")
+        || !download.eq_ignore_ascii_case("download")
+    {
         return false;
     }
-    // GitHub owner/repo names are case-insensitive, so compare the prefix
-    // case-insensitively to avoid rejecting an otherwise-legitimate asset URL
-    // that differs only in casing (e.g. `monke2525e/verenu`).
-    let expected_path = format!("/{RELEASE_REPO}/releases/download/").to_ascii_lowercase();
-    path_lower.starts_with(&expected_path)
+
+    // The tag and asset are attacker-influenced only insofar as a crafted URL
+    // could put traversal markers here; reject empties, dot segments, and
+    // percent-encoded dots/slashes/backslashes.
+    let is_suspicious = |s: &str| {
+        let lower = s.to_ascii_lowercase();
+        s.is_empty()
+            || s == "."
+            || s == ".."
+            || lower.contains("%2e")
+            || lower.contains("%2f")
+            || lower.contains("%5c")
+    };
+    !is_suspicious(tag) && !is_suspicious(asset)
 }
 
 /// Check the configured repo for a release newer than the current version. A
@@ -245,8 +265,8 @@ fn find_asset_with_suffix_and_hints<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        find_asset_with_suffix, is_newer, normalize_version, select_release_asset_for_target,
-        GhAsset, InstallMode, UpdateTarget,
+        find_asset_with_suffix, is_authorized_release_asset_url, is_newer, normalize_version,
+        select_release_asset_for_target, GhAsset, InstallMode, UpdateTarget,
     };
 
     fn asset(name: &str) -> GhAsset {
@@ -333,6 +353,43 @@ mod tests {
             select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
                 .expect("rosetta fallback");
         assert_eq!(selected.0.name, "Verenu_0.15.0_Intel.dmg");
+    }
+
+    #[test]
+    fn authorized_url_accepts_official_release_assets() {
+        assert!(is_authorized_release_asset_url(
+            "https://github.com/MONKE2525E/Verenu/releases/download/v0.15.0/Verenu_0.15.0_x64-setup.exe"
+        ));
+        // Owner/repo casing is insignificant on GitHub.
+        assert!(is_authorized_release_asset_url(
+            "https://github.com/monke2525e/verenu/releases/download/v0.15.0/Verenu_0.15.0_Apple_Silicon.dmg"
+        ));
+    }
+
+    #[test]
+    fn authorized_url_rejects_bypasses_and_foreign_hosts() {
+        let bad = [
+            // Wrong host / scheme.
+            "http://github.com/MONKE2525E/Verenu/releases/download/v1/a.exe",
+            "https://evil.com/MONKE2525E/Verenu/releases/download/v1/a.exe",
+            // Different repo.
+            "https://github.com/attacker/repo/releases/download/v1/a.exe",
+            // Literal dot-segment traversal.
+            "https://github.com/MONKE2525E/Verenu/releases/download/../../attacker/repo/releases/download/v1/a.exe",
+            // Percent-encoded dot / slash / backslash traversal.
+            "https://github.com/MONKE2525E/Verenu/releases/download/%2e%2e/a.exe",
+            "https://github.com/MONKE2525E/Verenu/releases/download/v1/%2fa.exe",
+            "https://github.com/MONKE2525E/Verenu/releases/download/..%5c..%5cattacker%5crepo/a.exe",
+            // Wrong structure (too few / too many segments).
+            "https://github.com/MONKE2525E/Verenu/releases/download/v1",
+            "https://github.com/MONKE2525E/Verenu/blob/main/releases/download/v1/a.exe",
+        ];
+        for url in bad {
+            assert!(
+                !is_authorized_release_asset_url(url),
+                "should reject: {url}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -209,7 +209,10 @@ fn select_macos_asset<'a>(
         .or_else(|| {
             assets.iter().find(|asset| {
                 let name = asset.name.to_ascii_lowercase();
-                name.ends_with(".dmg") && !exclude_hints.iter().any(|hint| name.contains(hint))
+                name.ends_with(".dmg")
+                    && !exclude_hints
+                        .iter()
+                        .any(|hint| name.contains(&hint.to_ascii_lowercase()))
             })
         })
         .map(|asset| (asset, InstallMode::Download))
@@ -232,7 +235,10 @@ fn find_asset_with_suffix_and_hints<'a>(
     let suffix = suffix.to_ascii_lowercase();
     assets.iter().find(|asset| {
         let name = asset.name.to_ascii_lowercase();
-        name.ends_with(&suffix) && hints.iter().any(|hint| name.contains(hint))
+        name.ends_with(&suffix)
+            && hints
+                .iter()
+                .any(|hint| name.contains(&hint.to_ascii_lowercase()))
     })
 }
 

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -40,6 +40,16 @@ enum UpdateTarget {
 /// Repo to check for releases.
 const RELEASE_REPO: &str = "MONKE2525E/Verenu";
 
+/// Returns true only for URLs that point at an official release asset for
+/// [`RELEASE_REPO`]. GitHub serves release assets from
+/// `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`, so any
+/// legitimate `download_url` we hand to the installer starts with this prefix.
+/// Used by the `install_update` command to reject arbitrary URLs.
+pub fn is_authorized_release_asset_url(url: &str) -> bool {
+    let prefix = format!("https://github.com/{RELEASE_REPO}/releases/download/");
+    url.starts_with(&prefix)
+}
+
 /// Check the configured repo for a release newer than the current version. A
 /// 404 (repo has no releases yet) or other request error is treated as "no
 /// release" rather than failing the whole check.

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 struct GhRelease {
@@ -6,15 +6,35 @@ struct GhRelease {
     assets: Vec<GhAsset>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct GhAsset {
     name: String,
     browser_download_url: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InstallMode {
+    Install,
+    Download,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateInfo {
     pub version: String,
     pub download_url: String,
+    pub asset_name: String,
+    pub install_mode: InstallMode,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UpdateTarget {
+    Windows,
+    MacOsAppleSilicon,
+    MacOsIntel,
+    Unsupported,
 }
 
 /// Repo to check for releases.
@@ -47,22 +67,22 @@ async fn check_repo(repo: &str) -> anyhow::Result<Option<UpdateInfo>> {
         return Ok(None);
     }
 
-    #[cfg(windows)]
-    let suffix = ".exe";
-    #[cfg(target_os = "macos")]
-    let suffix = if cfg!(target_arch = "aarch64") { "Apple_Silicon.dmg" } else { "Intel.dmg" };
-    #[cfg(not(any(windows, target_os = "macos")))]
-    let suffix = ".tar.gz";
-
-    let asset = release
-        .assets
-        .iter()
-        .find(|a| a.name.ends_with(suffix))
-        .ok_or_else(|| anyhow::anyhow!("No matching update asset ({suffix}) in release"))?;
+    let Some((asset, install_mode)) =
+        select_release_asset_for_target(&release.assets, current_update_target())
+    else {
+        log::warn!(
+            "No compatible update asset found for target {:?} in release {}",
+            current_update_target(),
+            release.tag_name
+        );
+        return Ok(None);
+    };
 
     Ok(Some(UpdateInfo {
         version: display_version,
         download_url: asset.browser_download_url.clone(),
+        asset_name: asset.name.clone(),
+        install_mode,
     }))
 }
 
@@ -94,4 +114,167 @@ fn version_tuple(version: &str) -> (u64, u64, u64) {
         parts.next().unwrap_or(0),
         parts.next().unwrap_or(0),
     )
+}
+
+fn current_update_target() -> UpdateTarget {
+    #[cfg(windows)]
+    {
+        return UpdateTarget::Windows;
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        return UpdateTarget::MacOsAppleSilicon;
+    }
+
+    #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+    {
+        return UpdateTarget::MacOsIntel;
+    }
+
+    #[allow(unreachable_code)]
+    UpdateTarget::Unsupported
+}
+
+fn select_release_asset_for_target(
+    assets: &[GhAsset],
+    target: UpdateTarget,
+) -> Option<(&GhAsset, InstallMode)> {
+    match target {
+        UpdateTarget::Windows => select_windows_asset(assets),
+        UpdateTarget::MacOsAppleSilicon => select_macos_asset(
+            assets,
+            &["apple_silicon", "aarch64", "arm64"],
+        ),
+        UpdateTarget::MacOsIntel => select_macos_asset(assets, &["intel", "x64", "x86_64"]),
+        UpdateTarget::Unsupported => None,
+    }
+}
+
+fn select_windows_asset(assets: &[GhAsset]) -> Option<(&GhAsset, InstallMode)> {
+    find_asset_with_suffix(assets, ".exe")
+        .or_else(|| find_asset_with_suffix(assets, ".msi"))
+        .map(|asset| (asset, InstallMode::Install))
+}
+
+fn select_macos_asset<'a>(
+    assets: &'a [GhAsset],
+    arch_hints: &[&str],
+) -> Option<(&'a GhAsset, InstallMode)> {
+    find_asset_with_suffix_and_hints(assets, ".dmg", arch_hints)
+        .or_else(|| find_asset_with_suffix(assets, ".dmg"))
+        .map(|asset| (asset, InstallMode::Download))
+}
+
+fn find_asset_with_suffix<'a>(assets: &'a [GhAsset], suffix: &str) -> Option<&'a GhAsset> {
+    assets.iter().find(|asset| {
+        asset
+            .name
+            .to_ascii_lowercase()
+            .ends_with(&suffix.to_ascii_lowercase())
+    })
+}
+
+fn find_asset_with_suffix_and_hints<'a>(
+    assets: &'a [GhAsset],
+    suffix: &str,
+    hints: &[&str],
+) -> Option<&'a GhAsset> {
+    let suffix = suffix.to_ascii_lowercase();
+    assets.iter().find(|asset| {
+        let name = asset.name.to_ascii_lowercase();
+        name.ends_with(&suffix) && hints.iter().any(|hint| name.contains(hint))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        find_asset_with_suffix, is_newer, normalize_version, select_release_asset_for_target,
+        GhAsset, InstallMode, UpdateTarget,
+    };
+
+    fn asset(name: &str) -> GhAsset {
+        GhAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example.invalid/{name}"),
+        }
+    }
+
+    #[test]
+    fn normalize_version_extracts_numeric_triplet() {
+        assert_eq!(normalize_version("vVerenu-0.5.0-beta"), "0.5.0");
+        assert_eq!(normalize_version("v1.2"), "1.2.0");
+        assert_eq!(normalize_version("release-7"), "7.0.0");
+    }
+
+    #[test]
+    fn newer_version_uses_normalized_comparison() {
+        assert!(is_newer("v0.15.0", "0.14.1"));
+        assert!(!is_newer("v0.14.1", "0.14.1"));
+        assert!(!is_newer("0.14.0", "0.14.1"));
+    }
+
+    #[test]
+    fn windows_prefers_exe_then_msi() {
+        let assets = [asset("Verenu_0.15.0_x64_en-US.msi"), asset("Verenu_0.15.0_x64-setup.exe")];
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::Windows)
+            .expect("windows asset");
+        assert_eq!(selected.0.name, "Verenu_0.15.0_x64-setup.exe");
+        assert_eq!(selected.1, InstallMode::Install);
+
+        let fallback_assets = [asset("Verenu_0.15.0_x64_en-US.msi")];
+        let fallback = select_release_asset_for_target(&fallback_assets, UpdateTarget::Windows)
+            .expect("windows msi fallback");
+        assert_eq!(fallback.0.name, "Verenu_0.15.0_x64_en-US.msi");
+    }
+
+    #[test]
+    fn macos_apple_silicon_prefers_matching_dmg() {
+        let assets = [
+            asset("Verenu_0.15.0_Intel.dmg"),
+            asset("Verenu_0.15.0_Apple_Silicon.dmg"),
+        ];
+        let selected =
+            select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
+                .expect("arm dmg");
+        assert_eq!(selected.0.name, "Verenu_0.15.0_Apple_Silicon.dmg");
+        assert_eq!(selected.1, InstallMode::Download);
+    }
+
+    #[test]
+    fn macos_intel_prefers_matching_dmg() {
+        let assets = [
+            asset("Verenu_0.15.0_Apple_Silicon.dmg"),
+            asset("Verenu_0.15.0_Intel.dmg"),
+        ];
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel)
+            .expect("intel dmg");
+        assert_eq!(selected.0.name, "Verenu_0.15.0_Intel.dmg");
+    }
+
+    #[test]
+    fn macos_falls_back_to_any_dmg() {
+        let assets = [asset("Verenu_0.15.0.dmg")];
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel)
+            .expect("generic dmg");
+        assert_eq!(selected.0.name, "Verenu_0.15.0.dmg");
+    }
+
+    #[test]
+    fn unsupported_target_skips_updates() {
+        let assets = [asset("Verenu_0.15.0_x64-setup.exe")];
+        assert!(select_release_asset_for_target(&assets, UpdateTarget::Unsupported).is_none());
+    }
+
+    #[test]
+    fn suffix_match_is_case_insensitive() {
+        let assets = [asset("Verenu_0.15.0_X64-SETUP.EXE")];
+        assert_eq!(
+            find_asset_with_suffix(&assets, ".exe")
+                .expect("case insensitive match")
+                .name,
+            "Verenu_0.15.0_X64-SETUP.EXE"
+        );
+    }
 }

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -69,8 +69,11 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
     if path_lower.contains("%2e") || path_lower.contains("%2f") {
         return false;
     }
-    let expected_path = format!("/{RELEASE_REPO}/releases/download/");
-    path.starts_with(&expected_path)
+    // GitHub owner/repo names are case-insensitive, so compare the prefix
+    // case-insensitively to avoid rejecting an otherwise-legitimate asset URL
+    // that differs only in casing (e.g. `monke2525e/verenu`).
+    let expected_path = format!("/{RELEASE_REPO}/releases/download/").to_ascii_lowercase();
+    path_lower.starts_with(&expected_path)
 }
 
 /// Check the configured repo for a release newer than the current version. A
@@ -175,11 +178,18 @@ fn select_release_asset_for_target(
 ) -> Option<(&GhAsset, InstallMode)> {
     match target {
         UpdateTarget::Windows => select_windows_asset(assets),
-        UpdateTarget::MacOsAppleSilicon => select_macos_asset(
+        // Apple Silicon can run Intel builds via Rosetta 2, so it may fall back
+        // to a generic/Intel DMG.
+        UpdateTarget::MacOsAppleSilicon => {
+            select_macos_asset(assets, &["apple_silicon", "aarch64", "arm64"], &[])
+        }
+        // Intel Macs cannot run arm64 binaries, so exclude Apple Silicon DMGs
+        // from the generic fallback rather than installing an unusable build.
+        UpdateTarget::MacOsIntel => select_macos_asset(
             assets,
+            &["intel", "x64", "x86_64"],
             &["apple_silicon", "aarch64", "arm64"],
         ),
-        UpdateTarget::MacOsIntel => select_macos_asset(assets, &["intel", "x64", "x86_64"]),
         UpdateTarget::Unsupported => None,
     }
 }
@@ -193,9 +203,15 @@ fn select_windows_asset(assets: &[GhAsset]) -> Option<(&GhAsset, InstallMode)> {
 fn select_macos_asset<'a>(
     assets: &'a [GhAsset],
     arch_hints: &[&str],
+    exclude_hints: &[&str],
 ) -> Option<(&'a GhAsset, InstallMode)> {
     find_asset_with_suffix_and_hints(assets, ".dmg", arch_hints)
-        .or_else(|| find_asset_with_suffix(assets, ".dmg"))
+        .or_else(|| {
+            assets.iter().find(|asset| {
+                let name = asset.name.to_ascii_lowercase();
+                name.ends_with(".dmg") && !exclude_hints.iter().any(|hint| name.contains(hint))
+            })
+        })
         .map(|asset| (asset, InstallMode::Download))
 }
 
@@ -292,6 +308,25 @@ mod tests {
         let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel)
             .expect("generic dmg");
         assert_eq!(selected.0.name, "Verenu_0.15.0.dmg");
+    }
+
+    #[test]
+    fn macos_intel_does_not_fall_back_to_apple_silicon_dmg() {
+        let assets = [asset("Verenu_0.15.0_Apple_Silicon.dmg")];
+        assert!(
+            select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel).is_none(),
+            "Intel must not install an Apple Silicon-only DMG"
+        );
+    }
+
+    #[test]
+    fn macos_apple_silicon_falls_back_to_intel_dmg() {
+        // Apple Silicon can run Intel builds via Rosetta 2.
+        let assets = [asset("Verenu_0.15.0_Intel.dmg")];
+        let selected =
+            select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
+                .expect("rosetta fallback");
+        assert_eq!(selected.0.name, "Verenu_0.15.0_Intel.dmg");
     }
 
     #[test]

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -82,13 +82,18 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
     }
 
     // The tag and asset are attacker-influenced only insofar as a crafted URL
-    // could put traversal markers here; reject empties, dot segments, and
-    // percent-encoded dots/slashes/backslashes.
+    // could put traversal markers here. `path_segments()` returns segments
+    // still percent-encoded (verified: `..%2f..` stays `..%2f..`, it is not
+    // decoded to `../..`), so we must catch the *encoded* forms. We also reject
+    // the *literal* separators/dot segments as belt-and-suspenders, so the
+    // check stays correct even if a future url-crate version were to decode.
     let is_suspicious = |s: &str| {
         let lower = s.to_ascii_lowercase();
         s.is_empty()
             || s == "."
             || s == ".."
+            || s.contains('/')
+            || s.contains('\\')
             || lower.contains("%2e")
             || lower.contains("%2f")
             || lower.contains("%5c")
@@ -379,6 +384,7 @@ mod tests {
             // Percent-encoded dot / slash / backslash traversal.
             "https://github.com/MONKE2525E/Verenu/releases/download/%2e%2e/a.exe",
             "https://github.com/MONKE2525E/Verenu/releases/download/v1/%2fa.exe",
+            "https://github.com/MONKE2525E/Verenu/releases/download/..%2f..%2fattacker/a.exe",
             "https://github.com/MONKE2525E/Verenu/releases/download/..%5c..%5cattacker%5crepo/a.exe",
             // Wrong structure (too few / too many segments).
             "https://github.com/MONKE2525E/Verenu/releases/download/v1",

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -40,7 +40,8 @@ pub fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), Stri
         | store::CLEANUP_INTENSITY
         | store::MICROPHONE_DEVICE
         | store::HISTORY_RETENTION
-        | store::UPDATE_DISMISSED_VERSION => value.is_string() || value.is_null(),
+        | store::UPDATE_DISMISSED_VERSION
+        | store::UPDATE_NOTIFIED_VERSION => value.is_string() || value.is_null(),
         store::TRANSCRIPTION_MODELS_BY_PROVIDER | store::CLEANUP_MODELS_BY_PROVIDER => {
             is_model_map(value)
         }
@@ -273,6 +274,7 @@ pub struct AllSettings {
     pub history_retention: Option<String>,
     pub microphone_device: Option<String>,
     pub update_dismissed_version: Option<String>,
+    pub update_notified_version: Option<String>,
     pub hotkey: Option<Vec<String>>,
     pub appearance_mode: Option<String>,
     pub cleanup_prompt_overrides: Option<serde_json::Value>,
@@ -344,6 +346,7 @@ pub struct ImportSummary {
 //   MICROPHONE_DEVICE   — device-specific hardware identifier
 //   SETUP_COMPLETE / FORCE_SETUP_ON_LAUNCH — one-time setup flags
 //   UPDATE_DISMISSED_VERSION — transient UI state
+//   UPDATE_NOTIFIED_VERSION — transient notification state
 // When adding a new setting to validate_setting, decide here whether it should also be exported.
 const EXPORTABLE_SETTINGS: &[&str] = &[
     store::TRANSCRIPTION_PROVIDER,
@@ -419,6 +422,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         history_retention: str_val(store::HISTORY_RETENTION),
         microphone_device: str_val(store::MICROPHONE_DEVICE),
         update_dismissed_version: str_val(store::UPDATE_DISMISSED_VERSION),
+        update_notified_version: str_val(store::UPDATE_NOTIFIED_VERSION),
         hotkey: s.get(store::HOTKEY).and_then(|v| {
             v.as_array().map(|arr| {
                 arr.iter()
@@ -802,3 +806,4 @@ pub async fn import_data(
     .await
     .map_err(|e| format!("import_data task panicked: {e}"))?
 }
+

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,17 +1,15 @@
 //! Update check + in-app install, with pre-update DB backup.
 
 use super::*;
+#[cfg(target_os = "macos")]
+use tauri_plugin_shell::ShellExt;
 
 // ---------- updates ----------
 
 #[tauri::command]
-pub async fn check_for_update() -> Result<Option<serde_json::Value>, String> {
+pub async fn check_for_update() -> Result<Option<crate::api::updater::UpdateInfo>, String> {
     match crate::api::updater::check().await {
-        Ok(Some(info)) => Ok(Some(serde_json::json!({
-            "version": info.version,
-            "downloadUrl": info.download_url,
-        }))),
-        Ok(None) => Ok(None),
+        Ok(update) => Ok(update),
         Err(e) => {
             log::warn!("Update check failed: {e}");
             Ok(None)
@@ -21,13 +19,18 @@ pub async fn check_for_update() -> Result<Option<serde_json::Value>, String> {
 
 #[tauri::command]
 pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), String> {
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
+    {
+        app.shell()
+            .open(download_url, None)
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    #[cfg(not(any(windows, target_os = "macos")))]
     {
         let _ = (&app, &download_url);
-        Err(
-            "In-app update is only available on Windows. Download the latest release from GitHub."
-                .into(),
-        )
+        Err("Updates are only supported on Windows and macOS.".into())
     }
 
     #[cfg(windows)]
@@ -120,8 +123,6 @@ pub fn backup_sqlite_database(
     // to exit right after this call, so there's nothing else to avoid blocking.
     match backup.step(-1).map_err(|e| e.to_string())? {
         rusqlite::backup::StepResult::Done => Ok(()),
-        other => Err(format!(
-            "Backup did not complete in a single step: {other:?}"
-        )),
+        other => Err(format!("Backup did not complete in a single step: {other:?}")),
     }
 }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -31,6 +31,12 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
 
     #[cfg(target_os = "macos")]
     {
+        // `Shell::open` is soft-deprecated in favour of tauri-plugin-opener,
+        // but the shell plugin is already the only one wired up here and
+        // opening the verified release URL in the user's browser to start the
+        // DMG download is exactly what we want. Allow the deprecation rather
+        // than pulling in (and configuring capabilities for) another plugin.
+        #[allow(deprecated)]
         app.shell()
             .open(download_url, None)
             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -19,6 +19,16 @@ pub async fn check_for_update() -> Result<Option<crate::api::updater::UpdateInfo
 
 #[tauri::command]
 pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), String> {
+    // Defense-in-depth: `download_url` ultimately originates from a GitHub
+    // release asset (`browser_download_url`), but this command accepts it
+    // straight from the frontend and either opens it (macOS) or downloads and
+    // executes it (Windows). Refuse anything that isn't an official release
+    // asset URL so a compromised/spoofed frontend can't turn this into an
+    // arbitrary download-and-execute primitive.
+    if !crate::api::updater::is_authorized_release_asset_url(&download_url) {
+        return Err("Refusing to install update from an unauthorized URL.".into());
+    }
+
     #[cfg(target_os = "macos")]
     {
         app.shell()

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -36,6 +36,7 @@ pub const CLEANUP_PROMPT_OVERRIDES: &str = "cleanup_prompt_overrides";
 pub const CREDENTIALS_MIGRATED: &str = "credentials_migrated_v1";
 pub const MACOS_CLIPBOARD_SNIFF: &str = "macos_clipboard_sniff_enabled";
 pub const UPDATE_DISMISSED_VERSION: &str = "update_dismissed_version";
+pub const UPDATE_NOTIFIED_VERSION: &str = "update_notified_version";
 pub const HISTORY_RETENTION: &str = "history_retention";
 pub const AUTOSTART_ENABLED: &str = "autostart_enabled";
 pub const CAPS_LOCK_UPPERCASE: &str = "caps_lock_uppercase_enabled";

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,6 +142,7 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             show_main_window(app);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,6 +71,7 @@
   onMount(() => {
     let cleanupFn: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
+    let destroyed = false;
 
     (async () => {
       try {
@@ -94,7 +95,16 @@
       });
       cleanupFn = unlisten;
 
-      stopAutomaticUpdateChecks = await startAutomaticUpdateChecks();
+      const stop = await startAutomaticUpdateChecks();
+      // If the component unmounted while this async init was in flight, the
+      // cleanup function below has already run (with stopAutomaticUpdateChecks
+      // still undefined), so stop the just-started interval immediately to
+      // avoid leaking a timer.
+      if (destroyed) {
+        stop();
+      } else {
+        stopAutomaticUpdateChecks = stop;
+      }
     })();
 
     const media = window.matchMedia?.('(prefers-color-scheme: dark)');
@@ -115,6 +125,7 @@
     document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
+      destroyed = true;
       if (cleanupFn) cleanupFn();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       media?.removeEventListener?.('change', onSystemThemeChange);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,7 +71,6 @@
   onMount(() => {
     let cleanupFn: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
-    let destroyed = false;
 
     (async () => {
       try {
@@ -94,22 +93,16 @@
         toastTimer = setTimeout(() => { errorToast = ''; }, 5000);
       });
       cleanupFn = unlisten;
-
-      try {
-        const stop = await startAutomaticUpdateChecks();
-        // If the component unmounted while this async init was in flight, the
-        // cleanup function below has already run (with stopAutomaticUpdateChecks
-        // still undefined), so stop the just-started interval immediately to
-        // avoid leaking a timer.
-        if (destroyed) {
-          stop();
-        } else {
-          stopAutomaticUpdateChecks = stop;
-        }
-      } catch (error) {
-        console.error('Failed to start automatic update checks:', error);
-      }
     })();
+
+    // Synchronous: startAutomaticUpdateChecks fires its first check in the
+    // background and returns the cleanup immediately, so there's no unmount
+    // race to guard and the interval is always registered before we return.
+    try {
+      stopAutomaticUpdateChecks = startAutomaticUpdateChecks();
+    } catch (error) {
+      console.error('Failed to start automatic update checks:', error);
+    }
 
     const media = window.matchMedia?.('(prefers-color-scheme: dark)');
     const onSystemThemeChange = () => {
@@ -129,7 +122,6 @@
     document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
-      destroyed = true;
       if (cleanupFn) cleanupFn();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       media?.removeEventListener?.('change', onSystemThemeChange);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -95,15 +95,19 @@
       });
       cleanupFn = unlisten;
 
-      const stop = await startAutomaticUpdateChecks();
-      // If the component unmounted while this async init was in flight, the
-      // cleanup function below has already run (with stopAutomaticUpdateChecks
-      // still undefined), so stop the just-started interval immediately to
-      // avoid leaking a timer.
-      if (destroyed) {
-        stop();
-      } else {
-        stopAutomaticUpdateChecks = stop;
+      try {
+        const stop = await startAutomaticUpdateChecks();
+        // If the component unmounted while this async init was in flight, the
+        // cleanup function below has already run (with stopAutomaticUpdateChecks
+        // still undefined), so stop the just-started interval immediately to
+        // avoid leaking a timer.
+        if (destroyed) {
+          stop();
+        } else {
+          stopAutomaticUpdateChecks = stop;
+        }
+      } catch (error) {
+        console.error('Failed to start automatic update checks:', error);
       }
     })();
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,6 +14,7 @@
   import DictationPill from './lib/components/layout/DictationPill.svelte';
   import Setup from './lib/views/Setup.svelte';
   import { invoke, listen } from './lib/tauri';
+  import { startAutomaticUpdateChecks } from './lib/updates';
   import { fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx, pageSwap, reducedMotionEnabled } from './lib/motion';
@@ -69,6 +70,7 @@
 
   onMount(() => {
     let cleanupFn: (() => void) | undefined;
+    let stopAutomaticUpdateChecks: (() => void) | undefined;
 
     (async () => {
       try {
@@ -91,6 +93,8 @@
         toastTimer = setTimeout(() => { errorToast = ''; }, 5000);
       });
       cleanupFn = unlisten;
+
+      stopAutomaticUpdateChecks = await startAutomaticUpdateChecks();
     })();
 
     const media = window.matchMedia?.('(prefers-color-scheme: dark)');
@@ -112,6 +116,7 @@
 
     return () => {
       if (cleanupFn) cleanupFn();
+      if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       media?.removeEventListener?.('change', onSystemThemeChange);
       clearInterval(connectivityTimer);
       document.removeEventListener('visibilitychange', handleVisibility);

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -129,7 +129,7 @@
     {#if updateCheckState === 'available' && appStore.updateInfo}
       <button class="btn-ghost" onclick={handleInstall} disabled={installingFromAbout}>
         {installingFromAbout
-          ? (appStore.updateInfo.installMode === 'download' ? 'Opening…' : 'Installing…')
+          ? (appStore.updateInfo?.installMode === 'download' ? 'Opening…' : 'Installing…')
           : installActionLabel(appStore.updateInfo)}
       </button>
     {:else}

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -44,8 +44,8 @@
     }
   }
 
-  function installActionLabel(update: UpdateInfo): string {
-    return update.installMode === 'download' ? 'Download DMG' : 'Install Now';
+  function installActionLabel(update: UpdateInfo | null): string {
+    return update?.installMode === 'download' ? 'Download DMG' : 'Install Now';
   }
 
   async function handleInstall() {

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -44,6 +44,10 @@
     }
   }
 
+  function installActionLabel(update: UpdateInfo): string {
+    return update.installMode === 'download' ? 'Download DMG' : 'Install Now';
+  }
+
   async function handleInstall() {
     if (!appStore.updateInfo) return;
     installingFromAbout = true;
@@ -124,7 +128,9 @@
   <div class="update-controls">
     {#if updateCheckState === 'available' && appStore.updateInfo}
       <button class="btn-ghost" onclick={handleInstall} disabled={installingFromAbout}>
-        {installingFromAbout ? 'Downloading…' : 'Install Now'}
+        {installingFromAbout
+          ? (appStore.updateInfo.installMode === 'download' ? 'Opening…' : 'Installing…')
+          : installActionLabel(appStore.updateInfo)}
       </button>
     {:else}
       <button

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -45,6 +45,7 @@ type SettingsValueMap = {
   history_retention: HistoryRetention;
   microphone_device: string | null;
   update_dismissed_version: string | null;
+  update_notified_version: string | null;
   appearance_mode: AppearanceMode;
   advanced_model_ui: boolean;
   cleanup_prompt_overrides: Record<string, string>;

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -29,6 +29,8 @@ export interface DictionaryEntry {
 export interface UpdateInfo {
   version: string;
   downloadUrl: string;
+  assetName: string;
+  installMode: 'install' | 'download';
 }
 
 export const appStore = $state({

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -82,6 +82,7 @@ const defaultSettings: Record<string, unknown> = {
   history_retention: '30 days',
   microphone_device: null,
   update_dismissed_version: null,
+  update_notified_version: null,
   advanced_model_ui: false,
   hotkey: defaultHotkey,
 };

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -53,10 +53,19 @@ async function checkForAutomaticUpdates(): Promise<void> {
 
   let dismissedVersion: string | null = null;
   let notifiedVersion: string | null = null;
+  // Resolve each lookup independently so a single failed setting read doesn't
+  // wipe out the other — otherwise one failure could re-show a dismissed
+  // update or re-fire an already-sent notification.
   try {
     [dismissedVersion, notifiedVersion] = await Promise.all([
-      invoke<string | null>('get_setting', { key: 'update_dismissed_version' }),
-      invoke<string | null>('get_setting', { key: 'update_notified_version' }),
+      invoke<string | null>('get_setting', { key: 'update_dismissed_version' }).catch((error) => {
+        console.warn('Failed to look up dismissed update version:', error);
+        return null;
+      }),
+      invoke<string | null>('get_setting', { key: 'update_notified_version' }).catch((error) => {
+        console.warn('Failed to look up notified update version:', error);
+        return null;
+      }),
     ]);
   } catch (error) {
     console.warn('Update state lookup failed:', error);

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -72,13 +72,17 @@ async function checkForAutomaticUpdates(): Promise<void> {
   try {
     await sendUpdateNotification(update);
   } catch (error) {
+    // Don't persist the notified version if delivery failed — otherwise the
+    // user never sees a notification yet we'd mark it as notified and never
+    // retry on the next check.
     console.warn('Update notification failed:', error);
-  } finally {
-    try {
-      await saveSetting('update_notified_version', update.version);
-    } catch (error) {
-      console.warn('Failed to persist notified update version:', error);
-    }
+    return;
+  }
+
+  try {
+    await saveSetting('update_notified_version', update.version);
+  } catch (error) {
+    console.warn('Failed to persist notified update version:', error);
   }
 }
 

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -1,0 +1,96 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from '@tauri-apps/plugin-notification';
+import type { UpdateInfo } from './stores';
+import { appStore } from './stores';
+import { saveSetting } from './settings';
+import { invoke, isTauriRuntime } from './tauri';
+
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+async function requestNotificationPermissionAtStartup(): Promise<void> {
+  if (!isTauriRuntime()) return;
+
+  try {
+    if (await isPermissionGranted()) return;
+    await requestPermission();
+  } catch (error) {
+    console.warn('Notification permission request failed:', error);
+  }
+}
+
+async function notificationsAllowed(): Promise<boolean> {
+  if (!isTauriRuntime()) return false;
+
+  try {
+    return await isPermissionGranted();
+  } catch (error) {
+    console.warn('Notification permission check failed:', error);
+    return false;
+  }
+}
+
+async function sendUpdateNotification(update: UpdateInfo): Promise<void> {
+  await sendNotification({
+    title: 'Verenu update available',
+    body: `Version v${update.version} is ready. Open Verenu to update.`,
+  });
+}
+
+async function checkForAutomaticUpdates(): Promise<void> {
+  let update: UpdateInfo | null = null;
+
+  try {
+    update = await invoke<UpdateInfo | null>('check_for_update');
+  } catch (error) {
+    console.warn('Automatic update check failed:', error);
+    return;
+  }
+
+  if (!update) return;
+
+  let dismissedVersion: string | null = null;
+  let notifiedVersion: string | null = null;
+  try {
+    [dismissedVersion, notifiedVersion] = await Promise.all([
+      invoke<string | null>('get_setting', { key: 'update_dismissed_version' }),
+      invoke<string | null>('get_setting', { key: 'update_notified_version' }),
+    ]);
+  } catch (error) {
+    console.warn('Update state lookup failed:', error);
+  }
+
+  if (dismissedVersion === update.version) return;
+
+  appStore.updateInfo = update;
+
+  if (notifiedVersion === update.version) return;
+  if (!(await notificationsAllowed())) return;
+
+  try {
+    await sendUpdateNotification(update);
+  } catch (error) {
+    console.warn('Update notification failed:', error);
+  } finally {
+    try {
+      await saveSetting('update_notified_version', update.version);
+    } catch (error) {
+      console.warn('Failed to persist notified update version:', error);
+    }
+  }
+}
+
+export async function startAutomaticUpdateChecks(): Promise<() => void> {
+  await requestNotificationPermissionAtStartup();
+  await checkForAutomaticUpdates();
+
+  const timer = window.setInterval(() => {
+    void checkForAutomaticUpdates();
+  }, UPDATE_CHECK_INTERVAL_MS);
+
+  return () => {
+    window.clearInterval(timer);
+  };
+}

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -89,8 +89,12 @@ async function checkForAutomaticUpdates(): Promise<void> {
   }
 }
 
-export async function startAutomaticUpdateChecks(): Promise<() => void> {
-  await checkForAutomaticUpdates();
+export function startAutomaticUpdateChecks(): () => void {
+  // Fire the first check in the background rather than awaiting it, so this
+  // function can return the cleanup synchronously. That removes the unmount
+  // race the caller would otherwise have to guard against — the interval is
+  // registered before we return, so cleanup can always clear it.
+  void checkForAutomaticUpdates();
 
   const timer = window.setInterval(() => {
     void checkForAutomaticUpdates();

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -10,24 +10,18 @@ import { invoke, isTauriRuntime } from './tauri';
 
 const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
-async function requestNotificationPermissionAtStartup(): Promise<void> {
-  if (!isTauriRuntime()) return;
-
-  try {
-    if (await isPermissionGranted()) return;
-    await requestPermission();
-  } catch (error) {
-    console.warn('Notification permission request failed:', error);
-  }
-}
-
-async function notificationsAllowed(): Promise<boolean> {
+// Request notification permission contextually — only when we actually have a
+// new update to tell the user about — rather than firing the system prompt at
+// startup with no context, which users tend to decline. Returns whether
+// notifications are permitted after the (possibly skipped) request.
+async function ensureNotificationPermission(): Promise<boolean> {
   if (!isTauriRuntime()) return false;
 
   try {
-    return await isPermissionGranted();
+    if (await isPermissionGranted()) return true;
+    return (await requestPermission()) === 'granted';
   } catch (error) {
-    console.warn('Notification permission check failed:', error);
+    console.warn('Notification permission request failed:', error);
     return false;
   }
 }
@@ -76,7 +70,7 @@ async function checkForAutomaticUpdates(): Promise<void> {
   appStore.updateInfo = update;
 
   if (notifiedVersion === update.version) return;
-  if (!(await notificationsAllowed())) return;
+  if (!(await ensureNotificationPermission())) return;
 
   try {
     await sendUpdateNotification(update);
@@ -96,7 +90,6 @@ async function checkForAutomaticUpdates(): Promise<void> {
 }
 
 export async function startAutomaticUpdateChecks(): Promise<() => void> {
-  await requestNotificationPermissionAtStartup();
   await checkForAutomaticUpdates();
 
   const timer = window.setInterval(() => {

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -369,13 +369,20 @@
     loading = false;
   }
 
-  function handleInstall() {
+  function installActionLabel(update: UpdateInfo): string {
+    return update.installMode === 'download' ? 'Download DMG' : 'Install & Restart';
+  }
+
+  async function handleInstall() {
     if (!appStore.updateInfo) return;
     installing = true;
-    invoke('install_update', { downloadUrl: appStore.updateInfo.downloadUrl }).catch((e) => {
+    try {
+      await invoke('install_update', { downloadUrl: appStore.updateInfo.downloadUrl });
+    } catch (e) {
       console.error('Install failed:', e);
+    } finally {
       installing = false;
-    });
+    }
   }
 
   async function dismissUpdate() {
@@ -412,16 +419,6 @@
         })
         .catch(() => {});
     }
-
-    invoke<UpdateInfo | null>('check_for_update').then(async (update) => {
-      if (update) {
-        try {
-          const dismissed = await invoke<string | null>('get_setting', { key: 'update_dismissed_version' });
-          if (dismissed === update.version) return;
-        } catch { /* dev mode */ }
-        appStore.updateInfo = update;
-      }
-    }).catch(() => {});
 
     trackListener(listen('verenu:transcribed', () => {
       failedEntry = null;
@@ -490,7 +487,9 @@
             <div class="update-actions">
               <button class="update-dismiss" onclick={dismissUpdate}>Dismiss</button>
               <button class="update-btn" onclick={handleInstall} disabled={installing}>
-                {installing ? 'Installing…' : 'Install & Restart'}
+                {installing
+                  ? (appStore.updateInfo.installMode === 'download' ? 'Opening…' : 'Installing…')
+                  : installActionLabel(appStore.updateInfo)}
               </button>
             </div>
           </div>

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -369,8 +369,8 @@
     loading = false;
   }
 
-  function installActionLabel(update: UpdateInfo): string {
-    return update.installMode === 'download' ? 'Download DMG' : 'Install & Restart';
+  function installActionLabel(update: UpdateInfo | null): string {
+    return update?.installMode === 'download' ? 'Download DMG' : 'Install & Restart';
   }
 
   async function handleInstall() {

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -488,7 +488,7 @@
               <button class="update-dismiss" onclick={dismissUpdate}>Dismiss</button>
               <button class="update-btn" onclick={handleInstall} disabled={installing}>
                 {installing
-                  ? (appStore.updateInfo.installMode === 'download' ? 'Opening…' : 'Installing…')
+                  ? (appStore.updateInfo?.installMode === 'download' ? 'Opening…' : 'Installing…')
                   : installActionLabel(appStore.updateInfo)}
               </button>
             </div>

--- a/tests/smoke/_tauri-mock.cjs
+++ b/tests/smoke/_tauri-mock.cjs
@@ -62,6 +62,7 @@ function tauriMock() {
     appearance_mode:         'system',
     advanced_model_ui:       true,
     update_dismissed_version: null,
+    update_notified_version: null,
     ...storedMem,
   };
 
@@ -148,6 +149,7 @@ function tauriMock() {
         appearance_mode:               mem.appearance_mode ?? null,
         advanced_model_ui:             mem.advanced_model_ui ?? null,
         update_dismissed_version:      mem.update_dismissed_version ?? null,
+        update_notified_version:       mem.update_notified_version ?? null,
       };
       case 'get_api_key_status': return { groq: false, openai: false, google: false };
       case 'check_api_key_set':  return false;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that turns a hold-to-record hotkey flow into transcription, cleanup, and text injection.
> - This change sits in the updater, settings store, and settings or home UI because automatic update detection already existed but only surfaced inside the app.
> - The gap was that background update checks did not send native OS notifications, and updater asset selection was too Windows-centric to safely guide macOS users.
> - That matters now because update discovery is easy to miss when the app is not focused, and a bad asset choice on macOS points users at a useless installer path.
> - This pull request adds native notification support, moves automatic update checks into shared startup logic, and persists once-per-version notification state.
> - It also makes updater asset selection platform-aware so Windows prefers installers and macOS gets the correct DMG for the current architecture.
> - The benefit is that users get a normal system notification plus the existing in-app banner, without personal data in the notification text and without dead-end update actions.

## What Changed

- Added Tauri's notification plugin on the Rust and frontend sides, enabled `notification:default` only for the main window capability, and requested notification permission during startup update initialization.
- Added persistent `update_notified_version` state across Rust store constants and validation, frontend settings types, and browser-dev defaults so automatic notifications fire once per release while `update_dismissed_version` still suppresses the banner.
- Moved automatic update checks out of `Home.svelte` into a shared `src/lib/updates.ts` helper that runs on startup and every 6 hours, while keeping About's manual check flow free of desktop notifications.
- Extended the update contract with `version`, `downloadUrl`, `assetName`, and `installMode`, and updated update CTAs so macOS shows `Download DMG` and opens the selected DMG URL instead of pretending to run an in-app installer.
- Reworked updater asset selection to prefer `.exe` then `.msi` on Windows, select architecture-matched `.dmg` assets on macOS, and return no update when no compatible asset exists.
- Added or updated tests for version normalization and comparison, platform asset selection, and mocked notification-state handling around the update banner path.

## Verification

- `npm run check`
- `npm run lint`
- `npm run test:rust`
- `npm test`
- `npm run test:smoke`
- `npm run test:smoke:state`
- Playwright regression against the local Vite app with mocked Tauri notification APIs verified the update banner, the macOS `Download DMG` CTA, one notification per version, generic notification copy, and `update_notified_version` persistence.

## Risks

- Low to moderate risk: this touches updater metadata, startup lifecycle, and OS notification permission flow.
- Windows native toast behavior still needs installed-build verification because browser-dev and mocked Tauri runs cannot prove shell-level notification delivery.
- macOS asset matching depends on release asset names containing the expected architecture hints or at least a generic `.dmg` fallback.
- Notification text stays generic and contains no API keys, dictated text, or other personal data.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- OpenAI GPT-5 Codex with tool use and long-context workspace execution.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above
