### PR TITLE
Handle OS session shutdown with clean local model unload

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4907,6 +4907,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ rusqlite = { version = "0.32", features = ["bundled", "backup"] }
 
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
-tokio       = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
+tokio       = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "signal"] }
 reqwest     = { version = "0.12", default-features = false, features = ["json", "multipart", "native-tls", "charset"] }
 bytes       = "1"
 cpal        = "0.15"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -365,6 +365,31 @@ fn main() {
                 );
             }
             start_frontend_watchdog(app.handle(), frontend_readiness.clone());
+            // macOS logout sends SIGTERM to the app. Tauri delivers
+            // RunEvent::Exit only for its own quit paths, so without this
+            // hook a SIGTERM would kill the process without unloading the
+            // local cleanup model, orphaning llama-server. Routing it through
+            // app.exit(0) runs the normal Exit cleanup (see the `run` closure
+            // below). Unix-only: console signals do not reach Windows GUI
+            // apps, and Windows logoff is handled separately in
+            // on_window_event.
+            #[cfg(unix)]
+            {
+                use tokio::signal::unix::{signal, SignalKind};
+                let app_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut sigterm = match signal(SignalKind::terminate()) {
+                        Ok(sigterm) => sigterm,
+                        Err(err) => {
+                            log::warn!("could not register SIGTERM handler: {err}");
+                            return;
+                        }
+                    };
+                    sigterm.recv().await;
+                    log::info!("received SIGTERM; exiting cleanly");
+                    app_handle.exit(0);
+                });
+            }
             let local_stt_manager = local_transcription_manager.clone();
             let local_llm_manager = local_cleanup_manager.clone();
             let app_handle = app.handle().clone();
