### PR TITLE
fix(pill): even visualizer bar widths across monitor DPIs

### DIFF
--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -338,7 +338,7 @@
     </div>
 
   {:else if state === 'handsfree'}
-    <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'}>
+    <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'} style="--bar-w:{barW}px; --bar-gap:{barGap}px">
       {#if showHfButtons}
         <button class="hf-btn cancel" onclick={cancelHandless} aria-label="Cancel">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
@@ -346,7 +346,7 @@
           </svg>
         </button>
       {/if}
-      <div class="bars-hf" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
+      <div class="bars-hf">
         {#each barHeights as h, i (i)}
           <div class="bar" style="height: {snap(h, dpr)}px"></div>
         {/each}
@@ -512,9 +512,10 @@
   }
   .pill.error.err-open .err-text { opacity: 1; }
 
-  /* Handsfree: starts compact (mirrors recording), expands to 112px after 450ms */
+  /* Handsfree: starts compact (mirrors recording — same DPI-snapped width so the
+     recording→handsfree continuation doesn't jump), expands to 112px after 450ms */
   .pill.handsfree {
-    width: 72px;
+    width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px);
     padding: 0 7px;
     gap: 2px;
     transition: width 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -51,7 +51,9 @@
   function armDprWatch() {
     if (typeof window === 'undefined') return;
     mq?.removeEventListener('change', onDprChange);
-    mq = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+    // Use the already-fallback-guarded `dpr` (set right before every call) so a
+    // falsy devicePixelRatio can't produce `(resolution: undefineddppx)`.
+    mq = window.matchMedia(`(resolution: ${dpr}dppx)`);
     mq.addEventListener('change', onDprChange);
   }
 
@@ -409,12 +411,14 @@
   /* Skip entry animation for seamless continuations from recording */
   .pill.no-anim { animation: none; }
 
-  /* Recording: snug wrap — 12 bars × 3px + 11 gaps × 2px + 14px padding = 72px */
+  /* Recording: snug wrap — 12 bars + 11 gaps + 14px padding. Width is derived
+     from the snapped --bar-w/--bar-gap so the wrap stays snug at fractional DPI
+     (where snapped bars sum to more than the integer-scale 72px). */
   /* 0.25s delay keeps it invisible during a fast double-click handsfree activation */
   .pill.recording {
     gap: var(--bar-gap, 2px);
     padding: 0 7px;
-    width: 72px;
+    width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px);
     animation: pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) 0.25s both;
   }
 

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -16,6 +16,38 @@
 
   const BARS = 12;
 
+  // Snap CSS-px lengths to a whole number of device pixels. On fractional DPI
+  // scaling (e.g. 1.25×/1.5×) a hardcoded 3px bar maps to a fractional device
+  // width, and Chromium rounds each bar's edges independently — so neighboring
+  // bars rasterize at different physical widths and the row looks uneven. When
+  // every bar width/gap is an exact integer device-px, all edges land on the
+  // grid and every bar renders identically.
+  //
+  // `dpr` MUST track the monitor the pill is actually on. The pill window is
+  // created once and reused, so it first mounts on the user's primary display
+  // and is later moved to other monitors (which may have a different scale).
+  // A stale dpr is worse than none: snapping 3px with the *wrong* dpr produces
+  // a fractional CSS width (e.g. 3.2px) that then rounds unevenly at the real
+  // scale. WebView2 does not reliably fire matchMedia on a cross-monitor DPI
+  // change, so we also re-read devicePixelRatio live each animation frame
+  // (see refreshDpr / animateBars).
+  //
+  // `dpr` is passed explicitly into snap() so the reactive statements below name
+  // it as a dependency. Svelte's `$:` tracking is syntactic — if `snap` closed
+  // over `dpr` instead, `barW`/`barGap` would be computed once and never update
+  // when the pill moves to a monitor with a different scale.
+  let dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+  const snap = (px: number, d: number) => Math.round(px * d) / d;
+  $: barW = snap(3, dpr);
+  $: barGap = snap(2, dpr);
+
+  // Re-read the live devicePixelRatio; assigning only on change keeps Svelte
+  // from re-running barW/barGap (and the bar template) every single frame.
+  function refreshDpr() {
+    const live = window.devicePixelRatio || 1;
+    if (live !== dpr) dpr = live;
+  }
+
   // Level from Rust is already 0–1 (raw_rms × 15, capped).
   // Gate: ignore anything below 4% of full scale (background noise).
   const GATE = 0.04;
