### PR TITLE
Position dictation pill on target monitor

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -1,6 +1,7 @@
 //! Microphone + recording/calibration session control commands.
 
 use super::*;
+use crate::core::window_geometry::{capture_webview_center, WindowTarget};
 
 fn lock_state<'a>(
     state: &'a tauri::State<'_, SharedState>,
@@ -8,6 +9,16 @@ fn lock_state<'a>(
     state
         .lock()
         .map_err(|_| "Recording state lock was poisoned".to_string())
+}
+
+fn capture_in_app_target(app: &AppHandle) -> WindowTarget {
+    let mut target = WindowTarget::capture_display_only();
+    if let Some(window) = app.get_webview_window("main") {
+        if let Some(display_point) = capture_webview_center(&window) {
+            target.display_point = Some(display_point);
+        }
+    }
+    target
 }
 // ---------- microphone ----------
 
@@ -35,6 +46,13 @@ pub async fn start_input_recording(
             return Err("Already recording".to_string());
         }
         st.starting = true;
+    }
+
+    let target = capture_in_app_target(&app);
+    {
+        let mut st = lock_state(&state)?;
+        st.target = target;
+        st.pill_placement_stale = true;
     }
 
     let state_clone = state.inner().clone();
@@ -81,7 +99,13 @@ pub async fn start_setup_try_recording(
             return Err("Already recording".to_string());
         }
         st.starting = true;
-        st.target_hwnd = 0;
+    }
+
+    let target = capture_in_app_target(&app);
+    {
+        let mut st = lock_state(&state)?;
+        st.target = target;
+        st.pill_placement_stale = true;
     }
 
     let state_clone = state.inner().clone();
@@ -145,6 +169,13 @@ pub async fn start_calibration_monitoring(
             return Err("Already recording".to_string());
         }
         st.starting = true;
+    }
+
+    let target = capture_in_app_target(&app);
+    {
+        let mut st = lock_state(&state)?;
+        st.target = target;
+        st.pill_placement_stale = true;
     }
 
     let state_clone = state.inner().clone();

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod hotkey;
 pub mod injection;
 pub mod text_context;
 pub mod window_context;
+pub mod window_geometry;
 
 #[cfg(target_os = "macos")]
 mod context_probe_macos;

