### PR TITLE
fix: app-mapping style leak (#144) + contextual caps for empty/Chromium text boxes

### DIFF
--- a/src-tauri/src/api/auto_learn/focused_text.rs
+++ b/src-tauri/src/api/auto_learn/focused_text.rs
@@ -383,6 +383,19 @@ impl FocusedTextReader {
             }
             let selection_state = describe_selection_state(range_seen, range_collapsed);
 
+            // Structural diagnostics for "blank box reads as full" (Antigravity /
+            // Chromium controls). App-control metadata only — never tail content.
+            log::debug!(
+                "injection: probe detail control_type={control_type} class={class_name} automation_id={automation_id} value_empty={value_is_empty:?} read_only={read_only:?} caret_active={range_seen} collapsed={range_collapsed} source={} context={} tail_len={} tail_newline={}",
+                source.as_str(),
+                context.as_str(),
+                caret_context.as_deref().map(|t| t.chars().count()).unwrap_or(0),
+                caret_context
+                    .as_deref()
+                    .map(|t| t.contains('\n') || t.contains('\r'))
+                    .unwrap_or(false),
+            );
+
             InjectionContextProbe {
                 context,
                 source,

--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -104,6 +104,40 @@ mod tests {
     }
 
     #[test]
+    fn sniff_verification_gate_only_for_caret_local_mid_sentence() {
+        use crate::core::text_context::SentenceContext;
+        // The one case that needs verification: caps on, caret-local, mid-sentence.
+        assert!(caret_local_needs_sniff_verification(
+            true,
+            ContextProbeSource::CaretLocal,
+            SentenceContext::MidSentence,
+        ));
+        // A caret read that already says "new sentence" capitalizes — no sniff.
+        assert!(!caret_local_needs_sniff_verification(
+            true,
+            ContextProbeSource::CaretLocal,
+            SentenceContext::NewSentence,
+        ));
+        // Empty-field and history sources are already trustworthy.
+        assert!(!caret_local_needs_sniff_verification(
+            true,
+            ContextProbeSource::EmptyField,
+            SentenceContext::MidSentence,
+        ));
+        assert!(!caret_local_needs_sniff_verification(
+            true,
+            ContextProbeSource::HistoryFallback,
+            SentenceContext::MidSentence,
+        ));
+        // Contextual caps off: never sniff.
+        assert!(!caret_local_needs_sniff_verification(
+            false,
+            ContextProbeSource::CaretLocal,
+            SentenceContext::MidSentence,
+        ));
+    }
+
+    #[test]
     fn uppercase_first_word_handles_prefix_symbols() {
         assert_eq!(uppercase_first_word("hello world"), "Hello world");
         assert_eq!(uppercase_first_word("\"hello world"), "\"Hello world");
@@ -468,6 +502,22 @@ fn fallback_probe_from_history(target_hwnd: usize) -> Option<InjectionContextPro
     }
 }
 
+/// Whether a UIA caret-local read that classified as mid-sentence should be
+/// double-checked with a clipboard sniff before lowercasing. Only caret-local
+/// reads are verified: that's the source that can return phantom text before the
+/// caret in a visually empty box (Chromium/Electron). Other sources are either
+/// already trustworthy (history) or already a new sentence (empty field).
+#[cfg_attr(not(windows), allow(dead_code))]
+fn caret_local_needs_sniff_verification(
+    contextual_caps: bool,
+    source: ContextProbeSource,
+    context: crate::core::text_context::SentenceContext,
+) -> bool {
+    contextual_caps
+        && source == ContextProbeSource::CaretLocal
+        && context == crate::core::text_context::SentenceContext::MidSentence
+}
+
 fn apply_probe_adjustments(
     text: &str,
     contextual_caps: bool,
@@ -536,7 +586,41 @@ fn apply_probe_adjustments(
         adjusted = format!(" {adjusted}");
     }
 
+    // Redacted diagnostics for capitalization decisions (issue follow-up: CLI /
+    // terminal inputs being read as mid-sentence). Logs the control identity and
+    // the *class* of the last char before the caret — never the tail content.
+    log::debug!(
+        "injection: caps decision control_type={} probe_source={} context={} prefix={} tail_len={} tail_signal={} case_decision={}",
+        probe.control_type,
+        probe.source.as_str(),
+        probe.context.as_str(),
+        prefix_class.as_str(),
+        probe.context_tail.chars().count(),
+        context_tail_signal(&probe.context_tail),
+        case_decision.as_str(),
+    );
+
     (adjusted, context_kind, case_decision)
+}
+
+/// Redacted classification of the last meaningful character before the caret,
+/// for diagnosing contextual-capitalization decisions. Returns only a category
+/// label, never the tail content.
+fn context_tail_signal(tail: &str) -> &'static str {
+    match tail.chars().rev().find(|c| !c.is_whitespace()) {
+        None => {
+            if tail.contains('\n') || tail.contains('\r') {
+                "newline_only"
+            } else {
+                "empty_or_ws"
+            }
+        }
+        Some('.') | Some('!') | Some('?') => "sentence_end",
+        Some(ch) if ch.is_alphanumeric() => "alnum",
+        Some(',') | Some(';') | Some(':') | Some('-') | Some('–') | Some('—') | Some('/')
+        | Some('\\') => "soft_punct",
+        Some(_) => "other",
+    }
 }
 #[cfg_attr(not(any(test, target_os = "windows")), allow(dead_code))]
 pub fn reset_injection_history() {

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -157,6 +157,49 @@ unsafe fn write_clipboard_unicode(data: &[u16]) -> anyhow::Result<()> {
     }
 }
 
