### PR TITLE
Add 0.15.1 changelog entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 - Evened out the Dictionary and Snippets sort segmented controls' selection highlight.
 - Fixed Caps Lock casing getting partially undone by contextual capitalization when dictating mid-sentence.
 - Fixed the dictation pill clipping on the first recording shown after switching monitors.
-- Tightened the handsfree start chime timing and animated the pill's move across monitors.
+- Tightened the hands-free start chime timing and animated the pill's move across monitors.
 - Signed macOS release builds with a persistent self-signed identity so permission grants carry over between updates.
 - Replaced the periodic HTTP connectivity probe with native OS connectivity checks, eliminating background network traffic for that check.
 - Organized project documentation around `docs/` instead of scattering full policy files at the repository root.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,34 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+## 0.15.1 beta - Audio & Polish
+
+- Added configurable dictation sound cues for start, stop, cancel, and error transitions.
+- Added a Windows-only option to pause active media sessions (Spotify, YouTube, etc.) during dictation and resume them afterward.
+- Added macOS-only exclusive microphone access so other apps can't capture audio while dictating.
+- Switched the Windows main window to native OS title bar chrome, recolored to match the app theme.
+- Fixed the Windows tray Relaunch action silently closing the app instead of restarting it.
+- Hardened the dictation pill window against exposing native chrome in hands-free mode on Windows.
+- Evened out the Dictionary and Snippets sort segmented controls' selection highlight.
+- Fixed Caps Lock casing getting partially undone by contextual capitalization when dictating mid-sentence.
+- Fixed the dictation pill clipping on the first recording shown after switching monitors.
+- Tightened the handsfree start chime timing and animated the pill's move across monitors.
+- Signed macOS release builds with a persistent self-signed identity so permission grants carry over between updates.
+- Replaced the periodic HTTP connectivity probe with native OS connectivity checks, eliminating background network traffic for that check.
 - Organized project documentation around `docs/` instead of scattering full policy files at the repository root.
 - Added GitHub issue templates for bug reports and feature requests.
 - Added public docs for architecture, testing, release process, troubleshooting, security, support, code of conduct, and RAM/reliability constraints.
 - Added npm package metadata and macOS signing script aliases so documented commands resolve.
+- Refactored oversized backend Rust modules (`commands/settings.rs`, `main.rs`) into focused modules with no behavior change.
+
+Installer hashes:
+
+| File | SHA-256 |
+| --- | --- |
+| `Verenu_0.15.1_Apple_Silicon.dmg` | `51eb5d40be4814d460efe9baf6c6214652961dd3abbeee2e32b19178899b1529` |
+| `Verenu_0.15.1_Intel.dmg` | `6770f15a82809c09741d4ef2b64e4428798bc865f0b7aea2be87a964e8407c2f` |
+| `Verenu_0.15.1_x64-setup.exe` | `ac36e31871a4919e08f0d0a17386df65c77b4374f96eab908d15643d83de0f8c` |
+| `Verenu_0.15.1_x64_en-US.msi` | `f605697435d7ce75ea1e1f6ecebc0e370d61158e8c97e410a1c8ab4b8fbe7ba6` |
 
 ## 0.15.0 beta - Polish
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: project documentation (`docs/CHANGELOG.md`)
> - The GitHub Release notes for 0.15.1 were just corrected to reflect everything that shipped between the 0.15.0 and 0.15.1 tags (10 PRs: audio features, Windows title bar, pill/tray/settings polish, bug fixes, macOS signing), but the repo's own `docs/CHANGELOG.md` still only had a stale "Unreleased" section for docs-reorg work
> - This needs fixing now because the changelog and the GitHub Release notes should describe the same release, and the "Unreleased" bullets were actually already part of what's shipping in 0.15.1
> - This pull request folds the stale Unreleased entries into a new 0.15.1 section alongside the rest of the release's changes and installer hashes
> - The benefit is `docs/CHANGELOG.md` stays an accurate, in-repo mirror of what's in each tagged release

## What Changed

- `docs/CHANGELOG.md`: added a "0.15.1 beta - Audio & Polish" section (matching the 0.15.0 section's format) covering all 10 PRs merged between the two tags, moved the former "Unreleased" docs-reorg bullets into it, and added the installer SHA-256 table

## Verification

- Manual: cross-checked every bullet against `git log Verenu-0.15.0-beta..Verenu-0.15.1-beta --oneline` and each PR's description
- Hashes match `installers/0.15.1/SHA256SUMS.txt`

## Risks

- Low risk: documentation-only change

## Model Used

- Claude Sonnet 5 (claude-sonnet-5), via Claude Code

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes - N/A, docs only
- [ ] `npm run lint` passes - N/A, docs only
- [ ] `npm run test:rust` passes - N/A, docs only
- [ ] Smoke tests pass - N/A, docs only
- [ ] Tests added or updated - N/A, docs only
- [ ] UI changes include before/after screenshots - N/A
- [x] No API keys, secrets, or personal data in code or logs
- [x] Version bumped - N/A, already done in #177
- [x] Relevant documentation updated to reflect changes (this is the doc update)
- [x] Risks documented above