### PR TITLE
Fix pill clipping on first dictation after a monitor switch

### DIFF
--- a/Agent-Skills/SmokeTest.md
+++ b/Agent-Skills/SmokeTest.md
@@ -77,6 +77,14 @@ the relevant subsystem:
   watch promotion behavior. Run: `pwsh tests/manual/auto-learn-harness.ps1`.
 - `tests/manual/hotkey.cjs` — manual hotkey/injection probe against the dev server.
 - `tests/manual/setup-layout-bounds.js` — manual setup-wizard layout-bounds check.
+- Pill cross-monitor placement (no script, requires real mixed-DPI hardware):
+  on a Windows dual-monitor setup with different scale factors (e.g. 1440p +
+  1080p), dictate on one monitor, switch focus to the other, dictate again,
+  and confirm the pill is fully visible (no bottom clipping) on that *first*
+  dictation on the new monitor — not just the second. Repeat in both monitor
+  directions and at 100/125/150% scaling. Regression-tested at the unit
+  level by `should_animate_cross_monitor_move` in
+  `src-tauri/src/pipeline/pill_position.rs`.
 
 ## Notes
 

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -96,9 +96,18 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
         return;
     };
 
+    // Marks "the pill has a real placement now" as soon as we have one to
+    // apply, independent of whether `current_placement()` below succeeds.
+    // Gating this swap on that `if let` instead (as an earlier version did)
+    // meant a `None` read on the very first call - e.g. WebView2 not yet
+    // settled right after `create_pill_if_needed` - left the flag `false`
+    // forever, so the *next* reveal would also skip animating, thinking
+    // *it* was the first ever placement.
+    #[cfg(target_os = "windows")]
+    let already_placed = PILL_PLACED_ONCE.swap(true, Ordering::SeqCst);
+
     #[cfg(target_os = "windows")]
     if let Some(current) = super::pill_position::current_placement(&pill) {
-        let already_placed = PILL_PLACED_ONCE.swap(true, Ordering::SeqCst);
         let needs_animated_move = super::pill_position::should_animate_cross_monitor_move(
             already_placed,
             current,

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -25,9 +25,17 @@ static REVEAL_GEN: AtomicU64 = AtomicU64::new(0);
 /// Tracks whether the pill is currently showing a non-idle frontend state.
 /// The native window itself stays visible even in idle so WebView2 doesn't
 /// suspend, which makes `pill.is_visible()` a bad proxy for "the user can
-/// already see the pill." We only animate when a prior non-idle state was
-/// actually on screen; otherwise the first visible reveal should be instant.
+/// already see the pill."
 static PILL_VISUALLY_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Whether the pill has ever had a real, monitor-resolved placement applied
+/// in this process. `false` only for the very first `show_pill_msg` call —
+/// after that, even a reveal that follows a `hide_pill` idle cycle still has
+/// real (if stale) geometry on screen, so a monitor change found on that
+/// reveal is still worth animating into rather than jumping. Unlike
+/// `PILL_VISUALLY_ACTIVE`, this never resets back to `false`.
+#[cfg(target_os = "windows")]
+static PILL_PLACED_ONCE: AtomicBool = AtomicBool::new(false);
 
 fn create_pill_if_needed(app: &AppHandle) {
     if app.get_webview_window("pill").is_some() {
@@ -61,12 +69,18 @@ pub(crate) fn show_pill(app: &AppHandle, state: &str) {
 /// of passing through while handsfree is active. Moving to a different
 /// monitor, whether or not its scale factor differs, animates the move on
 /// Windows (see `pill_animation.rs`) instead of jumping instantly, since an
-/// instant cross-monitor move on this always-visible window either visibly
-/// snapped (same-DPI repositions) or made WebView2 stutter recreating its
-/// swap chain (cross-DPI resizes). Only animates if the pill was already
-/// visible - the very first reveal (or one after a long idle period where
-/// its cached geometry might be stale) should never be held back by an
-/// animation nobody can see yet.
+/// instant cross-monitor move on this window either visibly snapped
+/// (same-DPI repositions) or made WebView2 stutter recreating its swap
+/// chain (cross-DPI resizes) - the latter is what showed up as a clipped
+/// pill on the first dictation after a monitor change, since `hide_pill`
+/// resets `PILL_VISUALLY_ACTIVE` between dictations even though the window
+/// keeps its stale geometry the whole time it's idle. Animates whenever the
+/// pill has been placed at least once before (`PILL_PLACED_ONCE`) and the
+/// resolved placement actually differs from where it currently sits - that
+/// covers both a monitor change mid-session and one only discovered on the
+/// next reveal after an idle cycle. Only the very first reveal of the whole
+/// process skips the animation, since nothing has been shown yet for it to
+/// glide from.
 fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
     create_pill_if_needed(app);
     let Some(pill) = app.get_webview_window("pill") else {
@@ -84,16 +98,19 @@ fn show_pill_msg(app: &AppHandle, state: &str, message: Option<&str>) {
 
     #[cfg(target_os = "windows")]
     if let Some(current) = super::pill_position::current_placement(&pill) {
-        let visually_active = PILL_VISUALLY_ACTIVE.load(Ordering::SeqCst);
-        let needs_animated_move = visually_active
-            && (super::pill_position::dimension_changed(
-                current.width as f64,
-                placement.width as f64,
-            ) || super::pill_position::dimension_changed(
-                current.height as f64,
-                placement.height as f64,
-            ) || super::pill_position::position_changed(current.x, placement.x)
-                || super::pill_position::position_changed(current.y, placement.y));
+        let already_placed = PILL_PLACED_ONCE.swap(true, Ordering::SeqCst);
+        let needs_animated_move = super::pill_position::should_animate_cross_monitor_move(
+            already_placed,
+            current,
+            placement,
+        );
+
+        // Temporary diagnostic for issue #161.
+        if crate::system::logger::is_verbose() {
+            log::debug!(
+                "pill show_pill_msg: state={state} already_placed={already_placed} current={current:?} target={placement:?} animate={needs_animated_move}"
+            );
+        }
 
         if needs_animated_move {
             let app = app.clone();

--- a/src-tauri/src/pipeline/pill_animation.rs
+++ b/src-tauri/src/pipeline/pill_animation.rs
@@ -158,6 +158,17 @@ pub(super) fn animate_pill_placement<R: Runtime>(
         }
 
         if PILL_TWEEN_GEN.load(Ordering::SeqCst) == generation {
+            // Temporary diagnostic for issue #161: the per-frame SetWindowPos
+            // calls use SWP_ASYNCWINDOWPOS (post-and-return), so the last
+            // frame's move may not have actually been processed by the
+            // window's owning thread yet when we read this back here. If
+            // `actual` doesn't match `to`, that's direct evidence the
+            // tween's final geometry hadn't landed before `on_complete`
+            // (and thus `ShowWindow`) ran.
+            if crate::system::logger::is_verbose() {
+                let actual = super::pill_position::current_placement(&pill);
+                log::debug!("pill tween landed: target={to:?} actual_immediately_after={actual:?}");
+            }
             on_complete();
         }
     });

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -78,8 +78,19 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
         .flatten()
         .map(|monitor| MonitorSnapshot::from(&monitor));
     let monitor = choose_monitor(target_monitor, primary_monitor)?;
+    let placement = placement_for_monitor(monitor);
 
-    Some(placement_for_monitor(monitor))
+    // Temporary diagnostic for issue #161 (pill clipped on first cross-monitor
+    // reveal) - coordinates/scale factors only, nothing sensitive, so this is
+    // safe at the normal verbose-logging privacy bar.
+    if crate::system::logger::is_verbose() {
+        log::debug!(
+            "pill resolve_pill_placement: target_point={target_point:?} used_target_monitor={} monitor={monitor:?} -> placement={placement:?}",
+            target_monitor.is_some()
+        );
+    }
+
+    Some(placement)
 }
 
 /// Reads the pill's actual on-screen geometry right now. Used by the
@@ -113,6 +124,27 @@ pub(super) fn dimension_changed(current: f64, desired: f64) -> bool {
 
 pub(super) fn position_changed(current: i32, desired: i32) -> bool {
     current.abs_diff(desired) > 1
+}
+
+/// Whether a cross-monitor pill move should glide via `pill_animation.rs`
+/// rather than jump instantly. Gated on `already_placed` (the pill has had a
+/// real, monitor-resolved placement applied at least once before — not just
+/// its just-created default geometry) so the very first reveal of a process
+/// never pays the tween's latency for an animation nobody can see yet, while
+/// every later reveal still gets the swap-chain-safe glide whenever the
+/// resolved placement actually differs from where the window currently sits
+/// — including a reveal that follows a `hide_pill` idle cycle, whose stale
+/// geometry still belongs to whatever monitor it was last shown on.
+pub(super) fn should_animate_cross_monitor_move(
+    already_placed: bool,
+    current: PillPlacement,
+    target: PillPlacement,
+) -> bool {
+    already_placed
+        && (dimension_changed(current.width as f64, target.width as f64)
+            || dimension_changed(current.height as f64, target.height as f64)
+            || position_changed(current.x, target.x)
+            || position_changed(current.y, target.y))
 }
 
 /// Moves/resizes the pill to `placement` if it isn't already there. Returns
@@ -170,6 +202,17 @@ pub(super) fn apply_pill_placement<R: Runtime>(
                         placement.width,
                         placement.height,
                         flags,
+                    );
+                }
+
+                // Temporary diagnostic for issue #161: compare the placement
+                // we asked for against what Tauri reads back from the HWND
+                // immediately after SetWindowPos returns, to catch any
+                // post-call DPI-driven override of our explicit size/position.
+                if crate::system::logger::is_verbose() {
+                    let actual = current_placement(pill);
+                    log::debug!(
+                        "pill apply_pill_placement (sync): needs_resize={needs_resize} needs_reposition={needs_reposition} intended={placement:?} actual_after_setwindowpos={actual:?}"
                     );
                 }
             }
@@ -272,5 +315,38 @@ mod tests {
         let placement = placement_for_monitor(monitor(0, 40, 1920, 1040, 1.0));
 
         assert_eq!(placement.y, 1020);
+    }
+
+    fn placement(x: i32, y: i32, width: i32, height: i32) -> PillPlacement {
+        PillPlacement {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn does_not_animate_before_first_placement_even_if_geometry_differs() {
+        let current = placement(0, 1000, 380, 44);
+        let target = placement(1920, 1340, 570, 66);
+
+        assert!(!should_animate_cross_monitor_move(false, current, target));
+    }
+
+    #[test]
+    fn animates_once_placed_when_geometry_differs() {
+        let current = placement(0, 1000, 380, 44);
+        let target = placement(1920, 1340, 570, 66);
+
+        assert!(should_animate_cross_monitor_move(true, current, target));
+    }
+
+    #[test]
+    fn does_not_animate_once_placed_when_geometry_already_matches() {
+        let current = placement(0, 1000, 380, 44);
+        let target = placement(0, 1000, 380, 44);
+
+        assert!(!should_animate_cross_monitor_move(true, current, target));
     }
 }

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -144,8 +144,8 @@ pub(super) fn should_animate_cross_monitor_move(
     target: PillPlacement,
 ) -> bool {
     already_placed
-        && (dimension_changed(current.width as f64, target.width as f64)
-            || dimension_changed(current.height as f64, target.height as f64)
+        && (position_changed(current.width, target.width)
+            || position_changed(current.height, target.height)
             || position_changed(current.x, target.x)
             || position_changed(current.y, target.y))
 }

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -134,7 +134,10 @@ pub(super) fn position_changed(current: i32, desired: i32) -> bool {
 /// every later reveal still gets the swap-chain-safe glide whenever the
 /// resolved placement actually differs from where the window currently sits
 /// — including a reveal that follows a `hide_pill` idle cycle, whose stale
-/// geometry still belongs to whatever monitor it was last shown on.
+/// geometry still belongs to whatever monitor it was last shown on. Only
+/// called from the Windows-only animated branch in `pill.rs`'s
+/// `show_pill_msg`, same as `current_placement` above.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(super) fn should_animate_cross_monitor_move(
     already_placed: bool,
     current: PillPlacement,


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: pipeline - the floating dictation pill window's cross-monitor placement (`pipeline/pill.rs`, `pill_position.rs`, `pill_animation.rs`)
> - The pill was visibly clipped at the bottom on the first dictation shown after the active window moved to a different monitor (issue #161), but corrected itself on the next dictation on that same monitor
> - The codebase already had a safeguard for exactly this class of bug - an animated cross-monitor move added to avoid WebView2 swap-chain stutter on an instant cross-DPI resize - but it was gated on whether the pill was *currently visible*, not on whether it had *ever* been placed, so it never engaged for the very next dictation after `hide_pill` reset that flag
> - This pull request replaces that gate with one that tracks "has the pill ever had a real placement," so any reveal after the first one animates into a changed monitor target instead of jumping
> - The benefit is the pill reliably displays fully on the first dictation after switching monitors, confirmed on real 1440p/1080p hardware, with regression tests and optional diagnostics for future mixed-DPI edge cases

## What Changed

- Added `PILL_PLACED_ONCE` (`pill.rs`), which - unlike `PILL_VISUALLY_ACTIVE` - never resets when the pill goes idle, and used it to gate the animated cross-monitor move instead
- Extracted the animate/no-animate decision into a pure, unit-tested `should_animate_cross_monitor_move()` in `pill_position.rs`
- Added verbose-gated (`is_verbose()`) diagnostic logging at each placement decision point - resolved monitor/placement, the animate decision, and the actual on-screen rect immediately after each `SetWindowPos` call - to help diagnose any future mixed-DPI edge case
- Added a manual verification note to `Agent-Skills/SmokeTest.md` for real mixed-DPI hardware checks
- Added 3 unit tests: no animation before the pill's first placement, animation once placed with differing geometry, no animation once placed when geometry already matches

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` and `npm run test:rust` - 272 passed, 1 pre-existing ignored, 0 failed (10 in `pipeline::pill_position::tests`, including the 3 new ones)
- `npm run lint` - `svelte-check` (0 errors) + `cargo clippy -- -D warnings` clean
- `npm test` (fast OnePyFone profile, 16 suites) - all passed
- Manual: on a real Windows dual-monitor setup (1440p @ 100% + 1080p), dictate on one monitor, switch focus to the other, dictate again - pill now displays fully on that first dictation; confirmed by the issue reporter
- No UI changes (backend-only), so no before/after screenshots apply

## Risks

- Windows-only change, scoped to the existing `#[cfg(target_os = "windows")]` animated-move path already used for cross-monitor moves; macOS pill placement is untouched
- New diagnostic logging is gated behind the existing verbose-logging flag (off by default) and only logs window coordinates/scale factors - never dictated text, prompts, or other sensitive content
- Low risk: corrects a stale boolean gate rather than the placement math itself, which was already covered by existing passing tests

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Claude Sonnet 4.6 (Anthropic), via Claude Code - standard tool use, no extended thinking mode

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [x] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

Fixes #161