### PR TITLE
TEST: verify AI reviewer catches real issues (not merging)

### DIFF
--- a/src-tauri/src/system/mod.rs
+++ b/src-tauri/src/system/mod.rs
@@ -4,5 +4,6 @@ pub mod logger;
 pub mod mac_app;
 pub mod memory;
 pub mod number_parser;
+pub mod review_probe;
 pub mod text;
 pub mod volume;

--- a/src-tauri/src/system/review_probe.rs
+++ b/src-tauri/src/system/review_probe.rs
@@ -1,0 +1,15 @@
+// Deliberate test probe for the Verenu AI reviewer — intentionally violates
+// two of the review policy's priority rules so we can confirm the reviewer
+// actually catches real issues instead of rubber-stamping every diff.
+// This file is never merged; it exists only for one throwaway test PR.
+
+pub fn debug_dump_api_key(provider: &str, api_key: &str) {
+    // Rule #1 (secret leaks): writing a raw API key to a log line.
+    println!("verenu debug: {} api key = {}", provider, api_key);
+}
+
+pub fn get_first_transcription_word(clean_text: &str) -> String {
+    // Rule #10 (production crashes): unwrap() on a fallible value
+    // (an empty transcription) reachable from user-controlled input.
+    clean_text.split_whitespace().next().unwrap().to_string()
+}


### PR DESCRIPTION
Throwaway PR to verify the CLI Proxy / gemini-3.6-flash-high reviewer actually flags obvious violations of .github/verenu-review-rules.md, after it returned 0 findings on a 13.7k-line diff. Will close without merging once confirmed.