### PR TITLE
Fix AI reviewer silently returning zero findings on every run

### DIFF
--- a/scripts/verenu-ai-review.mjs
+++ b/scripts/verenu-ai-review.mjs
@@ -401,15 +401,21 @@ function parseOcrFindings(stdout) {
     console.error(`raw stdout: ${stdout.slice(0, 2000)}`);
     return [];
   }
-  const rawList = Array.isArray(data) ? data : (data && (data.findings || data.issues || data.results)) || [];
+  // ocr's actual --format json shape is { comments: [...] }, each with
+  // path/content/start_line/severity — not the findings/issues/results
+  // shape this originally assumed (confirmed by comparing --format text
+  // output, which did surface real findings, against --format json, which
+  // silently produced zero every time). Both are accepted since the exact
+  // key names aren't documented and may vary by ocr version.
+  const rawList = Array.isArray(data) ? data : (data && (data.comments || data.findings || data.issues || data.results)) || [];
   const list = Array.isArray(rawList) ? rawList : [];
   return list
     .filter((f) => f && typeof f === "object")
     .map((f) => ({
       file: f.file || f.path || f.filename,
-      line: f.line || f.line_number || f.startLine,
+      line: f.line || f.line_number || f.startLine || f.start_line,
       severity: f.severity || f.level || "info",
-      message: f.message || f.description || f.body || "",
+      message: f.message || f.description || f.body || f.content || "",
     }))
     .filter((f) => f.message);
 }


### PR DESCRIPTION
## Summary
- Root cause of the reviewer always posting \"0 findings\", confirmed on PR #174 (13.7k-line real diff) and PR #187 (tiny diff with two deliberately planted, obvious issues — a logged API key and an `unwrap()` on user-controlled input).
- \`parseOcrFindings\` was looking for a top-level \`findings\`/\`issues\`/\`results\` key with \`message\`/\`line\` fields. \`ocr\`'s actual \`--format json\` output uses \`comments\` with \`content\`/\`start_line\`/\`path\`/\`severity\` instead — so the key lookup always missed, silently, with no error (parsing succeeded, the array was just always empty).
- Confirmed by running \`ocr review\` manually against the same diff/model with \`--format text\` (correctly showed both planted issues) vs. \`--format json\` (produced valid JSON, zero mapped findings) — then verified the fixed parser against the captured real JSON output.

## Test plan
- [x] Ran the exact review command from the workflow locally against a diff with 2 known issues; captured real \`ocr\` JSON output
- [x] Verified the old parser produced 0 findings from that output, the fixed parser produces exactly the 2 expected findings with correct file/line/severity/message
- [ ] Confirm a real PR now gets inline review comments posted, not just a summary