### PR TITLE
Prevent hands-free double-clicks from losing dictation

### DIFF
--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -299,3 +299,41 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handsfree_stop_guard_consumes_the_followup_click_but_not_escape() {
+        let now = Instant::now();
+        let mut guard = HandsfreeStopGuard::default();
+        guard.arm(now);
+
+        for event in [
+            HotkeyEvent::Press,
+            HotkeyEvent::Release,
+            HotkeyEvent::HandlessToggle,
+            HotkeyEvent::Cancel,
+        ] {
+            assert!(guard.suppresses(event, now + Duration::from_millis(1)));
+        }
+        assert!(!guard.suppresses(HotkeyEvent::EscapeCancel, now + Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn handsfree_stop_guard_expires_after_the_double_tap_window() {
+        let now = Instant::now();
+        let mut guard = HandsfreeStopGuard::default();
+        guard.arm(now);
+
+        assert!(!guard.suppresses(
+            HotkeyEvent::Press,
+            now + HANDSFREE_STOP_GUARD + Duration::from_millis(1),
+        ));
+        assert!(!guard.suppresses(
+            HotkeyEvent::Press,
+            now + HANDSFREE_STOP_GUARD + Duration::from_millis(2),
+        ));
+    }
+}

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -1,4 +1,5 @@
 use std::sync::MutexGuard;
+use std::time::{Duration, Instant};
 
 use crate::core::window_geometry::WindowTarget;
 use crate::pipeline::{self, hide_pill, start_recording_session, AppState, SharedState};
@@ -14,18 +15,53 @@ fn lock_app_state(state: &SharedState) -> Option<MutexGuard<'_, AppState>> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum HotkeyEvent {
+    Press,
+    Release,
+    HandlessToggle,
+    Cancel,
+    EscapeCancel,
+}
+
+/// A hands-free stop is itself a quick tap, so the next click can still be
+/// part of the same physical double-click. Without this fence, resetting the
+/// hook's tap state makes that second click look like a fresh Press, which can
+/// interrupt the transcription that the first click just started.
+const HANDSFREE_STOP_GUARD: Duration = Duration::from_millis(350);
+
+#[derive(Default)]
+struct HandsfreeStopGuard {
+    until: Option<Instant>,
+}
+
+impl HandsfreeStopGuard {
+    fn arm(&mut self, now: Instant) {
+        self.until = Some(now + HANDSFREE_STOP_GUARD);
+    }
+
+    fn suppresses(&mut self, event: HotkeyEvent, now: Instant) -> bool {
+        let Some(until) = self.until else {
+            return false;
+        };
+        if now >= until {
+            self.until = None;
+            return false;
+        }
+        matches!(
+            event,
+            HotkeyEvent::Press
+                | HotkeyEvent::Release
+                | HotkeyEvent::HandlessToggle
+                | HotkeyEvent::Cancel
+        )
+    }
+}
+
 pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
     // The WH_KEYBOARD_LL hook callback must return within Windows' hook timeout
     // (~300ms) or the hook is silently removed. All real work happens in a Tokio
     // task below; callbacks only send a lightweight channel message.
-    enum HotkeyEvent {
-        Press,
-        Release,
-        HandlessToggle,
-        Cancel,
-        EscapeCancel,
-    }
-
     let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::unbounded_channel::<HotkeyEvent>();
     let tx_press = hotkey_tx.clone();
     let tx_handless = hotkey_tx.clone();
@@ -72,7 +108,12 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
     let state_hk = shared;
 
     tauri::async_runtime::spawn(async move {
+        let mut handsfree_stop_guard = HandsfreeStopGuard::default();
         while let Some(event) = hotkey_rx.recv().await {
+            if handsfree_stop_guard.suppresses(event, Instant::now()) {
+                log::debug!("hotkey: ignored follow-up input after hands-free stop");
+                continue;
+            }
             match event {
                 HotkeyEvent::Press => {
                     pipeline::clear_handless_hold_marker(&state_hk);
@@ -198,6 +239,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // Quick tap while in handsfree = stop. Clear chord state
                         // immediately so the still-open double-tap window can't
                         // re-trigger a fresh handsfree session.
+                        handsfree_stop_guard.arm(Instant::now());
                         crate::core::hotkey::set_handless_active(false);
                         crate::core::hotkey::reset_chord_state();
                         tauri::async_runtime::spawn(pipeline::run_pipeline(


### PR DESCRIPTION
## Problem

In hands-free mode, the quick tap that finishes a transcription resets the hotkey tap state while the pipeline continues asynchronously. An accidental second click from a mouse-mapped double-click can then be interpreted as a new recording press, interrupting the just-finished transcription without output or an error.

## Change

Add a short hands-free completion guard that consumes follow-up press/release/toggle/cancel events during the existing double-click window. Escape cancellation remains available, and the guard expires automatically so normal input resumes.

## Verification

- cargo test --manifest-path src-tauri/Cargo.toml handsfree_stop_guard — 2 passed
- git diff --check — clean
- Focused rustfmt check was run; the base branch has two pre-existing formatting differences in this file.