### PR TITLE
fix(audio): tighten handsfree sound delay and animate pill move

### DIFF
--- a/src-tauri/src/media/sound.rs
+++ b/src-tauri/src/media/sound.rs
@@ -43,7 +43,7 @@ const AMPLITUDE: f32 = 0.30; // gentle, fixed master level
 pub const START_CUE_NORMAL_DELAY_MS: u64 = 260;
 /// Delay before the start cue when entering handsfree, so it lands after the
 /// pill's entry animation rather than before it looks like it's listening.
-pub const START_CUE_HANDSFREE_DELAY_MS: u64 = 700;
+pub const START_CUE_HANDSFREE_DELAY_MS: u64 = 220;
 
 /// Generation counter for the pending start cue. Scheduling a new start cue or
 /// cancelling supersedes any still-pending one, so the discarded first tap of a

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -19,6 +19,7 @@ mod finalize;
 mod fixture;
 mod gates;
 mod pill;
+mod pill_animation;
 mod pill_position;
 mod session;
 mod stages;

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -5,7 +5,7 @@
 
 use super::SharedState;
 use crate::pipeline::pill_position::PillPlacement;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 
 const PILL_WIDTH_POINTS: f64 = 380.0;
@@ -22,6 +22,12 @@ const PILL_HEIGHT_POINTS: f64 = 44.0;
 /// Every `show_pill_msg` call claims a new generation; a deferred reveal
 /// only runs if its generation is still current.
 static REVEAL_GEN: AtomicU64 = AtomicU64::new(0);