+// Reads CF_UNICODETEXT from the clipboard. Returns `Some("")` when the format
+// is present but empty, and `None` only when the clipboard can't be read.
+unsafe fn read_clipboard_text() -> Option<String> {
+    use ::windows::Win32::Foundation::HGLOBAL;
+    use ::windows::Win32::System::DataExchange::{
+        CloseClipboard, GetClipboardData, OpenClipboard,
+    };
+    use ::windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+
+    const CF_UNICODETEXT: u32 = 13;
+
+    let opened = (0..3).any(|i| {
+        if i > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_OPEN_RETRY_MS));
+        }
+        OpenClipboard(None).is_ok()
+    });
+    if !opened {
+        return None;
+    }
+
+    let mut text: Option<String> = None;
+    if let Ok(h) = GetClipboardData(CF_UNICODETEXT) {
+        let hg = HGLOBAL(h.0);
+        let size = GlobalSize(hg);
+        if size == 0 {
+            text = Some(String::new());
+        } else {
+            let ptr = GlobalLock(hg) as *const u16;
+            if !ptr.is_null() {
+                let units = size / 2;
+                let slice = std::slice::from_raw_parts(ptr, units);
+                let end = slice.iter().position(|&c| c == 0).unwrap_or(units);
+                text = Some(String::from_utf16_lossy(&slice[..end]));
+                let _ = GlobalUnlock(hg);
+            }
+        }
+    }
+
+    CloseClipboard().ok();
+    text
+}
+
 pub(super) async fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
     let wide: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
     for attempt in 0..3u32 {
@@ -168,6 +211,110 @@ pub(super) async fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
         }
     }
     anyhow::bail!("copy_to_clipboard: clipboard held after 3 attempts")
