### PR TITLE
fix(injection): skip corrupting clipboard sniff for very_casual

### DIFF
--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -111,29 +111,42 @@ mod tests {
             true,
             ContextProbeSource::CaretLocal,
             SentenceContext::MidSentence,
+            "casual",
         ));
         // A caret read that already says "new sentence" capitalizes — no sniff.
         assert!(!caret_local_needs_sniff_verification(
             true,
             ContextProbeSource::CaretLocal,
             SentenceContext::NewSentence,
+            "casual",
         ));
         // Empty-field and history sources are already trustworthy.
         assert!(!caret_local_needs_sniff_verification(
             true,
             ContextProbeSource::EmptyField,
             SentenceContext::MidSentence,
+            "casual",
         ));
         assert!(!caret_local_needs_sniff_verification(
             true,
             ContextProbeSource::HistoryFallback,
             SentenceContext::MidSentence,
+            "casual",
         ));
         // Contextual caps off: never sniff.
         assert!(!caret_local_needs_sniff_verification(
             false,
             ContextProbeSource::CaretLocal,
             SentenceContext::MidSentence,
+            "casual",
+        ));
+        // very_casual: the sniff can't change the lowercase outcome, so skip its
+        // destructive keystrokes even on a caret-local mid-sentence read.
+        assert!(!caret_local_needs_sniff_verification(
+            true,
+            ContextProbeSource::CaretLocal,
+            SentenceContext::MidSentence,
+            "very_casual",
         ));
     }
 
@@ -507,13 +520,22 @@ fn fallback_probe_from_history(target_hwnd: usize) -> Option<InjectionContextPro
 /// reads are verified: that's the source that can return phantom text before the
 /// caret in a visually empty box (Chromium/Electron). Other sources are either
 /// already trustworthy (history) or already a new sentence (empty field).
+///
+/// The sniff fires synthetic Shift+Left/Ctrl+C/Right keystrokes, which can
+/// corrupt the subsequent paste in Chromium-backed rich editors (Quill/Slack/
+/// Discord). It only earns that risk when its result could change the casing
+/// decision. For the `very_casual` profile it never can: both new-sentence and
+/// mid-sentence preserve the model's lowercase output, so we skip the sniff
+/// entirely and just paste.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn caret_local_needs_sniff_verification(
     contextual_caps: bool,
     source: ContextProbeSource,
     context: crate::core::text_context::SentenceContext,
+    profile: &str,
 ) -> bool {
     contextual_caps
+        && profile != "very_casual"
         && source == ContextProbeSource::CaretLocal
         && context == crate::core::text_context::SentenceContext::MidSentence
 }

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -378,6 +378,7 @@ pub(super) async fn inject_text(
             contextual_caps,
             injection_probe.source,
             injection_probe.context,
+            profile,
         ) {
             if let Some(mut sniff) = windows_clipboard_sniff_context(target_hwnd).await {
                 // Spacing must follow the reliable UIA tail ("is there a visible


### PR DESCRIPTION
## Problem

Dictating into Chromium-backed rich editors (Quill — used by Discord/Slack) produced scrambled output: correct cleaned text went in, gibberish came out.

Root cause is the Windows contextual-caps **clipboard sniff**. To verify a caret-local "mid-sentence" read before lowercasing, it fires synthetic Shift+Left / Ctrl+C / Right keystrokes immediately before the paste. Those editors report phantom "mid-sentence" text in a visually empty box, so the sniff trips on every dictation, and its keystrokes scramble the paste (the "HellHi.o" corruption the code already warns about).

## Fix

For the `very_casual` profile the sniff is pure downside: both new-sentence and mid-sentence contexts preserve the model's lowercase output, so the sniff can never change the casing decision — but it can still corrupt. Gate it out for `very_casual` so injection just pastes, with no destructive keystrokes.

`casual` / `formal` still sniff (they need the capitalization disambiguation); their behavior is unchanged.

## Validation

- The cleaned text is computed and stored correctly; only the keystroke sniff was garbling delivery. Confirmed against on-device history (raw vs. clean) — the model output was coherent.
- New unit assertion: `very_casual` returns `false` from the sniff gate even on a caret-local mid-sentence read.
- `cargo test injection` 6/6 pass; `cargo clippy -- -D warnings` clean.

## Follow-up (not in this PR)

`casual` / `formal` dictation into Chromium/Quill editors can still hit the same corruption. A complete fix would detect Chromium/contenteditable controls and skip the sniff regardless of profile, or make the sniff non-destructive.
