### PR TITLE
fix(injection): reduce post-paste verification false positives in Chromium

### DIFF
--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -100,6 +100,68 @@ enum CursorContextState {
     },
 }
 
+// Post-paste verification text helpers. Pure functions (no UIA/OS access) so
+// they're unit-testable on every platform; the Windows injection path drives
+// the actual reads and owns the retry timing. They exist because Chromium/
+// ProseMirror-style editors (ChatGPT, Claude, Slack, ...) commit a paste to
+// their own state before the accessibility tree catches up — a caret-local
+// read taken too early still sees the pre-paste text, which used to flag a
+// *successful* paste as failed (the false positives reported in Chrome).
+
+// Capped suffix for the cheap tail check — enough to catch "nothing landed" or
+// "wrong window" without being thrown off by trailing whitespace/newline
+// normalization differences between what we sent and what UIA reports back.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_SUFFIX_CHARS: usize = 20;
+
+// A `contains` cross-check on the control's full text only counts when the
+// fragment is long enough to be distinctive; short dictations rely on the
+// precise ends-with check instead.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_CONTAINS_MIN_CHARS: usize = 12;
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn injected_suffix(injected: &str) -> String {
+    let mut chars: Vec<char> = injected
+        .trim_end()
+        .chars()
+        .rev()
+        .take(PASTE_VERIFY_SUFFIX_CHARS)
+        .collect();
+    chars.reverse();
+    chars.into_iter().collect()
+}
+
+// Cheap, lenient tail check for post-paste verification: true if the
+// control's freshly-read caret-local tail ends with (roughly) the end of what
+// we just injected.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn paste_tail_matches(injected: &str, probe_tail: &str) -> bool {
+    if injected.trim_end().is_empty() {
+        return true;
+    }
+    probe_tail.trim_end().ends_with(&injected_suffix(injected))
+}
+
+// Full-text cross-check for the caret-range-lag case: the caret-range read
+// can stay stale/anchored (or scoped to a stale block) even after the
+// accessibility tree reflects the paste in the document/value text. Verifies
+// the injected text actually reached the field by looking at the whole thing.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn full_text_confirms_paste(injected: &str, full_text: &str) -> bool {
+    let injected_trim = injected.trim_end();
+    if injected_trim.is_empty() {
+        return true;
+    }
+    let suffix = injected_suffix(injected);
+    if full_text.trim_end().ends_with(&suffix) {
+        return true;
+    }
+    // A paste into the middle of existing text leaves our tail mid-field, not
+    // at the very end — only trust that when the fragment is distinctive.
+    suffix.chars().count() >= PASTE_VERIFY_CONTAINS_MIN_CHARS && full_text.contains(&suffix)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +333,46 @@ mod tests {
         backspace_injection_history(22);
         let state = last_injection().lock().expect("lock");
         assert!(matches!(&*state, CursorContextState::Unknown { .. }));
+    }
+
+    #[test]
+    fn paste_tail_matches_matches_our_suffix() {
+        assert!(paste_tail_matches("hello world", "some prefix hello world"));
+        assert!(paste_tail_matches("hello world", "hello world"));
+        // trailing whitespace / newline normalization is tolerated
+        assert!(paste_tail_matches("hello world ", "prefix hello world\n"));
+        // long injected text only needs its final fragment to match
+        let long = "the quick brown fox jumps over the lazy dog near the river";
+        assert!(paste_tail_matches(
+            long,
+            "stale pre-paste text the quick brown fox jumps over the lazy dog near the river"
+        ));
+        // empty injected text trivially passes
+        assert!(paste_tail_matches("", "anything at all"));
+        // a genuinely different tail fails
+        assert!(!paste_tail_matches("hello world", "some other text"));
+    }
+
+    #[test]
+    fn full_text_confirms_paste_checks_whole_document() {
+        // appended at the end of the field
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "existing prompt dictated text here"
+        ));
+        // pasted mid-document: our suffix sits mid-field, not at the end
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "start dictated text here rest of document"
+        ));
+        // short dictation still verified by the precise ends-with check
+        assert!(full_text_confirms_paste("short", "abc short"));
+        // ...but a short fragment is never trusted as a mid-field contains
+        assert!(!full_text_confirms_paste("short", "abc shortx"));
+        // empty injected text trivially passes
+        assert!(full_text_confirms_paste("", "anything at all"));
+        // unrelated text fails
+        assert!(!full_text_confirms_paste("didn't paste", "totally unrelated text"));
     }
 }
 #[derive(Clone, Copy, Debug)]

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -544,10 +544,15 @@ pub(super) async fn inject_text(
             } else {
                 let tail_frozen = !pre_injection_tail.is_empty()
                     && post_probe.context_tail == pre_injection_tail;
-                saw_frozen |= tail_frozen;
+                // An empty pre-injection baseline (an empty field, or a control
+                // UIA couldn't read) leaves no known caret state to compare
+                // against, so a non-matching read is ambiguous — not proof the
+                // paste went wrong.
+                let read_is_ambiguous = tail_frozen || pre_injection_tail.is_empty();
+                saw_frozen |= read_is_ambiguous;
                 if paste_tail_matches(&adjusted, &post_probe.context_tail) {
                     verified = true;
-                } else if !tail_frozen {
+                } else if !read_is_ambiguous {
                     saw_fresh_mismatch = true;
                 }
             }

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -542,13 +542,14 @@ pub(super) async fn inject_text(
                 // retrying either way.
                 verified = true;
             } else {
-                let tail_frozen = !pre_injection_tail.is_empty()
-                    && post_probe.context_tail == pre_injection_tail;
-                // An empty pre-injection baseline (an empty field, or a control
-                // UIA couldn't read) leaves no known caret state to compare
-                // against, so a non-matching read is ambiguous — not proof the
-                // paste went wrong.
-                let read_is_ambiguous = tail_frozen || pre_injection_tail.is_empty();
+                // A read byte-identical to the pre-injection tail carries no
+                // new information — either the accessibility tree hasn't
+                // caught up with the paste yet, or the field truly didn't
+                // change. That is ambiguous, not proof the paste failed. A
+                // read that CHANGED and still doesn't contain our text is a
+                // real signal the paste went wrong, even in a field that was
+                // empty before.
+                let read_is_ambiguous = post_probe.context_tail == pre_injection_tail;
                 saw_frozen |= read_is_ambiguous;
                 if paste_tail_matches(&adjusted, &post_probe.context_tail) {
                     verified = true;

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -363,6 +363,21 @@ async fn windows_clipboard_sniff_context(target_hwnd: usize) -> Option<Injection
     }
 }
 