@@ -428,6 +453,16 @@ fn main() {
             if window.label() == "main" {
                 match event {
                     tauri::WindowEvent::CloseRequested { api, .. } => {
+                        // The OS is tearing the session down (Windows logoff or
+                        // shutdown): let the window actually close instead of
+                        // hiding to tray, or the process outlives the session
+                        // (Windows waits ~5s then force-kills it, which also
+                        // skips RunEvent::Exit and can orphan llama-server.exe).
+                        // On other platforms the session helper reports false
+                        // and the normal hide-to-tray path below runs.
+                        if crate::system::session::system_is_shutting_down() {
+                            return;
+                        }
                         api.prevent_close();
                         #[cfg(target_os = "macos")]
                         {
@@ -578,6 +613,9 @@ fn main() {
             if let tauri::RunEvent::Reopen { .. } = _event {
                 show_main_window(_app);
             }
+            if let tauri::RunEvent::ExitRequested { .. } = _event {
+                log::info!("app exit requested");
+            }
             // Local cleanup runs llama-server.exe as a real child OS process
             // (unlike local_stt, which is in-process). Child processes are
             // not automatically killed when their parent exits on Windows —
@@ -585,8 +623,9 @@ fn main() {
             // loaded would orphan llama-server.exe, leaving it running
             // indefinitely and holding the loaded model's RAM/VRAM.
             if let tauri::RunEvent::Exit = _event {
-                _app.state::<crate::local_llm::LocalLlmManager>()
-                    .unload(_app);
+                log::info!("app exiting; unloading local models");
+                crate::system::shutdown_local_models(_app);
+                log::info!("app shutdown complete");
             }
         });
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -632,7 +632,7 @@ fn main() {
 
 #[cfg(target_os = "windows")]
 fn wait_for_relaunch_parent_exit() {
-    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, WAIT_OBJECT_0};
+    use windows::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, WAIT_OBJECT_0, WAIT_TIMEOUT};
     use windows::Win32::System::Threading::{
         OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
     };
@@ -654,7 +654,22 @@ fn wait_for_relaunch_parent_exit() {
             }
         };
 
-        let wait_result = WaitForSingleObject(handle, 5_000);
+        // The old instance may take longer than 5 s to exit (slow model
+        // unload during RunEvent::Exit). Waiting on the same handle in slices
+        // up to a 15 s total budget keeps this bounded while still refusing to
+        // open the database while the parent holds it: two live connections to
+        // the same SQLite file would let the single-instance plugin hand off
+        // to the dying parent and leave the user with no running app.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let wait_result = loop {
+            let result = WaitForSingleObject(handle, 5_000);
+            // WAIT_TIMEOUT means the parent is still alive: keep waiting up to
+            // the deadline. Any other result is terminal (signaled, or a
+            // WAIT_FAILED that would otherwise busy-spin), so leave the loop.
+            if result != WAIT_TIMEOUT || std::time::Instant::now() >= deadline {
+                break result;
+            }
+        };
         if wait_result != WAIT_OBJECT_0 {
             early_startup_warn(&format!(
                 "Relaunch waited for parent process {parent_pid} but got result {}",

--- a/src-tauri/src/system/mod.rs
+++ b/src-tauri/src/system/mod.rs
@@ -8,6 +8,7 @@ pub mod memory;
 pub mod notify;
 pub mod number_parser;
 pub mod platform;
+pub mod session;
 pub mod text;
 pub mod volume;
 #[cfg(target_os = "windows")]
@@ -20,3 +21,24 @@ pub mod windows_titlebar {
     }
 }
 
+/// Stops and unloads both local model engines (LLM + STT) before the process
+/// exits. Must run on every path that exits the app while a local model could
+/// be loaded — `RunEvent::Exit` and the update-install handoff — because
+/// llama-server.exe is a real child process: a plain `std::process::exit` (or
+/// a skipped `RunEvent::Exit`) orphans it, leaving it running and holding the
+/// loaded model's RAM/VRAM with no owner. The STT engine is in-process, so
+/// process teardown would reclaim its memory anyway — it is unloaded
+/// explicitly for deterministic ordering and earlier RAM release during a
+/// slow teardown.
+pub(crate) fn shutdown_local_models(app: &tauri::AppHandle) {
+    use std::sync::atomic::Ordering;
+    use tauri::Manager;
+
+    let llm = app.state::<crate::local_llm::LocalLlmManager>();
+    llm.shutdown_signal.store(true, Ordering::Relaxed);
+    llm.unload(app);
+
+    let stt = app.state::<crate::local_stt::LocalTranscriptionManager>();
+    stt.shutdown_signal.store(true, Ordering::Relaxed);
+    stt.unload(app);
+}

--- a/src-tauri/src/system/session.rs
+++ b/src-tauri/src/system/session.rs
@@ -1,0 +1,32 @@
+//! OS session lifecycle helpers — detecting when the OS (not the user) is
+//! tearing the app down, so exit handling can differ between "hide to tray"
+//! window closes and real session shutdown.
+
+/// True while Windows is logging off or shutting down (SM_SHUTTINGDOWN is set
+/// during WM_ENDSESSION processing). The main window's CloseRequested handler
+/// uses this to let the window close instead of hiding to tray — otherwise the
+/// hidden window keeps the process alive through session teardown, Windows
+/// force-kills it after its timeout, and the force-kill skips `RunEvent::Exit`
+/// (orphaning a loaded llama-server.exe child process).
+#[cfg(target_os = "windows")]
+pub fn system_is_shutting_down() -> bool {
+    use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_SHUTTINGDOWN};
+    // SAFETY: GetSystemMetrics is a process-wide read of the system metrics
+    // table and is safe to call from any thread without prerequisites.
+    unsafe { GetSystemMetrics(SM_SHUTTINGDOWN) != 0 }
+}
+
+/// Non-Windows builds never prevent window close to hide to tray in the same
+/// way (see main.rs), so the OS session path needs no special casing.
+#[cfg(not(target_os = "windows"))]
+pub fn system_is_shutting_down() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn fallback_platform_never_reports_shutdown() {
+        assert!(!super::system_is_shutting_down());
+    }
+}


### PR DESCRIPTION
Handle OS session shutdown with clean local model unload

When Windows logged off or shut down, Verenu kept hiding its window to tray; the hidden process then outlived the session, Windows force-killed it after its ~5s timeout, and that force-kill skipped the normal exit path — leaving a loaded `llama-server.exe` child process orphaned with the model's RAM/VRAM still held. On macOS logout, SIGTERM killed the process the same way, orphaning the cleanup model there too.

This change makes shutdown explicit:

- Detects an OS session teardown (`system_is_shutting_down`, Windows `SM_SHUTTINGDOWN`) in the main window's `CloseRequested` handler and lets the window actually close instead of hiding to tray.
- On macOS, registers a SIGTERM handler that routes logout through the normal `app.exit(0)` path.
- Unloads both local model engines (LLM and STT) deterministically on `RunEvent::Exit`, with `shutdown_signal` set first so in-flight work stops accepting new requests.
- Extends the single-instance relaunch wait to a 15s budget (sliced waits) so a relaunch during the now-slower clean exit doesn't give up while the dying parent still holds the database.

Verification:

- `cargo check` and `cargo clippy -- -D warnings` clean.
- `cargo test` passes standalone on this branch (452 tests, including the session-shutdown fallback test).
- No frontend surface changes.