+}
+
+// Chromium/Electron populate the clipboard asynchronously after Ctrl+C, so the
+// sniff polls a few times before concluding the field is empty.
+const SNIFF_READ_ATTEMPTS: usize = 4;
+const SNIFF_READ_INTERVAL_MS: u64 = 25;
+
+// Verifies what is actually selectable immediately before the caret. UIA can
+// report phantom text before the cursor in a visually empty box (Chromium /
+// Electron controls), which makes contextual-caps wrongly lowercase. Selecting
+// one char back reflects what the user actually sees. Mirrors
+// `macos_clipboard_sniff_context`. Relies on the caller (`inject_text`) having
+// already saved the clipboard before the probe step; the caller's paste and
+// final `restore_clipboard_all(&saved)` put the user's clipboard back.
+async fn windows_clipboard_sniff_context(target_hwnd: usize) -> Option<InjectionContextProbe> {
+    use ::windows::Win32::UI::Input::KeyboardAndMouse::{
+        INPUT, INPUT_0, INPUT_KEYBOARD, KEYBD_EVENT_FLAGS, KEYBDINPUT, KEYEVENTF_KEYUP, SendInput,
+        VK_C, VK_CONTROL, VK_LEFT, VK_RIGHT, VK_SHIFT,
+    };
+
+    // Don't send keystrokes to the wrong window if focus moved mid-pipeline.
+    if crate::core::window_context::get_foreground_hwnd() != target_hwnd {
+        return None;
+    }
+
+    unsafe {
+        let ki = |vk, flags: u32| INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: vk,
+                    wScan: 0,
+                    dwFlags: KEYBD_EVENT_FLAGS(flags),
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+
+        // Seed an empty sentinel so a failed copy (empty box) reads as empty
+        // rather than as a stale clipboard value. Bail if it can't be set so we
+        // never misread leftover clipboard text as content before the caret.
+        if write_clipboard_unicode(&[0u16]).is_err() {
+            return None;
+        }
+
+        let one = std::mem::size_of::<INPUT>() as i32;
+
+        // Select one character back. Press Shift, tap Left, release Shift as
+        // separate sends with gaps: an atomic Shift+Left batch is seen as a plain
+        // Left in some controls (Chromium/Electron), which moves the caret
+        // instead of selecting — that both fooled the sniff and corrupted the
+        // paste ("HellHi.o").
+        SendInput(&[ki(VK_SHIFT, 0)], one);
+        tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+        SendInput(&[ki(VK_LEFT, 0), ki(VK_LEFT, KEYEVENTF_KEYUP.0)], one);
+        tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+        SendInput(&[ki(VK_SHIFT, KEYEVENTF_KEYUP.0)], one);
+        tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+
+        // Ctrl+C: copy the selection, if any.
+        let copy = [
+            ki(VK_CONTROL, 0),
+            ki(VK_C, 0),
+            ki(VK_C, KEYEVENTF_KEYUP.0),
+            ki(VK_CONTROL, KEYEVENTF_KEYUP.0),
+        ];
+        SendInput(&copy, one);
+
+        // Poll the clipboard — Chromium/Electron populate it asynchronously, so a
+        // single immediate read can miss the copied character.
+        let mut sniffed = String::new();
+        for _ in 0..SNIFF_READ_ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_millis(SNIFF_READ_INTERVAL_MS)).await;
+            if let Some(s) = read_clipboard_text() {
+                if !s.is_empty() {
+                    sniffed = s;
+                    break;
+                }
+            }
+        }
+
+        // ALWAYS collapse back to the original caret. Right moves to the right
+        // edge of a selection, or undoes a Left that merely moved the caret —
+        // either way the caret returns to where it started. Skipping this on a
+        // failed read is what corrupted the paste, so it runs unconditionally.
+        SendInput(&[ki(VK_RIGHT, 0), ki(VK_RIGHT, KEYEVENTF_KEYUP.0)], one);
+        tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+
+        let context = if sniffed.is_empty() {
+            crate::core::text_context::SentenceContext::NewSentence
+        } else {
+            crate::core::text_context::classify_context_tail(&sniffed)
+        };
+
+        Some(InjectionContextProbe {
+            context,
+            source: ContextProbeSource::ClipboardSniff,
+            context_tail: sniffed,
+            control_type: "clipboard_sniff".to_string(),
+            selection_state: SelectionState::Unknown,
+            control_identity_hash: "clipboard_sniff".to_string(),
+        })
+    }
 }
 
 #[allow(unused_variables)]
@@ -217,6 +364,24 @@ pub(super) async fn inject_text(
                 injection_probe = history_probe;
             }
         }
