### PR TITLE
Fix native notification routing and update handoff

### DIFF
--- a/scripts/tauri-cli.mjs
+++ b/scripts/tauri-cli.mjs
@@ -24,6 +24,7 @@ const child = spawn(process.execPath, [tauriCli, ...args], {
   cwd: repoRoot,
   env: process.env,
   stdio: 'inherit',
+  windowsHide: true,
 });
 
 child.on('exit', (code, signal) => {

--- a/scripts/vite-dev-server.mjs
+++ b/scripts/vite-dev-server.mjs
@@ -22,6 +22,7 @@ const child = spawn(process.execPath, [viteEntry], {
   stdio: 'inherit',
   shell: false,
   env: process.env,
+  windowsHide: true,
 });
 
 for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
@@ -56,7 +57,15 @@ async function isServerReachable(url) {
       method: 'GET',
       signal: controller.signal,
     });
-    return response.ok || response.status < 500;
+    if (!response.ok) {
+      return false;
+    }
+
+    // Port 1420 is a convention, not proof that this project's Vite server is
+    // running. Reusing an unrelated local service makes Tauri load the wrong
+    // page and leaves the desktop window looking blank or transparent.
+    const html = await response.text();
+    return html.includes('<title>Verenu</title>');
   } catch {
     return false;
   } finally {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5404,6 +5404,7 @@ dependencies = [
  "libproc",
  "log",
  "nnnoiseless",
+ "notify-rust",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ zip         = { version = "2", default-features = false, features = ["deflate"] 
 transcribe-rs = { version = "0.3.11", features = ["onnx", "vad-silero"] }
 
 [target.'cfg(windows)'.dependencies]
+notify-rust = "4.18.0"
 windows = { version = "0.61", features = [
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_System_DataExchange",
@@ -61,8 +62,13 @@ windows = { version = "0.61", features = [
   "Win32_Media_Audio_Endpoints",
   "Media_Control",
   "Win32_System_Com",
+  "Win32_System_Com_StructuredStorage",
+  "Win32_System_Variant",
   "Win32_UI_Accessibility",
+  "Win32_UI_Shell",
+  "Win32_UI_Shell_PropertiesSystem",
   "Win32_Storage_FileSystem",
+  "Win32_Storage_EnhancedStorage",
   "Win32_Security_Credentials",
   "Win32_Networking_NetworkListManager",
   "Win32_Graphics_Dwm",

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -138,10 +138,21 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
 /// Check the configured repo for a release newer than the current version on
 /// the selected release channel.
 pub async fn check(channel: UpdateChannel) -> anyhow::Result<Option<UpdateInfo>> {
-    check_repo(RELEASE_REPO, channel).await
+    check_repo(RELEASE_REPO, channel, true).await
 }
 
-async fn check_repo(repo: &str, channel: UpdateChannel) -> anyhow::Result<Option<UpdateInfo>> {
+/// Resolve the newest installable release for a channel, including the version
+/// already running. This is used only by the developer reinstall control;
+/// normal update checks must continue to require a newer version.
+pub async fn latest_installable(channel: UpdateChannel) -> anyhow::Result<Option<UpdateInfo>> {
+    check_repo(RELEASE_REPO, channel, false).await
+}
+
+async fn check_repo(
+    repo: &str,
+    channel: UpdateChannel,
+    require_newer: bool,
+) -> anyhow::Result<Option<UpdateInfo>> {
     let url = format!("https://api.github.com/repos/{repo}/releases?per_page=100");
     let resp = super::client::get()
         .get(&url)
@@ -159,11 +170,19 @@ async fn check_repo(repo: &str, channel: UpdateChannel) -> anyhow::Result<Option
         return Ok(None);
     };
     let Some(display_version) = release_version(&release.tag_name) else {
-        log::warn!("Ignoring release with malformed version tag: {}", release.tag_name);
+        log::warn!(
+            "Ignoring release with malformed version tag: {}",
+            release.tag_name
+        );
         return Ok(None);
     };
 
-    if !is_newer(&display_version, &current_package_version()) {
+    if !should_offer_release_for_channel(
+        &display_version,
+        &current_package_version(),
+        channel,
+        require_newer,
+    ) {
         return Ok(None);
     }
 
@@ -192,28 +211,42 @@ fn select_release(releases: &[GhRelease], channel: UpdateChannel) -> Option<&GhR
         .enumerate()
         .filter(|(_, release)| !release.draft && release_matches_channel(release, channel))
         .filter_map(|(index, release)| {
-            release_version(&release.tag_name)
-                .map(|version| (index, release, version))
+            release_version(&release.tag_name).map(|version| (index, release, version))
         })
         // Keep the first release when normalized versions tie. GitHub returns
         // releases newest-first, so this preserves the newest prerelease build.
-        .max_by(|(left_index, _, left_version), (right_index, _, right_version)| {
-            compare_versions(left_version, right_version)
-                .then_with(|| right_index.cmp(left_index))
-        })
+        .max_by(
+            |(left_index, _, left_version), (right_index, _, right_version)| {
+                compare_versions(left_version, right_version)
+                    .then_with(|| right_index.cmp(left_index))
+            },
+        )
         .map(|(_, release, _)| release)
 }
 
 fn release_matches_channel(release: &GhRelease, channel: UpdateChannel) -> bool {
-    let wants_prerelease = matches!(channel, UpdateChannel::Beta);
-    if release.prerelease != wants_prerelease {
-        return false;
-    }
-
-    release
+    let target_is_branch = release
         .target_commitish
-        .eq_ignore_ascii_case(channel.target_branch())
-        || is_commit_sha(&release.target_commitish)
+        .eq_ignore_ascii_case(channel.target_branch());
+    let target_is_sha = is_commit_sha(&release.target_commitish);
+    let beta_tag = is_beta_release_tag(&release.tag_name);
+
+    match channel {
+        // Older beta releases were published with GitHub's prerelease flag
+        // off, but used either the dev branch or a `-beta` tag. Accept both
+        // publication styles so the beta toggle does not silently miss them.
+        UpdateChannel::Beta => {
+            (release.prerelease || beta_tag) && (target_is_branch || target_is_sha)
+        }
+        UpdateChannel::Stable => {
+            !release.prerelease && !beta_tag && (target_is_branch || target_is_sha)
+        }
+    }
+}
+
+fn is_beta_release_tag(tag: &str) -> bool {
+    let tag = tag.to_ascii_lowercase();
+    tag.contains("-beta") || tag.contains("-nightly") || tag.contains("-dev")
 }
 
 fn is_commit_sha(value: &str) -> bool {
@@ -259,12 +292,14 @@ fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
         return std::cmp::Ordering::Equal;
     };
 
-    left.core.cmp(&right.core).then_with(|| match (&left.prerelease, &right.prerelease) {
-        (None, None) => std::cmp::Ordering::Equal,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (Some(left), Some(right)) => compare_prerelease_parts(left, right),
-    })
+    left.core
+        .cmp(&right.core)
+        .then_with(|| match (&left.prerelease, &right.prerelease) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (Some(left), Some(right)) => compare_prerelease_parts(left, right),
+        })
 }
 
 fn parse_version(version: &str) -> Option<ParsedVersion> {
@@ -370,6 +405,46 @@ fn is_newer(latest: &str, current: &str) -> bool {
     compare_versions(latest, current) == std::cmp::Ordering::Greater
 }
 
+fn should_offer_release(latest: &str, current: &str, require_newer: bool) -> bool {
+    !require_newer || is_newer(latest, current)
+}
+
+/// SemVer deliberately considers `0.16.2-nightly` older than the final
+/// `0.16.2` release. That rule is normally correct, but an opted-in beta user
+/// needs to be able to move from the stable build to that matching nightly.
+/// The channel gate has already verified that `latest` is a beta release.
+fn should_offer_release_for_channel(
+    latest: &str,
+    current: &str,
+    channel: UpdateChannel,
+    require_newer: bool,
+) -> bool {
+    if should_offer_release(latest, current, require_newer) {
+        return true;
+    }
+
+    if !require_newer || channel != UpdateChannel::Beta {
+        return false;
+    }
+
+    let latest = release_version(latest).and_then(|version| parse_version(&version));
+    let current = release_version(current).and_then(|version| parse_version(&version));
+
+    matches!(
+        (latest, current),
+        (
+            Some(ParsedVersion {
+                core: latest_core,
+                prerelease: Some(_),
+            }),
+            Some(ParsedVersion {
+                core: current_core,
+                prerelease: None,
+            }),
+        ) if latest_core == current_core
+    )
+}
+
 fn current_update_target() -> UpdateTarget {
     #[cfg(windows)]
     {
@@ -413,9 +488,20 @@ fn select_release_asset_for_target(
 }
 
 fn select_windows_asset(assets: &[GhAsset]) -> Option<(&GhAsset, InstallMode)> {
-    find_asset_with_suffix(assets, ".exe")
+    // Only the NSIS setup executable supports Verenu's unattended install
+    // handoff. A random `.exe` release asset is not necessarily an installer,
+    // and MSI packages need a different silent-install contract, so those are
+    // download-only instead of being passed the NSIS `/S` argument.
+    find_asset_with_suffix(assets, "-setup.exe")
         .or_else(|| find_asset_with_suffix(assets, ".msi"))
-        .map(|asset| (asset, InstallMode::Download))
+        .map(|asset| {
+            let mode = if asset.name.to_ascii_lowercase().ends_with("-setup.exe") {
+                InstallMode::Install
+            } else {
+                InstallMode::Download
+            };
+            (asset, mode)
+        })
 }
 
 fn select_macos_asset<'a>(
@@ -463,10 +549,10 @@ fn find_asset_with_suffix_and_hints<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        find_asset_with_suffix, is_authorized_release_asset_url, is_newer, normalize_version,
-        parse_prerelease_parts, release_version, select_release, select_release_asset_for_target,
-        current_package_version, GhAsset, GhRelease, InstallMode, UpdateChannel, UpdateTarget,
-        VersionPart,
+        current_package_version, find_asset_with_suffix, is_authorized_release_asset_url, is_newer,
+        normalize_version, parse_prerelease_parts, release_version, select_release,
+        select_release_asset_for_target, should_offer_release, should_offer_release_for_channel,
+        GhAsset, GhRelease, InstallMode, UpdateChannel, UpdateTarget, VersionPart,
     };
 
     fn asset(name: &str) -> GhAsset {
@@ -477,10 +563,18 @@ mod tests {
     }
 
     fn release(tag_name: &str, target_commitish: &str) -> GhRelease {
-        release_with_prerelease(tag_name, target_commitish, target_commitish.eq_ignore_ascii_case("dev"))
+        release_with_prerelease(
+            tag_name,
+            target_commitish,
+            target_commitish.eq_ignore_ascii_case("dev"),
+        )
     }
 
-    fn release_with_prerelease(tag_name: &str, target_commitish: &str, prerelease: bool) -> GhRelease {
+    fn release_with_prerelease(
+        tag_name: &str,
+        target_commitish: &str,
+        prerelease: bool,
+    ) -> GhRelease {
         GhRelease {
             tag_name: tag_name.to_string(),
             target_commitish: target_commitish.to_string(),
@@ -529,6 +623,31 @@ mod tests {
     }
 
     #[test]
+    fn non_prerelease_beta_tags_are_selected_for_beta_channel() {
+        let release = release_with_prerelease("Verenu-0.16.2-beta", "dev", false);
+        assert_eq!(
+            select_release(&[release], UpdateChannel::Beta)
+                .expect("beta tag release")
+                .tag_name,
+            "Verenu-0.16.2-beta"
+        );
+    }
+
+    #[test]
+    fn beta_suffixes_are_not_selected_for_stable_channel() {
+        let releases = [
+            release_with_prerelease("Verenu-0.99.0-beta", "master", false),
+            release_with_prerelease("Verenu-0.16.0", "master", false),
+        ];
+        assert_eq!(
+            select_release(&releases, UpdateChannel::Stable)
+                .expect("stable release")
+                .tag_name,
+            "Verenu-0.16.0"
+        );
+    }
+
+    #[test]
     fn commit_sha_targets_use_github_prerelease_metadata_for_channels() {
         let target = "0123456789abcdef0123456789abcdef01234567";
         let releases = [
@@ -567,15 +686,15 @@ mod tests {
     #[test]
     fn malformed_release_tags_are_not_selected() {
         let releases = [
-            release("Verenu-013.0-beta", "master"),
-            release("Verenu-0.12.1-beta", "master"),
+            release("Verenu-013.0", "master"),
+            release("Verenu-0.12.1", "master"),
         ];
 
         assert_eq!(
             select_release(&releases, UpdateChannel::Stable)
                 .expect("valid stable release")
                 .tag_name,
-            "Verenu-0.12.1-beta"
+            "Verenu-0.12.1"
         );
         assert_eq!(release_version("Verenu-013.0-beta"), None);
         assert_eq!(
@@ -640,6 +759,35 @@ mod tests {
     }
 
     #[test]
+    fn reinstall_mode_offers_the_selected_channel_even_when_versions_match() {
+        assert!(!should_offer_release("0.16.0", "0.16.0", true));
+        assert!(should_offer_release("0.16.0", "0.16.0", false));
+        assert!(should_offer_release("0.16.1", "0.16.0", true));
+    }
+
+    #[test]
+    fn beta_channel_can_replace_a_same_core_stable_release() {
+        assert!(should_offer_release_for_channel(
+            "0.16.2-nightly.20260804",
+            "0.16.2",
+            UpdateChannel::Beta,
+            true,
+        ));
+        assert!(!should_offer_release_for_channel(
+            "0.16.2-nightly.20260804",
+            "0.16.2",
+            UpdateChannel::Stable,
+            true,
+        ));
+        assert!(!should_offer_release_for_channel(
+            "0.16.2-nightly.20260803",
+            "0.16.2-nightly.20260804",
+            UpdateChannel::Beta,
+            true,
+        ));
+    }
+
+    #[test]
     fn prerelease_versions_compare_without_losing_build_order() {
         assert!(is_newer("0.15.1-beta.2", "0.15.1-beta.1"));
         assert!(!is_newer("0.15.1-beta.1", "0.15.1-beta.2"));
@@ -664,12 +812,15 @@ mod tests {
     }
 
     #[test]
-    fn windows_prefers_exe_then_msi() {
-        let assets = [asset("Verenu_0.15.0_x64_en-US.msi"), asset("Verenu_0.15.0_x64-setup.exe")];
-        let selected = select_release_asset_for_target(&assets, UpdateTarget::Windows)
-            .expect("windows asset");
+    fn windows_prefers_nsis_setup_then_offers_msi_as_download() {
+        let assets = [
+            asset("Verenu_0.15.0_x64_en-US.msi"),
+            asset("Verenu_0.15.0_x64-setup.exe"),
+        ];
+        let selected =
+            select_release_asset_for_target(&assets, UpdateTarget::Windows).expect("windows asset");
         assert_eq!(selected.0.name, "Verenu_0.15.0_x64-setup.exe");
-        assert_eq!(selected.1, InstallMode::Download);
+        assert_eq!(selected.1, InstallMode::Install);
 
         let fallback_assets = [asset("Verenu_0.15.0_x64_en-US.msi")];
         let fallback = select_release_asset_for_target(&fallback_assets, UpdateTarget::Windows)
@@ -679,14 +830,25 @@ mod tests {
     }
 
     #[test]
+    fn windows_does_not_try_to_silently_install_an_arbitrary_exe() {
+        let assets = [
+            asset("Verenu-portable.exe"),
+            asset("Verenu_0.15.0_x64_en-US.msi"),
+        ];
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::Windows)
+            .expect("MSI download fallback");
+        assert_eq!(selected.0.name, "Verenu_0.15.0_x64_en-US.msi");
+        assert_eq!(selected.1, InstallMode::Download);
+    }
+
+    #[test]
     fn macos_apple_silicon_prefers_matching_dmg() {
         let assets = [
             asset("Verenu_0.15.0_Intel.dmg"),
             asset("Verenu_0.15.0_Apple_Silicon.dmg"),
         ];
-        let selected =
-            select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
-                .expect("arm dmg");
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
+            .expect("arm dmg");
         assert_eq!(selected.0.name, "Verenu_0.15.0_Apple_Silicon.dmg");
         assert_eq!(selected.1, InstallMode::Download);
     }
@@ -697,8 +859,8 @@ mod tests {
             asset("Verenu_0.15.0_Apple_Silicon.dmg"),
             asset("Verenu_0.15.0_Intel.dmg"),
         ];
-        let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel)
-            .expect("intel dmg");
+        let selected =
+            select_release_asset_for_target(&assets, UpdateTarget::MacOsIntel).expect("intel dmg");
         assert_eq!(selected.0.name, "Verenu_0.15.0_Intel.dmg");
     }
 
@@ -723,9 +885,8 @@ mod tests {
     fn macos_apple_silicon_falls_back_to_intel_dmg() {
         // Apple Silicon can run Intel builds via Rosetta 2.
         let assets = [asset("Verenu_0.15.0_Intel.dmg")];
-        let selected =
-            select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
-                .expect("rosetta fallback");
+        let selected = select_release_asset_for_target(&assets, UpdateTarget::MacOsAppleSilicon)
+            .expect("rosetta fallback");
         assert_eq!(selected.0.name, "Verenu_0.15.0_Intel.dmg");
     }
 
@@ -775,10 +936,9 @@ mod tests {
     // fails loudly, flagging that the encoded checks can be revisited.
     #[test]
     fn path_segments_preserve_percent_encoding() {
-        let parsed = reqwest::Url::parse(
-            "https://github.com/o/r/releases/download/v1/..%2f..%5cx%2e%2e",
-        )
-        .unwrap();
+        let parsed =
+            reqwest::Url::parse("https://github.com/o/r/releases/download/v1/..%2f..%5cx%2e%2e")
+                .unwrap();
         let segments: Vec<&str> = parsed.path_segments().unwrap().collect();
         assert_eq!(segments.last().copied(), Some("..%2f..%5cx%2e%2e"));
     }

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -427,8 +427,8 @@ fn should_offer_release_for_channel(
         return false;
     }
 
-    let latest = release_version(latest).and_then(|version| parse_version(&version));
-    let current = release_version(current).and_then(|version| parse_version(&version));
+    let latest = parse_version(latest);
+    let current = parse_version(current);
 
     matches!(
         (latest, current),

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -424,3 +424,34 @@ pub fn set_dev_logging_enabled(enabled: bool) {
 pub fn get_dev_logging_enabled() -> bool {
     crate::system::logger::is_verbose()
 }
+
+// ---------- system notifications ----------
+
+#[tauri::command]
+pub fn notify_update_available(app: AppHandle, version: String) -> Result<(), String> {
+    crate::system::notify::notify_update_available(&app, &version)
+}
+
+#[tauri::command]
+pub fn notify_provider_and_global_message(
+    app: AppHandle,
+    provider_summary: String,
+    global_message: String,
+) -> Result<(), String> {
+    crate::system::notify::notify_provider_and_global_message(
+        &app,
+        &provider_summary,
+        &global_message,
+    )
+}
+
+#[tauri::command]
+pub fn test_notifications(
+    app: AppHandle,
+    notification_type: Option<String>,
+) -> Result<(), String> {
+    crate::system::notify::notify_test_notification(
+        &app,
+        notification_type.as_deref().unwrap_or("update"),
+    )
+}

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,7 +1,7 @@
 //! Update check + in-app install, with pre-update DB backup.
 
 use super::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 use tauri_plugin_shell::ShellExt;
 
 // ---------- updates ----------
@@ -10,16 +10,7 @@ use tauri_plugin_shell::ShellExt;
 pub async fn check_for_update(
     app: AppHandle,
 ) -> Result<Option<crate::api::updater::UpdateInfo>, String> {
-    let handle = store::settings_handle(&app)?;
-    let channel = if handle
-        .get(store::BETA_UPDATES_ENABLED)
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        crate::api::updater::UpdateChannel::Beta
-    } else {
-        crate::api::updater::UpdateChannel::Stable
-    };
+    let channel = selected_update_channel(&app)?;
 
     match crate::api::updater::check(channel).await {
         Ok(update) => Ok(update),
@@ -28,6 +19,34 @@ pub async fn check_for_update(
             Ok(None)
         }
     }
+}
+
+/// Developer-only reinstall path. It deliberately uses the same selected
+/// stable/beta channel as normal update checks but does not require the chosen
+/// release to be newer than the currently installed version.
+#[tauri::command]
+pub async fn reinstall_latest_update(app: AppHandle) -> Result<String, String> {
+    let channel = selected_update_channel(&app)?;
+    let update = crate::api::updater::latest_installable(channel)
+        .await
+        .map_err(|e| format!("Could not look up the latest release: {e}"))?
+        .ok_or_else(|| "No compatible release asset is available for this device.".to_string())?;
+    let version = update.version.clone();
+    install_update(app, update.download_url).await?;
+    Ok(version)
+}
+
+fn selected_update_channel(app: &AppHandle) -> Result<crate::api::updater::UpdateChannel, String> {
+    let handle = store::settings_handle(app)?;
+    let beta_enabled = handle
+        .get(store::BETA_UPDATES_ENABLED)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    Ok(if beta_enabled {
+        crate::api::updater::UpdateChannel::Beta
+    } else {
+        crate::api::updater::UpdateChannel::Stable
+    })
 }
 
 #[tauri::command]
@@ -66,7 +85,17 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
     {
         use std::io::Write;
         use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        // MSI packages are valid release assets but do not support NSIS's
+        // `/S` switch. Let Windows download/open them normally instead of
+        // pretending they can use the in-app silent installer.
+        if !is_silent_nsis_setup_url(&download_url) {
+            #[allow(deprecated)]
+            app.shell()
+                .open(download_url, None)
+                .map_err(|e| e.to_string())?;
+            return Ok(());
+        }
 
         let db = app.state::<DbHandle>().inner().clone();
 
@@ -98,29 +127,43 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
                 }
             }
 
-            let installer = std::env::temp_dir().join("verenu-update.exe");
+            let installer = unique_update_installer_path()?;
             let mut f = std::fs::File::create(&installer).map_err(|e| e.to_string())?;
             f.write_all(&bytes).map_err(|e| e.to_string())?;
             drop(f);
 
-            // Batch launcher: waits for this process to exit, runs the installer
-            // silently, then relaunches the app. cmd.exe avoids PowerShell
-            // execution-policy issues; CREATE_NO_WINDOW suppresses any console flash.
+            // Start a second copy of Verenu in a private helper mode. Unlike the
+            // old `.cmd` launcher, this never invokes cmd.exe or PowerShell, and
+            // it waits for both this process and the NSIS installer before it
+            // relaunches the installed binary. The old handoff only slept for
+            // two seconds, so it could reopen Verenu while files were still
+            // being replaced.
             let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
-            let script = format!(
-                "@echo off\r\ntimeout /t 2 /nobreak >nul\r\n\"{}\" /S\r\nstart \"\" \"{}\"\r\n",
-                installer.display(),
-                current_exe.display()
-            );
-            let script_path = std::env::temp_dir().join("verenu-updater.cmd");
-            std::fs::write(&script_path, &script).map_err(|e| e.to_string())?;
-
-            std::process::Command::new("cmd")
-                .arg("/c")
-                .arg(&script_path)
-                .creation_flags(CREATE_NO_WINDOW)
+            // The helper cannot run from the installed binary itself: Windows
+            // keeps the helper's image locked, so NSIS would wait forever while
+            // trying to replace Verenu.exe. Run a temporary copy instead and
+            // pass the real executable path back for the final relaunch.
+            let helper_exe = unique_update_helper_path()?;
+            std::fs::copy(&current_exe, &helper_exe).map_err(|e| e.to_string())?;
+            let parent_pid = std::process::id().to_string();
+            if let Err(err) = std::process::Command::new(&helper_exe)
+                .arg("--apply-update")
+                .arg("--update-installer")
+                .arg(&installer)
+                .arg("--update-parent-pid")
+                .arg(parent_pid)
+                .arg("--update-target")
+                .arg(&current_exe)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
                 .spawn()
-                .map_err(|e| e.to_string())?;
+            {
+                let _ = std::fs::remove_file(&installer);
+                let _ = std::fs::remove_file(&helper_exe);
+                return Err(err.to_string());
+            }
 
             Ok(())
         })
@@ -130,6 +173,189 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
         // Exit immediately so the binary is free before the installer starts.
         std::process::exit(0)
     }
+}
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+#[cfg(windows)]
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+/// Run before Tauri is initialized when this executable was spawned as the
+/// private update helper. Returns `true` only when the helper arguments were
+/// complete and the caller should exit instead of launching the application.
+#[cfg(windows)]
+pub(crate) fn run_update_helper_if_requested() -> bool {
+    let Some(args) = parse_update_helper_args(std::env::args_os().skip(1)) else {
+        return false;
+    };
+    let helper_exe = std::env::current_exe().ok();
+
+    if let Err(err) = apply_downloaded_update(&args, helper_exe.as_deref()) {
+        early_update_helper_warn(&err);
+        // A failed install should still leave Verenu usable. Restart the
+        // existing binary rather than stranding the user with no app open.
+        let _ = relaunch_installed_app(&args.target, helper_exe.as_deref());
+    }
+    true
+}
+
+#[cfg(windows)]
+#[derive(Debug, PartialEq, Eq)]
+struct UpdateHelperArgs {
+    installer: std::path::PathBuf,
+    parent_pid: u32,
+    target: std::path::PathBuf,
+}
+
+#[cfg(windows)]
+fn parse_update_helper_args<I>(args: I) -> Option<UpdateHelperArgs>
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    let mut args = args.into_iter();
+    if args.next()?.to_string_lossy() != "--apply-update" {
+        return None;
+    }
+
+    let mut installer = None;
+    let mut parent_pid = None;
+    let mut target = None;
+    while let Some(arg) = args.next() {
+        match arg.to_string_lossy().as_ref() {
+            "--update-installer" => installer = args.next().map(std::path::PathBuf::from),
+            "--update-parent-pid" => {
+                parent_pid = args
+                    .next()
+                    .and_then(|value| value.to_string_lossy().parse::<u32>().ok())
+            }
+            "--update-target" => target = args.next().map(std::path::PathBuf::from),
+            _ => return None,
+        }
+    }
+
+    Some(UpdateHelperArgs {
+        installer: installer?,
+        parent_pid: parent_pid?,
+        target: target?,
+    })
+}
+
+#[cfg(windows)]
+fn apply_downloaded_update(
+    args: &UpdateHelperArgs,
+    helper_exe: Option<&std::path::Path>,
+) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
+    if !args.installer.is_file() {
+        return Err("Downloaded update installer is missing.".into());
+    }
+
+    wait_for_process_exit(args.parent_pid)?;
+
+    let status = std::process::Command::new(&args.installer)
+        .arg("/S")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("Could not start the downloaded update: {e}"))?;
+    let _ = std::fs::remove_file(&args.installer);
+    if !status.success() {
+        return Err(format!("Update installer exited with status {status}."));
+    }
+
+    relaunch_installed_app(&args.target, helper_exe)
+}
+
+#[cfg(windows)]
+fn wait_for_process_exit(pid: u32) -> Result<(), String> {
+    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, WAIT_OBJECT_0};
+    use windows::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+    };
+
+    unsafe {
+        let handle = match OpenProcess(PROCESS_SYNCHRONIZE, false, pid) {
+            Ok(handle) => handle,
+            Err(err)
+                if err.code() == windows::core::HRESULT::from_win32(ERROR_INVALID_PARAMETER.0) =>
+            {
+                return Ok(());
+            }
+            Err(err) => return Err(format!("Could not wait for Verenu to close: {err}")),
+        };
+        let result = WaitForSingleObject(handle, 15_000);
+        let _ = CloseHandle(handle);
+        if result != WAIT_OBJECT_0 {
+            return Err("Verenu did not finish closing before the update timed out.".into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn relaunch_installed_app(
+    target: &std::path::Path,
+    helper_exe: Option<&std::path::Path>,
+) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
+    let mut command = std::process::Command::new(target);
+    if let Some(helper_exe) = helper_exe {
+        command.arg(format!(
+            "--cleanup-update-helper={}",
+            helper_exe.to_string_lossy()
+        ));
+    }
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
+        .spawn()
+        .map_err(|e| format!("Could not relaunch Verenu after the update: {e}"))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn unique_update_installer_path() -> Result<std::path::PathBuf, String> {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_nanos();
+    Ok(std::env::temp_dir().join(format!("verenu-update-{}-{nonce}.exe", std::process::id())))
+}
+
+#[cfg(windows)]
+fn unique_update_helper_path() -> Result<std::path::PathBuf, String> {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_nanos();
+    Ok(std::env::temp_dir().join(format!(
+        "verenu-update-helper-{}-{nonce}.exe",
+        std::process::id()
+    )))
+}
+
+#[cfg(windows)]
+fn early_update_helper_warn(message: &str) {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Diagnostics::Debug::OutputDebugStringW;
+
+    let mut wide: Vec<u16> = format!("Verenu update helper: {message}")
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe { OutputDebugStringW(PCWSTR(wide.as_mut_ptr())) };
+}
+
+fn is_silent_nsis_setup_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .is_some_and(|parsed| parsed.path().to_ascii_lowercase().ends_with("-setup.exe"))
 }
 
 // Uses SQLite's Online Backup API rather than copying the .db/-wal files
@@ -152,6 +378,61 @@ pub fn backup_sqlite_database(
     // to exit right after this call, so there's nothing else to avoid blocking.
     match backup.step(-1).map_err(|e| e.to_string())? {
         rusqlite::backup::StepResult::Done => Ok(()),
-        other => Err(format!("Backup did not complete in a single step: {other:?}")),
+        other => Err(format!(
+            "Backup did not complete in a single step: {other:?}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_silent_nsis_setup_url;
+
+    #[test]
+    fn only_nsis_setup_urls_use_the_silent_installer_handoff() {
+        assert!(is_silent_nsis_setup_url(
+            "https://github.com/MONKE2525E/Verenu/releases/download/v0.16.0/Verenu_0.16.0_x64-setup.exe"
+        ));
+        assert!(!is_silent_nsis_setup_url(
+            "https://github.com/MONKE2525E/Verenu/releases/download/v0.16.0/Verenu_0.16.0_x64_en-US.msi"
+        ));
+        assert!(!is_silent_nsis_setup_url(
+            "https://github.com/MONKE2525E/Verenu/releases/download/v0.16.0/Verenu-portable.exe"
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn update_helper_requires_complete_and_exact_arguments() {
+        use super::parse_update_helper_args;
+
+        let valid = parse_update_helper_args([
+            "--apply-update".into(),
+            "--update-installer".into(),
+            "C:\\Temp\\verenu-update.exe".into(),
+            "--update-parent-pid".into(),
+            "123".into(),
+            "--update-target".into(),
+            "C:\\Program Files\\Verenu\\Verenu.exe".into(),
+        ])
+        .expect("valid helper args");
+        assert_eq!(valid.parent_pid, 123);
+        assert_eq!(
+            valid.installer,
+            std::path::PathBuf::from("C:\\Temp\\verenu-update.exe")
+        );
+        assert_eq!(
+            valid.target,
+            std::path::PathBuf::from("C:\\Program Files\\Verenu\\Verenu.exe")
+        );
+
+        assert!(parse_update_helper_args(["--apply-update".into()]).is_none());
+        assert!(parse_update_helper_args([
+            "--apply-update".into(),
+            "--update-installer".into(),
+            "C:\\Temp\\verenu-update.exe".into(),
+            "--unexpected".into(),
+        ])
+        .is_none());
     }
 }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -251,7 +251,10 @@ fn apply_downloaded_update(
         return Err("Downloaded update installer is missing.".into());
     }
 
-    wait_for_process_exit(args.parent_pid)?;
+    if let Err(error) = wait_for_process_exit(args.parent_pid) {
+        let _ = std::fs::remove_file(&args.installer);
+        return Err(error);
+    }
 
     let status = std::process::Command::new(&args.installer)
         .arg("/S")

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -259,9 +259,9 @@ fn apply_downloaded_update(
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .creation_flags(CREATE_NO_WINDOW)
-        .status()
-        .map_err(|e| format!("Could not start the downloaded update: {e}"))?;
+        .status();
     let _ = std::fs::remove_file(&args.installer);
+    let status = status.map_err(|e| format!("Could not start the downloaded update: {e}"))?;
     if !status.success() {
         return Err(format!("Update installer exited with status {status}."));
     }
@@ -352,6 +352,7 @@ fn early_update_helper_warn(message: &str) {
     unsafe { OutputDebugStringW(PCWSTR(wide.as_mut_ptr())) };
 }
 
+#[cfg(any(test, windows))]
 fn is_silent_nsis_setup_url(url: &str) -> bool {
     reqwest::Url::parse(url)
         .ok()

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -128,8 +128,14 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
             }
 
             let installer = unique_update_installer_path()?;
-            let mut f = std::fs::File::create(&installer).map_err(|e| e.to_string())?;
-            f.write_all(&bytes).map_err(|e| e.to_string())?;
+            let mut f = match std::fs::File::create(&installer) {
+                Ok(file) => file,
+                Err(error) => return Err(error.to_string()),
+            };
+            if let Err(error) = f.write_all(&bytes) {
+                let _ = std::fs::remove_file(&installer);
+                return Err(error.to_string());
+            }
             drop(f);
 
             // Start a second copy of Verenu in a private helper mode. Unlike the
@@ -138,13 +144,29 @@ pub async fn install_update(app: AppHandle, download_url: String) -> Result<(), 
             // relaunches the installed binary. The old handoff only slept for
             // two seconds, so it could reopen Verenu while files were still
             // being replaced.
-            let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
+            let current_exe = match std::env::current_exe() {
+                Ok(exe) => exe,
+                Err(error) => {
+                    let _ = std::fs::remove_file(&installer);
+                    return Err(error.to_string());
+                }
+            };
             // The helper cannot run from the installed binary itself: Windows
             // keeps the helper's image locked, so NSIS would wait forever while
             // trying to replace Verenu.exe. Run a temporary copy instead and
             // pass the real executable path back for the final relaunch.
-            let helper_exe = unique_update_helper_path()?;
-            std::fs::copy(&current_exe, &helper_exe).map_err(|e| e.to_string())?;
+            let helper_exe = match unique_update_helper_path() {
+                Ok(path) => path,
+                Err(error) => {
+                    let _ = std::fs::remove_file(&installer);
+                    return Err(error);
+                }
+            };
+            if let Err(error) = std::fs::copy(&current_exe, &helper_exe) {
+                let _ = std::fs::remove_file(&installer);
+                let _ = std::fs::remove_file(&helper_exe);
+                return Err(error.to_string());
+            }
             let parent_pid = std::process::id().to_string();
             if let Err(err) = std::process::Command::new(&helper_exe)
                 .arg("--apply-update")
@@ -192,9 +214,12 @@ pub(crate) fn run_update_helper_if_requested() -> bool {
 
     if let Err(err) = apply_downloaded_update(&args, helper_exe.as_deref()) {
         early_update_helper_warn(&err);
-        // A failed install should still leave Verenu usable. Restart the
-        // existing binary rather than stranding the user with no app open.
-        let _ = relaunch_installed_app(&args.target, helper_exe.as_deref());
+        // A failed install should still leave Verenu usable when the original
+        // process has already exited. Do not launch a second copy while the
+        // parent is still alive after a wait timeout.
+        if !process_is_running(args.parent_pid) {
+            let _ = relaunch_installed_app(&args.target, helper_exe.as_deref());
+        }
     }
     true
 }
@@ -296,6 +321,27 @@ fn wait_for_process_exit(pid: u32) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn process_is_running(pid: u32) -> bool {
+    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER};
+    use windows::Win32::System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE};
+
+    unsafe {
+        match OpenProcess(PROCESS_SYNCHRONIZE, false, pid) {
+            Ok(handle) => {
+                let _ = CloseHandle(handle);
+                true
+            }
+            Err(error)
+                if error.code() == windows::core::HRESULT::from_win32(ERROR_INVALID_PARAMETER.0) =>
+            {
+                false
+            }
+            Err(_) => true,
+        }
+    }
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -325,14 +325,15 @@ fn wait_for_process_exit(pid: u32) -> Result<(), String> {
 
 #[cfg(windows)]
 fn process_is_running(pid: u32) -> bool {
-    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER};
-    use windows::Win32::System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE};
+    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, WAIT_TIMEOUT};
+    use windows::Win32::System::Threading::{OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE};
 
     unsafe {
         match OpenProcess(PROCESS_SYNCHRONIZE, false, pid) {
             Ok(handle) => {
+                let wait_result = WaitForSingleObject(handle, 0);
                 let _ = CloseHandle(handle);
-                true
+                wait_result == WAIT_TIMEOUT
             }
             Err(error)
                 if error.code() == windows::core::HRESULT::from_win32(ERROR_INVALID_PARAMETER.0) =>

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -239,7 +239,7 @@ pub(crate) fn app_db_path() -> std::path::PathBuf {
 }
 
 fn main() {
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     {
         cleanup_update_helper_if_requested();
         if crate::commands::run_update_helper_if_requested() {
@@ -584,7 +584,7 @@ fn main() {
         });
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "windows")]
 fn cleanup_update_helper_if_requested() {
     let Some(helper) = std::env::args_os().find_map(|arg| {
         let text = arg.to_string_lossy();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -239,6 +239,14 @@ pub(crate) fn app_db_path() -> std::path::PathBuf {
 }
 
 fn main() {
+    #[cfg(windows)]
+    {
+        cleanup_update_helper_if_requested();
+        if crate::commands::run_update_helper_if_requested() {
+            return;
+        }
+    }
+
     #[cfg(target_os = "macos")]
     {
         let _ = crate::system::mac_app::set_process_name("Verenu");
@@ -278,6 +286,7 @@ fn main() {
         .manage(frontend_readiness.clone())
         .setup(move |app| {
             crate::system::logger::init(app.handle())?;
+            crate::system::notify::prepare_windows_notification_identity();
             let settings = crate::data::store::SettingsHandle::open(app.handle())
                 .map_err(std::io::Error::other)?;
             crate::data::credentials::migrate_from_store(app.handle(), &settings);
@@ -537,6 +546,7 @@ fn main() {
             commands::get_recent_auto_learn_activity,
             commands::retry_transcription,
             commands::check_for_update,
+            commands::reinstall_latest_update,
             commands::install_update,
             commands::check_provider_status,
             commands::check_provider_status_raw,
@@ -547,6 +557,9 @@ fn main() {
             commands::download_logs,
             commands::set_dev_logging_enabled,
             commands::get_dev_logging_enabled,
+            commands::notify_update_available,
+            commands::notify_provider_and_global_message,
+            commands::test_notifications,
             commands::export_data,
             commands::import_data,
             commands::log_frontend,
@@ -569,6 +582,27 @@ fn main() {
                     .unload(_app);
             }
         });
+}
+
+#[cfg(windows)]
+fn cleanup_update_helper_if_requested() {
+    let Some(helper) = std::env::args_os().find_map(|arg| {
+        let text = arg.to_string_lossy();
+        text.strip_prefix("--cleanup-update-helper=")
+            .map(std::path::PathBuf::from)
+    }) else {
+        return;
+    };
+
+    // The helper has just spawned this process and is exiting. Retry briefly so
+    // Windows has released the helper image before removing its temp copy.
+    for _ in 0..20 {
+        match std::fs::remove_file(&helper) {
+            Ok(()) => return,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(_) => std::thread::sleep(std::time::Duration::from_millis(100)),
+        }
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -90,10 +90,16 @@ pub fn notify_provider_and_global_message(
     provider_summary: &str,
     global_message: &str,
 ) -> Result<(), String> {
+    let body = match (provider_summary.is_empty(), global_message.is_empty()) {
+        (false, false) => format!("{provider_summary}\n\n{global_message}"),
+        (false, true) => provider_summary.to_owned(),
+        (true, false) => global_message.to_owned(),
+        (true, true) => return Err("Notification message is empty.".to_owned()),
+    };
     show(
         app,
         "Verenu service notice",
-        format!("{provider_summary}\n\n{global_message}"),
+        body,
         NotificationDestination::Home,
     )
 }

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -175,6 +175,7 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
     use std::mem::ManuallyDrop;
     use std::path::PathBuf;
     use windows::core::{GUID, Interface, PCWSTR, PWSTR};
+    use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
     use windows::Win32::Storage::EnhancedStorage::PKEY_AppUserModel_ID;
     use windows::Win32::System::Com::{
         CoCreateInstance, CoInitializeEx, CoTaskMemAlloc, CoUninitialize, IPersistFile,
@@ -240,9 +241,15 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
     }
 
     let initialized = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
-    if initialized.is_err() {
+    let should_uninitialize = if initialized.is_ok() {
+        true
+    } else if initialized == RPC_E_CHANGED_MODE {
+        // COM was already initialized on this thread with MTA. COM calls are
+        // still valid, but this call did not add a reference to release.
+        false
+    } else {
         return Err(format!("CoInitializeEx failed: {initialized:?}"));
-    }
+    };
 
     let result = (|| {
         let shell_link: IShellLinkW = unsafe {
@@ -284,6 +291,8 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
         Ok(())
     })();
 
-    unsafe { CoUninitialize() };
+    if should_uninitialize {
+        unsafe { CoUninitialize() };
+    }
     result
 }

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -1,26 +1,283 @@
-//! Thin wrapper over tauri-plugin-notification for the few app-level system
-//! notifications Verenu raises (currently: a local model finished downloading).
-//! Notifications are best-effort — a denied/unavailable permission must never
-//! turn into a pipeline or download error, so every failure is swallowed and
-//! logged at debug.
+//! Thin wrapper over tauri-plugin-notification for app-level system
+//! notifications. Keeping these calls in Rust gives Windows notifications
+//! Verenu's native app identity instead of the WebView host process.
 
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 use tauri_plugin_notification::NotificationExt;
 
-/// Raises a "download complete" system notification. Fires regardless of window
-/// focus/visibility (that's the point — the user may have tabbed away during a
-/// multi-GB download), so it's issued from the backend rather than the WebView,
-/// whose renderer can be suspended while the main window is hidden.
-pub fn notify_model_download_complete(app: &AppHandle, model_name: &str) {
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(windows)]
+const WINDOWS_DEV_APP_ID: &str = "com.verenu.app.dev";
+
+#[cfg(windows)]
+static WINDOWS_DEV_IDENTITY_READY: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy)]
+enum NotificationDestination {
+    Home,
+    Models,
+}
+
+impl NotificationDestination {
+    const fn event_payload(self) -> &'static str {
+        match self {
+            Self::Home => "home",
+            Self::Models => "models",
+        }
+    }
+}
+
+fn show(
+    app: &AppHandle,
+    title: &str,
+    body: impl Into<String>,
+    destination: NotificationDestination,
+) -> Result<(), String> {
+    let body = body.into();
+
+    #[cfg(windows)]
+    {
+        if let Err(err) = show_windows(app, title, &body, destination) {
+            log::debug!("notify: {title} native notification failed: {err}");
+        } else {
+            return Ok(());
+        }
+    }
+
     let result = app
         .notification()
         .builder()
-        .title("Model ready")
-        .body(format!(
-            "{model_name} finished downloading and is ready to use."
-        ))
+        .title(title)
+        .body(body)
         .show();
     if let Err(err) = result {
-        log::debug!("notify: model download-complete notification failed: {err}");
+        log::debug!("notify: {title} notification failed: {err}");
+        return Err(err.to_string());
     }
+    Ok(())
+}
+
+/// Raises a download-complete system notification from the backend so it can
+/// arrive while the main window is hidden.
+pub fn notify_model_download_complete(app: &AppHandle, model_name: &str) {
+    let _ = show(
+        app,
+        "Model ready",
+        format!("{model_name} finished downloading and is ready to use."),
+        NotificationDestination::Models,
+    );
+}
+
+pub fn notify_update_available(app: &AppHandle, version: &str) -> Result<(), String> {
+    show(
+        app,
+        "Verenu update available",
+        format!("Version v{version} is ready. Open Verenu to update."),
+        NotificationDestination::Home,
+    )
+}
+
+pub fn notify_provider_and_global_message(
+    app: &AppHandle,
+    provider_summary: &str,
+    global_message: &str,
+) -> Result<(), String> {
+    show(
+        app,
+        "Verenu service notice",
+        format!("{provider_summary}\n\n{global_message}"),
+        NotificationDestination::Home,
+    )
+}
+
+/// Sends a selected notification example through the same native path used by
+/// background notifications.
+pub fn notify_test_notification(
+    app: &AppHandle,
+    notification_type: &str,
+) -> Result<(), String> {
+    match notification_type {
+        "update" => notify_update_available(app, "0.16.1"),
+        "model" => show(
+            app,
+            "Model ready",
+            "Parakeet finished downloading and is ready to use.",
+            NotificationDestination::Models,
+        ),
+        "service" => notify_provider_and_global_message(
+            app,
+            "Groq: Some requests may be delayed or unavailable.",
+            "Verenu has an important service update.",
+        ),
+        other => Err(format!("Unknown notification test type: {other}")),
+    }
+}
+
+#[cfg(windows)]
+fn show_windows(
+    app: &AppHandle,
+    title: &str,
+    body: &str,
+    destination: NotificationDestination,
+) -> Result<(), String> {
+    let app_id = if WINDOWS_DEV_IDENTITY_READY.load(Ordering::Acquire) {
+        WINDOWS_DEV_APP_ID
+    } else {
+        "com.verenu.app"
+    };
+    let mut notification = notify_rust::Notification::new();
+    notification
+        .summary(title)
+        .body(body)
+        .app_id(app_id);
+
+    let handle = notification.show().map_err(|err| err.to_string())?;
+    let app = app.clone();
+    let destination = destination.event_payload();
+    std::thread::spawn(move || {
+        if let Err(err) = handle.wait_for_response(|response: &notify_rust::NotificationResponse| {
+            if response.is_default_action() {
+                crate::show_main_window(&app);
+                if let Err(err) = app.emit("verenu:notification-clicked", destination) {
+                    log::debug!("notify: could not emit notification click event: {err}");
+                }
+            }
+        }) {
+            log::debug!("notify: notification click listener failed: {err}");
+        }
+    });
+    Ok(())
+}
+
+/// Prepare a real Windows app identity for development notifications.
+///
+/// Windows toast notifications from unpackaged development executables need a
+/// Start Menu shortcut with an AppUserModelId. Without that shortcut, the
+/// Windows notification stack labels the toast as Windows PowerShell.
+pub fn prepare_windows_notification_identity() {
+    #[cfg(all(windows, debug_assertions))]
+    match install_windows_dev_shortcut() {
+        Ok(()) => WINDOWS_DEV_IDENTITY_READY.store(true, Ordering::Release),
+        Err(err) => log::warn!("Could not register the Windows notification identity: {err}"),
+    }
+}
+
+#[cfg(all(windows, debug_assertions))]
+fn install_windows_dev_shortcut() -> Result<(), String> {
+    use std::mem::ManuallyDrop;
+    use std::path::PathBuf;
+    use windows::core::{GUID, Interface, PCWSTR, PWSTR};
+    use windows::Win32::Storage::EnhancedStorage::PKEY_AppUserModel_ID;
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoTaskMemAlloc, CoUninitialize, IPersistFile,
+        CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+    };
+    use windows::Win32::System::Com::StructuredStorage::{
+        PropVariantClear, PROPVARIANT, PROPVARIANT_0, PROPVARIANT_0_0, PROPVARIANT_0_0_0,
+    };
+    use windows::Win32::System::Variant::VT_LPWSTR;
+    use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
+    use windows::Win32::UI::Shell::IShellLinkW;
+
+    const CLSID_SHELL_LINK: GUID =
+        GUID::from_u128(0x00021401_0000_0000_c000_000000000046);
+
+    fn wide(value: impl AsRef<std::ffi::OsStr>) -> Vec<u16> {
+        use std::os::windows::ffi::OsStrExt;
+        value.as_ref().encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    fn shortcut_path() -> Result<PathBuf, String> {
+        let app_data = std::env::var_os("APPDATA")
+            .ok_or_else(|| "APPDATA is not available".to_owned())?;
+        Ok(PathBuf::from(app_data)
+            .join("Microsoft")
+            .join("Windows")
+            .join("Start Menu")
+            .join("Programs")
+            .join("Verenu Development.lnk"))
+    }
+
+    fn app_id_propvariant() -> Result<PROPVARIANT, String> {
+        let value: Vec<u16> = WINDOWS_DEV_APP_ID
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let bytes = value.len() * std::mem::size_of::<u16>();
+        let ptr = unsafe { CoTaskMemAlloc(bytes) as *mut u16 };
+        if ptr.is_null() {
+            return Err("CoTaskMemAlloc failed".to_owned());
+        }
+        unsafe { std::ptr::copy_nonoverlapping(value.as_ptr(), ptr, value.len()) };
+
+        Ok(PROPVARIANT {
+            Anonymous: PROPVARIANT_0 {
+                Anonymous: ManuallyDrop::new(PROPVARIANT_0_0 {
+                    vt: VT_LPWSTR,
+                    wReserved1: 0,
+                    wReserved2: 0,
+                    wReserved3: 0,
+                    Anonymous: PROPVARIANT_0_0_0 {
+                        pwszVal: PWSTR(ptr),
+                    },
+                }),
+            },
+        })
+    }
+
+    let shortcut = shortcut_path()?;
+    let exe = std::env::current_exe().map_err(|err| err.to_string())?;
+    if let Some(parent) = shortcut.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    }
+
+    let initialized = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    if initialized.is_err() {
+        return Err(format!("CoInitializeEx failed: {initialized:?}"));
+    }
+
+    let result = (|| {
+        let shell_link: IShellLinkW = unsafe {
+            CoCreateInstance(&CLSID_SHELL_LINK, None, CLSCTX_INPROC_SERVER)
+                .map_err(|err| err.to_string())?
+        };
+        let exe_wide = wide(&exe);
+        let description = wide("Verenu development notifications");
+        unsafe {
+            shell_link
+                .SetPath(PCWSTR(exe_wide.as_ptr()))
+                .map_err(|err| err.to_string())?;
+            shell_link
+                .SetDescription(PCWSTR(description.as_ptr()))
+                .map_err(|err| err.to_string())?;
+        }
+
+        let property_store: IPropertyStore =
+            shell_link.cast().map_err(|err| err.to_string())?;
+        let mut app_id = app_id_propvariant()?;
+        let result = unsafe {
+            property_store
+                .SetValue(&PKEY_AppUserModel_ID, &app_id)
+                .and_then(|_| property_store.Commit())
+                .map_err(|err| err.to_string())
+        };
+        unsafe {
+            let _ = PropVariantClear(&mut app_id);
+        }
+        result?;
+
+        let shortcut_wide = wide(&shortcut);
+        let persist_file: IPersistFile = shell_link.cast().map_err(|err| err.to_string())?;
+        unsafe {
+            persist_file
+                .Save(PCWSTR(shortcut_wide.as_ptr()), true)
+                .map_err(|err| err.to_string())?;
+        }
+        Ok(())
+    })();
+
+    unsafe { CoUninitialize() };
+    result
 }

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -2,7 +2,9 @@
 //! notifications. Keeping these calls in Rust gives Windows notifications
 //! Verenu's native app identity instead of the WebView host process.
 
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
+#[cfg(windows)]
+use tauri::Emitter;
 use tauri_plugin_notification::NotificationExt;
 
 #[cfg(windows)]
@@ -21,6 +23,7 @@ enum NotificationDestination {
 }
 
 impl NotificationDestination {
+    #[cfg(windows)]
     const fn event_payload(self) -> &'static str {
         match self {
             Self::Home => "home",
@@ -36,6 +39,9 @@ fn show(
     destination: NotificationDestination,
 ) -> Result<(), String> {
     let body = body.into();
+
+    #[cfg(not(windows))]
+    let _ = destination;
 
     #[cfg(windows)]
     {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,6 +91,7 @@
   }
 
   onMount(() => {
+    let mounted = true;
     let cleanupFn: (() => void) | undefined;
     let stopNotificationClickListener: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
@@ -130,7 +131,13 @@
     listen<string>('verenu:notification-clicked', (event) => {
       openNotificationDestination(event.payload);
     })
-      .then((unlisten) => { stopNotificationClickListener = unlisten; })
+      .then((unlisten) => {
+        if (!mounted) {
+          unlisten();
+          return;
+        }
+        stopNotificationClickListener = unlisten;
+      })
       .catch((error) => { console.warn('Failed to listen for notification clicks:', error); });
 
     // Synchronous: startAutomaticUpdateChecks fires its first check in the
@@ -179,6 +186,7 @@
     document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
+      mounted = false;
       if (cleanupFn) cleanupFn();
       if (stopNotificationClickListener) stopNotificationClickListener();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,7 +21,7 @@
   import { scrollEdges } from './lib/scrollFade';
   import { fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
-  import { MOTION_MS, MOTION_PX, NAV_ORDER, directionFromOrder, motionMs, motionPx, pageSwap, reducedMotionEnabled } from './lib/motion';
+  import { MOTION_MS, MOTION_PX, NAV_ORDER, SETTINGS_SECTION_ORDER, directionFromOrder, motionMs, motionPx, pageSwap, reducedMotionEnabled } from './lib/motion';
 
   type EffectiveTheme = 'light' | 'dark';
 
@@ -74,8 +74,25 @@
     }
   }
 
+  function openNotificationDestination(destination: string) {
+    if (destination === 'models') {
+      appStore.settingsAnimDir = directionFromOrder(
+        appStore.settingsSection,
+        'models',
+        SETTINGS_SECTION_ORDER,
+      );
+      appStore.settingsSection = 'models';
+      appStore.settingsOpen = true;
+      return;
+    }
+
+    appStore.settingsOpen = false;
+    appStore.currentPage = 'home';
+  }
+
   onMount(() => {
     let cleanupFn: (() => void) | undefined;
+    let stopNotificationClickListener: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
     let stopLocalSttListeners: (() => void) | undefined;
     let stopLocalLlmListeners: (() => void) | undefined;
@@ -109,6 +126,12 @@
       });
       cleanupFn = unlisten;
     })();
+
+    listen<string>('verenu:notification-clicked', (event) => {
+      openNotificationDestination(event.payload);
+    })
+      .then((unlisten) => { stopNotificationClickListener = unlisten; })
+      .catch((error) => { console.warn('Failed to listen for notification clicks:', error); });
 
     // Synchronous: startAutomaticUpdateChecks fires its first check in the
     // background and returns the cleanup immediately, so there's no unmount
@@ -157,6 +180,7 @@
 
     return () => {
       if (cleanupFn) cleanupFn();
+      if (stopNotificationClickListener) stopNotificationClickListener();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       if (stopLocalSttListeners) stopLocalSttListeners();
       if (stopLocalLlmListeners) stopLocalLlmListeners();

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -27,6 +27,7 @@
   type NotificationTestType = 'update' | 'model' | 'service';
   let notificationTestType = $state<NotificationTestType>('update');
   let notificationDropdownOpen = $state(false);
+  let notificationTestMessage = $state('');
   let installerTesting = $state(false);
   let installerTestMessage = $state('');
   let simulationMessage = $state('');
@@ -133,16 +134,17 @@
   async function testNotifications() {
     if (notificationsTesting) return;
     notificationsTesting = true;
+    notificationTestMessage = '';
     simulationMessage = '';
     try {
       if (!(await ensureNotificationPermission())) {
-        simulationMessage = 'Notification permission was not granted.';
+        notificationTestMessage = 'Notification permission was not granted.';
         return;
       }
       await invoke('test_notifications', { notificationType: notificationTestType });
-      simulationMessage = 'Notification sent.';
+      notificationTestMessage = 'Notification sent.';
     } catch (err) {
-      simulationMessage = 'Notification test failed.';
+      notificationTestMessage = 'Notification test failed.';
       console.error('test_notifications failed:', err);
     } finally {
       notificationsTesting = false;
@@ -396,6 +398,9 @@
   <div>
     <div class="label">System Notification Test</div>
     <div class="desc">Choose a notification type, then send the native toast and test its click destination.</div>
+    {#if notificationTestMessage}
+      <div class="desc export-status" role="status">{notificationTestMessage}</div>
+    {/if}
   </div>
   <div class="notification-test-controls">
     <Dropdown bind:open={notificationDropdownOpen} closeSelector=".notification-test-dropdown">

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -7,8 +7,10 @@
   import { icons } from '../../icons';
   import { appStore } from '../../stores';
   import { checkStatus } from '../../serviceStatus';
+  import { ensureNotificationPermission } from '../../notifications';
+  import Dropdown from '../Dropdown.svelte';
   import type { ProviderId } from '../../settings';
-  import { MOTION_MS, MOTION_PX, motionMs, motionPx } from '../../motion';
+  import { MOTION_MS, MOTION_PX, animateWidth, motionMs, motionPx } from '../../motion';
 
   let logs = $state<string[]>([]);
   let autoScroll = $state(true);
@@ -21,6 +23,12 @@
   let copiedTimer: ReturnType<typeof setTimeout> | null = null;
   let providerStatusRaw = $state('');
   let providerStatusChecking = $state(false);
+  let notificationsTesting = $state(false);
+  type NotificationTestType = 'update' | 'model' | 'service';
+  let notificationTestType = $state<NotificationTestType>('update');
+  let notificationDropdownOpen = $state(false);
+  let installerTesting = $state(false);
+  let installerTestMessage = $state('');
   let simulationMessage = $state('');
   let simulatedProvider = $state<ProviderId>('groq');
   let providerDropdownOpen = $state(false);
@@ -31,6 +39,16 @@
     { id: 'google', label: 'Gemini' },
     { id: 'assemblyai', label: 'AssemblyAI' },
   ];
+
+  const notificationTestTypes: { value: NotificationTestType; label: string }[] = [
+    { value: 'update', label: 'Update available' },
+    { value: 'model', label: 'Model ready' },
+    { value: 'service', label: 'Service notice' },
+  ];
+
+  function notificationTypeLabel() {
+    return notificationTestTypes.find((option) => option.value === notificationTestType)?.label ?? 'Update available';
+  }
 
   async function loadRecentLogs() {
     try {
@@ -84,12 +102,14 @@
 
   async function loadDevFlags() {
     try {
-      const [force, verbose] = await Promise.all([
+      const [force, verbose, betaUpdates] = await Promise.all([
         invoke<boolean | null>('get_setting', { key: 'force_setup_on_launch' }),
         invoke<boolean>('get_dev_logging_enabled'),
+        invoke<boolean | null>('get_setting', { key: 'beta_updates_enabled' }),
       ]);
       forceSetupOnLaunch = force ?? false;
       verboseEnabled = verbose ?? false;
+      appStore.betaUpdatesEnabled = betaUpdates ?? false;
     } catch (err) {
       console.error('Failed to load dev flags:', err);
     }
@@ -107,6 +127,40 @@
       console.error('check_provider_status_raw failed:', err);
     } finally {
       providerStatusChecking = false;
+    }
+  }
+
+  async function testNotifications() {
+    if (notificationsTesting) return;
+    notificationsTesting = true;
+    simulationMessage = '';
+    try {
+      if (!(await ensureNotificationPermission())) {
+        simulationMessage = 'Notification permission was not granted.';
+        return;
+      }
+      await invoke('test_notifications', { notificationType: notificationTestType });
+      simulationMessage = 'Notification sent.';
+    } catch (err) {
+      simulationMessage = 'Notification test failed.';
+      console.error('test_notifications failed:', err);
+    } finally {
+      notificationsTesting = false;
+    }
+  }
+
+  async function testLatestInstaller() {
+    if (installerTesting) return;
+    installerTesting = true;
+    installerTestMessage = '';
+    try {
+      const version = await invoke<string>('reinstall_latest_update');
+      installerTestMessage = `Starting reinstall of v${version}. Verenu will reopen when it finishes.`;
+    } catch (err) {
+      installerTestMessage = `Installer test failed: ${err}`;
+      console.error('reinstall_latest_update failed:', err);
+    } finally {
+      installerTesting = false;
     }
   }
 
@@ -338,6 +392,91 @@
     <button class="btn-ghost" onclick={clearSimulations}>Clear</button>
   </div>
 </div>
+<div class="setting-row">
+  <div>
+    <div class="label">System Notification Test</div>
+    <div class="desc">Choose a notification type, then send the native toast and test its click destination.</div>
+  </div>
+  <div class="notification-test-controls">
+    <Dropdown bind:open={notificationDropdownOpen} closeSelector=".notification-test-dropdown">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="notification-test-dropdown"
+        onclick={(event) => event.stopPropagation()}
+        onkeydown={(event) => {
+          if (event.key === 'Escape' && notificationDropdownOpen) {
+            notificationDropdownOpen = false;
+            event.stopPropagation();
+          }
+        }}
+      >
+        <button
+          class="btn-ghost notification-test-dropdown-button"
+          type="button"
+          use:animateWidth={{ text: notificationTypeLabel(), max: 180 }}
+          onclick={() => (notificationDropdownOpen = !notificationDropdownOpen)}
+          aria-haspopup="listbox"
+          aria-expanded={notificationDropdownOpen}
+          aria-controls="notification-test-menu"
+          aria-label="Notification type"
+        >
+          <span>{notificationTypeLabel()}</span>
+          <svg class:open={notificationDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+        </button>
+        {#if notificationDropdownOpen}
+          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+          <div
+            id="notification-test-menu"
+            class="notification-test-menu"
+            role="listbox"
+            tabindex="0"
+            aria-label="Notification type options"
+            onclick={(event) => event.stopPropagation()}
+            in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
+            out:fade={{ duration: motionMs(MOTION_MS.fast) }}
+          >
+            {#each notificationTestTypes as option}
+              <button
+                class="notification-test-item"
+                class:active={notificationTestType === option.value}
+                type="button"
+                role="option"
+                aria-selected={notificationTestType === option.value}
+                onclick={() => {
+                  notificationTestType = option.value;
+                  notificationDropdownOpen = false;
+                }}
+              >{option.label}</button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </Dropdown>
+    <button class="btn-ghost notification-test-send-button" onclick={testNotifications} disabled={notificationsTesting}>
+      {notificationsTesting ? 'Sending...' : 'Send Notification'}
+    </button>
+  </div>
+</div>
+<div class="setting-row">
+  <div>
+    <div class="label">Installer Test</div>
+    <div class="desc">
+      Reinstalls the latest {appStore.betaUpdatesEnabled ? 'beta' : 'stable'} release and restarts Verenu.
+    </div>
+    {#if installerTestMessage}
+      <div class="desc export-status" role="status">{installerTestMessage}</div>
+    {/if}
+  </div>
+  <button class="btn-ghost" onclick={testLatestInstaller} disabled={installerTesting}>
+    {installerTesting
+      ? 'Starting...'
+      : appStore.betaUpdatesEnabled
+        ? 'Reinstall Latest Beta'
+        : 'Reinstall Latest Stable'}
+  </button>
+</div>
 
 <style>
   .logs-panel-wrap {
@@ -427,6 +566,67 @@
     margin-top: 6px;
     color: var(--ink-faint);
   }
+  .notification-test-controls {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .notification-test-dropdown {
+    position: relative;
+    flex-shrink: 0;
+  }
+  .notification-test-dropdown-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    height: 32px;
+    padding: 0 12px;
+    border-radius: var(--r-md);
+    background: var(--paper-2);
+    border: 1px solid var(--line);
+    color: var(--ink);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .notification-test-dropdown-button svg { transition: transform 150ms; }
+  .notification-test-dropdown-button svg.open { transform: rotate(180deg); }
+  .notification-test-send-button {
+    display: inline-flex;
+    align-items: center;
+    height: 32px;
+  }
+  .notification-test-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 170px;
+    padding: 4px;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-popover);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .notification-test-item {
+    width: 100%;
+    padding: 6px 10px;
+    border: none;
+    border-radius: var(--r-sm);
+    background: transparent;
+    color: var(--ink-soft);
+    font: inherit;
+    font-size: 12.5px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .notification-test-item:hover { background: var(--paper-2); color: var(--ink); }
+  .notification-test-item.active { background: var(--accent-soft); color: var(--accent-ink); font-weight: 500; }
   .actions {
     display: flex;
     gap: 8px;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -14,3 +14,13 @@ export async function ensureNotificationPermission(): Promise<boolean> {
     return false;
   }
 }
+
+export async function isNotificationPermissionGranted(): Promise<boolean> {
+  if (!isTauriRuntime()) return false;
+  try {
+    return await isPermissionGranted();
+  } catch (error) {
+    console.warn('Notification permission check failed:', error);
+    return false;
+  }
+}

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -95,7 +95,7 @@ export async function checkStatus(): Promise<void> {
 
   const globalMessage = appStore.globalMessage;
   const providerAlerts = appStore.providerStatusAlerts;
-  if (providerAlerts.length === 0 || !globalMessage) {
+  if (providerAlerts.length === 0 && !globalMessage) {
     lastStatusNotificationKey = null;
     inFlightStatusNotificationKey = null;
     return;
@@ -109,8 +109,8 @@ export async function checkStatus(): Promise<void> {
         message: alert.message,
       }))
       .sort((left, right) => left.id.localeCompare(right.id)),
-    message: globalMessage.message,
-    visibleUntil: globalMessage.visibleUntil ?? null,
+    message: globalMessage?.message ?? null,
+    visibleUntil: globalMessage?.visibleUntil ?? null,
   });
   if (notificationKey === lastStatusNotificationKey || notificationKey === inFlightStatusNotificationKey) {
     return;
@@ -128,7 +128,7 @@ export async function checkStatus(): Promise<void> {
     }
     await invoke('notify_provider_and_global_message', {
       providerSummary,
-      globalMessage: globalMessage.message,
+      globalMessage: globalMessage?.message ?? '',
     });
     lastStatusNotificationKey = notificationKey;
   } catch (error) {

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -122,7 +122,10 @@ export async function checkStatus(): Promise<void> {
     .map((alert) => `${alert.providerName}: ${alert.message || alert.status}`)
     .join('\n');
   try {
-    if (!(await ensureNotificationPermission())) return;
+    if (!(await ensureNotificationPermission())) {
+      lastStatusNotificationKey = notificationKey;
+      return;
+    }
     if (!serviceChecksEnabled || serviceChecksPreferenceVersion !== notificationPreferenceVersion) {
       return;
     }

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -1,6 +1,7 @@
 import type { GlobalMessage, ProviderStatusAlert } from './stores';
 import { appStore } from './stores';
 import { invoke, listen } from './tauri';
+import { ensureNotificationPermission } from './notifications';
 
 const PROVIDER_STATUS_INTERVAL_MS = 5 * 60 * 1000;
 const API_HEALTH_INTERVAL_MS = 20 * 60 * 1000;
@@ -9,6 +10,8 @@ const SERVICE_CHECKS_SETTING = 'verenu_service_checks_enabled';
 let serviceChecksEnabled = true;
 let serviceChecksPreference: Promise<boolean> | null = null;
 let serviceChecksPreferenceVersion = 0;
+let lastStatusNotificationKey: string | null = null;
+let inFlightStatusNotificationKey: string | null = null;
 
 async function getServiceChecksEnabled(): Promise<boolean> {
   if (!serviceChecksPreference) {
@@ -45,6 +48,8 @@ export function setServiceChecksEnabled(enabled: boolean): void {
     appStore.providerStatusAlerts = [];
     appStore.globalMessage = null;
     appStore.apiHealthy = null;
+    lastStatusNotificationKey = null;
+    inFlightStatusNotificationKey = null;
     return;
   }
 
@@ -82,6 +87,56 @@ export async function checkStatus(): Promise<void> {
     }
   } else {
     console.warn('Global message check failed:', messageResult.reason);
+  }
+
+  if (alertsResult.status !== 'fulfilled' || messageResult.status !== 'fulfilled') {
+    return;
+  }
+
+  const globalMessage = appStore.globalMessage;
+  const providerAlerts = appStore.providerStatusAlerts;
+  if (providerAlerts.length === 0 || !globalMessage) {
+    lastStatusNotificationKey = null;
+    inFlightStatusNotificationKey = null;
+    return;
+  }
+
+  const notificationKey = JSON.stringify({
+    providers: providerAlerts
+      .map((alert) => ({
+        id: alert.providerId,
+        status: alert.status,
+        message: alert.message,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    message: globalMessage.message,
+    visibleUntil: globalMessage.visibleUntil ?? null,
+  });
+  if (notificationKey === lastStatusNotificationKey || notificationKey === inFlightStatusNotificationKey) {
+    return;
+  }
+
+  inFlightStatusNotificationKey = notificationKey;
+  const notificationPreferenceVersion = serviceChecksPreferenceVersion;
+  const providerSummary = providerAlerts
+    .map((alert) => `${alert.providerName}: ${alert.message || alert.status}`)
+    .join('\n');
+  try {
+    if (!(await ensureNotificationPermission())) return;
+    if (!serviceChecksEnabled || serviceChecksPreferenceVersion !== notificationPreferenceVersion) {
+      return;
+    }
+    await invoke('notify_provider_and_global_message', {
+      providerSummary,
+      globalMessage: globalMessage.message,
+    });
+    lastStatusNotificationKey = notificationKey;
+  } catch (error) {
+    console.warn('Service status notification failed:', error);
+  } finally {
+    if (inFlightStatusNotificationKey === notificationKey) {
+      inFlightStatusNotificationKey = null;
+    }
   }
 }
 

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -1,7 +1,7 @@
 import type { GlobalMessage, ProviderStatusAlert } from './stores';
 import { appStore } from './stores';
 import { invoke, listen } from './tauri';
-import { ensureNotificationPermission } from './notifications';
+import { ensureNotificationPermission, isNotificationPermissionGranted } from './notifications';
 
 const PROVIDER_STATUS_INTERVAL_MS = 5 * 60 * 1000;
 const API_HEALTH_INTERVAL_MS = 20 * 60 * 1000;
@@ -11,6 +11,7 @@ let serviceChecksEnabled = true;
 let serviceChecksPreference: Promise<boolean> | null = null;
 let serviceChecksPreferenceVersion = 0;
 let lastStatusNotificationKey: string | null = null;
+let lastStatusPermissionDeniedKey: string | null = null;
 let inFlightStatusNotificationKey: string | null = null;
 
 async function getServiceChecksEnabled(): Promise<boolean> {
@@ -49,6 +50,7 @@ export function setServiceChecksEnabled(enabled: boolean): void {
     appStore.globalMessage = null;
     appStore.apiHealthy = null;
     lastStatusNotificationKey = null;
+    lastStatusPermissionDeniedKey = null;
     inFlightStatusNotificationKey = null;
     return;
   }
@@ -97,6 +99,7 @@ export async function checkStatus(): Promise<void> {
   const providerAlerts = appStore.providerStatusAlerts;
   if (providerAlerts.length === 0 && !globalMessage) {
     lastStatusNotificationKey = null;
+    lastStatusPermissionDeniedKey = null;
     inFlightStatusNotificationKey = null;
     return;
   }
@@ -122,8 +125,17 @@ export async function checkStatus(): Promise<void> {
     .map((alert) => `${alert.providerName}: ${alert.message || alert.status}`)
     .join('\n');
   try {
+    if (notificationKey === lastStatusPermissionDeniedKey
+      && !(await isNotificationPermissionGranted())) {
+      return;
+    }
+    if (!serviceChecksEnabled || serviceChecksPreferenceVersion !== notificationPreferenceVersion) {
+      return;
+    }
     if (!(await ensureNotificationPermission())) {
-      lastStatusNotificationKey = notificationKey;
+      if (serviceChecksEnabled && serviceChecksPreferenceVersion === notificationPreferenceVersion) {
+        lastStatusPermissionDeniedKey = notificationKey;
+      }
       return;
     }
     if (!serviceChecksEnabled || serviceChecksPreferenceVersion !== notificationPreferenceVersion) {
@@ -134,6 +146,7 @@ export async function checkStatus(): Promise<void> {
       globalMessage: globalMessage?.message ?? '',
     });
     lastStatusNotificationKey = notificationKey;
+    lastStatusPermissionDeniedKey = null;
   } catch (error) {
     console.warn('Service status notification failed:', error);
   } finally {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1269,6 +1269,10 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       } as T;
     case 'check_for_update':
       return null as T;
+    case 'notify_update_available':
+    case 'notify_provider_and_global_message':
+    case 'test_notifications':
+      return undefined as T;
     case 'check_provider_status':
       return [] as T;
     case 'check_provider_status_raw':

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -1,4 +1,3 @@
-import { sendNotification } from '@tauri-apps/plugin-notification';
 import type { UpdateInfo } from './stores';
 import { appStore } from './stores';
 import { saveSetting } from './settings';
@@ -6,13 +5,6 @@ import { invoke } from './tauri';
 import { ensureNotificationPermission } from './notifications';
 
 const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
-
-async function sendUpdateNotification(update: UpdateInfo): Promise<void> {
-  await sendNotification({
-    title: 'Verenu update available',
-    body: `Version v${update.version} is ready. Open Verenu to update.`,
-  });
-}
 
 async function checkForAutomaticUpdates(): Promise<void> {
   let update: UpdateInfo | null = null;
@@ -54,7 +46,9 @@ async function checkForAutomaticUpdates(): Promise<void> {
   if (!(await ensureNotificationPermission())) return;
 
   try {
-    await sendUpdateNotification(update);
+    // Deliver through Rust so Windows attributes the toast to Verenu rather
+    // than the WebView host process, which can be PowerShell in development.
+    await invoke('notify_update_available', { version: update.version });
   } catch (error) {
     // Don't persist the notified version if delivery failed — otherwise the
     // user never sees a notification yet we'd mark it as notified and never


### PR DESCRIPTION
## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Verenu is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5-8 steps.
-->

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The relevant subsystem is system notifications, service-status polling, settings/developer UI, and the Windows update handoff.
> - Windows development notifications were attributed to PowerShell, provider and global status information did not produce a combined notification, and update handoffs launched console hosts.
> - The Developer menu needed a standardized notification selector and a reliable way to test notification destinations and control sizing.
> - This pull request gives Windows notifications a Verenu app identity, combines provider/global alerts with deduplication, routes notification clicks into the relevant app page, and replaces the cmd.exe update handoff with a hidden helper.
> - The benefit is app-owned notifications, actionable navigation, and silent update behavior that can be exercised from Developer settings.

## What Changed

<!-- One bullet per logical unit of change. -->

- Routed update, model, and service notifications through native Rust notifications with a Windows app identity, click destinations, and frontend navigation for Home and Models.
- Sent a combined notification when provider outages and a visible global message are both present, while respecting permissions, preferences, and duplicate suppression.
- Added a standardized Developer menu notification dropdown with Update available, Model ready, and Service notice options, plus a Send Notification button matched to the dropdown height.
- Reworked Windows update installation to avoid cmd.exe and PowerShell launchers, hide Node-based development launchers, select valid installer assets, and expose a developer reinstall test.

## Verification

<!--
  How can a reviewer confirm this works?
  Include test commands, manual steps, or both.
  For UI changes: before/after screenshots.
  For pipeline changes: describe the test scenario (hotkey hold -> injection).
-->

- Passed `npm run check`, `npm run lint`, `cargo check --manifest-path src-tauri/Cargo.toml`, `cargo test --manifest-path src-tauri/Cargo.toml` (459 passed, 1 ignored), and `npm run build`.
- Focused Playwright check passed for all three dropdown options and equal 32px dropdown/send-button heights; native Windows testing covered notification type selection, outside-click/Escape behavior, status simulations, and no visible Command Prompt or PowerShell windows.
- The existing smoke scripts were attempted but timed out during their 8-second `networkidle` navigation wait against the active Vite HMR server, before reaching assertions.

## Risks

<!--
  What could go wrong? Call out: migration safety, breaking changes,
  clipboard/injection behavior shifts, API key exposure, hotkey timing,
  smoke test contract changes. Or "Low risk" if genuinely minor.
-->

- Medium risk: native Windows notification identity depends on a Start Menu shortcut and Windows toast APIs, while the update helper uses a copied executable and waits for the parent process. MSI assets now open for user confirmation instead of receiving the NSIS silent-install argument. Notification permission or API failures remain non-fatal.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

<!--
  Required. Which AI model assisted with this change?
  Include provider, model ID/version, and any special modes
  (e.g., extended thinking, tool use, long context).
  Write "None - human-authored" if no model was used.
-->

- OpenAI GPT-5, Codex desktop, tool use, and long context.

## Checklist

- [ ] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above
