### PR TITLE
Use native OS connectivity checks instead of an HTTP probe

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ windows = { version = "0.61", features = [
   "Win32_UI_Accessibility",
   "Win32_Storage_FileSystem",
   "Win32_Security_Credentials",
+  "Win32_Networking_NetworkListManager",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -273,6 +273,14 @@ fn run_launchctl(args: &[&str]) -> Result<(), String> {
 
 #[tauri::command]
 pub async fn check_connectivity() -> bool {
+    // Prefer the OS's own network state (see system/connectivity.rs) — on
+    // Windows this is a local COM call with zero network traffic; on macOS
+    // it's a local routing-table check. Only fall back to an HTTP probe when
+    // the native check is unavailable or inconclusive.
+    if let Some(connected) = native_connectivity_check().await {
+        return connected;
+    }
+
     // Probe github.com (a host Verenu already contacts for release downloads)
     // rather than a third-party beacon like google.com, so the connectivity check
     // doesn't quietly phone a separate domain. Deliberately NOT api.github.com:
@@ -286,6 +294,21 @@ pub async fn check_connectivity() -> bool {
         .send()
         .await
         .is_ok()
+}
+
+#[cfg(windows)]
+async fn native_connectivity_check() -> Option<bool> {
+    // COM requires apartment init on the calling thread, so run on a
+    // dedicated blocking thread rather than whatever tokio worker polls this.
+    tokio::task::spawn_blocking(crate::system::connectivity::check_native)
+        .await
+        .ok()
+        .flatten()
+}
+
+#[cfg(not(windows))]
+async fn native_connectivity_check() -> Option<bool> {
+    crate::system::connectivity::check_native()
 }
 
 // ---------- developer logs ----------

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -275,10 +275,13 @@ fn run_launchctl(args: &[&str]) -> Result<(), String> {
 pub async fn check_connectivity() -> bool {
     // Prefer the OS's own network state (see system/connectivity.rs) — on
     // Windows this is a local COM call with zero network traffic; on macOS
-    // it's a local routing-table check. Only fall back to an HTTP probe when
-    // the native check is unavailable or inconclusive.
-    if let Some(connected) = native_connectivity_check().await {
-        return connected;
+    // it's a local routing-table check. Only short-circuit on a confirmed
+    // "online" (Some(true)): both NCSI and SCNetworkReachability can report
+    // false negatives behind certain VPNs/enterprise proxies, so a "false" or
+    // unavailable native result still falls through to the HTTP probe rather
+    // than risking a wrong "no internet" banner.
+    if let Some(true) = native_connectivity_check().await {
+        return true;
     }
 
     // Probe github.com (a host Verenu already contacts for release downloads)

--- a/src-tauri/src/system/connectivity.rs
+++ b/src-tauri/src/system/connectivity.rs
@@ -10,8 +10,12 @@
 //! up" flag, so this only checks local route reachability via
 //! `SCNetworkReachability` (zero network traffic, but a positive result just
 //! means "there's a default route", not "the WAN is actually up" — e.g. a
-//! captive portal with no real internet still reads as reachable). Callers
-//! should treat `None` as "unknown, fall back to an active probe".
+//! captive portal with no real internet still reads as reachable).
+//!
+//! Both platforms can also report false negatives (VPNs, enterprise proxies,
+//! or NCSI getting stuck) — so callers should only trust a confirmed
+//! `Some(true)` and treat `Some(false)`/`None` alike as "unknown, fall back
+//! to an active probe" rather than concluding "offline".
 
 #[cfg(windows)]
 pub fn check_native() -> Option<bool> {

--- a/src-tauri/src/system/connectivity.rs
+++ b/src-tauri/src/system/connectivity.rs
@@ -46,7 +46,7 @@ pub fn check_native() -> Option<bool> {
         let manager: INetworkListManager =
             CoCreateInstance(&NetworkListManager, None, CLSCTX_ALL).ok()?;
         let connected = manager.IsConnectedToInternet().ok()?;
-        Some(connected.0 != 0)
+        Some(connected.as_bool())
     }
 }
 
@@ -95,14 +95,14 @@ pub fn check_native() -> Option<bool> {
 
         let mut flags: ScNetworkReachabilityFlags = 0;
         let ok = SCNetworkReachabilityGetFlags(target, &mut flags);
-        CFRelease(target as CfTypeRef);
+        CFRelease(target);
 
         if ok == 0 {
             return None;
         }
 
-        let reachable = flags & REACHABLE != 0;
-        let needs_connection = flags & CONNECTION_REQUIRED != 0;
+        let reachable = (flags & REACHABLE) != 0;
+        let needs_connection = (flags & CONNECTION_REQUIRED) != 0;
         Some(reachable && !needs_connection)
     }
 }

--- a/src-tauri/src/system/connectivity.rs
+++ b/src-tauri/src/system/connectivity.rs
@@ -1,0 +1,109 @@
+//! Native OS connectivity checks — read the OS's own network state instead of
+//! sending a probe request, so a routine "are we online" check costs zero bytes.
+//!
+//! Windows reads cached state from the Network List Manager, which Windows
+//! itself populates by periodically probing Microsoft's NCSI endpoints (the
+//! same signal behind the taskbar Wi-Fi icon) — querying it is a local COM
+//! call, no network traffic from this process at all.
+//!
+//! macOS has no equivalent public API for a verified "is the internet actually
+//! up" flag, so this only checks local route reachability via
+//! `SCNetworkReachability` (zero network traffic, but a positive result just
+//! means "there's a default route", not "the WAN is actually up" — e.g. a
+//! captive portal with no real internet still reads as reachable). Callers
+//! should treat `None` as "unknown, fall back to an active probe".
+
+#[cfg(windows)]
+pub fn check_native() -> Option<bool> {
+    use windows::Win32::Networking::NetworkListManager::{INetworkListManager, NetworkListManager};
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED,
+    };
+
+    // COM apartment is per-thread; `spawn_blocking` (see commands/system.rs)
+    // hands this a fresh thread-pool thread with no apartment by default.
+    struct ComGuard(bool);
+    impl ComGuard {
+        fn new() -> Self {
+            let initialized = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }.is_ok();
+            ComGuard(initialized)
+        }
+    }
+    impl Drop for ComGuard {
+        fn drop(&mut self) {
+            if self.0 {
+                unsafe { CoUninitialize() };
+            }
+        }
+    }
+
+    let _com = ComGuard::new();
+    unsafe {
+        let manager: INetworkListManager =
+            CoCreateInstance(&NetworkListManager, None, CLSCTX_ALL).ok()?;
+        let connected = manager.IsConnectedToInternet().ok()?;
+        Some(connected.0 != 0)
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn check_native() -> Option<bool> {
+    use core::ffi::c_void;
+
+    type ScNetworkReachabilityRef = *const c_void;
+    type CfTypeRef = *const c_void;
+    type ScNetworkReachabilityFlags = u32;
+
+    const REACHABLE: u32 = 1 << 1;
+    const CONNECTION_REQUIRED: u32 = 1 << 2;
+
+    #[link(name = "SystemConfiguration", kind = "framework")]
+    extern "C" {
+        fn SCNetworkReachabilityCreateWithAddress(
+            allocator: CfTypeRef,
+            address: *const libc::sockaddr,
+        ) -> ScNetworkReachabilityRef;
+        fn SCNetworkReachabilityGetFlags(
+            target: ScNetworkReachabilityRef,
+            flags: *mut ScNetworkReachabilityFlags,
+        ) -> u8;
+    }
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: CfTypeRef);
+    }
+
+    unsafe {
+        // The zero address (0.0.0.0) is Apple's documented pattern for a
+        // generic "is there any network route at all" check — it deliberately
+        // avoids resolving a hostname, which would mean a DNS lookup.
+        let mut addr: libc::sockaddr_in = std::mem::zeroed();
+        addr.sin_len = std::mem::size_of::<libc::sockaddr_in>() as u8;
+        addr.sin_family = libc::AF_INET as u8;
+
+        let target = SCNetworkReachabilityCreateWithAddress(
+            std::ptr::null(),
+            &addr as *const libc::sockaddr_in as *const libc::sockaddr,
+        );
+        if target.is_null() {
+            return None;
+        }
+
+        let mut flags: ScNetworkReachabilityFlags = 0;
+        let ok = SCNetworkReachabilityGetFlags(target, &mut flags);
+        CFRelease(target as CfTypeRef);
+
+        if ok == 0 {
+            return None;
+        }
+
+        let reachable = flags & REACHABLE != 0;
+        let needs_connection = flags & CONNECTION_REQUIRED != 0;
+        Some(reachable && !needs_connection)
+    }
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+pub fn check_native() -> Option<bool> {
+    None
+}

--- a/src-tauri/src/system/mod.rs
+++ b/src-tauri/src/system/mod.rs
@@ -1,4 +1,5 @@
 pub mod apps;
+pub mod connectivity;
 pub mod logger;
 #[cfg(target_os = "macos")]
 pub mod mac_app;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: system commands (`commands/system.rs`) - the `check_connectivity` Tauri command the frontend polls every 60s to show the "No internet connection" banner
> - The existing check did a `HEAD` request to `github.com` every poll. Measuring it showed it actually downloads ~3-4KB of response headers (full CSP policy + 3 `Set-Cookie` headers) despite an empty body - real, recurring data usage for something that's supposed to "load nothing"
> - It needs addressing now because the project explicitly targets minimal background data/resource usage (200MB idle RAM target, privacy-conscious networking already noted in the surrounding code comment), and there's a zero-cost alternative available on both target OSes
> - This pull request replaces the active HTTP probe with each OS's native connectivity signal - `INetworkListManager::IsConnectedToInternet()` (COM) on Windows, `SCNetworkReachability` on macOS - falling back to the original `github.com` probe only when the native check is unavailable or inconclusive
> - The benefit is the common case (Windows and macOS, i.e. every shipped build) now costs zero network bytes for a routine connectivity poll, with no behavior change visible to the user and no regression for the rare fallback path

## What Changed

- Added `src-tauri/src/system/connectivity.rs` with `check_native() -> Option<bool>`: Windows reads cached internet state via `INetworkListManager` (COM, zero network traffic - the same signal behind the taskbar Wi-Fi icon); macOS checks local route reachability via `SCNetworkReachability` against the zero address (zero network traffic, no DNS lookup); other platforms return `None`.
- `check_connectivity` in `commands/system.rs` now tries the native check first and only falls back to the existing `github.com` `HEAD` probe when native is unavailable or fails.
- Windows COM call runs inside `spawn_blocking` since COM requires apartment initialization on the calling thread (mirrors the existing `ComGuard` pattern in `system/media_control.rs`).
- Added the `Win32_Networking_NetworkListManager` feature to the `windows` crate dependency in `Cargo.toml`.

## Verification

- `cargo check`, `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`, and `cargo test` (272 passed, 0 failed) all green on Windows, the platform this sandbox can actually compile.
- `npm run check` (svelte-check, 0 errors) and `npm run lint` (ESLint + Clippy) pass - no frontend changes, contract (`check_connectivity` still returns a plain `bool`) is unchanged.
- Measured before/after header size with `curl -I`: `github.com` HEAD ≈ 3-4KB of headers vs. 0 bytes for the new native path.
- Not run locally: Playwright smoke tests (no frontend/UI files touched by this PR, so skipped) and a live online/offline toggle test on a real Windows machine. Recommend a reviewer toggle Wi-Fi off/on and confirm the "No internet connection" banner still appears/clears within ~60s.
- macOS path is not compile-verified in this environment (no macOS target available here) - it's written against stable, documented `SCNetworkReachability` APIs following the existing minimal-FFI style already used in `core/hotkey/mac.rs`, and will get its first real compile check from the OS-matrix CI job.

## Risks

- macOS `SCNetworkReachability` only confirms a local route exists, not verified internet (e.g. a captive-portal Wi-Fi network with no real WAN would still read as "online"). This is a deliberate accuracy-for-zero-data tradeoff, documented in the code comment in `connectivity.rs`. Apple doesn't expose a third-party-accessible verified-internet signal equivalent to Windows' NCSI.
- No automated test covers the native OS calls themselves (COM/FFI aren't practically unit-testable), consistent with how other native platform code in this codebase (`system/volume.rs`, `system/media_control.rs`) is tested only at the surrounding-logic level, not at the raw syscall level.
- Otherwise low risk: the fallback path preserves the exact prior behavior (same URL, same timeout, same `is_ok()` semantics) when the native check returns `None`.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Anthropic Claude Sonnet 4.6, via Claude Code (standard tool-use mode, no extended thinking).

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (not run - no frontend/UI files changed in this PR)
- [ ] Tests added or updated where applicable (native OS calls aren't practically unit-testable; see Risks)
- [ ] UI changes include before/after screenshots (N/A - no UI changes)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (N/A - no version bump)
- [x] Relevant documentation updated to reflect changes (no existing docs reference the old probe)
- [x] Risks documented above