--- a/src-tauri/src/core/window_geometry.rs
+++ b/src-tauri/src/core/window_geometry.rs
@@ -1,0 +1,205 @@
+//! Native target-window geometry used to choose the dictation pill's display.
+//!
+//! Coordinates intentionally stay in each platform's desktop coordinate space:
+//! physical pixels on Windows and Core Graphics logical coordinates on macOS.
+//! Those are the coordinate spaces expected by Tauri's `monitor_from_point`.
+
+use crate::core::window_context;
+use tauri::{Runtime, WebviewWindow};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct DesktopPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// The native focus target used for injection plus the display anchor captured
+/// at dictation start. The id is an HWND on Windows and an application PID on
+/// macOS.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct WindowTarget {
+    pub id: usize,
+    pub display_point: Option<DesktopPoint>,
+}
+
+impl WindowTarget {
+    pub fn capture_foreground() -> Self {
+        Self::from_id(window_context::get_foreground_hwnd())
+    }
+
+    pub fn capture_display_only() -> Self {
+        let target = Self::capture_foreground();
+        Self::from_parts(0, target.display_point)
+    }
+
+    pub fn from_parts(id: usize, display_point: Option<DesktopPoint>) -> Self {
+        Self { id, display_point }
+    }
+
+    pub fn from_id(id: usize) -> Self {
+        Self {
+            id,
+            display_point: window_center(id),
+        }
+    }
+
+    /// Re-read geometry for retries in case the target window moved. Retain the
+    /// original point if the native window is no longer queryable.
+    pub fn refreshed(self) -> Self {
+        let refreshed = Self::from_id(self.id);
+        Self {
+            id: self.id,
+            display_point: refreshed.display_point.or(self.display_point),
+        }
+    }
+}
+
+/// Returns the center of a Tauri webview window in the platform coordinate
+/// space used by `WindowTarget::display_point`.
+pub fn capture_webview_center<R: Runtime>(window: &WebviewWindow<R>) -> Option<DesktopPoint> {
+    let position = window.outer_position().ok()?;
+    let size = window.outer_size().ok()?;
+    if size.width == 0 || size.height == 0 {
+        return None;
+    }
+
+    #[cfg(target_os = "macos")]
+    let scale_factor = window
+        .scale_factor()
+        .ok()
+        .filter(|scale| *scale > 0.0)
+        .unwrap_or(1.0);
+
+    #[cfg(not(target_os = "macos"))]
+    let scale_factor = 1.0;
+
+    Some(DesktopPoint {
+        x: (position.x as f64 + size.width as f64 / 2.0) / scale_factor,
+        y: (position.y as f64 + size.height as f64 / 2.0) / scale_factor,
+    })
+}
+
+#[cfg(windows)]
+fn window_center(id: usize) -> Option<DesktopPoint> {
+    use windows::Win32::Foundation::{HWND, RECT};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    if id == 0 {
+        return None;
+    }
+
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(HWND(id as *mut core::ffi::c_void), &mut rect) }.ok()?;
+    if rect.right <= rect.left || rect.bottom <= rect.top {
+        return None;
+    }
+
+    Some(DesktopPoint {
+        x: (f64::from(rect.left) + f64::from(rect.right)) / 2.0,
+        y: (f64::from(rect.top) + f64::from(rect.bottom)) / 2.0,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn window_center(id: usize) -> Option<DesktopPoint> {
+    use accessibility_sys::{
+        kAXErrorSuccess, kAXFocusedWindowAttribute, kAXPositionAttribute, kAXSizeAttribute,
+        kAXValueTypeCGPoint, kAXValueTypeCGSize, AXUIElementCopyAttributeValue,
+        AXUIElementCreateApplication, AXUIElementRef, AXUIElementSetMessagingTimeout,
+        AXValueGetValue, AXValueRef,
+    };
+    use core_foundation::base::{CFRelease, CFTypeRef, TCFType};
+    use core_foundation::string::CFString;
+    use std::ffi::c_void;
+    use std::ptr;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct Point {
+        x: f64,
+        y: f64,
+    }
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct Size {
+        width: f64,
+        height: f64,
+    }
+
+    unsafe fn copy_attribute(element: AXUIElementRef, name: &str) -> Option<CFTypeRef> {
+        let attribute = CFString::new(name);
+        let mut value: CFTypeRef = ptr::null();
+        if AXUIElementCopyAttributeValue(element, attribute.as_concrete_TypeRef(), &mut value)
+            != kAXErrorSuccess
+            || value.is_null()
+        {
+            return None;
+        }
+        Some(value)
+    }
+
+    if id == 0 || id > i32::MAX as usize {
+        return None;
+    }
+
+    unsafe {
+        let application = AXUIElementCreateApplication(id as i32);
+        if application.is_null() {
+            return None;
+        }
+        let _ = AXUIElementSetMessagingTimeout(application, 0.015);
+
+        let result = (|| {
+            let window_value = copy_attribute(application, kAXFocusedWindowAttribute)?;
+            let window = window_value as AXUIElementRef;
+            let _ = AXUIElementSetMessagingTimeout(window, 0.015);
+
+            let position_value = copy_attribute(window, kAXPositionAttribute);
+            let size_value = copy_attribute(window, kAXSizeAttribute);
+
+            let center = match (position_value, size_value) {
+                (Some(position_value), Some(size_value)) => {
+                    let mut position = Point::default();
+                    let mut size = Size::default();
+                    let position_ok = AXValueGetValue(
+                        position_value as AXValueRef,
+                        kAXValueTypeCGPoint,
+                        &mut position as *mut Point as *mut c_void,
+                    );
+                    let size_ok = AXValueGetValue(
+                        size_value as AXValueRef,
+                        kAXValueTypeCGSize,
+                        &mut size as *mut Size as *mut c_void,
+                    );
+                    if position_ok && size_ok && size.width > 0.0 && size.height > 0.0 {
+                        Some(DesktopPoint {
+                            x: position.x + size.width / 2.0,
+                            y: position.y + size.height / 2.0,
+                        })
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(value) = position_value {
+                CFRelease(value);
+            }
+            if let Some(value) = size_value {
+                CFRelease(value);
+            }
+            CFRelease(window_value);
+            center
+        })();
+
+        CFRelease(application as CFTypeRef);
+        result
+    }
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+fn window_center(_id: usize) -> Option<DesktopPoint> {
+    None
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@ mod system;
 #[cfg(any(test, debug_assertions))]
 mod testing;
 
+use crate::core::window_geometry::WindowTarget;
 use crate::data::db;
 use crate::pipeline::{hide_pill, start_recording_session, AppState, SharedState};
 
@@ -131,7 +132,9 @@ fn main() {
         session: None,
         starting: false,
         handless: false,
-        target_hwnd: 0,
+        target: WindowTarget::default(),
+        pill_placement: None,
+        pill_placement_stale: false,
         retry_capture: None,
     }));
 
@@ -166,8 +169,10 @@ fn main() {
                                 #[cfg(target_os = "macos")]
                                 let (k1, k2) = if !crate::core::hotkey::is_hotkey_available(k1, k2)
                                 {
-                                    let _ = settings
-                                        .set(crate::data::store::HOTKEY, serde_json::json!(["AltLeft", "Space"]));
+                                    let _ = settings.set(
+                                        crate::data::store::HOTKEY,
+                                        serde_json::json!(["AltLeft", "Space"]),
+                                    );
                                     if let Err(e) = settings.save() {
                                         log::warn!(
                                             "Failed to save migrated hotkey to settings.json: {e:?}"
@@ -707,9 +712,10 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // Capture the target window before recording starts so
                         // inject_text can restore focus to it after the pipeline,
                         // even if the user switched windows during transcription.
-                        let hwnd = crate::core::window_context::get_foreground_hwnd();
+                        let target = WindowTarget::capture_foreground();
                         if let Some(mut st) = lock_app_state(&state_hk) {
-                            st.target_hwnd = hwnd;
+                            st.target = target;
+                            st.pill_placement_stale = true;
                         }
                         start_recording_session(&app_hk, &state_hk, "recording", false);
                     }
@@ -742,9 +748,10 @@ fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                             state_hk.clone(),
                         ));
                     } else if !has_session {
-                        let hwnd = crate::core::window_context::get_foreground_hwnd();
+                        let target = WindowTarget::capture_foreground();
                         if let Some(mut st) = lock_app_state(&state_hk) {
-                            st.target_hwnd = hwnd;
+                            st.target = target;
+                            st.pill_placement_stale = true;
                         }
                         start_recording_session(&app_hk, &state_hk, "handsfree", true);
                         core::hotkey::set_handless_active(true);

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -19,6 +19,7 @@ mod finalize;
 mod fixture;
 mod gates;
 mod pill;
+mod pill_position;
 mod session;
 mod stages;
 mod state;
@@ -152,7 +153,7 @@ pub async fn run_pipeline_event_only(app: AppHandle, state: SharedState) {
 
 async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_only: bool) {
     let started_at = std::time::Instant::now();
-    let Some((session, target_hwnd)) = take_pipeline_session(&state) else {
+    let Some((session, target)) = take_pipeline_session(&state) else {
         log::debug!("pipeline: no session - recording never started or was already consumed");
         return;
     };
@@ -162,10 +163,16 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // typing (toggling Caps Lock) while it runs.
     let caps_lock_on = crate::core::hotkey::caps_lock_is_on();
 
-    let process_name = window_context::get_active_process_name()
+    // Resolve the app identity from the window text will actually be injected
+    // into (captured at record-start), not the live foreground at release — the
+    // two can diverge (handsfree, focus shifts) and that divergence let one
+    // app's mapping style leak into another app. Issue #144. Falls back to the
+    // live foreground only when the captured target id is unavailable (null/0).
+    let process_name = window_context::get_process_name_for_hwnd(target.id)
+        .or_else(window_context::get_active_process_name)
         .unwrap_or_else(|| "unknown".into())
         .to_lowercase();
-    log::info!("pipeline: start process={process_name} target_hwnd={target_hwnd}");
+    log::info!("pipeline: start target_id={}", target.id);
 
     std::thread::spawn(crate::system::volume::unmute);
     show_pill(&app, "processing");
@@ -209,8 +216,8 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         profile
     );
     log::debug!(
-        "pipeline: context resolved app_context={} stage_ms={}",
-        app_context.as_deref().unwrap_or("none"),
+        "pipeline: context resolved app_context_present={} stage_ms={}",
+        app_context.is_some(),
         stage_config.elapsed().as_millis()
     );
 
@@ -220,7 +227,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
             wav: wav.clone(),
             captured_at: retry_captured_at,
             duration_ms,
-            target_hwnd,
+            target,
             process_name: process_name.clone(),
             profile: profile.clone(),
             app_context: app_context.clone(),
@@ -284,7 +291,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
             dict_entries: &dict_entries,
             duration_ms,
             api_used: &api_used,
-            target_hwnd,
+            target_hwnd: target.id,
             cfg: &cfg,
             profile: &profile,
             process_name,
@@ -315,7 +322,6 @@ pub async fn retry_transcription_impl(
     app: &AppHandle,
     state: &SharedState,
 ) -> anyhow::Result<db::RecentEntry> {
-    show_pill(app, "processing");
     let mut retry_expired = false;
     let capture = {
         let mut st = lock_state(state)?;
@@ -340,6 +346,13 @@ pub async fn retry_transcription_impl(
         hide_pill(app);
         anyhow::bail!("No retry available");
     };
+
+    capture.target = capture.target.refreshed();
+    if let Ok(mut st) = lock_state(state) {
+        st.target = capture.target;
+        st.pill_placement_stale = true;
+    }
+    show_pill(app, "processing");
 
     let settings_store = store::settings_snapshot(app).map_err(anyhow::Error::msg)?;
     let mut cfg = store::load_pipeline_config(&settings_store);
@@ -384,7 +397,7 @@ pub async fn retry_transcription_impl(
             dict_entries: &dict_entries,
             duration_ms: capture.duration_ms,
             api_used: &api_used,
-            target_hwnd: capture.target_hwnd,
+            target_hwnd: capture.target.id,
             cfg: &cfg,
             profile: &capture.profile,
             process_name: capture.process_name,

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -1,15 +1,14 @@
 //! Floating dictation-pill window lifecycle: creation, per-state show with
-//! atomic resize/reposition, and the deliberately-never-hide idle path. Pulled
-//! out of pipeline.rs verbatim; see the module docs on each function for the
-//! WebView2/AppKit gotchas that dictate this ordering. Not unit-tested (GUI),
-//! so changes here must be validated by running the app.
+//! atomic resize/reposition, and the deliberately-never-hide idle path. The
+//! placement math lives in `pill_position.rs` so the monitor selection can be
+//! tested without dragging the window lifecycle code along with it.
 
-use tauri::{AppHandle, Emitter, Manager};
+use super::SharedState;
+use crate::pipeline::pill_position::PillPlacement;
+use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 
 const PILL_WIDTH_POINTS: f64 = 380.0;
 const PILL_HEIGHT_POINTS: f64 = 44.0;
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-const PILL_BOTTOM_GAP_POINTS: f64 = 16.0;
 
 fn create_pill_if_needed(app: &AppHandle) {
     if app.get_webview_window("pill").is_some() {
@@ -18,7 +17,7 @@ fn create_pill_if_needed(app: &AppHandle) {
     let _ =
         tauri::WebviewWindowBuilder::new(app, "pill", tauri::WebviewUrl::App("/pill.html".into()))
             .title("")
-            .inner_size(140.0, 44.0)
+            .inner_size(PILL_WIDTH_POINTS, PILL_HEIGHT_POINTS)
             .decorations(false)
             .transparent(true)
             .always_on_top(true)
@@ -37,106 +36,20 @@ pub(crate) fn show_pill(app: &AppHandle, state: &str) {
 /// Shows the pill window in the given state, optionally carrying an error
 /// message. The window is always kept at the same width regardless of state
 /// (room enough for the error text to expand into) so it never needs to
-/// resize or reposition after its first appearance — resizing a WebView2
-/// window causes a visible repaint-lag flicker even when the native resize
-/// itself is atomic, so the fix is to avoid triggering one at all rather
-/// than to make it faster. Handsfree's click-capture zone is therefore wider
-/// than the visible pill; clicks in the empty space around it are swallowed
-/// instead of passing through while handsfree is active.
+/// resize or reposition after its first appearance. Handsfree's click-capture
+/// zone is therefore wider than the visible pill; clicks in the empty space
+/// around it are swallowed instead of passing through while handsfree is
+/// active.
 fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     create_pill_if_needed(app);
     if let Some(pill) = app.get_webview_window("pill") {
+        if let Some(placement) = next_pill_placement(app, &pill) {
+            super::pill_position::apply_pill_placement(&pill, placement);
+        }
+
         // Click-through for passive states so nothing behind the pill is blocked.
         // Handsfree needs real cursor events for its cancel/confirm buttons.
         pill.set_ignore_cursor_events(state != "handsfree").ok();
-
-        // Size and position while still hidden, so the window appears already
-        // in place instead of flashing at its previous geometry and jumping.
-        let width = PILL_WIDTH_POINTS;
-
-        // Resize and reposition are checked independently: primary_monitor()
-        // can return None on some platforms (e.g. macOS) while the window is
-        // still hidden, which would otherwise skip positioning on the first
-        // call and then skip it again on every later call once needs_resize
-        // is false — permanently mispositioning the pill. Falling back to a
-        // scale factor of 1.0 keeps the resize check meaningful even before
-        // monitor info is available.
-        let monitor = pill.primary_monitor().ok().flatten();
-        let scale_factor = monitor.as_ref().map(|m| m.scale_factor()).unwrap_or(1.0);
-
-        // Most transitions (recording/processing/error/idle) share this same
-        // width, so skip the resize when the window is already at the target
-        // size — re-issuing identical set_size calls can still make the OS
-        // window manager flicker.
-        let needs_resize = pill
-            .inner_size()
-            .map(|cur| (cur.width as f64 - width * scale_factor).abs() > 1.0)
-            .unwrap_or(true);
-
-        // Target position (physical pixels) on the current monitor, if known.
-        let target_pos = monitor.as_ref().map(|m| {
-            let sz = m.size();
-            let sf = m.scale_factor();
-            let pos = m.position();
-            let target_x = pos.x + ((sz.width as f64 - width * sf) / 2.0) as i32;
-            let bottom_offset_points = pill_bottom_offset_points();
-            let target_y = pos.y
-                + (sz.height as f64 - (PILL_HEIGHT_POINTS + bottom_offset_points) * sf) as i32;
-            (target_x, target_y)
-        });
-
-        let needs_reposition = match target_pos {
-            Some((target_x, target_y)) => pill
-                .outer_position()
-                .map(|cur| (cur.x - target_x).abs() > 1 || (cur.y - target_y).abs() > 1)
-                .unwrap_or(true),
-            None => false,
-        };
-
-        // On Windows, resize and reposition are merged into a single
-        // SetWindowPos call so the two are atomic if both are ever needed at
-        // once (e.g. a monitor/DPI change). With a constant width this only
-        // actually fires on the very first show, while still hidden.
-        #[cfg(target_os = "windows")]
-        {
-            use windows::Win32::UI::WindowsAndMessaging::{
-                SetWindowPos, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
-            };
-
-            if needs_resize || needs_reposition {
-                if let Ok(hwnd) = pill.hwnd() {
-                    let cx = (width * scale_factor).round() as i32;
-                    let cy = (PILL_HEIGHT_POINTS * scale_factor).round() as i32;
-                    let (x, y) = target_pos.unwrap_or((0, 0));
-
-                    let mut flags = SWP_NOZORDER | SWP_NOACTIVATE;
-                    if !needs_resize {
-                        flags |= SWP_NOSIZE;
-                    }
-                    if !needs_reposition {
-                        flags |= SWP_NOMOVE;
-                    }
-
-                    unsafe {
-                        let _ = SetWindowPos(hwnd, None, x, y, cx, cy, flags);
-                    }
-                }
-            }
-        }
-
-        #[cfg(not(target_os = "windows"))]
-        {
-            if needs_resize {
-                pill.set_size(tauri::LogicalSize::new(width, PILL_HEIGHT_POINTS))
-                    .ok();
-            }
-            if let Some((target_x, target_y)) = target_pos {
-                if needs_reposition {
-                    pill.set_position(tauri::PhysicalPosition::new(target_x, target_y))
-                        .ok();
-                }
-            }
-        }
 
         // Show the window before emitting state so WebView2 is active when it
         // receives the event. WebView2 suspends event processing while hidden;
@@ -159,7 +72,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
         // macOS: `show()` (orderFront:) is ignored for a background app, so the
         // pill only appeared when Verenu was frontmost. Force it above the
         // active app's windows without stealing focus. AppKit window calls must
-        // run on the main thread — show_pill is invoked from pipeline worker
+        // run on the main thread - show_pill is invoked from pipeline worker
         // threads, so dispatch there (a raw msg_send off-thread raises an ObjC
         // exception and aborts the process).
         #[cfg(target_os = "macos")]
@@ -181,23 +94,44 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     }
 }
 
-fn pill_bottom_offset_points() -> f64 {
-    #[cfg(target_os = "macos")]
-    {
-        let dock_height = crate::system::mac_app::dock_height_points();
-        dock_height + PILL_BOTTOM_GAP_POINTS
+fn next_pill_placement<R: Runtime>(
+    app: &AppHandle,
+    pill: &WebviewWindow<R>,
+) -> Option<PillPlacement> {
+    let (target_point, cached, stale) = {
+        let state = app.try_state::<SharedState>()?;
+        let guard = state.lock().ok()?;
+        (
+            guard.target.display_point,
+            guard.pill_placement,
+            guard.pill_placement_stale,
+        )
+    };
+
+    if !stale && cached.is_some() {
+        return None;
     }
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        64.0
+    let resolved = super::pill_position::resolve_pill_placement(pill, target_point).or(cached);
+
+    if let Some(placement) = resolved {
+        if stale || cached != Some(placement) {
+            if let Some(state) = app.try_state::<SharedState>() {
+                if let Ok(mut guard) = state.lock() {
+                    guard.pill_placement = Some(placement);
+                    guard.pill_placement_stale = false;
+                }
+            }
+        }
     }
+
+    resolved
 }
 
 pub(crate) fn hide_pill(app: &AppHandle) {
     if let Some(pill) = app.get_webview_window("pill") {
         pill.emit("pill-state", "idle").ok();
-        // Do not call pill.hide() — hiding the window suspends the WebView2
+        // Do not call pill.hide() - hiding the window suspends the WebView2
         // renderer. The next show_pill("recording") emit would then be lost
         // before WebView2 wakes up, causing only "processing" to appear.
         // The pill window is transparent + click-through in idle state, so

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -1,0 +1,218 @@
+use crate::core::window_geometry::DesktopPoint;
+use tauri::{Runtime, WebviewWindow};
+
+const PILL_WIDTH_POINTS: f64 = 380.0;
+const PILL_HEIGHT_POINTS: f64 = 44.0;
+const PILL_BOTTOM_GAP_POINTS: f64 = 16.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MonitorSnapshot {
+    work_x: i32,
+    work_y: i32,
+    work_width: u32,
+    work_height: u32,
+    scale_factor: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct PillPlacement {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl From<&tauri::Monitor> for MonitorSnapshot {
+    fn from(monitor: &tauri::Monitor) -> Self {
+        let work_area = monitor.work_area();
+        Self {
+            work_x: work_area.position.x,
+            work_y: work_area.position.y,
+            work_width: work_area.size.width,
+            work_height: work_area.size.height,
+            scale_factor: monitor.scale_factor(),
+        }
+    }
+}
+
+fn round_to_physical(points: f64, scale_factor: f64) -> i32 {
+    (points * scale_factor).round() as i32
+}
+
+fn placement_for_monitor(monitor: MonitorSnapshot) -> PillPlacement {
+    let width = round_to_physical(PILL_WIDTH_POINTS, monitor.scale_factor);
+    let height = round_to_physical(PILL_HEIGHT_POINTS, monitor.scale_factor);
+    let gap = round_to_physical(PILL_BOTTOM_GAP_POINTS, monitor.scale_factor);
+    let work_width = monitor.work_width as f64;
+    let target_x = monitor.work_x + ((work_width - width as f64) / 2.0).round() as i32;
+    let target_y = monitor.work_y + monitor.work_height as i32 - height - gap;
+
+    PillPlacement {
+        x: target_x,
+        y: target_y,
+        width,
+        height,
+    }
+}
+
+fn choose_monitor(
+    target_monitor: Option<MonitorSnapshot>,
+    primary_monitor: Option<MonitorSnapshot>,
+) -> Option<MonitorSnapshot> {
+    target_monitor.or(primary_monitor)
+}
+
+pub(super) fn resolve_pill_placement<R: Runtime>(
+    pill: &WebviewWindow<R>,
+    target_point: Option<DesktopPoint>,
+) -> Option<PillPlacement> {
+    let target_monitor = target_point.and_then(|point| {
+        pill.monitor_from_point(point.x, point.y)
+            .ok()
+            .flatten()
+            .map(|monitor| MonitorSnapshot::from(&monitor))
+    });
+    let primary_monitor = pill
+        .primary_monitor()
+        .ok()
+        .flatten()
+        .map(|monitor| MonitorSnapshot::from(&monitor));
+    let monitor = choose_monitor(target_monitor, primary_monitor)?;
+
+    Some(placement_for_monitor(monitor))
+}
+
+pub(super) fn apply_pill_placement<R: Runtime>(pill: &WebviewWindow<R>, placement: PillPlacement) {
+    let desired_size = (
+        placement.width.max(1) as f64,
+        placement.height.max(1) as f64,
+    );
+
+    let needs_resize = pill
+        .inner_size()
+        .map(|cur| {
+            (cur.width as f64 - desired_size.0).abs() > 1.0
+                || (cur.height as f64 - desired_size.1).abs() > 1.0
+        })
+        .unwrap_or(true);
+
+    let needs_reposition = pill
+        .outer_position()
+        .map(|cur| (cur.x - placement.x).abs() > 1 || (cur.y - placement.y).abs() > 1)
+        .unwrap_or(true);
+
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::UI::WindowsAndMessaging::{
+            SetWindowPos, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
+        };
+
+        if needs_resize || needs_reposition {
+            if let Ok(hwnd) = pill.hwnd() {
+                let mut flags = SWP_NOZORDER | SWP_NOACTIVATE;
+                if !needs_resize {
+                    flags |= SWP_NOSIZE;
+                }
+                if !needs_reposition {
+                    flags |= SWP_NOMOVE;
+                }
+
+                unsafe {
+                    let _ = SetWindowPos(
+                        hwnd,
+                        None,
+                        placement.x,
+                        placement.y,
+                        placement.width,
+                        placement.height,
+                        flags,
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if needs_resize {
+            pill.set_size(tauri::LogicalSize::new(
+                PILL_WIDTH_POINTS,
+                PILL_HEIGHT_POINTS,
+            ))
+            .ok();
+        }
+        if needs_reposition {
+            pill.set_position(tauri::PhysicalPosition::new(placement.x, placement.y))
+                .ok();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor(
+        work_x: i32,
+        work_y: i32,
+        work_width: u32,
+        work_height: u32,
+        scale_factor: f64,
+    ) -> MonitorSnapshot {
+        MonitorSnapshot {
+            work_x,
+            work_y,
+            work_width,
+            work_height,
+            scale_factor,
+        }
+    }
+
+    #[test]
+    fn prefers_target_monitor_then_primary_monitor() {
+        let primary = monitor(0, 0, 1920, 1080, 1.0);
+        let secondary = monitor(1920, 0, 2560, 1440, 1.5);
+
+        assert_eq!(
+            choose_monitor(Some(secondary), Some(primary)),
+            Some(secondary)
+        );
+        assert_eq!(choose_monitor(None, Some(primary)), Some(primary));
+        assert_eq!(choose_monitor(None, None), None);
+    }
+
+    #[test]
+    fn centers_on_secondary_monitor_with_positive_coordinates() {
+        let placement = placement_for_monitor(monitor(1920, 0, 2560, 1400, 1.0));
+
+        assert_eq!(placement.width, 380);
+        assert_eq!(placement.height, 44);
+        assert_eq!(placement.x, 3010);
+        assert_eq!(placement.y, 1340);
+    }
+
+    #[test]
+    fn centers_on_monitor_with_negative_coordinates() {
+        let placement = placement_for_monitor(monitor(-2560, 0, 2560, 1400, 1.0));
+
+        assert_eq!(placement.x, -1470);
+        assert_eq!(placement.y, 1340);
+    }
+
+    #[test]
+    fn respects_retina_scaling() {
+        let placement = placement_for_monitor(monitor(0, 0, 2880, 1800, 2.0));
+
+        assert_eq!(placement.width, 760);
+        assert_eq!(placement.height, 88);
+        assert_eq!(placement.x, 1060);
+        assert_eq!(placement.y, 1680);
+    }
+
+    #[test]
+    fn uses_work_area_bottom_instead_of_full_monitor_height() {
+        let placement = placement_for_monitor(monitor(0, 40, 1920, 1040, 1.0));
+
+        assert_eq!(placement.y, 1020);
+    }
+}

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::window_geometry::WindowTarget;
 
 // ---------- recording session helpers ----------
 
@@ -150,7 +151,7 @@ pub fn spawn_level_emitter(
 }
 pub(super) fn take_pipeline_session(
     state: &SharedState,
-) -> Option<(audio::RecordingSession, usize)> {
+) -> Option<(audio::RecordingSession, WindowTarget)> {
     let mut st = match lock_state(state) {
         Ok(st) => st,
         Err(e) => {
@@ -159,5 +160,5 @@ pub(super) fn take_pipeline_session(
         }
     };
     let session = st.session.take()?;
-    Some((session, st.target_hwnd))
+    Some((session, st.target))
 }

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::core::window_geometry::WindowTarget;
+use crate::pipeline::pill_position::PillPlacement;
 
 pub(super) const RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
 // ---------- shared state ----------
@@ -7,7 +9,9 @@ pub struct AppState {
     pub session: Option<audio::RecordingSession>,
     pub starting: bool,
     pub handless: bool,
-    pub target_hwnd: usize,
+    pub target: WindowTarget,
+    pub pill_placement: Option<PillPlacement>,
+    pub pill_placement_stale: bool,
     pub retry_capture: Option<RetryCapture>,
 }
 
@@ -18,7 +22,7 @@ pub struct RetryCapture {
     pub wav: bytes::Bytes,
     pub captured_at: std::time::Instant,
     pub duration_ms: u64,
-    pub target_hwnd: usize,
+    pub target: WindowTarget,
     pub process_name: String,
     pub profile: String,
     pub app_context: Option<String>,
@@ -82,4 +86,4 @@ pub(super) fn hwnd_is_own_process(hwnd: usize) -> bool {
     {
         false
     }
-}
+}

--- a/src-tauri/src/system/mac_app.rs
+++ b/src-tauri/src/system/mac_app.rs
@@ -40,63 +40,6 @@ unsafe impl objc2::Encode for NSApplicationActivationPolicy {
     const ENCODING: objc2::Encoding = isize::ENCODING;
 }
 
-// CGRect-compatible structs for msg_send! return values (64-bit macOS).
-// AppKit returns CGRect here; objc2 checks the exact type code at runtime, so
-// we mirror the CoreGraphics encodings rather than the NS* aliases.
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-struct MacPoint {
-    x: f64,
-    y: f64,
-}
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-struct MacSize {
-    width: f64,
-    height: f64,
-}
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-struct MacRect {
-    origin: MacPoint,
-    size: MacSize,
-}
-
-unsafe impl objc2::Encode for MacPoint {
-    const ENCODING: objc2::Encoding = objc2::Encoding::Struct(
-        "CGPoint",
-        &[objc2::Encoding::Double, objc2::Encoding::Double],
-    );
-}
-unsafe impl objc2::Encode for MacSize {
-    const ENCODING: objc2::Encoding = objc2::Encoding::Struct(
-        "CGSize",
-        &[objc2::Encoding::Double, objc2::Encoding::Double],
-    );
-}
-unsafe impl objc2::Encode for MacRect {
-    const ENCODING: objc2::Encoding =
-        objc2::Encoding::Struct("CGRect", &[MacPoint::ENCODING, MacSize::ENCODING]);
-}
-
-/// Height of the Dock in logical points when it is positioned at the bottom of
-/// the screen. Returns 0.0 if the Dock is on a side or auto-hidden, in which
-/// case the caller should use its own fallback gap.
-pub fn dock_height_points() -> f64 {
-    autoreleasepool(|_| unsafe {
-        let main: *mut AnyObject = msg_send![class!(NSScreen), mainScreen];
-        if main.is_null() {
-            return 0.0;
-        }
-        let frame: MacRect = msg_send![main, frame];
-        let visible: MacRect = msg_send![main, visibleFrame];
-        // NSScreen uses a bottom-left origin (Y increases upward).
-        // When the Dock is at the bottom, visibleFrame.origin.y > frame.origin.y
-        // by exactly the Dock height. Side-positioned or hidden Dock → no Y inset.
-        (visible.origin.y - frame.origin.y).max(0.0)
-    })
-}
-
 /// Apply the current bundled PNG as the macOS application icon at runtime.
 /// This sidesteps Dock/LaunchServices caching during development and keeps the
 /// visible Dock icon in sync with `icons/icon-source.svg`.
@@ -157,7 +100,7 @@ pub fn set_regular_activation_policy_on_main_thread(app: &AppHandle) {
 
 /// Float the pill window above other apps' windows *without* activating Open
 /// Flow. Tauri's `show()` maps to `-[NSWindow orderFront:]`, which AppKit
-/// suppresses for a background (non-active) app — so the pill only appeared
+/// suppresses for a background (non-active) app - so the pill only appeared
 /// while Verenu was frontmost. We instead:
 ///   1. raise the window level above normal windows (NSStatusWindowLevel = 25),
 ///   2. let it appear on every Space and over full-screen apps,
@@ -293,7 +236,7 @@ pub fn refresh_dock_icon() {
 
 /// Latched once a `cpal` input stream opens successfully. macOS only hands out a
 /// working audio stream when the microphone permission is actually granted, so a
-/// successful capture is authoritative proof — unlike
+/// successful capture is authoritative proof - unlike
 /// `AVCaptureDevice authorizationStatusForMediaType:`, which can return a value
 /// cached at first call for the lifetime of the process and never refresh after
 /// the user grants access mid-session.
@@ -309,7 +252,7 @@ pub fn is_microphone_verified() -> bool {
     MIC_VERIFIED.load(Ordering::SeqCst)
 }
 
-/// Latched once a cross-process Accessibility (AX) read succeeds — i.e. the app
+/// Latched once a cross-process Accessibility (AX) read succeeds - i.e. the app
 /// actually read another application's focused-element tree. Like the microphone
 /// latch, an empirically successful AX call is authoritative proof the permission
 /// is granted, which matters when `AXIsProcessTrusted()` reports a stale `false`
@@ -356,7 +299,7 @@ pub fn microphone_permission_status() -> &'static str {
 }
 
 /// Request microphone access, showing the macOS consent prompt when the
-/// permission is undetermined. The completion handler is a no-op — callers read
+/// permission is undetermined. The completion handler is a no-op - callers read
 /// the resulting status separately via `microphone_permission_status()` once the
 /// user responds. Safe to call when already authorized (no prompt is shown).
 pub async fn request_microphone() -> bool {
@@ -380,7 +323,7 @@ pub async fn request_microphone() -> bool {
     rx.await.unwrap_or(false)
 }
 
-// UTI for plain UTF-8 text — the value of `NSPasteboardTypeString`.
+// UTI for plain UTF-8 text - the value of `NSPasteboardTypeString`.
 const PASTEBOARD_TYPE_STRING: &str = "public.utf8-plain-text";
 
 /// PID of the frontmost (active) application, or `None` if unavailable.


### PR DESCRIPTION
## Thinking Path

> - Verenu is a desktop AI dictation app where the backend captures audio, runs transcription and cleanup, and shows a floating pill while the pipeline runs.
> - This change sits in the native pipeline and pill-window path that decides where the dictation pill appears during recording and processing.
> - The pill was always anchored to the primary monitor, which looked wrong on multi-monitor setups and broke the visual connection between the target app and the dictation state.
> - Mixed-resolution monitors also exposed a follow-up bug where the pill could shift between listening and processing after crossing to a different DPI monitor.
> - This pull request captures target-window geometry at dictation start, resolves the correct monitor from that target, and places the pill inside that monitor's work area on Windows and macOS.
> - It also keeps the resolved placement stable for the full recording and processing cycle so the pill does not hop between states on mixed-DPI setups.
> - The benefit is that the pill now stays on the monitor the user is actually dictating into, with cleaner behavior across dual-monitor Windows and macOS setups.

## What Changed

- Added a focused native window-geometry module that captures the injection target plus an optional display anchor point for Windows and macOS.
- Updated recording state, retry capture, hotkey starts, and in-app recording flows to carry a structured `WindowTarget` instead of an unstructured target handle.
- Extracted pill placement math into a dedicated helper that selects the target monitor from a point, respects monitor work areas, and falls back cleanly when monitor lookup fails.
- Reworked pill positioning so each recording cycle resolves placement once and reuses it across listening, processing, and error states, which fixes the first-hop drift on mixed-resolution monitors.
- Added unit coverage for monitor selection and placement with positive and negative coordinates, Retina scaling, and work-area offsets.
- Kept logging redacted so the change does not expose dictated text, window titles, or display names.

## Verification

- `npm run check`
- `npm run lint`
- `npm run test:rust`
- Manual verification on Windows dual-monitor setups:
  - start dictation on monitor A, then on monitor B
  - confirm the pill opens on the target monitor instead of the primary monitor
  - confirm the pill stays aligned between listening and processing on mixed-resolution monitors
  - confirm retry keeps the pill on the original target monitor for that cycle

## Risks

- Low risk overall. The change is isolated to target capture and pill placement, with primary-monitor and last-known-position fallbacks still intact.
- The highest-risk area is native DPI behavior on Windows when monitors have different scale factors, so mixed-resolution desktop testing remains the important acceptance check.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- OpenAI GPT-5 Codex with tool use in Codex CLI

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above