+/// Tracks whether the pill is currently showing a non-idle frontend state.
+/// The native window itself stays visible even in idle so WebView2 doesn't
+/// suspend, which makes `pill.is_visible()` a bad proxy for "the user can
+/// already see the pill." We only animate when a prior non-idle state was
+/// actually on screen; otherwise the first visible reveal should be instant.
+static PILL_VISUALLY_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 fn create_pill_if_needed(app: &AppHandle) {
     if app.get_webview_window("pill").is_some() {
@@ -52,11 +58,15 @@ pub(crate) fn show_pill(app: &AppHandle, state: &str) {
 /// monitor it never needs to resize or reposition after its first
 /// appearance. Handsfree's click-capture zone is therefore wider than the
 /// visible pill; clicks in the empty space around it are swallowed instead
-/// of passing through while handsfree is active. Moving to a monitor with a
-/// different scale factor still resizes it — on Windows that resize is
-/// animated (see `pill_animation.rs`) instead of jumping instantly, since an
-/// instant cross-DPI resize on this always-visible window made WebView2
-/// visibly stutter recreating its swap chain.
+/// of passing through while handsfree is active. Moving to a different
+/// monitor, whether or not its scale factor differs, animates the move on
+/// Windows (see `pill_animation.rs`) instead of jumping instantly, since an
+/// instant cross-monitor move on this always-visible window either visibly
+/// snapped (same-DPI repositions) or made WebView2 stutter recreating its
+/// swap chain (cross-DPI resizes). Only animates if the pill was already
+/// visible - the very first reveal (or one after a long idle period where
+/// its cached geometry might be stale) should never be held back by an
+/// animation nobody can see yet.
 fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     create_pill_if_needed(app);
     let Some(pill) = app.get_webview_window("pill") else {
@@ -74,12 +84,16 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
 
     #[cfg(target_os = "windows")]
     if let Some(current) = super::pill_position::current_placement(&pill) {
-        let needs_animated_move =
-            super::pill_position::dimension_changed(current.width as f64, placement.width as f64)
-                || super::pill_position::dimension_changed(
-                    current.height as f64,
-                    placement.height as f64,
-                );
+        let visually_active = PILL_VISUALLY_ACTIVE.load(Ordering::SeqCst);
+        let needs_animated_move = visually_active
+            && (super::pill_position::dimension_changed(
+                current.width as f64,
+                placement.width as f64,
+            ) || super::pill_position::dimension_changed(
+                current.height as f64,
+                placement.height as f64,
+            ) || super::pill_position::position_changed(current.x, placement.x)
+                || super::pill_position::position_changed(current.y, placement.y));
 
         if needs_animated_move {
             let app = app.clone();
@@ -110,6 +124,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
 fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Option<&str>) {
     #[cfg(not(target_os = "macos"))]
     let _ = app; // only the macOS float-above-foreground-app step below reads this.
+    PILL_VISUALLY_ACTIVE.store(true, Ordering::SeqCst);
 
     // Click-through for passive states so nothing behind the pill is blocked.
     // Handsfree needs real cursor events for its cancel/confirm buttons.
@@ -193,11 +208,12 @@ fn next_pill_placement<R: Runtime>(
 
 pub(crate) fn hide_pill(app: &AppHandle) {
     if let Some(pill) = app.get_webview_window("pill") {
-        // Invalidate any in-flight animated move's deferred reveal — without
+        // Invalidate any in-flight animated move's deferred reveal - without
         // this, a tween started by an earlier show_pill_msg call could land
         // after this "idle" and re-emit its own (now stale) state, reverting
         // the pill right back to looking like it's recording/processing.
         // Also stop the tween itself from continuing to move the window.
+        PILL_VISUALLY_ACTIVE.store(false, Ordering::SeqCst);
         REVEAL_GEN.fetch_add(1, Ordering::SeqCst);
         super::pill_animation::cancel_pending_pill_tween();
 

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -5,10 +5,23 @@
 
 use super::SharedState;
 use crate::pipeline::pill_position::PillPlacement;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 
 const PILL_WIDTH_POINTS: f64 = 380.0;
 const PILL_HEIGHT_POINTS: f64 = 44.0;
+
+/// Guards the animated path's deferred reveal against being overtaken by a
+/// newer `show_pill_msg` call. The animated cross-monitor move (see
+/// `pill_animation.rs`) defers its `reveal_pill` until the ~180ms tween
+/// lands; if the dictation state moves on (e.g. recording -> processing, or
+/// `hide_pill`) before that tween finishes, the newer call already revealed
+/// the correct state synchronously (since `next_pill_placement` returns
+/// `None` once the placement is no longer stale), and the stale deferred
+/// reveal must not clobber it by re-emitting the *old* state afterward.
+/// Every `show_pill_msg` call claims a new generation; a deferred reveal
+/// only runs if its generation is still current.
+static REVEAL_GEN: AtomicU64 = AtomicU64::new(0);
 
 fn create_pill_if_needed(app: &AppHandle) {
     if app.get_webview_window("pill").is_some() {
@@ -50,6 +63,8 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
         return;
     };
 
+    let _generation = REVEAL_GEN.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
+
     let Some(placement) = next_pill_placement(app, &pill) else {
         reveal_pill(app, &pill, state, message);
         return;
@@ -69,6 +84,9 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
             let state = state.to_string();
             let message = message.map(str::to_string);
             super::pill_animation::animate_pill_placement(&pill, current, placement, move || {
+                if REVEAL_GEN.load(Ordering::SeqCst) != _generation {
+                    return; // a newer show_pill_msg call already revealed the real state.
+                }
                 if let Some(pill) = app.get_webview_window("pill") {
                     reveal_pill(&app, &pill, &state, message.as_deref());
                 }
@@ -170,6 +188,14 @@ fn next_pill_placement<R: Runtime>(
 
 pub(crate) fn hide_pill(app: &AppHandle) {
     if let Some(pill) = app.get_webview_window("pill") {
+        // Invalidate any in-flight animated move's deferred reveal — without
+        // this, a tween started by an earlier show_pill_msg call could land
+        // after this "idle" and re-emit its own (now stale) state, reverting
+        // the pill right back to looking like it's recording/processing.
+        // Also stop the tween itself from continuing to move the window.
+        REVEAL_GEN.fetch_add(1, Ordering::SeqCst);
+        super::pill_animation::cancel_pending_pill_tween();
+
         pill.emit("pill-state", "idle").ok();
         // Do not call pill.hide() - hiding the window suspends the WebView2
         // renderer. The next show_pill("recording") emit would then be lost

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -56,8 +56,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     };
 
     #[cfg(target_os = "windows")]
-    {
-        let current = super::pill_position::current_placement(&pill);
+    if let Some(current) = super::pill_position::current_placement(&pill) {
         let needs_animated_move =
             super::pill_position::dimension_changed(current.width as f64, placement.width as f64)
                 || super::pill_position::dimension_changed(

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -63,7 +63,9 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
         return;
     };
 
-    let _generation = REVEAL_GEN.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
+    let generation = REVEAL_GEN.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
+    #[cfg(not(target_os = "windows"))]
+    let _ = generation; // only the Windows animated path below reads this.
 
     let Some(placement) = next_pill_placement(app, &pill) else {
         reveal_pill(app, &pill, state, message);
@@ -84,7 +86,7 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
             let state = state.to_string();
             let message = message.map(str::to_string);
             super::pill_animation::animate_pill_placement(&pill, current, placement, move || {
-                if REVEAL_GEN.load(Ordering::SeqCst) != _generation {
+                if REVEAL_GEN.load(Ordering::SeqCst) != generation {
                     return; // a newer show_pill_msg call already revealed the real state.
                 }
                 if let Some(pill) = app.get_webview_window("pill") {
@@ -105,7 +107,10 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
 /// synchronous same-monitor path and the animated cross-monitor path in
 /// `show_pill_msg` — the animated path just defers this until its tween
 /// lands.
-fn reveal_pill(_app: &AppHandle, pill: &WebviewWindow, state: &str, message: Option<&str>) {
+fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Option<&str>) {
+    #[cfg(not(target_os = "macos"))]
+    let _ = app; // only the macOS float-above-foreground-app step below reads this.
+
     // Click-through for passive states so nothing behind the pill is blocked.
     // Handsfree needs real cursor events for its cancel/confirm buttons.
     pill.set_ignore_cursor_events(state != "handsfree").ok();
@@ -137,7 +142,7 @@ fn reveal_pill(_app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opt
     #[cfg(target_os = "macos")]
     {
         let pill_for_main = pill.clone();
-        let _ = _app.run_on_main_thread(move || {
+        let _ = app.run_on_main_thread(move || {
             if let Ok(ns_window) = pill_for_main.ns_window() {
                 crate::system::mac_app::float_pill_window(ns_window);
             }

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -35,63 +35,104 @@ pub(crate) fn show_pill(app: &AppHandle, state: &str) {
 
 /// Shows the pill window in the given state, optionally carrying an error
 /// message. The window is always kept at the same width regardless of state
-/// (room enough for the error text to expand into) so it never needs to
-/// resize or reposition after its first appearance. Handsfree's click-capture
-/// zone is therefore wider than the visible pill; clicks in the empty space
-/// around it are swallowed instead of passing through while handsfree is
-/// active.
+/// (room enough for the error text to expand into), so within a single
+/// monitor it never needs to resize or reposition after its first
+/// appearance. Handsfree's click-capture zone is therefore wider than the
+/// visible pill; clicks in the empty space around it are swallowed instead
+/// of passing through while handsfree is active. Moving to a monitor with a
+/// different scale factor still resizes it — on Windows that resize is
+/// animated (see `pill_animation.rs`) instead of jumping instantly, since an
+/// instant cross-DPI resize on this always-visible window made WebView2
+/// visibly stutter recreating its swap chain.
 fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     create_pill_if_needed(app);
-    if let Some(pill) = app.get_webview_window("pill") {
-        if let Some(placement) = next_pill_placement(app, &pill) {
-            super::pill_position::apply_pill_placement(&pill, placement);
-        }
+    let Some(pill) = app.get_webview_window("pill") else {
+        return;
+    };
 
-        // Click-through for passive states so nothing behind the pill is blocked.
-        // Handsfree needs real cursor events for its cancel/confirm buttons.
-        pill.set_ignore_cursor_events(state != "handsfree").ok();
+    let Some(placement) = next_pill_placement(app, &pill) else {
+        reveal_pill(app, &pill, state, message);
+        return;
+    };
 
-        // Show the window before emitting state so WebView2 is active when it
-        // receives the event. WebView2 suspends event processing while hidden;
-        // emitting into a suspended view causes the first state to be dropped or
-        // overtaken by the next emit (e.g. "recording" lost, only "processing" seen).
-        // SW_SHOWNOACTIVATE: appears without stealing keyboard focus from
-        // whatever window the user is dictating into.
-        #[cfg(target_os = "windows")]
-        {
-            use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_SHOWNOACTIVATE};
-            if let Ok(hwnd) = pill.hwnd() {
-                unsafe {
-                    let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
-                }
-            }
-        }
-        #[cfg(not(target_os = "windows"))]
-        pill.show().ok();
+    #[cfg(target_os = "windows")]
+    {
+        let current = super::pill_position::current_placement(&pill);
+        let needs_animated_move =
+            super::pill_position::dimension_changed(current.width as f64, placement.width as f64)
+                || super::pill_position::dimension_changed(
+                    current.height as f64,
+                    placement.height as f64,
+                );
 
-        // macOS: `show()` (orderFront:) is ignored for a background app, so the
-        // pill only appeared when Verenu was frontmost. Force it above the
-        // active app's windows without stealing focus. AppKit window calls must
-        // run on the main thread - show_pill is invoked from pipeline worker
-        // threads, so dispatch there (a raw msg_send off-thread raises an ObjC
-        // exception and aborts the process).
-        #[cfg(target_os = "macos")]
-        {
-            let pill_for_main = pill.clone();
-            let _ = app.run_on_main_thread(move || {
-                if let Ok(ns_window) = pill_for_main.ns_window() {
-                    crate::system::mac_app::float_pill_window(ns_window);
+        if needs_animated_move {
+            let app = app.clone();
+            let state = state.to_string();
+            let message = message.map(str::to_string);
+            super::pill_animation::animate_pill_placement(&pill, current, placement, move || {
+                if let Some(pill) = app.get_webview_window("pill") {
+                    reveal_pill(&app, &pill, &state, message.as_deref());
                 }
             });
+            return;
         }
-
-        // Emit the message before the state so the pill has the error text
-        // ready before it measures and animates open.
-        if let Some(msg) = message {
-            pill.emit("pill-error", msg).ok();
-        }
-        pill.emit("pill-state", state).ok();
     }
+
+    super::pill_position::apply_pill_placement(&pill, placement);
+    reveal_pill(app, &pill, state, message);
+}
+
+/// The non-placement part of showing the pill: click-through flag, bringing
+/// it to the front without stealing focus, and emitting the state (plus
+/// optional error message) the frontend reacts to. Shared by both the
+/// synchronous same-monitor path and the animated cross-monitor path in
+/// `show_pill_msg` — the animated path just defers this until its tween
+/// lands.
+fn reveal_pill(_app: &AppHandle, pill: &WebviewWindow, state: &str, message: Option<&str>) {
+    // Click-through for passive states so nothing behind the pill is blocked.
+    // Handsfree needs real cursor events for its cancel/confirm buttons.
+    pill.set_ignore_cursor_events(state != "handsfree").ok();
+
+    // Show the window before emitting state so WebView2 is active when it
+    // receives the event. WebView2 suspends event processing while hidden;
+    // emitting into a suspended view causes the first state to be dropped or
+    // overtaken by the next emit (e.g. "recording" lost, only "processing" seen).
+    // SW_SHOWNOACTIVATE: appears without stealing keyboard focus from
+    // whatever window the user is dictating into.
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_SHOWNOACTIVATE};
+        if let Ok(hwnd) = pill.hwnd() {
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    pill.show().ok();
+
+    // macOS: `show()` (orderFront:) is ignored for a background app, so the
+    // pill only appeared when Verenu was frontmost. Force it above the
+    // active app's windows without stealing focus. AppKit window calls must
+    // run on the main thread - show_pill is invoked from pipeline worker
+    // threads, so dispatch there (a raw msg_send off-thread raises an ObjC
+    // exception and aborts the process).
+    #[cfg(target_os = "macos")]
+    {
+        let pill_for_main = pill.clone();
+        let _ = _app.run_on_main_thread(move || {
+            if let Ok(ns_window) = pill_for_main.ns_window() {
+                crate::system::mac_app::float_pill_window(ns_window);
+            }
+        });
+    }
+
+    // Emit the message before the state so the pill has the error text
+    // ready before it measures and animates open.
+    if let Some(msg) = message {
+        pill.emit("pill-error", msg).ok();
+    }
+    pill.emit("pill-state", state).ok();
 }
 
 fn next_pill_placement<R: Runtime>(

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -118,12 +118,14 @@ pub(super) fn animate_pill_placement<R: Runtime>(
     let frames = build_tween_frames(from, to, step_count);
 
     tauri::async_runtime::spawn(async move {
-        for frame in frames {
+        let mut remaining = frames.into_iter().peekable();
+        while let Some(frame) = remaining.next() {
             if PILL_TWEEN_GEN.load(Ordering::SeqCst) != generation {
                 return; // superseded — cede the window to the newer move.
             }
-            // If the window was closed/destroyed mid-tween, stop immediately
-            // instead of sleeping through the remaining frames for nothing.
+            // Re-checked every frame (not cached) so a window closed/destroyed
+            // mid-tween is caught immediately instead of sleeping through the
+            // remaining frames for nothing.
             let Ok(hwnd) = pill.hwnd() else {
                 return;
             };
@@ -138,7 +140,11 @@ pub(super) fn animate_pill_placement<R: Runtime>(
                     SWP_NOZORDER | SWP_NOACTIVATE,
                 );
             }
-            tokio::time::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS)).await;
+            // Skip the sleep after the last frame — nothing left to wait for
+            // before revealing, so don't add a pointless ~12ms of latency.
+            if remaining.peek().is_some() {
+                tokio::time::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS)).await;
+            }
         }
 
         if PILL_TWEEN_GEN.load(Ordering::SeqCst) == generation {

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -1,7 +1,7 @@
 //! Animated cross-monitor pill move: a hand-rolled `SetWindowPos` tween so a
 //! cross-DPI monitor switch reads as a deliberate glide instead of an
 //! instant jump. Pure interpolation math (testable without a window) is kept
-//! apart from the Windows-only driver that actually touches the HWND — same
+//! apart from the Windows-only driver that actually touches the HWND - same
 //! split as `pill_position.rs`'s placement math vs `pill.rs`'s lifecycle.
 
 use crate::pipeline::pill_position::PillPlacement;
@@ -93,7 +93,7 @@ pub(super) fn cancel_pending_pill_tween() {
 
 /// Starts an animated move/resize from `from` to `to` on Tauri's async
 /// runtime and returns immediately. `on_complete` runs once the tween lands
-/// exactly on `to` — never if a newer tween or instant move superseded this
+/// exactly on `to` - never if a newer tween or instant move superseded this
 /// one first. Win32 `SetWindowPos` can be called from any thread (thread
 /// affinity governs who *receives* a window's messages, not who can issue
 /// commands to it), and this codebase already calls it from non-main
@@ -108,7 +108,9 @@ pub(super) fn animate_pill_placement<R: Runtime>(
     to: PillPlacement,
     on_complete: impl FnOnce() + Send + 'static,
 ) {
-    use windows::Win32::UI::WindowsAndMessaging::{SetWindowPos, SWP_NOACTIVATE, SWP_NOZORDER};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        SetWindowPos, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOZORDER,
+    };
 
     let generation = PILL_TWEEN_GEN
         .fetch_add(1, Ordering::SeqCst)
@@ -130,6 +132,14 @@ pub(super) fn animate_pill_placement<R: Runtime>(
                 return;
             };
             unsafe {
+                // SWP_ASYNCWINDOWPOS: this runs on a tokio worker thread, not
+                // the pill's owning (main/UI) thread. Without this flag,
+                // SetWindowPos posts the request to the owning thread's
+                // message queue and *blocks the caller* until that thread
+                // processes it - tying up the worker for however long the
+                // main thread takes, and making the animation's cadence
+                // depend on how busy the UI thread is. With it, the call
+                // posts and returns immediately.
                 let _ = SetWindowPos(
                     hwnd,
                     None,
@@ -137,10 +147,10 @@ pub(super) fn animate_pill_placement<R: Runtime>(
                     frame.y,
                     frame.width,
                     frame.height,
-                    SWP_NOZORDER | SWP_NOACTIVATE,
+                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS,
                 );
             }
-            // Skip the sleep after the last frame — nothing left to wait for
+            // Skip the sleep after the last frame - nothing left to wait for
             // before revealing, so don't add a pointless ~12ms of latency.
             if remaining.peek().is_some() {
                 tokio::time::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS)).await;

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -119,18 +119,21 @@ pub(super) fn animate_pill_placement<R: Runtime>(
             if PILL_TWEEN_GEN.load(Ordering::SeqCst) != generation {
                 return; // superseded — cede the window to the newer move.
             }
-            if let Ok(hwnd) = pill.hwnd() {
-                unsafe {
-                    let _ = SetWindowPos(
-                        hwnd,
-                        None,
-                        frame.x,
-                        frame.y,
-                        frame.width,
-                        frame.height,
-                        SWP_NOZORDER | SWP_NOACTIVATE,
-                    );
-                }
+            // If the window was closed/destroyed mid-tween, stop immediately
+            // instead of sleeping through the remaining frames for nothing.
+            let Ok(hwnd) = pill.hwnd() else {
+                return;
+            };
+            unsafe {
+                let _ = SetWindowPos(
+                    hwnd,
+                    None,
+                    frame.x,
+                    frame.y,
+                    frame.width,
+                    frame.height,
+                    SWP_NOZORDER | SWP_NOACTIVATE,
+                );
             }
             std::thread::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS));
         }

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -1,0 +1,236 @@
+//! Animated cross-monitor pill move: a hand-rolled `SetWindowPos` tween so a
+//! cross-DPI monitor switch reads as a deliberate glide instead of an
+//! instant jump. Pure interpolation math (testable without a window) is kept
+//! apart from the Windows-only driver that actually touches the HWND — same
+//! split as `pill_position.rs`'s placement math vs `pill.rs`'s lifecycle.
+
+use crate::pipeline::pill_position::PillPlacement;
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(target_os = "windows")]
+use tauri::{Runtime, WebviewWindow};
+
+/// Total tween length and per-step cadence. Named so they can be retuned by
+/// ear the same way `MONITOR_MOVE_SETTLE_MS`/the sound-cue delays were tuned
+/// in earlier passes — adjust freely if real-hardware testing shows the
+/// motion feels off.
+#[cfg(target_os = "windows")]
+const TWEEN_DURATION_MS: u64 = 180;
+#[cfg(target_os = "windows")]
+const TWEEN_STEP_MS: u64 = 12;
+
+/// Guards against two tweens (or a tween and an instant same-monitor move)
+/// racing over the same HWND. Mirrors `media::sound::START_CUE_GEN` exactly:
+/// a bare static generation counter, not `SharedState`, since this is purely
+/// an internal sequencing concern of "which thread may currently call
+/// SetWindowPos on the pill," not application state anything else reads.
+static PILL_TWEEN_GEN: AtomicU64 = AtomicU64::new(0);
+
+/// One interpolated frame of the tween: physical-pixel geometry to apply via
+/// `SetWindowPos` at a given point in the animation.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(super) struct TweenFrame {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+/// Monotonic ease-out curve, no overshoot. The bouncy
+/// `cubic-bezier(0.34, 1.56, 0.64, 1)` used elsewhere in PillApp.svelte's CSS
+/// would overshoot past 1.0 partway through, which is fine for a CSS element
+/// growing past its own final size but wrong for a native window move —
+/// `placement_for_monitor` sits the pill flush against the work-area's
+/// bottom edge, so overshoot here would briefly push it past the edge of the
+/// visible work area.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn ease_out_cubic(t: f64) -> f64 {
+    let u = 1.0 - t;
+    1.0 - u * u * u
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn lerp_i32(a: i32, b: i32, t: f64) -> i32 {
+    (a as f64 + (b - a) as f64 * t).round() as i32
+}
+
+/// Builds the tween's frame sequence from `from` to `to`. Frame 0 (`from`) is
+/// intentionally not included — the window is already showing that geometry
+/// — and the last frame is guaranteed to equal `to` exactly (since
+/// `ease_out_cubic(1.0) == 1.0`), so the tween always lands precisely on the
+/// already-verified-correct placement math in `pill_position.rs`, with no
+/// separate "snap to final" step needed. All four axes share one eased
+/// progress value per frame so the pill glides rather than wobbling (e.g.
+/// width finishing before position does).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(super) fn build_tween_frames(
+    from: PillPlacement,
+    to: PillPlacement,
+    step_count: u32,
+) -> Vec<TweenFrame> {
+    let step_count = step_count.max(1);
+    (1..=step_count)
+        .map(|i| {
+            let t = i as f64 / step_count as f64;
+            let eased = ease_out_cubic(t);
+            TweenFrame {
+                x: lerp_i32(from.x, to.x, eased),
+                y: lerp_i32(from.y, to.y, eased),
+                width: lerp_i32(from.width, to.width, eased),
+                height: lerp_i32(from.height, to.height, eased),
+            }
+        })
+        .collect()
+}
+
+/// Bumps the generation counter so any in-flight tween bails out on its next
+/// frame instead of fighting an instant same-monitor move over the window.
+/// Cheap enough to call unconditionally regardless of whether a tween is
+/// actually running — mirrors `media::sound::cancel_pending_start()`.
+pub(super) fn cancel_pending_pill_tween() {
+    PILL_TWEEN_GEN.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Starts an animated move/resize from `from` to `to` on a dedicated thread
+/// and returns immediately. `on_complete` runs once the tween lands exactly
+/// on `to` — never if a newer tween or instant move superseded this one
+/// first. Win32 `SetWindowPos` can be called from any thread (thread
+/// affinity governs who *receives* a window's messages, not who can issue
+/// commands to it), and this codebase already calls it from non-main
+/// threads today (`pill_position::apply_pill_placement`).
+#[cfg(target_os = "windows")]
+pub(super) fn animate_pill_placement<R: Runtime>(
+    pill: &WebviewWindow<R>,
+    from: PillPlacement,
+    to: PillPlacement,
+    on_complete: impl FnOnce() + Send + 'static,
+) {
+    use windows::Win32::UI::WindowsAndMessaging::{SetWindowPos, SWP_NOACTIVATE, SWP_NOZORDER};
+
+    let generation = PILL_TWEEN_GEN
+        .fetch_add(1, Ordering::SeqCst)
+        .wrapping_add(1);
+    let pill = pill.clone();
+    let step_count = (TWEEN_DURATION_MS / TWEEN_STEP_MS).max(1) as u32;
+    let frames = build_tween_frames(from, to, step_count);
+
+    std::thread::spawn(move || {
+        for frame in frames {
+            if PILL_TWEEN_GEN.load(Ordering::SeqCst) != generation {
+                return; // superseded — cede the window to the newer move.
+            }
+            if let Ok(hwnd) = pill.hwnd() {
+                unsafe {
+                    let _ = SetWindowPos(
+                        hwnd,
+                        None,
+                        frame.x,
+                        frame.y,
+                        frame.width,
+                        frame.height,
+                        SWP_NOZORDER | SWP_NOACTIVATE,
+                    );
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS));
+        }
+
+        if PILL_TWEEN_GEN.load(Ordering::SeqCst) == generation {
+            on_complete();
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placement(x: i32, y: i32, width: i32, height: i32) -> PillPlacement {
+        PillPlacement {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn ease_out_cubic_is_monotonic_and_bounded() {
+        assert_eq!(ease_out_cubic(0.0), 0.0);
+        assert_eq!(ease_out_cubic(1.0), 1.0);
+        let samples: Vec<f64> = (0..=10).map(|i| ease_out_cubic(i as f64 / 10.0)).collect();
+        for pair in samples.windows(2) {
+            assert!(pair[1] >= pair[0], "ease_out_cubic must be non-decreasing");
+        }
+    }
+
+    #[test]
+    fn build_tween_frames_lands_exactly_on_target() {
+        let from = placement(0, 1000, 380, 44);
+        let to = placement(1920, 1340, 475, 55);
+        let frames = build_tween_frames(from, to, 15);
+        let last = frames.last().expect("at least one frame");
+        assert_eq!(
+            (last.x, last.y, last.width, last.height),
+            (to.x, to.y, to.width, to.height)
+        );
+    }
+
+    #[test]
+    fn build_tween_frames_returns_step_count_frames() {
+        let from = placement(0, 0, 380, 44);
+        let to = placement(1920, 0, 475, 55);
+        assert_eq!(build_tween_frames(from, to, 15).len(), 15);
+    }
+
+    fn assert_axis_monotonic_toward_target(from: i32, to: i32, values: &[i32]) {
+        let lo = from.min(to);
+        let hi = from.max(to);
+        let mut prev = from;
+        for &v in values {
+            assert!(v >= lo && v <= hi, "{v} escaped range [{lo},{hi}]");
+            if to >= from {
+                assert!(
+                    v >= prev,
+                    "expected non-decreasing toward target, got {v} after {prev}"
+                );
+            } else {
+                assert!(
+                    v <= prev,
+                    "expected non-increasing toward target, got {v} after {prev}"
+                );
+            }
+            prev = v;
+        }
+    }
+
+    #[test]
+    fn build_tween_frames_is_monotonic_per_axis_with_no_overshoot() {
+        // Cover both directions: growing+moving right (A -> higher-DPI B) and
+        // shrinking+moving left (B -> A), since a real setup crosses both ways.
+        for (from, to) in [
+            (placement(0, 1000, 380, 44), placement(1920, 1340, 475, 55)),
+            (placement(1920, 1340, 475, 55), placement(0, 1000, 380, 44)),
+        ] {
+            let frames = build_tween_frames(from, to, 15);
+            let xs: Vec<i32> = frames.iter().map(|f| f.x).collect();
+            let ys: Vec<i32> = frames.iter().map(|f| f.y).collect();
+            let widths: Vec<i32> = frames.iter().map(|f| f.width).collect();
+            let heights: Vec<i32> = frames.iter().map(|f| f.height).collect();
+            assert_axis_monotonic_toward_target(from.x, to.x, &xs);
+            assert_axis_monotonic_toward_target(from.y, to.y, &ys);
+            assert_axis_monotonic_toward_target(from.width, to.width, &widths);
+            assert_axis_monotonic_toward_target(from.height, to.height, &heights);
+        }
+    }
+
+    #[test]
+    fn cancel_pending_pill_tween_bumps_generation() {
+        // Verifies only the atomic mechanics; real thread-cancellation
+        // behavior needs a live window and can't be unit tested here.
+        let before = PILL_TWEEN_GEN.load(Ordering::SeqCst);
+        cancel_pending_pill_tween();
+        cancel_pending_pill_tween();
+        assert!(PILL_TWEEN_GEN.load(Ordering::SeqCst) >= before + 2);
+    }
+}

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -91,13 +91,16 @@ pub(super) fn cancel_pending_pill_tween() {
     PILL_TWEEN_GEN.fetch_add(1, Ordering::SeqCst);
 }
 
-/// Starts an animated move/resize from `from` to `to` on a dedicated thread
-/// and returns immediately. `on_complete` runs once the tween lands exactly
-/// on `to` — never if a newer tween or instant move superseded this one
-/// first. Win32 `SetWindowPos` can be called from any thread (thread
+/// Starts an animated move/resize from `from` to `to` on Tauri's async
+/// runtime and returns immediately. `on_complete` runs once the tween lands
+/// exactly on `to` — never if a newer tween or instant move superseded this
+/// one first. Win32 `SetWindowPos` can be called from any thread (thread
 /// affinity governs who *receives* a window's messages, not who can issue
 /// commands to it), and this codebase already calls it from non-main
-/// threads today (`pill_position::apply_pill_placement`).
+/// threads today (`pill_position::apply_pill_placement`). Uses
+/// `tauri::async_runtime::spawn` + `tokio::time::sleep` rather than a raw OS
+/// thread, matching the same generation-counter-guarded delayed-action shape
+/// already used in `media::sound::play_start_delayed_then`.
 #[cfg(target_os = "windows")]
 pub(super) fn animate_pill_placement<R: Runtime>(
     pill: &WebviewWindow<R>,
@@ -114,7 +117,7 @@ pub(super) fn animate_pill_placement<R: Runtime>(
     let step_count = (TWEEN_DURATION_MS / TWEEN_STEP_MS).max(1) as u32;
     let frames = build_tween_frames(from, to, step_count);
 
-    std::thread::spawn(move || {
+    tauri::async_runtime::spawn(async move {
         for frame in frames {
             if PILL_TWEEN_GEN.load(Ordering::SeqCst) != generation {
                 return; // superseded — cede the window to the newer move.
@@ -135,7 +138,7 @@ pub(super) fn animate_pill_placement<R: Runtime>(
                     SWP_NOZORDER | SWP_NOACTIVATE,
                 );
             }
-            std::thread::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS));
+            tokio::time::sleep(std::time::Duration::from_millis(TWEEN_STEP_MS)).await;
         }
 
         if PILL_TWEEN_GEN.load(Ordering::SeqCst) == generation {

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -111,7 +111,7 @@ pub(super) fn dimension_changed(current: f64, desired: f64) -> bool {
     (current - desired).abs() > 1.0
 }
 
-fn position_changed(current: i32, desired: i32) -> bool {
+pub(super) fn position_changed(current: i32, desired: i32) -> bool {
     current.abs_diff(desired) > 1
 }
 

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -82,7 +82,44 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
     Some(placement_for_monitor(monitor))
 }
 
-pub(super) fn apply_pill_placement<R: Runtime>(pill: &WebviewWindow<R>, placement: PillPlacement) {
+/// Reads the pill's actual on-screen geometry right now. Used by the
+/// animated cross-monitor path (`pill_animation.rs`) as the tween's starting
+/// point — it needs the literal current placement to interpolate from, not
+/// just a changed/unchanged boolean.
+pub(super) fn current_placement<R: Runtime>(pill: &WebviewWindow<R>) -> PillPlacement {
+    let (width, height) = pill
+        .inner_size()
+        .map(|s| (s.width as i32, s.height as i32))
+        .unwrap_or((0, 0));
+    let (x, y) = pill.outer_position().map(|p| (p.x, p.y)).unwrap_or((0, 0));
+    PillPlacement {
+        x,
+        y,
+        width,
+        height,
+    }
+}
+
+pub(super) fn dimension_changed(current: f64, desired: f64) -> bool {
+    (current - desired).abs() > 1.0
+}
+
+fn position_changed(current: i32, desired: i32) -> bool {
+    (current - desired).abs() > 1
+}
+
+/// Moves/resizes the pill to `placement` if it isn't already there. Returns
+/// `true` if a native resize or reposition was actually issued. Used as-is
+/// for the synchronous same-monitor path; the animated cross-monitor path in
+/// `pill_animation.rs` has its own per-frame `SetWindowPos` calls instead,
+/// since every tween frame must apply unconditionally to progress the
+/// animation rather than skip via this function's no-op check.
+pub(super) fn apply_pill_placement<R: Runtime>(
+    pill: &WebviewWindow<R>,
+    placement: PillPlacement,
+) -> bool {
+    super::pill_animation::cancel_pending_pill_tween();
+
     let desired_size = (
         placement.width.max(1) as f64,
         placement.height.max(1) as f64,
@@ -91,14 +128,14 @@ pub(super) fn apply_pill_placement<R: Runtime>(pill: &WebviewWindow<R>, placemen
     let needs_resize = pill
         .inner_size()
         .map(|cur| {
-            (cur.width as f64 - desired_size.0).abs() > 1.0
-                || (cur.height as f64 - desired_size.1).abs() > 1.0
+            dimension_changed(cur.width as f64, desired_size.0)
+                || dimension_changed(cur.height as f64, desired_size.1)
         })
         .unwrap_or(true);
 
     let needs_reposition = pill
         .outer_position()
-        .map(|cur| (cur.x - placement.x).abs() > 1 || (cur.y - placement.y).abs() > 1)
+        .map(|cur| position_changed(cur.x, placement.x) || position_changed(cur.y, placement.y))
         .unwrap_or(true);
 
     #[cfg(target_os = "windows")]
@@ -146,11 +183,25 @@ pub(super) fn apply_pill_placement<R: Runtime>(pill: &WebviewWindow<R>, placemen
                 .ok();
         }
     }
+
+    needs_resize || needs_reposition
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dimension_changed_respects_one_pixel_tolerance() {
+        assert!(!dimension_changed(380.0, 380.9));
+        assert!(dimension_changed(380.0, 475.0));
+    }
+
+    #[test]
+    fn position_changed_respects_one_pixel_tolerance() {
+        assert!(!position_changed(100, 101));
+        assert!(position_changed(100, 250));
+    }
 
     fn monitor(
         work_x: i32,

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -86,20 +86,25 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
 /// animated cross-monitor path (`pill_animation.rs`) as the tween's starting
 /// point — it needs the literal current placement to interpolate from, not
 /// just a changed/unchanged boolean. Only called from the Windows-only
-/// animated branch in `pill.rs`'s `show_pill_msg`.
+/// animated branch in `pill.rs`'s `show_pill_msg`. Returns `None` if the
+/// geometry can't be read or comes back zero-sized (e.g. very early in
+/// window initialization) rather than guessing `(0, 0)` — a tween that
+/// actually started from `(0, 0, 0, 0)` would visibly grow in from the
+/// screen's top-left corner, which is worse than just skipping the
+/// animation for that one call.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-pub(super) fn current_placement<R: Runtime>(pill: &WebviewWindow<R>) -> PillPlacement {
-    let (width, height) = pill
-        .inner_size()
-        .map(|s| (s.width as i32, s.height as i32))
-        .unwrap_or((0, 0));
-    let (x, y) = pill.outer_position().map(|p| (p.x, p.y)).unwrap_or((0, 0));
-    PillPlacement {
-        x,
-        y,
-        width,
-        height,
+pub(super) fn current_placement<R: Runtime>(pill: &WebviewWindow<R>) -> Option<PillPlacement> {
+    let size = pill.inner_size().ok()?;
+    let pos = pill.outer_position().ok()?;
+    if size.width == 0 || size.height == 0 {
+        return None;
     }
+    Some(PillPlacement {
+        x: pos.x,
+        y: pos.y,
+        width: size.width as i32,
+        height: size.height as i32,
+    })
 }
 
 pub(super) fn dimension_changed(current: f64, desired: f64) -> bool {

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -85,7 +85,9 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
 /// Reads the pill's actual on-screen geometry right now. Used by the
 /// animated cross-monitor path (`pill_animation.rs`) as the tween's starting
 /// point — it needs the literal current placement to interpolate from, not
-/// just a changed/unchanged boolean.
+/// just a changed/unchanged boolean. Only called from the Windows-only
+/// animated branch in `pill.rs`'s `show_pill_msg`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(super) fn current_placement<R: Runtime>(pill: &WebviewWindow<R>) -> PillPlacement {
     let (width, height) = pill
         .inner_size()

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -112,7 +112,7 @@ pub(super) fn dimension_changed(current: f64, desired: f64) -> bool {
 }
 
 fn position_changed(current: i32, desired: i32) -> bool {
-    (current - desired).abs() > 1
+    current.abs_diff(desired) > 1
 }
 
 /// Moves/resizes the pill to `placement` if it isn't already there. Returns


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Audio/UI subsystem: the synthesized start/stop/error/cancel sound cues in `media/sound.rs`, and the floating dictation pill's per-monitor placement in `pipeline/pill.rs` / `pipeline/pill_position.rs`
> - Two related but distinct timing problems surfaced from real usage: (1) the handsfree start chime was delayed 700ms so it would land after the pill's entry animation, but the pill actually finishes expanding around 350ms after the state event fires, so the chime trailed the pill by several hundred ms; (2) on a two-monitor setup with different Windows display scales (e.g. 100% and 125%), the pill's native window must resize (it's sized in physical pixels per-monitor), and that resize-while-visible made WebView2 visibly stutter recreating its swap chain when crossing monitors
> - Both needed correcting because they make dictation feedback feel laggy/janky exactly at the moment a user is watching the pill for confirmation that it's listening
> - This pull request lowers `START_CUE_HANDSFREE_DELAY_MS` from 700ms to 220ms (tuned by ear), and replaces the pill's instant cross-monitor jump (previously masked by a blocking 120ms blank delay) with a real animated `SetWindowPos` tween
> - The benefit is the handsfree chime now lands close to when the pill visually appears, and switching monitors mid-dictation reads as a deliberate glide instead of a sudden snap-and-flicker

## What Changed

- Lowered `START_CUE_HANDSFREE_DELAY_MS` in `src-tauri/src/media/sound.rs` from `700` to `220`. No other sound-cue logic changed; the normal (non-handsfree) start-cue delay, the "Dictation sounds" toggle gating, and all other cues are untouched.
- Added `src-tauri/src/pipeline/pill_animation.rs`: a hand-rolled, ease-out (no overshoot) multi-step `SetWindowPos` tween (~180ms, ~15 steps) that animates the pill's position+size together when a cross-monitor move requires a real resize. Guarded by a generation counter (`PILL_TWEEN_GEN`) mirroring `sound.rs`'s existing `START_CUE_GEN` pattern, so an in-flight tween can't fight a newer move over the window.
- `pipeline/pill.rs`: `show_pill_msg` now branches on Windows — same-monitor redictation stays exactly as fast/synchronous as before; a real cross-DPI move spawns the tween and defers the reveal (click-through, show, state/error emit, extracted into a shared `reveal_pill`) until it lands. Removed the old blocking `MONITOR_MOVE_SETTLE_MS` sleep-then-jump, since the tween's own duration is now the settle time.
- `pipeline/pill_position.rs`: added a `current_placement` accessor and promoted `dimension_changed` to module visibility so `pill.rs` can detect when a move actually needs animating.

## Verification

- `cargo build` / `cargo test --manifest-path src-tauri/Cargo.toml` - 270 passed, 1 ignored, 0 failed (5 new tests covering the tween's easing curve, exact landing on target, no-overshoot monotonicity in both directions, frame count, and generation-counter mechanics)
- `cargo clippy --manifest-path src-tauri/Cargo.toml` - clean
- `cargo fmt -- --check` - clean on all touched files
- Manual (sound delay): ran `npm run tauri dev`, triggered handsfree dictation repeatedly, iterated the delay down (700ms -> 380ms -> 220ms) by ear against the pill's visual expand animation
- Manual (pill animation): confirmed on the reporter's real two-monitor mixed-DPI setup (1080p @ 100%, 1440p @ 125%) — dictating back and forth between monitors now shows a smooth glide instead of a flicker/jump

## Risks

- Sound delay: low risk, single constant value change, no new code paths.
- Pill animation: touches a delicate, previously-flicker-prone code path (this is the second fix to this exact symptom this cycle). Mitigated by: keeping the synchronous same-monitor path byte-for-byte unchanged in cost, gating the entire animated path behind `#[cfg(target_os = "windows")]` (macOS keeps its existing untouched code path), and a generation counter to prevent overlapping tweens from fighting over the window. The interpolation math is unit tested; the actual native `SetWindowPos`/WebView2 behavior can't be unit tested and was verified manually instead.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Claude Sonnet 4.6 (Anthropic), via Claude Code (agentic file edits + Bash test/build runs; the pill-animation design went through Claude Code's plan mode with a dedicated Plan-agent design pass before implementation).

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript) - n/a, no frontend files changed
- [x] `npm run lint` passes (ESLint + Clippy) - clippy clean; no frontend files changed
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands) - not run, no frontend/UI surface touched
- [x] Tests added or updated where applicable - 5 new unit tests for the tween math in `pill_animation.rs`
- [ ] UI changes include before/after screenshots - n/a, native window motion isn't screenshot-able; verified live instead
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together - n/a, no version bump
- [x] Relevant documentation updated to reflect changes - n/a, no doc-facing behavior change
- [x] Risks documented above