### PR TITLE
Route AI review through self-hosted CLI Proxy API (Tailscale)

### DIFF
--- a/.github/workflows/verenu-ai-review.yml
+++ b/.github/workflows/verenu-ai-review.yml
@@ -42,11 +42,19 @@ jobs:
       - name: Install Open Code Review
         run: npm install -g @alibaba-group/open-code-review@1.7.1
 
+      # Joins the runner to the tailnet as an ephemeral node so it can reach
+      # the self-hosted CLI Proxy API on the home LAN over its Tailscale IP
+      # — that box is never exposed to the public internet. The node leaves
+      # the tailnet automatically when this job ends (ephemeral auth key).
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
       - name: Run Verenu AI review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
-          OPENROUTER_MODEL: ${{ secrets.OPENROUTER_MODEL }}
-          OPENROUTER_ESCALATION_MODEL: ${{ secrets.OPENROUTER_ESCALATION_MODEL }}
+          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          CLIPROXY_URL: ${{ secrets.CLIPROXY_URL }}
+          CLIPROXY_MODEL: ${{ secrets.CLIPROXY_MODEL }}
         run: node scripts/verenu-ai-review.mjs

--- a/scripts/verenu-ai-review.mjs
+++ b/scripts/verenu-ai-review.mjs
@@ -191,29 +191,25 @@ async function upsertStateComment(prNumber, existing, summary, state) {
 
 // --- provider selection ----------------------------------------------------
 
-// One OpenRouter key fronts every model, so there's no separate-key fallback
-// to reason about — just pick which model tier this run wants.
-const DEFAULT_MODEL = "deepseek/deepseek-v4-pro";
-const DEFAULT_ESCALATION_MODEL = "z-ai/glm-5.2";
+// CLI Proxy API is a self-hosted OpenAI-protocol-compatible gateway (reached
+// over Tailscale, see the workflow's "Connect to Tailscale" step) fronting a
+// subscription-quota model rather than a metered API — one model tier, no
+// escalation-for-cost-reasons logic needed.
+const DEFAULT_MODEL = "gemini-3.6-flash-high";
 
 function selectProvider(pr, mode) {
   const changedLines = (pr.additions || 0) + (pr.deletions || 0);
-  const escalated = changedLines > 3000 || mode === "security";
-  if (!process.env.OPENROUTER_API_KEY) return null;
-  const model = escalated
-    ? process.env.OPENROUTER_ESCALATION_MODEL || DEFAULT_ESCALATION_MODEL
-    : process.env.OPENROUTER_MODEL || DEFAULT_MODEL;
-  return { model, escalated, changedLines };
+  if (!process.env.CLIPROXY_API_KEY) return null;
+  const model = process.env.CLIPROXY_MODEL || DEFAULT_MODEL;
+  return { model, changedLines };
 }
 
-// OpenRouter is an OpenAI-protocol-compatible gateway in front of every
-// provider's models, never Anthropic-protocol — OCR_USE_ANTHROPIC is forced
-// to "false". OCR_LLM_MODEL is set here (not just passed as --model) because
-// the cheap --preview check below never receives --model.
+// OCR_LLM_MODEL is set here (not just passed as --model) because the cheap
+// --preview check below never receives --model.
 function providerEnv(model) {
   return {
-    OCR_LLM_URL: process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
-    OCR_LLM_TOKEN: requireEnv("OPENROUTER_API_KEY"),
+    OCR_LLM_URL: requireEnv("CLIPROXY_URL"),
+    OCR_LLM_TOKEN: requireEnv("CLIPROXY_API_KEY"),
     OCR_LLM_MODEL: model,
     OCR_USE_ANTHROPIC: "false",
   };
@@ -489,7 +485,7 @@ async function main() {
     await upsertStateComment(
       prNumber,
       existingComment,
-      "No AI review provider is configured (missing `OPENROUTER_API_KEY`). Skipping automated review.",
+      "No AI review provider is configured (missing `CLIPROXY_API_KEY`). Skipping automated review.",
       { ...(existingState || {}), prNumber, headSha: pr.head.sha, mode, model: null, timestamp: new Date().toISOString(), completed: false },
     );
     return;
@@ -508,7 +504,7 @@ async function main() {
   const args = ocrReviewArgs({ baseSha: pr.base.sha, headSha: pr.head.sha, model: selection.model, background });
   const ocrHome = makeOcrHome();
 
-  console.log(`running ocr review: mode=${mode} model=${selection.model} escalated=${selection.escalated} changedLines=${selection.changedLines}`);
+  console.log(`running ocr review: mode=${mode} model=${selection.model} changedLines=${selection.changedLines}`);
 
   try {
     // Always review from the quarantined worktree, never process.cwd(). cwd
@@ -540,7 +536,7 @@ async function main() {
       headSha: pr.head.sha,
       mode,
       model: selection.model,
-      provider: "openrouter",
+      provider: "cliproxy",
       timestamp: new Date().toISOString(),
       completed: true,
     });


### PR DESCRIPTION
## Summary
- Replaces the OpenRouter-billed backend with the self-hosted CLI Proxy API (fronting Antigravity, model `gemini-3.6-flash-high`) — a subscription quota instead of metered per-token billing.
- The GitHub-hosted runner joins the tailnet as an ephemeral node (`tailscale/github-action`) to reach the proxy's Tailscale IP directly. The proxy is never exposed to the public internet; the ephemeral node leaves the tailnet when the job ends.
- Drops the diff-size-based model escalation from the OpenRouter version — no cost reason to pick a pricier model tier when billing is quota-based, not per-token.
- New repo secrets: `CLIPROXY_API_KEY`, `CLIPROXY_URL`, `TAILSCALE_AUTHKEY` (optional `CLIPROXY_MODEL` override). Removed `OPENROUTER_API_KEY`.

## Test plan
- [x] CLI Proxy API confirmed reachable over its Tailscale IP after widening its bind address to `0.0.0.0` and restarting the service
- [ ] Confirm the workflow's Tailscale step successfully joins the tailnet and the review step reaches the proxy
- [ ] Confirm a real review posts findings/summary on a test PR