+        // A caret-local read that says "mid-sentence" can be wrong in Chromium /
+        // Electron controls that report phantom text before the caret in an empty
+        // box. Verify against what's actually selectable before lowercasing.
+        if caret_local_needs_sniff_verification(
+            contextual_caps,
+            injection_probe.source,
+            injection_probe.context,
+        ) {
+            if let Some(mut sniff) = windows_clipboard_sniff_context(target_hwnd).await {
+                // Spacing must follow the reliable UIA tail ("is there a visible
+                // char before the caret?"), not the sniff: in Chromium/Electron
+                // editors synthetic Ctrl+C is a no-op, so the sniff always reads
+                // empty there. Let the sniff drive only the capitalization
+                // decision, keeping UIA's tail so appends still get a space.
+                sniff.context_tail = injection_probe.context_tail.clone();
+                injection_probe = sniff;
+            }
+        }
         let (adjusted, context_kind, case_decision) = apply_probe_adjustments(
             text,
             contextual_caps,
@@ -244,6 +409,8 @@ pub(super) async fn inject_text(
             }
         }
         if !clipboard_written {
+            // Put the user's clipboard back — a sniff may have left its sentinel.
+            restore_clipboard_all(&saved);
             return Err(anyhow::anyhow!(
                 "OpenClipboard failed after 3 attempts - clipboard held by another process"
             ));

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -158,8 +158,10 @@ unsafe fn write_clipboard_unicode(data: &[u16]) -> anyhow::Result<()> {
 }
 
 // Reads CF_UNICODETEXT from the clipboard. Returns `Some("")` when the format
-// is present but empty, and `None` only when the clipboard can't be read.
-unsafe fn read_clipboard_text() -> Option<String> {
+// is present but empty, and `None` only when the clipboard can't be read. Async
+// so the OpenClipboard retry backoff yields to the runtime instead of blocking
+// the executor thread with a synchronous sleep.
+async fn read_clipboard_text() -> Option<String> {
     use ::windows::Win32::Foundation::HGLOBAL;
     use ::windows::Win32::System::DataExchange::{
         CloseClipboard, GetClipboardData, OpenClipboard,
@@ -168,35 +170,40 @@ unsafe fn read_clipboard_text() -> Option<String> {
 
     const CF_UNICODETEXT: u32 = 13;
 
-    let opened = (0..3).any(|i| {
+    let mut opened = false;
+    for i in 0..3 {
         if i > 0 {
-            std::thread::sleep(std::time::Duration::from_millis(CLIPBOARD_OPEN_RETRY_MS));
+            tokio::time::sleep(tokio::time::Duration::from_millis(CLIPBOARD_OPEN_RETRY_MS)).await;
         }
-        OpenClipboard(None).is_ok()
-    });
+        if unsafe { OpenClipboard(None) }.is_ok() {
+            opened = true;
+            break;
+        }
+    }
     if !opened {
         return None;
     }
 
     let mut text: Option<String> = None;
-    if let Ok(h) = GetClipboardData(CF_UNICODETEXT) {
-        let hg = HGLOBAL(h.0);
-        let size = GlobalSize(hg);
-        if size == 0 {
-            text = Some(String::new());
-        } else {
-            let ptr = GlobalLock(hg) as *const u16;
-            if !ptr.is_null() {
-                let units = size / 2;
-                let slice = std::slice::from_raw_parts(ptr, units);
-                let end = slice.iter().position(|&c| c == 0).unwrap_or(units);
-                text = Some(String::from_utf16_lossy(&slice[..end]));
-                let _ = GlobalUnlock(hg);
+    unsafe {
+        if let Ok(h) = GetClipboardData(CF_UNICODETEXT) {
+            let hg = HGLOBAL(h.0);
+            let size = GlobalSize(hg);
+            if size == 0 {
+                text = Some(String::new());
+            } else {
+                let ptr = GlobalLock(hg) as *const u16;
+                if !ptr.is_null() {
+                    let units = size / 2;
+                    let slice = std::slice::from_raw_parts(ptr, units);
+                    let end = slice.iter().position(|&c| c == 0).unwrap_or(units);
+                    text = Some(String::from_utf16_lossy(&slice[..end]));
+                    let _ = GlobalUnlock(hg);
+                }
             }
         }
+        CloseClipboard().ok();
     }
-
-    CloseClipboard().ok();
     text
 }
 
@@ -285,7 +292,7 @@ async fn windows_clipboard_sniff_context(target_hwnd: usize) -> Option<Injection
         let mut sniffed = String::new();
         for _ in 0..SNIFF_READ_ATTEMPTS {
             tokio::time::sleep(tokio::time::Duration::from_millis(SNIFF_READ_INTERVAL_MS)).await;
-            if let Some(s) = read_clipboard_text() {
+            if let Some(s) = read_clipboard_text().await {
                 if !s.is_empty() {
                     sniffed = s;
                     break;

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -25,6 +25,12 @@ impl SettingsSnapshot {
         self.values.get(key).cloned()
     }
 
+    #[cfg(test)]
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, Value)>) -> Self {
+        SettingsSnapshot {
+            values: pairs.into_iter().collect(),
+        }
+    }
 }
 
 impl SettingsHandle {

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -162,7 +162,13 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // typing (toggling Caps Lock) while it runs.
     let caps_lock_on = crate::core::hotkey::caps_lock_is_on();
 
-    let process_name = window_context::get_active_process_name()
+    // Resolve the app identity from the window text will actually be injected
+    // into (captured at record-start), not the live foreground at release — the
+    // two can diverge (handsfree, focus shifts) and that divergence let one
+    // app's mapping style leak into another app. Issue #144. Falls back to the
+    // live foreground only when the captured hwnd is unavailable (null/0).
+    let process_name = window_context::get_process_name_for_hwnd(target_hwnd)
+        .or_else(window_context::get_active_process_name)
         .unwrap_or_else(|| "unknown".into())
         .to_lowercase();
     log::info!("pipeline: start process={process_name} target_hwnd={target_hwnd}");

--- a/src-tauri/src/pipeline/stages.rs
+++ b/src-tauri/src/pipeline/stages.rs
@@ -126,11 +126,23 @@ pub(super) fn ensure_terminal_punctuation(
     let trimmed = text.trim_end();
     match trimmed.chars().next_back() {
         Some(last) if last.is_alphanumeric() => {
+            // Chinese/Japanese text uses the full-width period; a Western "."
+            // reads as out of place after CJK ideographs or kana.
+            let punct = if is_cjk(last) { "。" } else { "." };
             // Preserve any trailing whitespace the model emitted after the word.
-            format!("{trimmed}.{}", &text[trimmed.len()..])
+            format!("{trimmed}{punct}{}", &text[trimmed.len()..])
         }
         _ => text.to_owned(),
     }
+}
+
+fn is_cjk(c: char) -> bool {
+    matches!(c,
+        '\u{4e00}'..='\u{9fff}'   // CJK Unified Ideographs
+        | '\u{3400}'..='\u{4dbf}' // CJK Unified Ideographs Extension A
+        | '\u{3040}'..='\u{309f}' // Hiragana
+        | '\u{30a0}'..='\u{30ff}' // Katakana
+    )
 }
 // session.stop() blocks until the audio thread finishes (denoise + resample + WAV encode).
 // spawn_blocking keeps the tokio worker free during that wait.

--- a/src-tauri/src/pipeline/stages.rs
+++ b/src-tauri/src/pipeline/stages.rs
@@ -101,6 +101,37 @@ pub(super) fn apply_app_style_overrides(
         .filter(|p| !p.is_empty())
         .unwrap_or_else(|| cfg.default_tone.clone())
 }
+
+/// Casual/formal cleanup sometimes omits a closing period on short utterances.
+/// That leaves a bare word before the caret, which the contextual-capitalization
+/// probe then reads as a mid-sentence continuation — so the *next* dictation has
+/// its first letter lowercased. Appending a period when the cleaned text ends on
+/// a plain word makes consecutive dictations read as separate sentences and
+/// capitalize naturally.
+///
+/// Deliberately conservative:
+/// - `very_casual` is skipped (its style is intentionally near-punctuation-free).
+/// - `none`/verbatim intensity is skipped (must echo speech without editorializing).
+/// - Only acts when the last non-space character is alphanumeric. Text already
+///   ending in terminal punctuation, a comma/colon/dash (intentional
+///   continuation), or a closing bracket/quote is left untouched.
+pub(super) fn ensure_terminal_punctuation(
+    text: &str,
+    profile: &str,
+    cleanup_intensity: &str,
+) -> String {
+    if profile == "very_casual" || cleanup_intensity == "none" {
+        return text.to_owned();
+    }
+    let trimmed = text.trim_end();
+    match trimmed.chars().next_back() {
+        Some(last) if last.is_alphanumeric() => {
+            // Preserve any trailing whitespace the model emitted after the word.
+            format!("{trimmed}.{}", &text[trimmed.len()..])
+        }
+        _ => text.to_owned(),
+    }
+}
 // session.stop() blocks until the audio thread finishes (denoise + resample + WAV encode).
 // spawn_blocking keeps the tokio worker free during that wait.
 pub(super) async fn stop_and_validate_audio(
@@ -182,6 +213,12 @@ pub(super) async fn open_config_and_context(
     }
     let mapping = resolve_app_mapping(Some(&settings_store), process_name);
     let profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
+    log::debug!(
+        "pipeline: app mapping resolved process={process_name} matched={} profile={profile} cleanup_intensity={} default_tone={}",
+        mapping.as_ref().map(|m| m.exe.as_str()).unwrap_or("none"),
+        cfg.cleanup_intensity,
+        cfg.default_tone,
+    );
     let app_context = if cfg.app_context_hint {
         window_context::get_app_context_hint(process_name)
     } else {
@@ -395,8 +432,13 @@ pub(super) async fn run_cleanup_and_snippets_for_db(
                     new_hit_count,
                     new_expires_at
                 );
-                let overridden = snippets::apply_cleanup_instruction_overrides(
+                let punctuated = ensure_terminal_punctuation(
                     &entry.clean_text,
+                    profile,
+                    &cfg.cleanup_intensity,
+                );
+                let overridden = snippets::apply_cleanup_instruction_overrides(
+                    &punctuated,
                     &snippet_instructions,
                 );
                 return Ok((overridden, dict_entries, cache_key));
@@ -497,6 +539,10 @@ pub(super) async fn run_cleanup_and_snippets_for_db(
 
         match guarded {
             Some(cleaned) => {
+                // Punctuate before caching + overrides so the cache stores the
+                // normalized text and snippet "no period" instructions can still
+                // override it afterward.
+                let cleaned = ensure_terminal_punctuation(&cleaned, profile, &cfg.cleanup_intensity);
                 let overridden =
                     snippets::apply_cleanup_instruction_overrides(&cleaned, &snippet_instructions);
                 if !cache_key.is_empty() {

--- a/src-tauri/src/pipeline/tests.rs
+++ b/src-tauri/src/pipeline/tests.rs
@@ -1,9 +1,11 @@
     use super::{
-        is_transcription_hallucination, normalize_transcription_math_artifacts, preview_text,
-        recording_gate_rms, run_pipeline_fixture, should_run_cleanup_llm, should_use_cleanup_cache,
+        apply_app_style_overrides, ensure_terminal_punctuation, is_transcription_hallucination,
+        normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
+        resolve_app_mapping, run_pipeline_fixture, should_run_cleanup_llm, should_use_cleanup_cache,
         style_scoped_cleanup_cache_key, PipelineTestDictionaryEntry, PipelineTestRequest,
         PipelineTestSnippet,
     };
+    use crate::system::apps::AppMapping;
 
     #[test]
     fn preview_text_redacts_dictation_content_when_not_verbose() {
@@ -122,6 +124,114 @@
         assert!((default_gate - 0.008).abs() < f32::EPSILON);
         assert!(high_gain_gate < default_gate);
         assert!((high_gain_gate - 0.0035).abs() < 0.0001);
+    }
+
+    #[test]
+    fn terminal_punctuation_added_for_casual_bare_word() {
+        assert_eq!(
+            ensure_terminal_punctuation("smart decision", "casual", "medium"),
+            "smart decision."
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("the report is done", "formal", "high"),
+            "the report is done."
+        );
+    }
+
+    #[test]
+    fn terminal_punctuation_left_alone_when_already_terminated() {
+        assert_eq!(
+            ensure_terminal_punctuation("all good.", "casual", "medium"),
+            "all good."
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("really?", "casual", "medium"),
+            "really?"
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("wait,", "casual", "medium"),
+            "wait,"
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("as follows:", "casual", "medium"),
+            "as follows:"
+        );
+    }
+
+    #[test]
+    fn terminal_punctuation_skipped_for_very_casual_and_verbatim() {
+        assert_eq!(
+            ensure_terminal_punctuation("smart decision", "very_casual", "medium"),
+            "smart decision"
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("smart decision", "casual", "none"),
+            "smart decision"
+        );
+    }
+
+    #[test]
+    fn terminal_punctuation_preserves_trailing_whitespace_and_empty() {
+        assert_eq!(
+            ensure_terminal_punctuation("hello ", "casual", "medium"),
+            "hello. "
+        );
+        assert_eq!(ensure_terminal_punctuation("", "casual", "medium"), "");
+        assert_eq!(ensure_terminal_punctuation("   ", "casual", "medium"), "   ");
+    }
+
+    fn mapping(exe: &str, profile: &str, cleanup_intensity: Option<&str>) -> AppMapping {
+        AppMapping {
+            exe: exe.into(),
+            profile: profile.into(),
+            name: String::new(),
+            cleanup_intensity: cleanup_intensity.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn app_mapping_override_applies_for_matching_app() {
+        // base_config(): default_tone = "casual", cleanup_intensity = "medium".
+        let mut cfg = base_config();
+        let m = mapping("appa.exe", "very_casual", Some("high"));
+        let profile = apply_app_style_overrides(&mut cfg, Some(&m));
+        assert_eq!(profile, "very_casual");
+        assert_eq!(cfg.cleanup_intensity, "high");
+    }
+
+    #[test]
+    fn app_mapping_no_match_leaves_global_defaults_untouched() {
+        // Regression for issue #144: when no mapping matches the active app, the
+        // effective tone falls back to default_tone and the global cleanup
+        // intensity must NOT be mutated by a different app's override.
+        let mut cfg = base_config();
+        let profile = apply_app_style_overrides(&mut cfg, None);
+        assert_eq!(profile, "casual");
+        assert_eq!(cfg.cleanup_intensity, "medium");
+    }
+
+    #[test]
+    fn app_mapping_empty_override_fields_fall_back_to_globals() {
+        let mut cfg = base_config();
+        let m = mapping("appa.exe", "   ", Some("   "));
+        let profile = apply_app_style_overrides(&mut cfg, Some(&m));
+        assert_eq!(profile, "casual");
+        assert_eq!(cfg.cleanup_intensity, "medium");
+    }
+
+    #[test]
+    fn resolve_app_mapping_is_scoped_to_matching_exe() {
+        let mappings = serde_json::json!([
+            { "exe": "appa.exe", "profile": "very_casual", "cleanup_intensity": "high" }
+        ]);
+        let snap = store::SettingsSnapshot::from_pairs([(store::APP_MAPPINGS.to_string(), mappings)]);
+
+        let matched = resolve_app_mapping(Some(&snap), "appa.exe").expect("App A should match");
+        assert_eq!(matched.profile, "very_casual");
+        assert_eq!(matched.cleanup_intensity.as_deref(), Some("high"));
+
+        // A different foreground app must not resolve App A's mapping.
+        assert!(resolve_app_mapping(Some(&snap), "appb.exe").is_none());
     }
 
     fn base_config() -> store::PipelineConfig {
@@ -359,8 +469,8 @@
         let result = run_pipeline_fixture(base_request(config))
             .await
             .expect("cleanup fallback should succeed");
-        assert_eq!(result.final_text_before_dictionary, "clean fallback result");
-        assert_eq!(result.history_entry.clean_text, "clean fallback result");
+        assert_eq!(result.final_text_before_dictionary, "clean fallback result.");
+        assert_eq!(result.history_entry.clean_text, "clean fallback result.");
         assert_eq!(result.stats.total_words, 4);
         assert_eq!(result.recent.len(), 1);
         assert_eq!(
@@ -442,6 +552,8 @@
         let result = run_pipeline_fixture(base_request(base_config()))
             .await
             .expect("model refusal should fall back to pre-cleanup text");
+        // Cleanup refused, so the pipeline falls back to the pre-cleanup text via
+        // the non-cleaned path — which is intentionally left unpunctuated.
         assert_eq!(
             result.final_text_before_dictionary,
             "what time is it in tokyo right now"
@@ -530,8 +642,10 @@
         let result = run_pipeline_fixture(request)
             .await
             .expect("instruction and dictionary path should succeed");
-        assert_eq!(result.final_text_before_dictionary, "ACME ALERT");
-        assert_eq!(result.injected_text, "Verenu ALERT");
+        // Casual cleanup now guarantees a terminal period (so consecutive
+        // dictations capitalize); the "all capitals" override still applies.
+        assert_eq!(result.final_text_before_dictionary, "ACME ALERT.");
+        assert_eq!(result.injected_text, "Verenu ALERT.");
         reset();
     }
 

--- a/src-tauri/src/pipeline/tests.rs
+++ b/src-tauri/src/pipeline/tests.rs
@@ -180,6 +180,27 @@
         assert_eq!(ensure_terminal_punctuation("   ", "casual", "medium"), "   ");
     }
 
+    #[test]
+    fn terminal_punctuation_uses_fullwidth_period_for_cjk() {
+        assert_eq!(
+            ensure_terminal_punctuation("今晩予定がある", "casual", "medium"),
+            "今晩予定がある。"
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("这是一个决定", "formal", "high"),
+            "这是一个决定。"
+        );
+        assert_eq!(
+            ensure_terminal_punctuation("コーヒーを飲む", "casual", "medium"),
+            "コーヒーを飲む。"
+        );
+        // Already terminated with a fullwidth period stays untouched.
+        assert_eq!(
+            ensure_terminal_punctuation("今晩予定がある。", "casual", "medium"),
+            "今晩予定がある。"
+        );
+    }
+
     fn mapping(exe: &str, profile: &str, cleanup_intensity: Option<&str>) -> AppMapping {
         AppMapping {
             exe: exe.into(),


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - This touches two subsystems: the **pipeline** (per-app tone/cleanup mapping) and **text injection** (contextual capitalization + spacing)
> - Two everyday-correctness gaps existed: a per-app mapping could leak its style into other apps, and dictation into empty or Chromium/Electron text boxes (e.g. Antigravity's Monaco composer) came out lowercased with no leading space because UI Automation reports phantom text before the caret
> - These needed addressing now because they made app tone-mappings effectively unusable (issue #144) and made everyday dictation output look wrong in real editors — directly in scope of ROADMAP §3 "Contextual Capitalization Reliability Regression"
> - This pull request anchors mapping resolution to the window text is actually injected into, and adds a Windows clipboard sniff that verifies the real box contents before deciding capitalization, while keeping spacing on the reliable UIA signal
> - The benefit is that tone mappings stay scoped to their app, and dictation capitalizes and spaces correctly even where the accessibility layer lies — and it fails closed (never randomly lowercases), advancing the deterministic-context goal in ROADMAP §3

## What Changed

- **App-mapping style leak (#144):** the per-app tone + cleanup-intensity now resolve from the captured injection-target window (`target_hwnd`) instead of the live foreground at hotkey-release. The two could diverge (handsfree, focus shifts), which let one app's Very Casual/Direct style leak into dictation injected into other apps. Falls back to the live foreground only when the captured hwnd is unavailable.
- **Casual/formal cleanup now guarantees terminal punctuation**, so a following dictation into the same field reads as a new sentence and capitalizes (`very_casual`/verbatim intensity are deliberately exempt).
- **Windows clipboard sniff for contextual caps:** when a caret-local UIA read would lowercase, it selects one character back and inspects what is *actually* selectable. An empty box now capitalizes; genuine mid-sentence joins still lowercase. The sniff drives **only** capitalization — **spacing follows the reliable UIA tail**, so appends keep their leading space even in Chromium where synthetic `Ctrl+C` is a no-op. The caret is **always** restored, so a failed read can never corrupt text.
- **Redacted diagnostics** (verbose-only): mapping resolution (process, matched exe, profile, intensity) and the capitalization decision (probe source, previous-character class, case decision) — the metadata called for in ROADMAP §3.
- **Tests:** mapping-scope regression tests, terminal-punctuation tests, and a unit-tested gate for when sniff verification runs.

## Verification

- `npm run test:rust` (`cargo test --manifest-path src-tauri/Cargo.toml`) — **246 passed**, includes new mapping, punctuation, and sniff-gate tests
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `npm run check` (svelte-check) — 0 errors / 0 warnings (no frontend changes)
- Manual (Windows):
  - Map App A → Very Casual/Direct, dictate into App B → output stays the global tone (verbose log shows `matched=none`); deleting the mapping is no longer required.
  - Type `Hello`, dictate `Hi` immediately after the `o` → `Hello Hi` (capitalized, space added, **no character deleted**).
  - Dictate into a visually empty Antigravity composer → first letter capitalized.

## Risks

- **Injection behavior shift (Windows only):** the sniff sends synthetic `Shift+Left` / `Ctrl+C` / `Right` and touches the clipboard, but only on lowercase-candidate dictations. It guards on the foreground HWND, restores the caret **unconditionally**, and restores the clipboard via the existing save/restore path, so it cannot corrupt text. Worst case is an append occasionally missing its leading space, or a truly-empty Chromium box getting one leading space — both cosmetic. It adds ~150-220 ms to mid-sentence dictations. Turning off contextual capitalization disables the sniff entirely.
- **macOS path unchanged.** No settings migration, no API-key surface, no smoke-test contract changes. All new logs are redacted metadata only (no dictated text).

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Anthropic Claude Opus 4.8 (`claude-opus-4-8`), extended thinking + tool use

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR advances ROADMAP §3 (contextual capitalization) rather than duplicating planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy) — Clippy `-D warnings` clean; no frontend/TS lint changes
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (not run for this backend-only injection change)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (no UI changes)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (no version bump)
- [ ] Relevant documentation updated to reflect changes (behavior already described generically in CLAUDE.md injection section)
- [x] Risks documented above