+// Post-paste verification loop timing (the matching logic itself lives in
+// `super::paste_tail_matches` / `super::full_text_confirms_paste`). Heavier
+// editors (ProseMirror-style rich text, React-rendered chat inputs) commit a
+// paste to their own state before the accessibility tree catches up — a UIA
+// read taken immediately after PASTE_SETTLE_MS can still see the pre-paste
+// text and read as a false mismatch. Chromium's a11y lag is variable and can
+// exceed a second while the editor is still settling, so retry with growing
+// gaps, then cross-check the control's full text, before ever reporting
+// failure (see the verify loop below).
+const PASTE_VERIFY_ATTEMPTS: u32 = 6;
+const PASTE_VERIFY_RETRY_MS: u64 = 100;
+const PASTE_VERIFY_RETRY_GROWTH_MS: u64 = 40;
+const PASTE_VERIFY_MAX_RETRY_MS: u64 = 260;
+const PASTE_VERIFY_FULLTEXT_ATTEMPTS: u32 = 2;
+
 #[allow(unused_variables)]
 pub(super) async fn inject_text(
     text: &str,
@@ -488,6 +503,111 @@ pub(super) async fn inject_text(
     tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_SETTLE_MS)).await;
 
     restore_guard.restore_now();
+
+    // Best-effort post-paste verification: reuse the same UIA read already
+    // used pre-injection for caret reads, not new plumbing. Only act on a
+    // real CaretLocal readback — any other source (unavailable, permission
+    // missing, unsupported control, etc.) means UIA can't reliably tell
+    // either way (many working Chromium/Electron widgets fall in this
+    // bucket), so it's left lenient here.
+    //
+    // Chromium/ProseMirror-style editors commit a paste to their own state
+    // before the accessibility tree catches up, and that lag is variable —
+    // often well over the retry window — so a read taken too early reads the
+    // pre-paste text and flags a *successful* paste as failed (the false
+    // positives reported in Chrome). The loop retries with growing gaps and,
+    // before giving up, cross-checks the control's full text (the
+    // ValuePattern/document read reflects the DOM even when the caret-range
+    // read stays stale). A hard failure is only declared when the tree
+    // *freshly* read the caret as not containing our text. A read that stays
+    // frozen on the pre-injection tail means UIA never observed the change at
+    // all — an unverifiable paste, not a failed one — which we log and treat
+    // as best-effort success, since a false "paste failed" report is worse
+    // than an unverified-but-likely-fine paste.
+    if !adjusted.trim_end().is_empty() {
+        let pre_injection_tail = injection_probe.context_tail.as_str();
+        let mut verified = false;
+        // A caret-local read that differs from the pre-injection tail but
+        // still doesn't match our text is real evidence the paste didn't land
+        // where expected. Frozen reads (identical to before the paste) are no
+        // signal either way.
+        let mut saw_fresh_mismatch = false;
+        let mut saw_frozen = false;
+
+        for attempt in 0..PASTE_VERIFY_ATTEMPTS {
+            let post_probe = crate::core::context_probe::read_injection_context_probe().await;
+
+            if post_probe.source != ContextProbeSource::CaretLocal {
+                // This source can't tell us anything reliable — no point
+                // retrying either way.
+                verified = true;
+            } else {
+                let tail_frozen = !pre_injection_tail.is_empty()
+                    && post_probe.context_tail == pre_injection_tail;
+                saw_frozen |= tail_frozen;
+                if paste_tail_matches(&adjusted, &post_probe.context_tail) {
+                    verified = true;
+                } else if !tail_frozen {
+                    saw_fresh_mismatch = true;
+                }
+            }
+
+            log::debug!(
+                "inject: post-paste verify attempt={} probe_source={} probe_tail_len={} injected_len={} verified={}",
+                attempt + 1,
+                post_probe.source.as_str(),
+                post_probe.context_tail.chars().count(),
+                adjusted.chars().count(),
+                verified
+            );
+
+            if verified {
+                break;
+            }
+            if attempt + 1 < PASTE_VERIFY_ATTEMPTS {
+                let grow =
+                    PASTE_VERIFY_RETRY_MS + (attempt as u64) * PASTE_VERIFY_RETRY_GROWTH_MS;
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    grow.min(PASTE_VERIFY_MAX_RETRY_MS),
+                ))
+                .await;
+            }
+        }
+
+        // Cross-check the full field text before concluding anything — the
+        // caret-range read can stay stale/anchored even after the document
+        // text reflects the paste (Chromium re-anchors lazily).
+        if !verified {
+            for _ in 0..PASTE_VERIFY_FULLTEXT_ATTEMPTS {
+                if let Some(full_text) = crate::api::auto_learn::read_focused_text() {
+                    if full_text_confirms_paste(&adjusted, &full_text) {
+                        verified = true;
+                        log::debug!("inject: post-paste verified via full-text match");
+                        break;
+                    }
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_VERIFY_RETRY_MS))
+                    .await;
+            }
+        }
+
+        if !verified {
+            if saw_fresh_mismatch {
+                // The tree updated and the text before the caret genuinely
+                // doesn't contain our paste — a real failure.
+                log::warn!("inject: aborting — post-paste verification tail mismatch");
+                return Err(anyhow::anyhow!(
+                    "Paste could not be verified — target text does not match"
+                ));
+            }
+            // Frozen reads only: UIA never caught up with the paste. Treat
+            // this as unverifiable rather than failed.
+            log::warn!(
+                "inject: paste unverified after {} attempts (saw_frozen={saw_frozen}) — treating as best-effort success",
+                PASTE_VERIFY_ATTEMPTS,
+            );
+        }
+    }
 
     if target_hwnd != 0 && !adjusted.is_empty() {
         if let Ok(mut guard) = last_injection().lock() {


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection.
> - This change is in the **injection** subsystem (`core/injection`), specifically the best-effort post-paste verification that runs right after Ctrl+V.
> - The post-paste verification re-reads the target text field via UI Automation to confirm the paste landed. In Chromium/ProseMirror-style editors (ChatGPT, Claude, Slack), the accessibility tree commits a paste to its own state *before* it catches up to the DOM, and that lag is variable — often well over a second.
> - The old code retried for a short fixed window and then hard-errored with "Paste could not be verified" even though the paste had landed — the false positives reported in Chrome ("it says it didn't paste but it actually did paste").
> - It needs to be addressed because a false failure sticks the "paste failed" pill up, makes the user re-dictate, and can even duplicate the text that already landed.
> - This pull request makes verification wait longer (growing gaps), cross-checks the control's full document/value text as a fallback, and only hard-fails when the accessibility tree *freshly* read the caret as genuinely not containing the injected text. A read that stays frozen on the pre-injection tail is treated as "unverifiable, not failed."
> - The benefit is a near-elimination of false "paste failed" reports in Chrome while still catching genuine failures (paste went to the wrong window / nothing landed).

## What Changed

- `src-tauri/src/core/injection/windows.rs`: post-paste verification now retries 6 times with growing gaps (100ms -> 260ms) instead of 4 fixed 100ms waits, giving Chromium's a11y tree time to catch up.
- `src-tauri/src/core/injection/windows.rs`: added a full-text fallback — when the caret-local read can't confirm the paste, read the control's whole ValuePattern/document text and verify the injected text reached the field (handles stale caret-range anchoring).
- `src-tauri/src/core/injection/windows.rs`: failure decision changed — hard error only when a *fresh* caret-local read genuinely doesn't contain the injected text; frozen reads (identical to the pre-injection tail) are logged and treated as best-effort success.
- `src-tauri/src/core/injection/mod.rs`: extracted the pure text-matching helpers (`injected_suffix`, `paste_tail_matches`, `full_text_confirms_paste`) plus the suffix/min-chars constants so they're unit-testable cross-platform.
- `src-tauri/src/core/injection/mod.rs`: added unit tests covering the tail match and full-text confirmation helpers.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` — 461 passed (459 base + 2 new), 0 failed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --bin verenu` — clean.
- Manual scenario: hold hotkey and dictate into the ChatGPT (ProseMirror) prompt textarea. Previously the failing logs showed `post-paste verify attempt=1..4 verified=false` then a hard "Paste could not be verified" error even though the text landed. After this change the same flow either verifies within the longer window / full-text cross-check, or logs the lenient "treating as best-effort success" path instead of erroring.

## Risks

- Low. The tradeoff is that a paste which *genuinely* fails while UIA never observes the change is now reported as best-effort success rather than a hard error. This is acceptable because: (a) the pre-existing guards already confirm a focused, writable text control before the paste, (b) the transcription is saved to History regardless of injection outcome, and (c) the previous behavior caused frequent false positives in Chromium apps.
- Behavior is Windows-only; the macOS injection path has no post-paste verification and is untouched.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- opencode (`opencode-go/deepseek-v4-flash`, deepseek-v4-flash) — code analysis, implementation, and PR authoring.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript) — no frontend changes
- [x] `npm run lint` passes (ESLint + Clippy) — Clippy clean for the changed crate
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots — no UI changes
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) — no version bump
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above
