### PR TITLE
Fix Caps Lock casing getting partially undone by contextual capitalization

### DIFF
--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -151,6 +151,29 @@ mod tests {
     }
 
     #[test]
+    fn contextual_caps_disabled_preserves_caps_lock_uppercased_text() {
+        // Regression: caps-lock uppercasing must be the final casing decision.
+        // With contextual_caps off (as finalize.rs forces when caps lock is on),
+        // a mid-sentence continuation must not lowercase the first letter of an
+        // already-all-caps word ("THE" -> "tHE").
+        let probe = InjectionContextProbe {
+            context: crate::core::text_context::SentenceContext::MidSentence,
+            source: ContextProbeSource::CaretLocal,
+            context_tail: "hello ".to_string(),
+            selection_state: SelectionState::CollapsedCaret,
+            control_identity_hash: "test".to_string(),
+            control_type: "test".to_string(),
+        };
+        let (adjusted, _, case_decision) =
+            apply_probe_adjustments("THE REPORT IS READY", false, false, "casual", &probe);
+        assert_eq!(adjusted, "THE REPORT IS READY");
+        assert!(matches!(
+            case_decision,
+            CaseDecision::ContextualCapsDisabled
+        ));
+    }
+
+    #[test]
     fn uppercase_first_word_handles_prefix_symbols() {
         assert_eq!(uppercase_first_word("hello world"), "Hello world");
         assert_eq!(uppercase_first_word("\"hello world"), "\"Hello world");

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -127,7 +127,10 @@ pub(super) async fn finalize_pipeline_completion(
         match injection::inject_text(
             &final_text_substituted,
             ctx.target_hwnd,
-            ctx.cfg.contextual_caps_enabled,
+            // Caps lock must be the final word on casing: contextual capitalization
+            // (e.g. lowercasing a continuation's first letter) would otherwise run
+            // on top of the all-caps text and undo part of it.
+            ctx.cfg.contextual_caps_enabled && !apply_caps_lock_upper,
             ctx.cfg.auto_spacing_enabled,
             ctx.profile,
             ctx.cfg.macos_clipboard_sniff_enabled,


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: pipeline finalization / text injection
> - Caps Lock uppercasing (`caps_lock_uppercase_enabled` + `caps_lock_on`) was applied to the final text in `finalize.rs`, but `injection::inject_text()` then ran its own contextual mid-sentence capitalization pass on top of that already-uppercased text
> - When dictating into an existing sentence (or with the casual/very_casual style, whose output is more likely to be classified mid-sentence), that pass would lowercase just the first letter of a common word match (e.g. "THE" -> "tHE"), corrupting the caps-lock output
> - This needs fixing now because it silently breaks a user-facing accessibility/workflow feature (Caps Lock override) any time dictation lands mid-sentence in an app
> - This pull request makes Caps Lock the final casing decision by disabling contextual capitalization whenever the Caps Lock override is active
> - The benefit is Caps Lock output is never partially re-cased after the fact, regardless of app, cursor position, or formatting profile

## What Changed

- `src-tauri/src/pipeline/finalize.rs`: pass `contextual_caps_enabled && !apply_caps_lock_upper` into `injection::inject_text()` so contextual capitalization is skipped whenever Caps Lock override already decided the casing
- `src-tauri/src/core/injection/mod.rs`: added a regression test (`contextual_caps_disabled_preserves_caps_lock_uppercased_text`) asserting a mid-sentence, all-caps string passes through `apply_probe_adjustments` unchanged when contextual caps is disabled

## Verification

- `cargo test --bin verenu injection::tests` - 7 passed, including the new regression test
- `cargo test --bin verenu pipeline::` - 53 passed (includes `pipeline_fixture_uppercases_output_only_when_setting_and_caps_lock_both_on`)
- `cargo check` - clean build
- Manual scenario reasoned through: Caps Lock on, cursor placed mid-sentence in a text field, casual/very_casual profile - previously produced `tHE REPORT IS READY`, now produces `THE REPORT IS READY`

## Risks

- Low risk: the change only narrows when contextual capitalization runs (it's now skipped in the Caps Lock case it was previously corrupting); no behavior change when Caps Lock is off, which is the common path
- No change to injection timing, clipboard handling, or auto-spacing logic

## Model Used

- Claude Sonnet 5 (claude-sonnet-5), via Claude Code, standard reasoning mode

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript) - not run (no frontend changes)
- [ ] `npm run lint` passes (ESLint + Clippy) - not run in this session
- [x] `npm run test:rust` passes (ran targeted `cargo test` for the affected modules)
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands) - not run (no frontend/smoke-relevant changes)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots - N/A, no UI changes
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together - N/A, no version bump
- [x] Relevant documentation updated to reflect changes - N/A, no doc-visible behavior change
- [x] Risks documented above