### PR TITLE
Fix Verenu startup recovery and service check privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Verenu's own server (`api.verenu.com`) serves only public app metadata — relea
 - Snippet instructions, cleanup settings, and selected model metadata go with cleanup requests
 - Active app context may be sent if you enable app-context hints
 - Update checks hit GitHub release metadata
-- Provider status checks hit `api.verenu.com` (public status only, no dictated content, keys, or history)
+- Provider status and health checks hit `api.verenu.com` (public status only, no dictated content, keys, or history). You can disable these background checks in Settings → Privacy.
 
 Read the full breakdown in [docs/DATA_AND_PRIVACY.md](docs/DATA_AND_PRIVACY.md).
 

--- a/docs/DATA_AND_PRIVACY.md
+++ b/docs/DATA_AND_PRIVACY.md
@@ -113,6 +113,7 @@ That request carries no dictated text, history, snippets, or API keys.
 
 Verenu periodically asks `api.verenu.com` for the operating status of the transcription and cleanup providers you have selected:
 
+- Settings → Privacy includes **Allow Verenu service checks**, enabled by default. Turn it off to stop these background requests. Verenu clears the in-memory status and health results when you disable the setting.
 - Every 5 minutes, it fetches provider status and shows an in-app banner only if the status API flags a real problem for a provider you have actually selected. A provider reporting `operational` or `unknown` does not trigger a banner, and providers you have not selected never surface regardless of their status.
 - Every 20 minutes, it does a plain up/down health check of `api.verenu.com` itself. This currently has no UI; the result is kept in memory for future features.
 - If a transcription or cleanup call fails in a way that looks provider-side (a quota error, or a retryable timeout/429/5xx), Verenu immediately re-checks provider status instead of waiting for the next scheduled poll.
@@ -152,8 +153,8 @@ That said, once data is sent to a third-party AI provider, that provider's reten
 | Auto-learn | local monitoring data and promoted entries | nothing by default |
 | Update check | current app state stays local | GitHub release metadata request |
 | Connectivity check | current app state stays local | periodic `HEAD` request to `api.github.com` |
-| Provider status check | current app state stays local | periodic GET to `api.verenu.com/v1/provider-status` (every 5 min, plus an immediate recheck after a provider-side pipeline failure) |
-| API health check | current app state stays local | periodic GET to `api.verenu.com/v1/health` (every 20 min) |
+| Provider status check | current app state stays local | optional periodic GET to `api.verenu.com/v1/provider-status` (every 5 min, plus an immediate recheck after a provider-side pipeline failure) |
+| API health check | current app state stays local | optional periodic GET to `api.verenu.com/v1/health` (every 20 min) |
 | Export data | backup file on local disk | nothing unless you share the file yourself |
 | Logs export | log file on local disk | nothing unless you share the file yourself |
 

--- a/docs/PRIVACY_SUMMARY.md
+++ b/docs/PRIVACY_SUMMARY.md
@@ -17,6 +17,7 @@ Verenu doesn't run its own servers, doesn't have an account system, and doesn't 
 - **Cleanup context** goes along with cleanup requests, including snippet instructions, cleanup settings, and model metadata
 - **Active app context** leaves your device only if you've enabled app-context hints
 - **Update checks** request GitHub release metadata without sending dictated text, history, or keys
+- **Verenu service checks** optionally request public provider status and health data from `api.verenu.com`; disable them in Settings → Privacy
 
 ## One important caveat
 

--- a/scripts/vite-dev-server.mjs
+++ b/scripts/vite-dev-server.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const DEV_PORT = 1420;
 const DEV_URLS = [
-  `http://localhost:${DEV_PORT}/`,
   `http://127.0.0.1:${DEV_PORT}/`,
+  `http://localhost:${DEV_PORT}/`,
   `http://[::1]:${DEV_PORT}/`,
 ];
 
@@ -16,9 +17,10 @@ if (runningUrl) {
   process.exit(0);
 }
 