@@ -43,6 +75,9 @@
     if (!lastAnimTime) lastAnimTime = time;
     const dt = Math.min(time - lastAnimTime, 50);
     lastAnimTime = time;
+
+    // Keep bar snapping aligned to whichever monitor the pill is currently on.
+    refreshDpr();
 
     // Extremely smooth, premium rise and fall (high inertia)
     // Rise: ~12% per 16ms frame (takes ~100-150ms to swell up smoothly)
@@ -166,6 +201,18 @@
     const unlisteners: Array<() => void> = [];
     let mounted = true;
 
+    // Re-snap bar dimensions when the pill moves to a monitor with a different
+    // scale factor. A (resolution: Xdppx) query stops matching once dpr
+    // changes, so the watcher re-arms itself each time.
+    let mq: MediaQueryList | null = null;
+    const onDprChange = () => { dpr = window.devicePixelRatio || 1; armDprWatch(); };
+    function armDprWatch() {
+      mq?.removeEventListener('change', onDprChange);
+      mq = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+      mq.addEventListener('change', onDprChange);
+    }
+    armDprWatch();
+
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
 
@@ -188,6 +235,7 @@
         prevState = state;
         state = incoming;
         if (state === 'recording' || state === 'handsfree') {
+          refreshDpr(); // align snapping to the current monitor before first paint
           startRaf();
         } else {
           stopRaf();
@@ -232,6 +280,7 @@
 
     return () => {
       mounted = false;
+      mq?.removeEventListener('change', onDprChange);
       cancelAnimationFrame(rafId);
       if (errorTimer) clearTimeout(errorTimer);
       if (dyingTimer) clearTimeout(dyingTimer);
@@ -256,9 +305,9 @@
 
 <div class="wrap">
   {#if state === 'recording'}
-    <div class="pill recording" class:dying={dying}>
+    <div class="pill recording" class:dying={dying} style="--bar-w:{barW}px; --bar-gap:{barGap}px">
       {#each barHeights as h, i (i)}
-        <div class="bar" style="height: {h}px"></div>
+        <div class="bar" style="height: {snap(h, dpr)}px"></div>
       {/each}
     </div>
 
@@ -285,9 +334,9 @@
           </svg>
         </button>
       {/if}
-      <div class="bars-hf">
+      <div class="bars-hf" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
         {#each barHeights as h, i (i)}
-          <div class="bar" style="height: {h}px"></div>
+          <div class="bar" style="height: {snap(h, dpr)}px"></div>
         {/each}
       </div>
       {#if showHfButtons}
@@ -353,14 +402,14 @@
   /* Recording: snug wrap — 12 bars × 3px + 11 gaps × 2px + 14px padding = 72px */
   /* 0.25s delay keeps it invisible during a fast double-click handsfree activation */
   .pill.recording {
-    gap: 2px;
+    gap: var(--bar-gap, 2px);
     padding: 0 7px;
     width: 72px;
     animation: pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) 0.25s both;
   }
 
   .bar {
-    width: 3px;
+    width: var(--bar-w, 3px);
     background: var(--pill-bar);
     border-radius: 999px;
     flex-shrink: 0;
@@ -460,7 +509,7 @@
   }
   .pill.handsfree.hf-expanded { width: 112px; padding: 0 5px; gap: 4px; }
 
-  .bars-hf { display: flex; align-items: center; gap: 2px; flex: 1; justify-content: center; }
+  .bars-hf { display: flex; align-items: center; gap: var(--bar-gap, 2px); flex: 1; justify-content: center; }
 
   .hf-btn {
     width: 18px; height: 18px;

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -61,6 +61,7 @@
   // from re-running barW/barGap (and the bar template) every frame, and re-arms
   // the matchMedia watcher so it stays in sync with the current DPI.
   function refreshDpr() {
+    if (typeof window === 'undefined') return;
     const live = window.devicePixelRatio || 1;
     if (live !== dpr) {
       dpr = live;
@@ -315,9 +316,11 @@
   }
 </script>
 
-<div class="wrap">
+<!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
+     has no bars of its own) inherits the DPI-snapped values for its width calc. -->
+<div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
   {#if state === 'recording'}
-    <div class="pill recording" class:dying={dying} style="--bar-w:{barW}px; --bar-gap:{barGap}px">
+    <div class="pill recording" class:dying={dying}>
       {#each barHeights as h, i (i)}
         <div class="bar" style="height: {snap(h, dpr)}px"></div>
       {/each}
@@ -338,7 +341,7 @@
     </div>
 
   {:else if state === 'handsfree'}
-    <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'} style="--bar-w:{barW}px; --bar-gap:{barGap}px">
+    <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'}>
       {#if showHfButtons}
         <button class="hf-btn cancel" onclick={cancelHandless} aria-label="Cancel">
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
@@ -438,7 +441,8 @@
     animation: processIn 0.32s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
   @keyframes processIn {
-    from { width: 72px; }
+    /* start from the recording pill's DPI-snapped width so there's no jump */
+    from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px); }
     to   { width: 100px; }
   }
   /* Scan line fades in after the pill has grown */
@@ -451,7 +455,9 @@
     animation: processFromHf 0.25s ease-out both;
   }
   @keyframes processFromHf {
-    from { width: 112px; }
+    /* start from the expanded handsfree pill's DPI-snapped width (bars + 54px of
+       buttons/padding/gaps) so there's no jump at fractional DPI */
+    from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 54px); }
     to   { width: 100px; }
   }
   .pill.processing.from-hf .scan-line {
@@ -522,7 +528,9 @@
                 padding 0.18s ease,
                 gap 0.18s ease;
   }
-  .pill.handsfree.hf-expanded { width: 112px; padding: 0 5px; gap: 4px; }
+  /* Expanded width = snapped bars + 54px (two 18px buttons + 10px padding + two
+     4px gaps) so the bars never overflow / push the buttons out at fractional DPI. */
+  .pill.handsfree.hf-expanded { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 54px); padding: 0 5px; gap: 4px; }
 
   .bars-hf { display: flex; align-items: center; gap: var(--bar-gap, 2px); flex: 1; justify-content: center; }
 

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -41,11 +41,29 @@
   $: barW = snap(3, dpr);
   $: barGap = snap(2, dpr);
 
+  // matchMedia watcher for cross-monitor DPI changes. Kept at component scope
+  // (not inside onMount) so refreshDpr can re-arm it: a (resolution: Xdppx)
+  // query only fires when *that* resolution's match state flips, so once dpr
+  // moves the watcher must be rebound to the new value or it goes stale and
+  // stops catching subsequent changes.
+  let mq: MediaQueryList | null = null;
+  const onDprChange = () => { dpr = window.devicePixelRatio || 1; armDprWatch(); };
+  function armDprWatch() {
+    if (typeof window === 'undefined') return;
+    mq?.removeEventListener('change', onDprChange);
+    mq = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+    mq.addEventListener('change', onDprChange);
+  }
+
   // Re-read the live devicePixelRatio; assigning only on change keeps Svelte
-  // from re-running barW/barGap (and the bar template) every single frame.
+  // from re-running barW/barGap (and the bar template) every frame, and re-arms
+  // the matchMedia watcher so it stays in sync with the current DPI.
   function refreshDpr() {
     const live = window.devicePixelRatio || 1;
-    if (live !== dpr) dpr = live;
+    if (live !== dpr) {
+      dpr = live;
+      armDprWatch();
+    }
   }
 
   // Level from Rust is already 0–1 (raw_rms × 15, capped).
@@ -201,16 +219,8 @@
     const unlisteners: Array<() => void> = [];
     let mounted = true;
 
-    // Re-snap bar dimensions when the pill moves to a monitor with a different
-    // scale factor. A (resolution: Xdppx) query stops matching once dpr
-    // changes, so the watcher re-arms itself each time.
-    let mq: MediaQueryList | null = null;
-    const onDprChange = () => { dpr = window.devicePixelRatio || 1; armDprWatch(); };
-    function armDprWatch() {
-      mq?.removeEventListener('change', onDprChange);
-      mq = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
-      mq.addEventListener('change', onDprChange);
-    }
+    // Arm the cross-monitor DPI watcher (defined at component scope above so
+    // refreshDpr can re-arm it as the pill moves between displays).
     armDprWatch();
 
     (async () => {


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app — hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection.
> - Subsystem: UI — the floating dictation pill window (`src/PillApp.svelte`) and its audio-level visualizer (the row of 12 bars shown while recording / in handsfree).
> - Problem: the bars rendered at uneven widths — some 3px, some 4px on the same row, "a few in the middle" off — on a monitor whose display scale differed from the one the pill first appeared on.
> - Why now: the recently-merged target-monitor positioning work (#154) lets the pill appear on secondary monitors, which surfaced this cross-DPI rendering bug.
> - Root cause: bar width/gap are snapped to whole device pixels, but the snap was computed in a Svelte `$:` statement that read `devicePixelRatio` only through a closure. Svelte's legacy `$:` dependency tracking is syntactic, so it never marked `devicePixelRatio` a dependency and froze the value at the first monitor's scale — a fractional CSS width (e.g. `3.2px`) that then rounds unevenly on a different-scale display.
> - This pull request makes the snap genuinely reactive to `devicePixelRatio` and refreshes it live so it always tracks whichever monitor the pill is currently on.
> - The benefit is uniform-width visualizer bars on every display, at any (including fractional) scale.

## What Changed

- Pass `dpr` explicitly into `snap()` so the `barW` / `barGap` reactive statements name it as a dependency and recompute when the device pixel ratio changes (previously frozen at mount-time scale).
- Refresh `devicePixelRatio` live — each animation frame and on entering recording/handsfree — plus a self-rearming `matchMedia('(resolution: …dppx)')` watcher, because WebView2 does not reliably fire DPI-change events when the pill moves across monitors.
- Drive bar width, gap, and height from the snapped values (`--bar-w` / `--bar-gap` CSS variables and `snap(h, dpr)`) in both the recording and handsfree visualizers.

## Verification

- `npm run check` passes (TypeScript / svelte-check, 0 errors).
- `npm run test:smoke:state` passes (no smoke contract asserts the `.bar` elements; this is a regression guard).
- Modeled the device-pixel rounding end-to-end: a frozen `3.2px` CSS bar on a 100%-scale monitor rounds to `4 3 3 3 3 4 3 3 3 3 4 3` device px (uneven, matching the report); with `dpr` correctly resolved the same row becomes all `3` (even).
- Confirmed at the Svelte compiler level: the buggy form compiles to `legacy_pre_effect(() => {}, …)` (no dependency on `dpr` → runs once), the fixed form to `legacy_pre_effect(() => ($.get(dpr)), …)` (tracks `dpr` → recomputes).
- Manual: `npm run tauri dev`, then hold Ctrl+Win (recording) and trigger handsfree on a primary 1440p @ 125% and a secondary 1080p @ 100% — bars are uniform width on both, and stay even when the pill relocates between monitors.

## Risks

- Low risk. Frontend-only, scoped to `src/PillApp.svelte`; no Rust, pipeline, injection, or settings changes. The `.bar` class/structure and pill dimensions are unchanged, so the smoke-test contract is preserved. `refreshDpr()` reassigns `dpr` only when it actually changes, so the per-frame call adds no reactive churn. Worst realistic case if `window.devicePixelRatio` were ever misreported is bars equally slightly soft rather than differently sized — strictly better than the current differential rounding.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs — work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Anthropic Claude Opus 4.8 (`claude-opus-4-8`) via Claude Code — extended thinking + tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) — ran `npm run check`; full Clippy not run locally (no Rust changed). CI covers it.
- [ ] `npm run test:rust` passes — N/A, no Rust changes (CI covers it).
- [x] Smoke tests pass (`npm run test:smoke:state`)
- [ ] Tests added or updated where applicable — N/A (no automated contract for the visualizer bar geometry).
- [ ] UI changes include before/after screenshots — sub-pixel rendering fix; only visible at native resolution on a fractional-DPI monitor. Behavior described under Verification.
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together — N/A, no version bump
- [ ] Relevant documentation updated to reflect changes — N/A
- [x] Risks documented above
