### PR TITLE
Fix logo bar proportions in app UI and Windows taskbar icon

### DIFF
--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -450,11 +450,11 @@ fn runtime_icon_image(theme: IconTheme, size: u32) -> tauri::image::Image<'stati
 
     #[cfg(not(target_os = "macos"))]
     let bar_rects = [
-        (88, 304, 48, 112, 24),
-        (160, 192, 48, 224, 24),
-        (232, 96, 48, 320, 24),
-        (304, 240, 48, 176, 24),
-        (376, 336, 48, 80, 24),
+        (88, 328, 48, 88, 24),
+        (160, 239, 48, 177, 24),
+        (232, 153, 48, 263, 24),
+        (304, 264, 48, 152, 24),
+        (376, 338, 48, 78, 24),
     ];
 
     for (x, y, width, height, radius) in bar_rects {

--- a/src/lib/components/layout/LogoMark.svelte
+++ b/src/lib/components/layout/LogoMark.svelte
@@ -3,10 +3,10 @@
   // rasterization making one bar appear narrower at fractional DPI.
 </script>
 
-<svg viewBox="0 0 48 40" width="100%" height="100%" fill="none" aria-hidden="true">
-  <rect x="3"  y="26" width="6" height="14" rx="3" fill="currentColor"/>
-  <rect x="12" y="12" width="6" height="28" rx="3" fill="currentColor"/>
-  <rect x="21" y="0"  width="6" height="40" rx="3" fill="currentColor"/>
-  <rect x="30" y="18" width="6" height="22" rx="3" fill="currentColor"/>
-  <rect x="39" y="30" width="6" height="10" rx="3" fill="currentColor"/>
+<svg viewBox="129 152 254 208" width="100%" height="100%" fill="none" aria-hidden="true">
+  <rect x="129" y="290" width="38" height="70"  rx="19" fill="currentColor"/>
+  <rect x="183" y="220" width="38" height="140" rx="19" fill="currentColor"/>
+  <rect x="237" y="152" width="38" height="208" rx="19" fill="currentColor"/>
+  <rect x="291" y="240" width="38" height="120" rx="19" fill="currentColor"/>
+  <rect x="345" y="298" width="38" height="62"  rx="19" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: UI / branding assets (sidebar wordmark, first-run wizard, Windows tray/taskbar icon)
> - The five-bar app mark was drawn with different bar height-to-width ratios in three places, and two of them (the in-app `LogoMark.svelte` and the Windows tray/taskbar icon in `app_tray.rs`) used a noticeably taller, skinnier ratio than the canonical mark on the marketing website
> - This makes the in-app logo and the Windows taskbar icon look visually inconsistent with the website and with each other, which is a small but easily-spotted brand polish gap
> - This pull request re-derives both drawings from the website's `BrandMark` component's exact bar coordinates so all three renderings (website, in-app SVG, Windows tray icon) share one geometric source of truth
> - The benefit is a consistent, correctly-proportioned mark everywhere the brand appears, with no behavior change

## What Changed

- `src/lib/components/layout/LogoMark.svelte`: replaced the hand-tuned `viewBox="0 0 48 40"` bars with the exact `viewBox="129 152 254 208"` bar geometry from the website's `BrandMark` (`bare` variant) — used by the sidebar logo and the first-run wizard intro step.
- `src-tauri/src/app_tray.rs`: fixed the non-macOS `bar_rects` used by `runtime_icon_image()` (Windows taskbar/tray icon), which had the same skewed height ratios as the old in-app mark. Rescaled to the website's bar-height ratios while keeping the same bar width, x-positions, and baseline as before, so icon padding/centering is unchanged.

## Verification

- `cargo check` (src-tauri) — clean, no warnings introduced.
- `npm run check` — 0 errors / 0 warnings.
- Manual: compared bar height-to-width ratios numerically against the website's `BrandMark` bare-variant coordinates (`G:/Verenu Website/src/design-system/BrandMark.jsx`) to confirm the new geometry is an exact match, not an approximation.
- No UI screenshot attached — this is a pure SVG/coordinate correction with no layout or behavioral change; reviewers can diff the coordinates directly against `BrandMark.jsx`.

## Risks

- Low risk. Pure visual/geometry change to a decorative mark — no logic, state, or IPC surface touched. The Windows icon fix only adjusts `bar_rects` height/y values; bar width, x-position, radius, and baseline are unchanged, so icon sizing/centering behavior is preserved.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Claude Sonnet 5 (claude-sonnet-5), via Claude Code, standard mode with tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) — not run in this session
- [ ] `npm run test:rust` passes — not run in this session
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands) — not run in this session
- [ ] Tests added or updated where applicable — N/A, no test coverage for icon rendering geometry
- [ ] UI changes include before/after screenshots — not captured in this session
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) — N/A, no version bump
- [x] Relevant documentation updated to reflect changes — N/A, no documented behavior changed
- [x] Risks documented above