-const child = spawn('vite', [], {
+const viteEntry = fileURLToPath(new URL('../node_modules/vite/bin/vite.js', import.meta.url));
+const child = spawn(process.execPath, [viteEntry], {
   stdio: 'inherit',
-  shell: true,
+  shell: false,
   env: process.env,
 });
 

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -93,8 +93,24 @@ fn relaunch_app(app: &AppHandle) {
     app.restart();
 }
 
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
+pub(crate) fn relaunch_for_startup_recovery(app: &AppHandle) {
+    if let Err(err) = spawn_relaunch_and_exit_with_args(app, &["--startup-recovery-attempted"]) {
+        log::error!("Failed to recover Verenu startup: {err}");
+        app.exit(0);
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn spawn_relaunch_and_exit(app: &AppHandle) -> Result<(), String> {
+    spawn_relaunch_and_exit_with_args(app, &[])
+}
+
+#[cfg(target_os = "windows")]
+fn spawn_relaunch_and_exit_with_args(
+    app: &AppHandle,
+    extra_args: &[&str],
+) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
 
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
@@ -104,8 +120,10 @@ fn spawn_relaunch_and_exit(app: &AppHandle) -> Result<(), String> {
         .map_err(|err| format!("could not locate current executable: {err}"))?;
     let parent_pid = std::process::id().to_string();
     let forwarded_args = forwarded_relaunch_args();
-    std::process::Command::new(exe)
+    let mut command = std::process::Command::new(exe);
+    command
         .args(forwarded_args)
+        .args(extra_args)
         .arg("--relaunch-parent-pid")
         .arg(parent_pid)
         .creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)

--- a/src-tauri/src/commands/service_status.rs
+++ b/src-tauri/src/commands/service_status.rs
@@ -4,8 +4,20 @@
 use super::*;
 use crate::api::service_status::ProviderStatusAlert;
 
+fn service_checks_enabled(app: &AppHandle) -> bool {
+    store::settings_handle(app)
+        .ok()
+        .and_then(|handle| handle.get(store::VERENU_SERVICE_CHECKS_ENABLED))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true)
+}
+
 #[tauri::command]
 pub async fn check_provider_status(app: AppHandle) -> Result<Vec<ProviderStatusAlert>, String> {
+    if !service_checks_enabled(&app) {
+        return Ok(Vec::new());
+    }
+
     let handle = store::settings_handle(&app)?;
     let provider_or_default = |key: &str| {
         handle
@@ -30,7 +42,11 @@ pub async fn check_provider_status(app: AppHandle) -> Result<Vec<ProviderStatusA
 }
 
 #[tauri::command]
-pub async fn check_verenu_api_health() -> bool {
+pub async fn check_verenu_api_health(app: AppHandle) -> bool {
+    if !service_checks_enabled(&app) {
+        return false;
+    }
+
     crate::api::service_status::check_health().await
 }
 
@@ -43,7 +59,12 @@ pub async fn check_provider_status_raw() -> Result<serde_json::Value, String> {
 
 #[tauri::command]
 pub async fn check_global_message(
+    app: AppHandle,
 ) -> Result<Option<crate::api::service_status::GlobalMessage>, String> {
+    if !service_checks_enabled(&app) {
+        return Ok(None);
+    }
+
     crate::api::service_status::fetch_global_message()
         .await
         .map_err(|e| e.to_string())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -177,6 +177,12 @@ const SETTING_SPECS: &[SettingSpec] = &[
     ),
     setting_spec(store::BETA_UPDATES_ENABLED, SettingKind::Bool, true, true),
     setting_spec(
+        store::VERENU_SERVICE_CHECKS_ENABLED,
+        SettingKind::Bool,
+        true,
+        true,
+    ),
+    setting_spec(
         store::HISTORY_RETENTION,
         SettingKind::HistoryRetention,
         true,
@@ -422,6 +428,7 @@ pub struct AllSettings {
     pub update_dismissed_version: Option<String>,
     pub update_notified_version: Option<String>,
     pub beta_updates_enabled: Option<bool>,
+    pub verenu_service_checks_enabled: Option<bool>,
     pub hotkey: Option<Vec<String>>,
     pub appearance_mode: Option<String>,
     pub cleanup_prompt_overrides: Option<serde_json::Value>,
@@ -483,6 +490,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         update_dismissed_version: str_val(store::UPDATE_DISMISSED_VERSION),
         update_notified_version: str_val(store::UPDATE_NOTIFIED_VERSION),
         beta_updates_enabled: bool_val(store::BETA_UPDATES_ENABLED),
+        verenu_service_checks_enabled: bool_val(store::VERENU_SERVICE_CHECKS_ENABLED),
         hotkey: s.get(store::HOTKEY).and_then(|v| {
             v.as_array().map(|arr| {
                 arr.iter()

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -4,6 +4,23 @@ use super::*;
 
 // ---------- window management ----------
 
+/// Completes the startup handshake for the window that has just mounted its
+/// frontend. This is intentionally reported by the frontend rather than
+/// inferred from backend process liveness because WebView2 can display a
+/// connection-refused page while the Rust process continues working.
+#[tauri::command]
+pub fn frontend_ready(
+    window: tauri::WebviewWindow,
+    readiness: tauri::State<'_, crate::FrontendReadiness>,
+) -> Result<(), String> {
+    match window.label() {
+        "main" => readiness.main.store(true, std::sync::atomic::Ordering::Release),
+        "pill" => readiness.pill.store(true, std::sync::atomic::Ordering::Release),
+        label => return Err(format!("Unknown frontend window: {label}")),
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn show_main(app: AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window("main") {

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -215,6 +215,7 @@ pub const MACOS_CLIPBOARD_SNIFF: &str = "macos_clipboard_sniff_enabled";
 pub const UPDATE_DISMISSED_VERSION: &str = "update_dismissed_version";
 pub const UPDATE_NOTIFIED_VERSION: &str = "update_notified_version";
 pub const BETA_UPDATES_ENABLED: &str = "beta_updates_enabled";
+pub const VERENU_SERVICE_CHECKS_ENABLED: &str = "verenu_service_checks_enabled";
 pub const HISTORY_RETENTION: &str = "history_retention";
 pub const AUTOSTART_ENABLED: &str = "autostart_enabled";
 pub const CAPS_LOCK_UPPERCASE: &str = "caps_lock_uppercase_enabled";

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(windows, windows_subsystem = "windows")]
 
 mod api;
 mod app_hotkey;
@@ -18,10 +18,39 @@ use crate::core::window_geometry::WindowTarget;
 use crate::data::db;
 use crate::pipeline::{AppState, SharedState};
 
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::AtomicBool,
+    Arc, Mutex,
+};
+#[cfg(target_os = "windows")]
+use std::sync::atomic::Ordering;
+#[cfg(target_os = "windows")]
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 pub type DbHandle = db::Db;
+
+/// Startup readiness reported by each Tauri WebView after its frontend has
+/// mounted successfully. A backend can be fully alive while WebView2 is
+/// showing a stale connection-refused page, so backend liveness alone is not
+/// enough to declare startup successful.
+#[derive(Clone, Default)]
+pub(crate) struct FrontendReadiness {
+    pub(crate) main: Arc<AtomicBool>,
+    pub(crate) pill: Arc<AtomicBool>,
+}
+
+#[cfg(target_os = "windows")]
+impl FrontendReadiness {
+    fn main_ready(&self) -> bool {
+        self.main.load(Ordering::Acquire)
+    }
+
+    fn reset(&self) {
+        self.main.store(false, Ordering::Release);
+        self.pill.store(false, Ordering::Release);
+    }
+}
 
 pub(crate) use app_tray::apply_runtime_icons;
 
@@ -58,6 +87,115 @@ fn hide_main_window(app: &AppHandle) {
 /// to equal this path, so backups would silently target a different file.
 fn app_data_dir_override() -> Option<std::path::PathBuf> {
     std::env::var_os("VERENU_APP_DATA_DIR_OVERRIDE").map(std::path::PathBuf::from)
+}
+
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
+fn startup_recovery_was_attempted() -> bool {
+    std::env::args_os().any(|arg| arg == "--startup-recovery-attempted")
+}
+
+#[cfg(debug_assertions)]
+async fn wait_for_dev_frontend() -> bool {
+    let Ok(client) = reqwest::Client::builder()
+        .connect_timeout(Duration::from_millis(500))
+        .timeout(Duration::from_secs(1))
+        .build()
+    else {
+        return false;
+    };
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(response) = client.get("http://127.0.0.1:1420/").send().await {
+            if response.status().is_success() {
+                return true;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    false
+}
+
+#[cfg(target_os = "windows")]
+fn start_frontend_watchdog(app: &AppHandle, readiness: FrontendReadiness) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let reveal_windows = || {
+            // The main window is the startup gate. Create the pill only after
+            // the main UI is healthy because a hidden WebView2 renderer can
+            // suspend before it reports its own readiness.
+            show_main_window(&app);
+            crate::pipeline::show_pill(&app, "idle");
+        };
+
+        // WebView2 normally mounts in well under a second. This grace period
+        // leaves room for a cold Vite/WebView2 start without delaying normal
+        // startup or flashing a recovery window.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
+        while tokio::time::Instant::now() < deadline {
+            if readiness.main_ready() {
+                log::debug!("startup handshake completed");
+                reveal_windows();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        if readiness.main_ready() {
+            reveal_windows();
+            return;
+        }
+
+        // In development, the WebView can fail its first navigation while
+        // Vite is restarting or optimizing dependencies. Reload the existing
+        // windows once the server is reachable before restarting the entire
+        // process. This also avoids creating an orphaned app if the parent
+        // `tauri dev` session has already stopped its Vite child.
+        #[cfg(debug_assertions)]
+        if wait_for_dev_frontend().await {
+            readiness.reset();
+            if let Some(window) = app.get_webview_window("main") {
+                window.reload().ok();
+            }
+
+            let retry_deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+            while tokio::time::Instant::now() < retry_deadline {
+                if readiness.main_ready() {
+                    reveal_windows();
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        log::error!(
+            "startup handshake did not complete in development; keeping the dev process alive for diagnosis"
+        );
+
+        #[cfg(not(debug_assertions))]
+        {
+            if startup_recovery_was_attempted() {
+                log::error!(
+                    "startup handshake did not complete after the automatic recovery attempt; leaving the app running for diagnosis"
+                );
+                return;
+            }
+
+            log::warn!(
+                "startup handshake timed out: main_ready={} pill_ready={}; relaunching once",
+                readiness.main.load(Ordering::Acquire),
+                readiness.pill.load(Ordering::Acquire)
+            );
+            crate::app_tray::relaunch_for_startup_recovery(&app);
+        }
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+fn start_frontend_watchdog(app: &AppHandle, _readiness: FrontendReadiness) {
+    crate::pipeline::show_pill(app, "idle");
+    show_main_window(app);
 }
 
 #[cfg(windows)]
@@ -120,6 +258,7 @@ fn main() {
     }
     let local_cleanup_manager = crate::local_llm::LocalLlmManager::new();
     let local_transcription_manager = crate::local_stt::LocalTranscriptionManager::new();
+    let frontend_readiness = FrontendReadiness::default();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
@@ -131,6 +270,7 @@ fn main() {
         .manage(db_handle.clone())
         .manage(local_cleanup_manager.clone())
         .manage(local_transcription_manager.clone())
+        .manage(frontend_readiness.clone())
         .setup(move |app| {
             crate::system::logger::init(app.handle())?;
             let settings = crate::data::store::SettingsHandle::open(app.handle())
@@ -210,7 +350,7 @@ fn main() {
                     app.handle(),
                 );
             }
-            crate::pipeline::show_pill(app.handle(), "idle");
+            start_frontend_watchdog(app.handle(), frontend_readiness.clone());
             let local_stt_manager = local_transcription_manager.clone();
             let local_llm_manager = local_cleanup_manager.clone();
             let app_handle = app.handle().clone();
@@ -267,10 +407,6 @@ fn main() {
                     }
                 }
             });
-
-            // Keep the main UI visible on startup so normal launches don't
-            // feel like the app disappeared into the tray.
-            show_main_window(app.handle());
 
             Ok(())
         })
@@ -355,6 +491,7 @@ fn main() {
             commands::request_microphone_permission_snapshot,
             commands::open_microphone_settings,
             commands::restart_app,
+            commands::frontend_ready,
             commands::open_privacy_security_settings,
             commands::reset_macos_core_permissions,
             commands::check_keychain_access,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use std::sync::{
 };
 #[cfg(target_os = "windows")]
 use std::sync::atomic::Ordering;
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, target_os = "windows"))]
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -46,6 +46,7 @@ impl FrontendReadiness {
         self.main.load(Ordering::Acquire)
     }
 
+    #[cfg(debug_assertions)]
     fn reset(&self) {
         self.main.store(false, Ordering::Release);
         self.pill.store(false, Ordering::Release);
@@ -94,7 +95,7 @@ fn startup_recovery_was_attempted() -> bool {
     std::env::args_os().any(|arg| arg == "--startup-recovery-attempted")
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, target_os = "windows"))]
 async fn wait_for_dev_frontend() -> bool {
     let Ok(client) = reqwest::Client::builder()
         .connect_timeout(Duration::from_millis(500))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use std::sync::{
 };
 #[cfg(target_os = "windows")]
 use std::sync::atomic::Ordering;
-#[cfg(target_os = "windows")]
+#[cfg(debug_assertions)]
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -37,6 +37,8 @@ pub type DbHandle = db::Db;
 #[derive(Clone, Default)]
 pub(crate) struct FrontendReadiness {
     pub(crate) main: Arc<AtomicBool>,
+    /// Diagnostic state only. The pill is created after the main frontend has
+    /// passed the startup gate, so its readiness is not a separate gate.
     pub(crate) pill: Arc<AtomicBool>,
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use std::sync::{
 };
 #[cfg(target_os = "windows")]
 use std::sync::atomic::Ordering;
-#[cfg(any(debug_assertions, target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(windows, windows_subsystem = "windows")]
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 mod api;
 mod app_hotkey;

--- a/src-tauri/src/system/memory.rs
+++ b/src-tauri/src/system/memory.rs
@@ -144,6 +144,15 @@ fn run_with_timeout(
     mut command: std::process::Command,
     timeout: Duration,
 ) -> Option<std::process::Output> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        // Hardware probes are background work. CREATE_NO_WINDOW prevents
+        // nvidia-smi from flashing a console over the app on Windows.
+        command.creation_flags(0x08000000);
+    }
+
     let mut child = command
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "version": "0.15.1",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://127.0.0.1:1420",
     "beforeDevCommand": "npm run dev:tauri-host",
     "beforeBuildCommand": "npm run build"
   },
@@ -45,7 +45,7 @@
       },
       "devCsp": {
         "default-src": "'self'",
-        "connect-src": "'self' ipc: http://ipc.localhost ws://localhost:1420 http://localhost:1420",
+        "connect-src": "'self' ipc: http://ipc.localhost ws://127.0.0.1:1420 http://127.0.0.1:1420",
         "img-src": "'self' asset: http://asset.localhost blob: data:",
         "font-src": "'self' data:",
         "style-src": "'self' 'unsafe-inline'",

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -4,6 +4,7 @@
   import { expoOut } from 'svelte/easing';
   import Toggle from '../Toggle.svelte';
   import { saveSetting, type HistoryRetention } from '../../settings';
+  import { setServiceChecksEnabled } from '../../serviceStatus';
   import { modalFocusTrap } from '../../modalFocus';
   import { animateWidth, modalBackdrop, modalCard, MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
 
@@ -20,6 +21,7 @@
   let historyDropdownOpen = $state(false);
   let appContextHint = $state(false);
   let autoLearn = $state(false);
+  let serviceChecksEnabled = $state(true);
   let cleanupCacheEntries = $state(0);
   let cleanupCacheSpaceConstrained = $state(false);
   let cleanupCacheFreeBytes = $state<number | null>(null);
@@ -36,10 +38,11 @@
 
   async function loadSettings() {
     try {
-      const [retention, hint, learn, cacheStatus, summary, recent] = await Promise.all([
+      const [retention, hint, learn, serviceChecks, cacheStatus, summary, recent] = await Promise.all([
         invoke<string | null>('get_setting', { key: 'history_retention' }),
         invoke<boolean | null>('get_setting', { key: 'app_context_hint' }),
         invoke<boolean | null>('get_setting', { key: 'auto_learn_enabled' }),
+        invoke<boolean | null>('get_setting', { key: 'verenu_service_checks_enabled' }),
         invoke<CleanupCacheStatus>('get_cleanup_cache_status'),
         invoke<typeof autoLearnSummary>('get_auto_learn_status_summary'),
         invoke<typeof recentAutoLearn>('get_recent_auto_learn_activity', { limit: 5 }),
@@ -47,6 +50,8 @@
       if (retention) historyRetention = retention;
       appContextHint = hint ?? false;
       autoLearn = learn ?? false;
+      serviceChecksEnabled = serviceChecks ?? true;
+      setServiceChecksEnabled(serviceChecksEnabled);
       cleanupCacheEntries = cacheStatus?.entry_count ?? 0;
       cleanupCacheSpaceConstrained = cacheStatus?.is_space_constrained ?? false;
       cleanupCacheFreeBytes = cacheStatus?.free_bytes ?? null;
@@ -110,6 +115,20 @@
     } catch (err) {
       autoLearn = !value;
       console.error('save auto_learn_enabled failed:', err);
+    }
+  }
+
+  async function handleServiceChecks(value: boolean) {
+    const previous = serviceChecksEnabled;
+    serviceChecksEnabled = value;
+    if (!value) setServiceChecksEnabled(false);
+    try {
+      await saveSetting('verenu_service_checks_enabled', value);
+      setServiceChecksEnabled(value);
+    } catch (err) {
+      serviceChecksEnabled = previous;
+      setServiceChecksEnabled(previous);
+      console.error('save verenu_service_checks_enabled failed:', err);
     }
   }
 
@@ -240,6 +259,15 @@
 <div class="setting-row">
   <div><div class="label">App context hint</div><div class="desc">Passes the active app to the cleanup model to tailor formatting</div></div>
   <Toggle checked={appContextHint} onchange={handleAppContextHint} label="App context hint" />
+</div>
+
+<h3 class="settings-subhead">Verenu services</h3>
+<div class="setting-row">
+  <div>
+    <div class="label">Allow Verenu service checks</div>
+    <div class="desc">Checks provider status, service health, and global messages in the background. Turn this off to stop background requests to api.verenu.com. Dictation requests to your selected AI provider are unaffected.</div>
+  </div>
+  <Toggle checked={serviceChecksEnabled} onchange={handleServiceChecks} label="Allow Verenu service checks" />
 </div>
 
 <h3 class="settings-subhead">On-device learning</h3>

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -8,20 +8,31 @@ const SERVICE_CHECKS_SETTING = 'verenu_service_checks_enabled';
 
 let serviceChecksEnabled = true;
 let serviceChecksPreference: Promise<boolean> | null = null;
+let serviceChecksPreferenceVersion = 0;
 
 async function getServiceChecksEnabled(): Promise<boolean> {
   if (!serviceChecksPreference) {
+    const requestVersion = serviceChecksPreferenceVersion;
     serviceChecksPreference = invoke<boolean | null>('get_setting', { key: SERVICE_CHECKS_SETTING })
       .then((value) => {
-        serviceChecksEnabled = value ?? true;
+        if (requestVersion === serviceChecksPreferenceVersion) {
+          serviceChecksEnabled = value ?? true;
+        }
         return serviceChecksEnabled;
       })
-      .catch(() => true);
+      .catch(() => {
+        if (requestVersion === serviceChecksPreferenceVersion) {
+          serviceChecksEnabled = true;
+        }
+        return serviceChecksEnabled;
+      });
   }
   return serviceChecksPreference;
 }
 
 export function setServiceChecksEnabled(enabled: boolean): void {
+  serviceChecksPreferenceVersion += 1;
+
   if (serviceChecksEnabled === enabled) {
     serviceChecksPreference = Promise.resolve(enabled);
     return;

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -4,12 +4,55 @@ import { invoke, listen } from './tauri';
 
 const PROVIDER_STATUS_INTERVAL_MS = 5 * 60 * 1000;
 const API_HEALTH_INTERVAL_MS = 20 * 60 * 1000;
+const SERVICE_CHECKS_SETTING = 'verenu_service_checks_enabled';
+
+let serviceChecksEnabled = true;
+let serviceChecksPreference: Promise<boolean> | null = null;
+
+async function getServiceChecksEnabled(): Promise<boolean> {
+  if (!serviceChecksPreference) {
+    serviceChecksPreference = invoke<boolean | null>('get_setting', { key: SERVICE_CHECKS_SETTING })
+      .then((value) => {
+        serviceChecksEnabled = value ?? true;
+        return serviceChecksEnabled;
+      })
+      .catch(() => true);
+  }
+  return serviceChecksPreference;
+}
+
+export function setServiceChecksEnabled(enabled: boolean): void {
+  if (serviceChecksEnabled === enabled) {
+    serviceChecksPreference = Promise.resolve(enabled);
+    return;
+  }
+
+  serviceChecksEnabled = enabled;
+  serviceChecksPreference = Promise.resolve(enabled);
+
+  if (!enabled) {
+    appStore.providerStatusAlerts = [];
+    appStore.globalMessage = null;
+    appStore.apiHealthy = null;
+    return;
+  }
+
+  // An explicit opt-in should take effect immediately rather than waiting
+  // for the next scheduled interval.
+  void checkStatus();
+  void checkApiHealth();
+}
 
 export async function checkStatus(): Promise<void> {
+  if (!(await getServiceChecksEnabled())) return;
+
   const [alertsResult, messageResult] = await Promise.allSettled([
     invoke<ProviderStatusAlert[] | null>('check_provider_status'),
     invoke<GlobalMessage | null>('check_global_message'),
   ]);
+
+  // The setting may have been changed while the requests were in flight.
+  if (!serviceChecksEnabled) return;
 
   if (alertsResult.status === 'fulfilled') {
     if (!appStore.providerStatusSimulation) {
@@ -33,8 +76,14 @@ export async function checkStatus(): Promise<void> {
 // already warm for future features that need to know whether api.verenu.com
 // is reachable.
 async function checkApiHealth(): Promise<void> {
+  if (!(await getServiceChecksEnabled())) {
+    appStore.apiHealthy = null;
+    return;
+  }
+
   try {
-    appStore.apiHealthy = await invoke<boolean>('check_verenu_api_health');
+    const healthy = await invoke<boolean>('check_verenu_api_health');
+    appStore.apiHealthy = serviceChecksEnabled ? healthy : null;
   } catch (error) {
     // Don't leave a stale prior result in place — a failed check means we no
     // longer know the current state, not that it's confirmed unhealthy.

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -57,6 +57,7 @@ type SettingsValueMap = {
   update_dismissed_version: string | null;
   update_notified_version: string | null;
   beta_updates_enabled: boolean;
+  verenu_service_checks_enabled: boolean;
   appearance_mode: AppearanceMode;
   advanced_model_ui: boolean;
   cleanup_prompt_overrides: Record<string, string>;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -851,6 +851,8 @@ function assertDevText(value: unknown, field: string): string {
 
 async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
   switch (command) {
+    case 'frontend_ready':
+      return undefined as T;
     case 'get_setting':
       return getDevSetting(String(args?.key ?? '')) as T;
     case 'save_setting':

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,15 @@
 import { mount } from 'svelte';
+import { invoke } from '@tauri-apps/api/core';
 import App from './App.svelte';
 import './theme.css';
 import './app.css';
 
 const app = mount(App, {
   target: document.getElementById('app') as HTMLElement,
+});
+
+void invoke('frontend_ready').catch((error) => {
+  console.error('Failed to complete startup handshake:', error);
 });
 
 export default app;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { mount } from 'svelte';
-import { invoke } from '@tauri-apps/api/core';
 import App from './App.svelte';
+import { invoke } from './lib/tauri';
 import './theme.css';
 import './app.css';
 

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -1,5 +1,6 @@
 import { mount } from 'svelte';
 import PillApp from './PillApp.svelte';
+import { invoke } from './lib/tauri';
 import './theme.css';
 
 type AppearanceMode = 'system' | 'light' | 'dark';
@@ -20,7 +21,6 @@ applyTheme('system');
 
 (async () => {
   try {
-    const { invoke } = await import('@tauri-apps/api/core');
     const mode = await invoke<AppearanceMode | null>('get_setting', { key: 'appearance_mode' });
     if (mode === 'system' || mode === 'light' || mode === 'dark') {
       applyTheme(mode);
@@ -34,8 +34,6 @@ window.matchMedia?.('(prefers-color-scheme: dark)').addEventListener?.('change',
 
 mount(PillApp, { target: document.getElementById('pill-root')! });
 
-void import('@tauri-apps/api/core')
-  .then(({ invoke }) => invoke('frontend_ready'))
-  .catch((error) => {
-    console.error('Failed to complete pill startup handshake:', error);
-  });
+void invoke('frontend_ready').catch((error) => {
+  console.error('Failed to complete pill startup handshake:', error);
+});

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -33,3 +33,9 @@ window.matchMedia?.('(prefers-color-scheme: dark)').addEventListener?.('change',
 });
 
 mount(PillApp, { target: document.getElementById('pill-root')! });
+
+void import('@tauri-apps/api/core')
+  .then(({ invoke }) => invoke('frontend_ready'))
+  .catch((error) => {
+    console.error('Failed to complete pill startup handshake:', error);
+  });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+    host: '127.0.0.1',
   },
   build: {
     target: ['es2020', 'chrome100'],


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The affected subsystems are startup readiness, Windows background process launching, Models settings hardware detection, and Privacy settings.
> - A failed or incomplete startup handshake could leave the WebView on a localhost error page, while the Models page could launch `nvidia-smi` with a visible console window.
> - Verenu also performed periodic Verenu-owned provider status, global message, and API health checks without a visible opt-out.
> - This pull request hardens startup recovery, hides background hardware probes, and restores an explicit Privacy control for Verenu service checks.
> - The benefit is a cleaner startup and Models experience plus user control over background requests to `api.verenu.com`.

## What Changed

- Added a main-window readiness handshake and guarded startup recovery so the app does not reveal an unhealthy WebView or repeatedly relaunch the development supervisor.
- Hid the Windows `nvidia-smi` subprocess used by Models hardware detection, preventing the brief Command Prompt flash.
- Added the Privacy setting `Allow Verenu service checks`, enabled by default for existing installs and included in settings export/import.
- Enforced the service-check preference in both frontend polling and backend commands. Disabling it stops provider status, global message, and API health background requests and clears cached results.
- Updated README and privacy documentation to describe the setting and its scope.

## Verification

- `npm run check` passes with 0 diagnostics.
- `npm run lint` passes.
- `npm run test:rust` passes: 442 passed, 0 failed, 1 ignored.
- `npm run build` passes.
- Targeted Playwright browser check passed: Privacy control rendered, toggled from true to false, and produced no page exceptions.
- Full smoke suite and before/after screenshots were not run for this PR.

## Risks

- Startup recovery changes are platform-specific on Windows and intentionally keep the development process alive for diagnosis if the handshake still fails in development.
- The service-check setting controls Verenu-owned background status, health, and global-message requests only. It does not disable explicit Developer checks or cloud AI provider requests required for dictation.
- The new setting defaults to enabled when absent, so existing installations retain current behavior until the user opts out.
- No API keys, dictated text, or personal data were added to code or logs.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- OpenAI GPT-5 through Codex, with tool use and long-context code analysis.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above