### PR TITLE
Add history search/filter, row metadata, and dictation-pill feedback

### DIFF
--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -297,7 +297,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                     let app_for_copy = app_hk.clone();
                     tauri::async_runtime::spawn(async move {
                         let recent = tokio::task::spawn_blocking(move || {
-                            crate::data::db::query_recent_page(&db_handle, 1, 0)
+                            crate::data::db::query_recent_page(&db_handle, 1, 0, None, None)
                         })
                         .await
                         .ok()

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -10,12 +10,27 @@ pub async fn get_recent(
     app: AppHandle,
     limit: Option<usize>,
     offset: Option<usize>,
+    search: Option<String>,
+    app_name: Option<String>,
 ) -> Result<Vec<db::RecentEntry>, String> {
     let db = db_state(&app);
     let limit = limit.unwrap_or(100);
     let offset = offset.unwrap_or(0);
+    let search = search.filter(|s| !s.trim().is_empty());
+    let app_name = app_name.filter(|s| !s.trim().is_empty());
     run_blocking("get_recent", move || {
-        db::query_recent_page(&db, limit, offset).map_err(|e| e.to_string())
+        db::query_recent_page(&db, limit, offset, search.as_deref(), app_name.as_deref())
+            .map_err(|e| e.to_string())
+    })
+    .await
+}
+
+/// Distinct apps present in transcription history, for the History app filter.
+#[tauri::command]
+pub async fn get_history_apps(app: AppHandle) -> Result<Vec<String>, String> {
+    let db = db_state(&app);
+    run_blocking("get_history_apps", move || {
+        db::query_distinct_apps(&db).map_err(|e| e.to_string())
     })
     .await
 }

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -741,7 +741,7 @@ mod tests {
     }
 
     fn insert_on_day(db: &Db, days_ago: i64, text: &str, words: i64, duration_ms: i64) -> i64 {
-        let entry = insert_transcription_returning(db, text, text, words, duration_ms, "groq/whisper-large-v3-turbo")
+        let entry = insert_transcription_returning(db, text, text, words, duration_ms, "groq/whisper-large-v3-turbo", None)
             .expect("insert transcription");
         {
             let conn = lock_conn(db).expect("lock");
@@ -919,6 +919,7 @@ mod tests {
             3,
             1000,
             "groq/whisper-large-v3-turbo",
+            None,
         )
         .expect("insert transcription");
         let created_at = utc_for_local_day(2, 23, 50);
@@ -957,7 +958,7 @@ mod tests {
     fn top_words_exclude_stopwords_and_sort_descending() {
         let db = test_db();
         let text = "the the the and and and apple banana banana cherry the";
-        insert_transcription_returning(&db, text, text, 11, 1000, "groq/whisper-large-v3-turbo")
+        insert_transcription_returning(&db, text, text, 11, 1000, "groq/whisper-large-v3-turbo", None)
             .expect("insert transcription");
 
         let insights = query_insights(&db, 7).expect("insights");
@@ -983,7 +984,7 @@ mod tests {
     fn top_words_strip_punctuation_and_drop_short_tokens() {
         let db = test_db();
         let text = "React, Vue! React? Vue. Svelte. i a um go";
-        insert_transcription_returning(&db, text, text, 10, 1000, "groq/whisper-large-v3-turbo")
+        insert_transcription_returning(&db, text, text, 10, 1000, "groq/whisper-large-v3-turbo", None)
             .expect("insert transcription");
 
         let insights = query_insights(&db, 7).expect("insights");

--- a/src-tauri/src/data/db/mod.rs
+++ b/src-tauri/src/data/db/mod.rs
@@ -186,7 +186,7 @@ mod tests {
         let db = open(path.to_str().expect("path string")).expect("open repairs stuck db");
 
         // Inserting a new transcription must succeed now that spoken_words exists.
-        insert_transcription_returning(&db, "second clip", "second clip", 2, 1000, "test")
+        insert_transcription_returning(&db, "second clip", "second clip", 2, 1000, "test", None)
             .expect("insert after repair");
 
         let conn = lock_conn(&db).expect("lock");
@@ -549,7 +549,7 @@ mod tests {
             "",
         )
         .expect("snippet");
-        insert_transcription_returning(&db, "sig.", "A long email signature", 9, 2000, "test")
+        insert_transcription_returning(&db, "sig.", "A long email signature", 9, 2000, "test", None)
             .expect("transcription");
 
         let stats = query_stats(&db).expect("stats");
@@ -569,6 +569,7 @@ mod tests {
             4,
             2000,
             "test",
+            None,
         )
         .expect("transcription");
 
@@ -581,9 +582,9 @@ mod tests {
     fn stats_avg_wpm_excludes_pure_snippet_rows_from_average() {
         let db = test_db();
         insert_snippet(&db, "sig", "A long email signature", "").expect("snippet");
-        insert_transcription_returning(&db, "hello world", "hello world", 2, 1000, "test")
+        insert_transcription_returning(&db, "hello world", "hello world", 2, 1000, "test", None)
             .expect("normal transcription");
-        insert_transcription_returning(&db, "sig.", "A long email signature", 4, 1000, "test")
+        insert_transcription_returning(&db, "sig.", "A long email signature", 4, 1000, "test", None)
             .expect("snippet transcription");
 
         let stats = query_stats(&db).expect("stats");
@@ -608,6 +609,7 @@ mod tests {
                 3,
                 1000,
                 "test",
+                None,
             )
             .expect("transcription");
         }
@@ -621,9 +623,9 @@ mod tests {
     #[test]
     fn prune_transcriptions_older_than_deletes_only_old_rows() {
         let db = test_db();
-        insert_transcription_returning(&db, "old one", "old one", 2, 1000, "test")
+        insert_transcription_returning(&db, "old one", "old one", 2, 1000, "test", None)
             .expect("old transcription");
-        insert_transcription_returning(&db, "recent one", "recent one", 2, 1000, "test")
+        insert_transcription_returning(&db, "recent one", "recent one", 2, 1000, "test", None)
             .expect("recent transcription");
         {
             let conn = lock_conn(&db).expect("lock");
@@ -651,9 +653,9 @@ mod tests {
     #[test]
     fn pruning_old_transcriptions_does_not_reduce_lifetime_word_total() {
         let db = test_db();
-        insert_transcription_returning(&db, "old one", "old one", 5, 1000, "test")
+        insert_transcription_returning(&db, "old one", "old one", 5, 1000, "test", None)
             .expect("old transcription");
-        insert_transcription_returning(&db, "recent one", "recent one", 3, 1000, "test")
+        insert_transcription_returning(&db, "recent one", "recent one", 3, 1000, "test", None)
             .expect("recent transcription");
         {
             let conn = lock_conn(&db).expect("lock");

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -15,10 +15,14 @@ CREATE TABLE IF NOT EXISTS transcriptions (
   spoken_words INTEGER,
   duration_ms INTEGER NOT NULL DEFAULT 0,
   api_used    TEXT    NOT NULL DEFAULT '',
+  app_name    TEXT,
   created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_transcriptions_created_at
   ON transcriptions(created_at);
+-- Note: idx_transcriptions_app_name is NOT declared here because SCHEMA runs
+-- before migrations, and a legacy database predating the app_name column would
+-- fail the index build. The v13 migration adds the column then the index.
 CREATE TABLE IF NOT EXISTS lifetime_stats (
   id               INTEGER PRIMARY KEY CHECK (id = 1),
   total_words      INTEGER NOT NULL DEFAULT 0,
@@ -349,6 +353,28 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
                 "ALTER TABLE lifetime_stats ADD COLUMN dictionary_fixes INTEGER NOT NULL DEFAULT 0;",
             )?;
             conn.execute_batch("PRAGMA user_version = 11;")?;
+            Ok(())
+        })?;
+    }
+    if user_version < 13 {
+        log::info!("db: migrating schema {user_version} -> 13");
+        // Per-dictation foreground app (the lowercase executable name, e.g.
+        // "outlook.exe") so History can filter/annotate by app. The value was
+        // never persisted before v13, so past rows keep NULL and simply have
+        // no app metadata. Declared in SCHEMA for fresh databases;
+        // ensure_table_column is idempotent for databases that already have it.
+        run_migration(&mut conn, |conn| {
+            ensure_table_column(
+                conn,
+                "transcriptions",
+                "app_name",
+                "ALTER TABLE transcriptions ADD COLUMN app_name TEXT;",
+            )?;
+            conn.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_transcriptions_app_name
+                   ON transcriptions(app_name);
+                 PRAGMA user_version = 13;",
+            )?;
             Ok(())
         })?;
     }

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -145,11 +145,12 @@ pub fn query_recent_page(
     // overhead in SQLite.
     let mut sql = String::from(
         "SELECT id, clean_text, words, duration_ms, app_name, created_at \
-         FROM transcriptions WHERE (?1 IS NULL OR app_name = ?1)",
+         FROM transcriptions WHERE (? IS NULL OR app_name = ?)",
     );
-    let mut values: Vec<rusqlite::types::Value> = vec![app_name
+    let app_value = app_name
         .map(|s| rusqlite::types::Value::from(s.to_string()))
-        .unwrap_or(rusqlite::types::Value::Null)];
+        .unwrap_or(rusqlite::types::Value::Null);
+    let mut values: Vec<rusqlite::types::Value> = vec![app_value.clone(), app_value];
     for term in &terms {
         sql.push_str(
             " AND (lower(clean_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -11,6 +11,8 @@ pub struct RecentEntry {
     pub id: i64,
     pub clean_text: String,
     pub words: i64,
+    pub duration_ms: i64,
+    pub app_name: Option<String>,
     pub created_at: String,
 }
 
@@ -28,21 +30,24 @@ pub fn insert_transcription_returning(
     words: i64,
     duration_ms: i64,
     api_used: &str,
+    app_name: Option<&str>,
 ) -> Result<RecentEntry> {
     let mut conn = lock_conn(db)?;
     let spoken_words = compute_spoken_words(&conn, raw)?;
     let tx = conn.transaction()?;
     let entry = tx.query_row(
-        "INSERT INTO transcriptions (raw_text, clean_text, words, spoken_words, duration_ms, api_used) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-         RETURNING id, clean_text, words, created_at",
-        params![raw, clean, words, spoken_words, duration_ms, api_used],
+        "INSERT INTO transcriptions (raw_text, clean_text, words, spoken_words, duration_ms, api_used, app_name) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         RETURNING id, clean_text, words, duration_ms, app_name, created_at",
+        params![raw, clean, words, spoken_words, duration_ms, api_used, app_name],
         |r| {
             Ok(RecentEntry {
                 id: r.get(0)?,
                 clean_text: r.get(1)?,
                 words: r.get(2)?,
-                created_at: r.get(3)?,
+                duration_ms: r.get(3)?,
+                app_name: r.get(4)?,
+                created_at: r.get(5)?,
             })
         },
     )?;
@@ -84,7 +89,7 @@ pub fn query_recent(db: &Db) -> Result<Vec<RecentEntry>> {
     // same chronological order but leverages the primary key index directly, avoiding
     // full table scans and manual sorting overhead in SQLite.
     let mut stmt = conn.prepare(
-        "SELECT id, clean_text, words, created_at \
+        "SELECT id, clean_text, words, duration_ms, app_name, created_at \
          FROM transcriptions ORDER BY id DESC",
     )?;
     let rows = stmt
@@ -93,34 +98,99 @@ pub fn query_recent(db: &Db) -> Result<Vec<RecentEntry>> {
                 id: r.get(0)?,
                 clean_text: r.get(1)?,
                 words: r.get(2)?,
-                created_at: r.get(3)?,
+                duration_ms: r.get(3)?,
+                app_name: r.get(4)?,
+                created_at: r.get(5)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
 }
 
-pub fn query_recent_page(db: &Db, limit: usize, offset: usize) -> Result<Vec<RecentEntry>> {
+/// Escapes `%`, `_`, and `\` so a user's search text is treated literally inside
+/// a `LIKE ... ESCAPE '\'` pattern instead of acting as wildcards.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
+/// Recent transcription history, newest-first. `search` (when present) matches
+/// case-insensitively against the cleaned text, the raw transcription, AND the
+/// app name — each whitespace-separated term must match at least one of those
+/// fields (multi-term AND), so typing an app name like "chrome" works straight
+/// in the search box; `app_name` (when present) narrows to a single app.
+/// Search/filtering lives in SQLite so pagination stays intact and the whole
+/// table never reaches the frontend — a `LIKE` scan over short dictation text
+/// is cheap even for large histories, and the `idx_transcriptions_app_name`
+/// index narrows app-filtered queries before the text scan runs.
+pub fn query_recent_page(
+    db: &Db,
+    limit: usize,
+    offset: usize,
+    search: Option<&str>,
+    app_name: Option<&str>,
+) -> Result<Vec<RecentEntry>> {
     let conn = lock_conn(db)?;
     let limit = limit.clamp(1, 500) as i64;
     let offset = offset.min(i64::MAX as usize) as i64;
-    // We order by id DESC instead of created_at DESC because id is the autoincrementing
-    // primary key. Since IDs are monotonically increasing, this retrieves items in the
-    // same chronological order but leverages the primary key index directly, avoiding
-    // full table scans and manual sorting overhead in SQLite.
-    let mut stmt = conn.prepare(
-        "SELECT id, clean_text, words, created_at \
-         FROM transcriptions ORDER BY id DESC LIMIT ?1 OFFSET ?2",
-    )?;
+    let search = search.map(str::trim).filter(|s| !s.is_empty());
+    let app_name = app_name.map(str::trim).filter(|s| !s.is_empty());
+    let terms: Vec<String> = search
+        .map(|s| s.split_whitespace().map(escape_like).collect())
+        .unwrap_or_default();
+
+    // We order by id DESC instead of created_at DESC because id is the
+    // autoincrementing primary key. Since IDs are monotonically increasing,
+    // this retrieves items in the same chronological order but leverages the
+    // primary key index directly, avoiding full table scans and manual sorting
+    // overhead in SQLite.
+    let mut sql = String::from(
+        "SELECT id, clean_text, words, duration_ms, app_name, created_at \
+         FROM transcriptions WHERE (?1 IS NULL OR app_name = ?1)",
+    );
+    let mut values: Vec<rusqlite::types::Value> = vec![app_name
+        .map(|s| rusqlite::types::Value::from(s.to_string()))
+        .unwrap_or(rusqlite::types::Value::Null)];
+    for term in &terms {
+        sql.push_str(
+            " AND (lower(clean_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
+             OR lower(raw_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
+             OR lower(app_name) LIKE '%' || lower(?) || '%' ESCAPE '\\')",
+        );
+        for _ in 0..3 {
+            values.push(rusqlite::types::Value::from(term.clone()));
+        }
+    }
+    sql.push_str(" ORDER BY id DESC LIMIT ? OFFSET ?");
+    values.push(rusqlite::types::Value::from(limit));
+    values.push(rusqlite::types::Value::from(offset));
+
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
-        .query_map(params![limit, offset], |r| {
+        .query_map(rusqlite::params_from_iter(values.iter()), |r| {
             Ok(RecentEntry {
                 id: r.get(0)?,
                 clean_text: r.get(1)?,
                 words: r.get(2)?,
-                created_at: r.get(3)?,
+                duration_ms: r.get(3)?,
+                app_name: r.get(4)?,
+                created_at: r.get(5)?,
             })
         })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Distinct apps that have dictation history, for the History app filter. Only
+/// non-empty names are returned; pre-v13 rows have no app and simply appear
+/// under the unfiltered view.
+pub fn query_distinct_apps(db: &Db) -> Result<Vec<String>> {
+    let conn = lock_conn(db)?;
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT app_name FROM transcriptions \
+         WHERE app_name IS NOT NULL AND app_name != '' ORDER BY app_name",
+    )?;
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
 }
@@ -176,17 +246,28 @@ pub fn count_transcriptions_older_than(db: &Db, max_age_days: i64) -> Result<i64
 }
 
 pub fn prune_transcriptions_older_than(db: &Db, max_age_days: i64) -> Result<usize> {
-    let conn = lock_conn(db)?;
-    let changed = conn.execute(
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let changed = tx.execute(
         "DELETE FROM transcriptions WHERE created_at < datetime('now', ?1)",
         params![format!("-{} days", max_age_days.max(1))],
     )?;
+    if changed > 0 {
+        // History pruning must not orphan the per-call cost rows used by
+        // Insights: rows for deleted transcriptions are unrepresentable in
+        // the UI and would otherwise accumulate forever.
+        tx.execute(
+            "DELETE FROM api_calls WHERE transcription_id NOT IN (SELECT id FROM transcriptions)",
+            [],
+        )?;
+    }
+    tx.commit()?;
     Ok(changed)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{insert_transcription_returning, query_recent_page};
+    use super::{insert_transcription_returning, query_distinct_apps, query_recent_page};
 
     #[test]
     fn query_recent_page_applies_limit_and_offset() {
@@ -199,18 +280,187 @@ mod tests {
                 i + 1,
                 1000,
                 "groq/whisper-large-v3-turbo",
+                None,
             )
             .expect("insert transcription");
         }
 
-        let first_page = query_recent_page(&db, 2, 0).expect("first page");
+        let first_page = query_recent_page(&db, 2, 0, None, None).expect("first page");
         assert_eq!(first_page.len(), 2);
         assert_eq!(first_page[0].clean_text, "clean 4");
         assert_eq!(first_page[1].clean_text, "clean 3");
 
-        let second_page = query_recent_page(&db, 2, 2).expect("second page");
+        let second_page = query_recent_page(&db, 2, 2, None, None).expect("second page");
         assert_eq!(second_page.len(), 2);
         assert_eq!(second_page[0].clean_text, "clean 2");
         assert_eq!(second_page[1].clean_text, "clean 1");
+    }
+
+    #[test]
+    fn query_recent_page_filters_by_search_case_insensitive_and_partial() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(&db, "raw apple pie", "Clean Apple Pie", 3, 1000, "t", None)
+            .expect("insert apple");
+        insert_transcription_returning(&db, "raw banana", "Clean Banana Split", 2, 1000, "t", None)
+            .expect("insert banana");
+        insert_transcription_returning(&db, "raw raisin", "Clean Raisin Bread", 2, 1000, "t", None)
+            .expect("insert raisin");
+
+        // Partial + case-insensitive on clean_text.
+        let hits = query_recent_page(&db, 50, 0, Some("apple"), None).expect("search apple");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Clean Apple Pie");
+
+        // Lowercase query matches uppercase stored text.
+        let hits = query_recent_page(&db, 50, 0, Some("banana split"), None).expect("search banana");
+        assert_eq!(hits.len(), 1);
+
+        // Case-insensitive on raw_text too.
+        let hits = query_recent_page(&db, 50, 0, Some("RAW RAISIN"), None).expect("search raw");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Clean Raisin Bread");
+
+        // No match.
+        let hits = query_recent_page(&db, 50, 0, Some("kiwi"), None).expect("search kiwi");
+        assert!(hits.is_empty());
+
+        // Missing search returns everything.
+        let hits = query_recent_page(&db, 50, 0, None, None).expect("all");
+        assert_eq!(hits.len(), 3);
+    }
+
+    #[test]
+    fn query_recent_page_filters_by_app_and_combines_with_search() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("outlook.exe"))
+            .expect("insert outlook a");
+        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"))
+            .expect("insert outlook b");
+        insert_transcription_returning(&db, "raw c", "Clean C", 1, 1000, "t", Some("code.exe"))
+            .expect("insert code c");
+
+        let outlook = query_recent_page(&db, 50, 0, None, Some("outlook.exe")).expect("outlook");
+        assert_eq!(outlook.len(), 2);
+        assert!(outlook.iter().all(|e| e.app_name.as_deref() == Some("outlook.exe")));
+
+        // App + search combine: only Outlook rows matching the search text.
+        let combined =
+            query_recent_page(&db, 50, 0, Some("clean b"), Some("outlook.exe")).expect("combined");
+        assert_eq!(combined.len(), 1);
+        assert_eq!(combined[0].clean_text, "Clean B");
+
+        // Unknown app matches nothing.
+        let none = query_recent_page(&db, 50, 0, None, Some("slack.exe")).expect("slack");
+        assert!(none.is_empty());
+
+        // Entries round-trip their app name + duration.
+        assert_eq!(outlook[0].duration_ms, 1000);
+    }
+
+    #[test]
+    fn query_recent_page_treats_like_wildcards_in_search_literally() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(&db, "raw 100%", "Clean 100% Sure", 3, 1000, "t", None)
+            .expect("insert percent");
+
+        // A literal "%" must match its own character, not act as a wildcard.
+        let hits = query_recent_page(&db, 50, 0, Some("100%"), None).expect("literal percent");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Clean 100% Sure");
+
+        let hits = query_recent_page(&db, 50, 0, Some("100"), None).expect("numeric");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn query_recent_page_matches_app_name_from_search_box() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("chrome.exe"))
+            .expect("insert chrome");
+        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"))
+            .expect("insert outlook");
+
+        // Typing an app name finds that app's dictations without the dropdown.
+        let hits = query_recent_page(&db, 50, 0, Some("chrome"), None).expect("search chrome");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Clean A");
+
+        // Case-insensitive partial matches the .exe too.
+        let hits = query_recent_page(&db, 50, 0, Some("LOOK"), None).expect("search look");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Clean B");
+    }
+
+    #[test]
+    fn query_recent_page_multi_term_search_requires_all_terms() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(
+            &db,
+            "raw apple pie",
+            "Send the quarterly report",
+            4,
+            1000,
+            "t",
+            Some("outlook.exe"),
+        )
+        .expect("insert quarterly");
+        insert_transcription_returning(
+            &db,
+            "raw banana",
+            "Send a follow-up to Dan",
+            5,
+            1000,
+            "t",
+            None,
+        )
+        .expect("insert follow-up");
+        insert_transcription_returning(
+            &db,
+            "raw raisin",
+            "Refactor the report module",
+            4,
+            1000,
+            "t",
+            Some("code.exe"),
+        )
+        .expect("insert report");
+
+        // Both terms must match (AND) across the searched fields.
+        let hits = query_recent_page(&db, 50, 0, Some("send report"), None).expect("two terms");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Send the quarterly report");
+
+        // Term order within the query doesn't matter.
+        let hits = query_recent_page(&db, 50, 0, Some("REPORT send"), None).expect("reversed");
+        assert_eq!(hits.len(), 1);
+
+        // One term in text + one in the app name: both must hold.
+        let hits = query_recent_page(&db, 50, 0, Some("report code"), None).expect("text+app");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].clean_text, "Refactor the report module");
+
+        // A term matching nothing kills the whole query.
+        let hits = query_recent_page(&db, 50, 0, Some("send zzz"), None).expect("no match");
+        assert!(hits.is_empty());
+
+        // Extra whitespace is ignored.
+        let hits = query_recent_page(&db, 50, 0, Some("  send   report "), None).expect("padded");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn query_distinct_apps_returns_non_empty_unique_names() {
+        let db = crate::data::db::open(":memory:").expect("db");
+        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("outlook.exe"))
+            .expect("insert outlook");
+        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"))
+            .expect("insert outlook again");
+        insert_transcription_returning(&db, "raw c", "Clean C", 1, 1000, "t", Some("code.exe"))
+            .expect("insert code");
+        insert_transcription_returning(&db, "raw d", "Clean D", 1, 1000, "t", None)
+            .expect("insert no app");
+
+        let apps = query_distinct_apps(&db).expect("distinct apps");
+        assert_eq!(apps, vec!["code.exe".to_string(), "outlook.exe".to_string()]);
     }
 }

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -145,17 +145,24 @@ pub fn query_recent_page(
     // overhead in SQLite.
     let mut sql = String::from(
         "SELECT id, clean_text, words, duration_ms, app_name, created_at \
-         FROM transcriptions WHERE (? IS NULL OR app_name = ?)",
+         FROM transcriptions",
     );
-    let app_value = app_name
-        .map(|s| rusqlite::types::Value::from(s.to_string()))
-        .unwrap_or(rusqlite::types::Value::Null);
-    let mut values: Vec<rusqlite::types::Value> = vec![app_value.clone(), app_value];
+    let mut values: Vec<rusqlite::types::Value> = Vec::new();
+    if let Some(app_name) = app_name {
+        sql.push_str(" WHERE app_name = ?");
+        values.push(rusqlite::types::Value::from(app_name.to_string()));
+    }
     for term in &terms {
         sql.push_str(
-            " AND (lower(clean_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
+            if values.is_empty() && app_name.is_none() {
+                " WHERE (lower(clean_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
              OR lower(raw_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
-             OR lower(app_name) LIKE '%' || lower(?) || '%' ESCAPE '\\')",
+             OR lower(app_name) LIKE '%' || lower(?) || '%' ESCAPE '\\')"
+            } else {
+                " AND (lower(clean_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
+             OR lower(raw_text) LIKE '%' || lower(?) || '%' ESCAPE '\\' \
+             OR lower(app_name) LIKE '%' || lower(?) || '%' ESCAPE '\\')"
+            },
         );
         for _ in 0..3 {
             values.push(rusqlite::types::Value::from(term.clone()));

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -569,6 +569,7 @@ fn main() {
             commands::show_main,
             commands::hide_main,
             commands::get_recent,
+            commands::get_history_apps,
             commands::get_stats,
             commands::get_insights,
             commands::count_old_transcriptions,

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -63,6 +63,11 @@ pub(super) async fn finalize_pipeline_completion(
     let words = ctx.raw.split_whitespace().count() as i64;
     let db_for_insert = db_handle.inner().clone();
     let raw_for_insert = ctx.raw.to_string();
+    // History's per-entry app metadata is the lowercase executable name. The
+    // "unknown" fallback from window_context carries no signal (failed read /
+    // lost foreground), so it is stored as NULL and simply has no app.
+    let app_name_for_insert = (!ctx.process_name.is_empty() && ctx.process_name != "unknown")
+        .then(|| ctx.process_name.clone());
     // `final_text_substituted` already has caps-lock uppercasing AND
     // dictionary substitution applied (see above) — it's the same text that
     // gets injected below. History must save exactly that, not
@@ -82,6 +87,7 @@ pub(super) async fn finalize_pipeline_completion(
             words,
             duration_for_insert,
             &api_used_for_insert,
+            app_name_for_insert.as_deref(),
         )?;
         if dictionary_fixes_applied > 0 {
             // Lifetime counter for the Insights "fixes made by Verenu" card;

--- a/src-tauri/src/pipeline/fixture.rs
+++ b/src-tauri/src/pipeline/fixture.rs
@@ -166,6 +166,7 @@ pub async fn run_pipeline_fixture(
         words,
         request.audio.duration_ms as i64,
         &api_used,
+        None,
     )?;
     let injected = injection::inject_text(
         &injected_text,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -38,7 +38,9 @@ use gates::{
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
     silence_floor_gate_rms, strip_hallucinated_suffix, MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
-pub(crate) use pill::{hide_pill, show_copied_pill, show_pill, update_pill_state};
+pub(crate) use pill::{
+    emit_pill_profile, emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
+};
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub use session::*;
 use stages::*;
@@ -108,6 +110,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
 
     let mut transcribed: Option<String> = None;
     let mut last_err: Option<anyhow::Error> = None;
+    emit_pill_stage(&app, "transcribing");
     for (provider_id, model) in transcription_model_chain(&cfg) {
         let language = cfg.transcription_language.clone();
         let key = cfg.key_for(&provider_id).to_owned();
@@ -346,6 +349,9 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         state::leave_processing_if_owned(&state, generation);
         return;
     };
+    // The profile is now resolved — surface it so the pill can show which
+    // style applies to this dictation (same value emitted at record start).
+    emit_pill_profile(&app, &profile);
     log::debug!(
         "pipeline: config t_provider={} c_provider={} t_model={} c_model={} cleanup_enabled={} intensity={} app_context_hint={} profile={}",
         cfg.transcription_provider,
@@ -421,6 +427,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     }
 
     let stage_transcribe = std::time::Instant::now();
+    emit_pill_stage(&app, "transcribing");
     let transcribe_race = tokio::select! {
         r = run_transcription(&app, &captured_audio, &cfg) => Some(r),
         _ = wait_for_cancel(&mut cancel_rx) => None,
@@ -513,6 +520,20 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     }
 
     let stage_cleanup = std::time::Instant::now();
+    // Only advertise the cleaning stage when the cleanup LLM will actually run
+    // (cleanup enabled + intensity + a key in the chain). When cleanup is off
+    // the cleanup call resolves to local snippet/dictionary work that is
+    // effectively instant, so advertising it would just flash the label.
+    let cleanup_will_run_llm = should_run_cleanup_llm(
+        cfg.cleanup_enabled,
+        has_cleanup_key_in_chain(&cfg),
+        true,
+        &cfg.cleanup_intensity,
+        &profile,
+    );
+    if cleanup_will_run_llm {
+        emit_pill_stage(&app, "cleaning");
+    }
     let cleanup_race = tokio::select! {
         r = run_cleanup_and_snippets(&app, &raw, alternate.as_ref(), &cfg, &profile, app_context.as_deref()) => Some(r),
         _ = wait_for_cancel(&mut cancel_rx) => None,
@@ -550,6 +571,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // finalize (see core/injection's serialized critical section). Failure
     // here means an interrupt/Escape branch already took ownership of this
     // generation; abandon without inserting anything.
+    emit_pill_stage(&app, "pasting");
     if !state::enter_finalizing(&state, generation) {
         return;
     }
@@ -647,7 +669,9 @@ pub async fn retry_transcription_impl(
 
     let mapping = resolve_app_mapping(Some(&settings_store), &capture.process_name);
     capture.profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
+    emit_pill_profile(app, &capture.profile);
 
+    emit_pill_stage(app, "transcribing");
     let Some((raw_unorm, api_used, alternate)) = run_transcription(app, &capture.audio, &cfg).await
     else {
         hide_pill(app);
@@ -671,6 +695,15 @@ pub async fn retry_transcription_impl(
         hide_pill(app);
         anyhow::bail!("Recording was too quiet — nothing was transcribed");
     }
+    if should_run_cleanup_llm(
+        cfg.cleanup_enabled,
+        has_cleanup_key_in_chain(&cfg),
+        true,
+        &cfg.cleanup_intensity,
+        &capture.profile,
+    ) {
+        emit_pill_stage(app, "cleaning");
+    }
     let Some((final_text, dict_entries, cleanup_cache_key, cleanup_api_used)) =
         run_cleanup_and_snippets(
             app,
@@ -691,6 +724,7 @@ pub async fn retry_transcription_impl(
         format!("{api_used};cleanup={cleanup_api_used}")
     };
 
+    emit_pill_stage(app, "pasting");
     finalize_pipeline_completion(
         app,
         state,

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -369,6 +369,26 @@ pub(crate) fn show_copied_pill(app: &AppHandle, msg: &str) {
     show_pill_msg(app, "copied", Some(msg));
 }
 
+/// Emits the current processing sub-stage to the pill window. The pill is
+/// already showing `processing`; this only refines what it displays
+/// ("Transcribing…" / "Cleaning…" / "Pasting…"). Payload is a bare stage id
+/// string; the frontend maps it to a label, so adding a stage never requires
+/// an IPC schema change.
+pub(crate) fn emit_pill_stage(app: &AppHandle, stage: &str) {
+    if let Some(pill) = app.get_webview_window("pill") {
+        pill.emit("pill-stage", stage).ok();
+    }
+}
+
+/// Emits the resolved tone profile (e.g. "casual") to the pill window so it
+/// can show which style will apply to the current dictation. Emitted from the
+/// pipeline itself — the frontend never re-resolves it.
+pub(crate) fn emit_pill_profile(app: &AppHandle, profile: &str) {
+    if let Some(pill) = app.get_webview_window("pill") {
+        pill.emit("pill-profile", profile).ok();
+    }
+}
+
 pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {
     log::error!("pipeline error: {msg}");
     app.emit("verenu:error", msg).ok();

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -166,6 +166,12 @@ pub fn start_recording_session_ex(
             }
             if options.show_recording_pill {
                 show_pill(app, pill_state);
+                // Surface the tone profile that will apply to this dictation
+                // (resolved from the same captured target the pipeline uses)
+                // so the recording pill can show it. Best-effort — a failed
+                // read simply leaves the label hidden.
+                let target_hwnd = lock_state(state).map(|st| st.target.id).unwrap_or(0);
+                emit_profile_for_window(app, target_hwnd);
             }
             spawn_level_emitter(
                 app.clone(),

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -124,6 +124,7 @@ pub fn start_recording_session_ex(
             let raw_level_arc = session.raw_level.clone();
             let active_arc = session.active.clone();
             let start_cue_active = session.active.clone();
+            let target_hwnd;
             {
                 let mut st = match lock_state(state) {
                     Ok(st) => st,
@@ -160,6 +161,7 @@ pub fn start_recording_session_ex(
                     handless_from_hold: false,
                     prepend_audio,
                 };
+                target_hwnd = st.target.id;
             }
             if let Some(manager) = app.try_state::<crate::local_stt::LocalTranscriptionManager>() {
                 manager.set_recording_active(true);
@@ -170,7 +172,6 @@ pub fn start_recording_session_ex(
                 // (resolved from the same captured target the pipeline uses)
                 // so the recording pill can show it. Best-effort — a failed
                 // read simply leaves the label hidden.
-                let target_hwnd = lock_state(state).map(|st| st.target.id).unwrap_or(0);
                 emit_profile_for_window(app, target_hwnd);
             }
             spawn_level_emitter(

--- a/src-tauri/src/pipeline/stages.rs
+++ b/src-tauri/src/pipeline/stages.rs
@@ -263,6 +263,29 @@ pub(super) fn apply_app_style_overrides(
         .unwrap_or_else(|| cfg.default_tone.clone())
 }
 
+/// Resolves the tone profile that would apply to a foreground window without
+/// running the full pipeline, and emits it to the pill so the recording state
+/// can show which style will apply. Used at recording start, where the full
+/// `open_config_and_context` (chain validation + error pills) is too heavy and
+/// would double-resolve; the pipeline re-emits the same value at processing
+/// time so the shown profile always matches what actually runs.
+pub(super) fn emit_profile_for_window(app: &AppHandle, hwnd: usize) {
+    if hwnd == 0 {
+        return;
+    }
+    let process_name = window_context::get_process_name_for_hwnd(hwnd).unwrap_or_default();
+    if process_name.is_empty() {
+        return;
+    }
+    let Ok(settings) = store::settings_snapshot(app) else {
+        return;
+    };
+    let mapping = resolve_app_mapping(Some(&settings), &process_name);
+    let mut cfg = store::load_pipeline_config(&settings);
+    let profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
+    crate::pipeline::pill::emit_pill_profile(app, &profile);
+}
+
 /// Casual/formal cleanup sometimes omits a closing period on short utterances.
 /// That leaves a bare word before the caret, which the contextual-capitalization
 /// probe then reads as a mid-sentence continuation — so the *next* dictation has

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { getProfileLabel } from './lib/appMappings';
 
   type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied';
   let state: PillState = 'idle';
@@ -24,7 +25,112 @@
   let dying = false;
   let dyingTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Resolved tone profile for the current dictation (label form, e.g. "Casual"),
+  // emitted by the backend from the pipeline's own resolution.
+  let profileLabel: string | null = null;
+
+  // Processing sub-stage ("Transcribing…" / "Cleaning…" / "Pasting…"), driven
+  // by real `pill-stage` events from the pipeline. All three rows stay mounted
+  // in a fixed stack (see .stage-roll) and the active one is selected by index,
+  // so a stage change is a pure transform roll — the text never remounts, which
+  // is what makes the transition flicker-free. A stage only replaces the
+  // previous one once it has been visible a minimum time, so a sub-400ms stage
+  // (e.g. cleanup resolving instantly when disabled) can't flash; the newest
+  // pending stage always wins and terminal states clear everything.
+  const STAGE_MIN_MS = 400;
+  const STAGE_ROWS = ['Transcribing…', 'Cleaning…', 'Pasting…'] as const;
+  const STAGE_INDEX: Record<string, number> = {
+    transcribing: 0,
+    cleaning: 1,
+    pasting: 2,
+  };
+  const STAGE_ROW_H = 14;
+  let stageIndex = -1;
+  let pendingStageIndex: number | null = null;
+  let stageTimer: ReturnType<typeof setTimeout> | null = null;
+  let stageShownAt = 0;
+
+  function onPillStage(stageName: string) {
+    const idx = STAGE_INDEX[stageName];
+    if (idx === undefined || state === 'idle' || stageIndex === idx) return;
+    if (stageIndex === -1 || performance.now() - stageShownAt >= STAGE_MIN_MS) {
+      stageIndex = idx;
+      stageShownAt = performance.now();
+      pendingStageIndex = null;
+      return;
+    }
+    pendingStageIndex = idx;
+    if (stageTimer) return;
+    const remaining = STAGE_MIN_MS - (performance.now() - stageShownAt);
+    stageTimer = setTimeout(() => {
+      stageTimer = null;
+      if (pendingStageIndex !== null) {
+        stageIndex = pendingStageIndex;
+        pendingStageIndex = null;
+        stageShownAt = performance.now();
+      }
+    }, remaining);
+  }
+
+  function clearStage() {
+    if (stageTimer) {
+      clearTimeout(stageTimer);
+      stageTimer = null;
+    }
+    pendingStageIndex = null;
+    stageIndex = -1;
+  }
+
   const BARS = 12;
+
+  // --- Content-fit window sizing -------------------------------------------
+  // The pill window's native size follows the visible content (capsule +
+  // profile label floating above it + expanded error text) so the transparent
+  // click-capture zone around the pill never exceeds the pill itself.
+  // Measured here (CSS px == logical points on the pill's monitor) and pushed
+  // to the backend, which resizes the window center-anchored horizontally and
+  // bottom-anchored vertically, so the pill never moves while it grows.
+  // `offsetWidth/offsetHeight` are layout dimensions, so the entrance/exit
+  // scale transforms don't pollute the measurement.
+  const PILL_PAD_W = 20; // shadow bleed margin (10px per side)
+  const PILL_PAD_H = 10; // shadow bleed margin (5px top + bottom)
+  const MIN_PILL_WINDOW_W = 92; // smallest capsule (recording) + PAD_W
+  const MIN_PILL_WINDOW_H = 44; // bare capsule + PAD_H
+  let clusterEl: HTMLDivElement | null = null;
+  let lastSentWidth = 0;
+  let lastSentHeight = 0;
+  // Deferred "final size" report: growth is sent immediately (so content is
+  // never clipped mid-transition), but shrinking waits for ~100ms of quiet —
+  // a shrinking pill's ResizeObserver fires every animation frame, and chasing
+  // it with a native resize per frame is exactly the flicker this avoids.
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function reportPillSize(width: number, height: number) {
+    const w = Math.max(Math.round(width + PILL_PAD_W), MIN_PILL_WINDOW_W);
+    const h = Math.max(Math.round(height + PILL_PAD_H), MIN_PILL_WINDOW_H);
+    if (w === lastSentWidth && h === lastSentHeight) return;
+    lastSentWidth = w;
+    lastSentHeight = h;
+    import('@tauri-apps/api/core')
+      .then(({ invoke }) => invoke('set_pill_size', { width: w, height: h }))
+      .catch(() => {});
+  }
+
+  function measureAndResize() {
+    if (!clusterEl) return;
+    const w = Math.max(Math.round(clusterEl.offsetWidth + PILL_PAD_W), MIN_PILL_WINDOW_W);
+    const h = Math.max(Math.round(clusterEl.offsetHeight + PILL_PAD_H), MIN_PILL_WINDOW_H);
+    if (w > lastSentWidth || h > lastSentHeight) {
+      reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
+    }
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => {
+      settleTimer = null;
+      if (clusterEl) reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
+    }, 100);
+  }
+
+  let pillResizeObserver: ResizeObserver | null = null;
 
   // Snap CSS-px lengths to a whole number of device pixels. On fractional DPI
   // scaling (e.g. 1.25×/1.5×) a hardcoded 3px bar maps to a fractional device
@@ -174,6 +280,8 @@
       dyingTimer = null;
       prevState = state;
       state = 'idle';
+      clearStage();
+      profileLabel = null;
       smoothed = 0;
       errOpen = false;
       errWidth = 0;
@@ -247,6 +355,10 @@
         : ERROR_COLLAPSED_WIDTH;
       errWidth = errWidthNatural;
       errOpen = true;
+      // Eagerly size the native window to the target before the CSS width
+      // transition starts, so the growing error pill is never clipped while
+      // the ResizeObserver catch-up lags the transition.
+      reportPillSize(errWidthNatural, clusterEl?.offsetHeight ?? 34);
     };
 
     if (wasOpen) {
@@ -267,12 +379,37 @@
     // refreshDpr can re-arm it as the pill moves between displays).
     armDprWatch();
 
+    // Track the rendered content size so the native window stays snug around
+    // it. Fires on every width transition/animation frame of the pill, on
+    // label/stage text appearing, and on the initial idle mount (which
+    // pre-sizes the window to the minimum before the first reveal).
+    if (clusterEl && typeof ResizeObserver !== 'undefined') {
+      pillResizeObserver = new ResizeObserver(() => measureAndResize());
+      pillResizeObserver.observe(clusterEl);
+    }
+
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
 
       const l1 = await listen<string>('pill-state', (ev) => {
         const incoming = (ev.payload as PillState) || 'idle';
         if (hfTimer !== null) { clearTimeout(hfTimer); hfTimer = null; }
+
+        // A fresh recording starts a brand-new dictation: drop the previous
+        // one's profile/stage. Terminal states are no longer "in progress", so
+        // they clear too (idle is handled by goIdle).
+        if (incoming === 'recording') {
+          profileLabel = null;
+          clearStage();
+        } else if (
+          incoming === 'error' ||
+          incoming === 'cancelled' ||
+          incoming === 'paste_failed' ||
+          incoming === 'copied'
+        ) {
+          clearStage();
+          profileLabel = null;
+        }
 
         if (incoming === 'idle' && state !== 'idle') {
           stopRaf();
@@ -412,6 +549,19 @@
       if (!mounted) { l3(); return; }
       unlisteners.push(l3);
 
+      const l5 = await listen<string>('pill-profile', (ev) => {
+        const profile = ev.payload;
+        profileLabel = profile && profile !== 'unknown' ? getProfileLabel(profile) : null;
+      });
+      if (!mounted) { l5(); return; }
+      unlisteners.push(l5);
+
+      const l6 = await listen<string>('pill-stage', (ev) => {
+        onPillStage(ev.payload);
+      });
+      if (!mounted) { l6(); return; }
+      unlisteners.push(l6);
+
       // Fired when the cancelled capture is resumed or dismissed from
       // *another* window (Home's banner) — if this toast is still showing,
       // it's now stale, so drop it without re-invoking dismiss.
@@ -424,6 +574,12 @@
 
     return () => {
       mounted = false;
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+        settleTimer = null;
+      }
+      pillResizeObserver?.disconnect();
+      pillResizeObserver = null;
       mq?.removeEventListener('change', onDprChange);
       cancelAnimationFrame(rafId);
       if (errorTimer) clearTimeout(errorTimer);
@@ -500,6 +656,11 @@
 <!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
      has no bars of its own) inherits the DPI-snapped values for its width calc. -->
 <div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
+  <div class="pill-cluster" bind:this={clusterEl}>
+    {#if profileLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
+      <span class="pill-profile">{profileLabel}</span>
+    {/if}
+
   {#if state === 'recording'}
     <div class="pill recording" class:dying={dying}>
       {#each barHeights as h, i (i)}
@@ -513,7 +674,14 @@
          class:from-hf={prevState === 'handsfree'}
          class:from-loading={prevState === 'loading_local_model'}
          class:dying={dying}>
-      <div class="scan-line"></div>
+      <div class="stage-counter" aria-hidden="true">
+        <div class="stage-roll" style="transform: translateY({stageIndex * -STAGE_ROW_H}px)">
+          {#each STAGE_ROWS as label, i (label)}
+            <span class="stage-row">{label}</span>
+          {/each}
+        </div>
+      </div>
+      <div class="spinner"></div>
     </div>
 
   {:else if state === 'loading_local_model'}
@@ -605,6 +773,7 @@
       {/if}
     </div>
   {/if}
+  </div>
 </div>
 
 <style>
@@ -613,15 +782,48 @@
     margin: 0; padding: 0;
     background: transparent;
     overflow: hidden;
-    width: 100vw; height: 44px;
+    width: 100vw; height: 100vh;
     font-family: var(--sans);
   }
 
   .wrap {
-    width: 100vw; height: 44px;
+    width: 100vw; height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  /* Measured wrapper — the backend sizes the native window to this element's
+     size (see measureAndResize) so the transparent click-capture zone stays
+     as small as the visible content. Column layout: the profile label floats
+     above the capsule (centered) instead of pushing it off-center. */
+  .pill-cluster {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Resolved tone profile, shown as a small floating tag above the pill so
+     the otherwise-invisible style setting stays legible without crowding or
+     offsetting the pill capsule itself. Fades in softly so its appearance
+     reads as the pill growing, not a new element popping in. */
+  .pill-profile {
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--pill-muted);
+    background: var(--pill-bg);
+    border-radius: 999px;
+    padding: 2px 8px;
+    white-space: nowrap;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.35);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+    animation: chipIn 0.18s ease-out both;
+  }
+  @keyframes chipIn {
+    from { opacity: 0; transform: translateY(-3px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 
   .pill {
@@ -681,7 +883,7 @@
   }
 
   /* Processing */
-  .pill.processing { width: 100px; padding: 0 14px; }
+  .pill.processing { width: 140px; padding: 0 12px; gap: 7px; }
   .pill.loading-local { width: 144px; padding: 0 14px; gap: 9px; }
 
   /* Recording→processing: grow in width */
@@ -691,11 +893,7 @@
   @keyframes processIn {
     /* start from the recording pill's DPI-snapped width so there's no jump */
     from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px); }
-    to   { width: 100px; }
-  }
-  /* Scan line fades in after the pill has grown */
-  .pill.processing.from-rec .scan-line {
-    animation: scanIn 0.18s ease 0.18s both;
+    to   { width: 140px; }
   }
 
   /* Handsfree→processing: pill shrinks slightly */
@@ -706,10 +904,7 @@
     /* start from the expanded handsfree pill's DPI-snapped width (bars + 54px of
        buttons/padding/gaps) so there's no jump at fractional DPI */
     from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 54px); }
-    to   { width: 100px; }
-  }
-  .pill.processing.from-hf .scan-line {
-    animation: scanIn 0.18s ease 0.08s both;
+    to   { width: 140px; }
   }
 
   /* Processing→loading model: grow smoothly into the wider pill instead of
@@ -719,7 +914,7 @@
     animation: loadingLocalIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
   @keyframes loadingLocalIn {
-    from { width: 100px; }
+    from { width: 140px; }
     to   { width: 144px; }
   }
   /* Comma-separated, not a separate rule: the entrance fade and the
@@ -740,10 +935,7 @@
   }
   @keyframes processFromLoading {
     from { width: 144px; }
-    to   { width: 100px; }
-  }
-  .pill.processing.from-loading .scan-line {
-    animation: scanIn 0.18s ease 0.08s both;
+    to   { width: 140px; }
   }
 
   /* If the pipeline exits idle mid-transition (e.g. cancelled right as a
@@ -758,27 +950,48 @@
     animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
   }
 
-  /* Scan line: dim track with a bright light sweeping back and forth */
-  .scan-line {
-    flex: 1;
-    height: 2px;
-    border-radius: 999px;
-    background: rgba(255,255,255,0.12);
-    position: relative;
+  /* Stage counter: all three stage labels stay mounted in one vertical stack
+     and the active one is picked by a translateY roll — no remounting, no
+     opacity flashes, just a mechanical-counter roll between stages. The clip
+     window is exactly one row tall; the stack's width is the widest row, so
+     the pill's width never changes between stages. */
+  .stage-counter {
+    height: 14px;
     overflow: hidden;
+    display: flex;
   }
-  .scan-line::after {
-    content: '';
-    position: absolute;
-    top: 0; left: -40%;
-    width: 80%; height: 100%;
-    background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.9) 50%, transparent 100%);
-    border-radius: 999px;
-    animation: scan 1.1s ease-in-out infinite alternate;
+  .stage-roll {
+    display: flex;
+    flex-direction: column;
+    will-change: transform;
+    transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
   }
-  @keyframes scan {
-    from { left: -40%; }
-    to   { left: 60%; }
+  /* A soft white light sweeps across the letters while the stage is active —
+     the scan lives on the text itself (background-clip), replacing the old
+     separate moving line so nothing flickers past the label. */
+  .stage-row {
+    height: 14px;
+    line-height: 14px;
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+    color: transparent;
+    background-image: linear-gradient(
+      90deg,
+      var(--pill-muted-strong) 0%,
+      var(--pill-muted-strong) 44%,
+      rgba(255, 255, 255, 0.95) 50%,
+      var(--pill-muted-strong) 56%,
+      var(--pill-muted-strong) 100%
+    );
+    background-size: 200% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    animation: stage-scan 2.2s ease-in-out infinite alternate;
+  }
+  @keyframes stage-scan {
+    from { background-position: -110% 0; }
+    to   { background-position: 10% 0; }
   }
   @keyframes scanIn {
     from { opacity: 0; }
@@ -951,9 +1164,11 @@
   .hf-btn.confirm:hover { color: var(--accent-ink); }
 
   @keyframes hfBtnIn {
-    from { opacity: 0; transform: scale(0.7); }
-    to   { opacity: 1; transform: scale(1); }
+    /* Gentle fade + tiny rise, deliberately no scale — a pop reads as the UI
+       switching elements on and off, a settle reads as the pill growing. */
+    from { opacity: 0; transform: translateY(3px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
-  .hf-btn.cancel  { animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) both; }
-  .hf-btn.confirm { animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.02s both; }
+  .hf-btn.cancel  { animation: hfBtnIn 0.16s ease-out both; }
+  .hf-btn.confirm { animation: hfBtnIn 0.16s ease-out 0.03s both; }
 </style>

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -607,7 +607,7 @@
          class:from-loading={prevState === 'loading_local_model'}
          class:dying={dying}>
       <div class="stage-counter" aria-hidden="true">
-        <div class="stage-roll" style="transform: translateY({stageIndex * -STAGE_ROW_H}px)">
+        <div class="stage-roll" style="transform: translateY({Math.max(0, stageIndex) * -STAGE_ROW_H}px)">
           {#each STAGE_ROWS as label, i (label)}
             <span class="stage-row">{label}</span>
           {/each}

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -591,6 +591,7 @@
       if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
       if (copiedTimer) clearTimeout(copiedTimer);
       if (copiedPillTimer) clearTimeout(copiedPillTimer);
+      clearStage();
       unlisteners.forEach(u => u());
     };
   });

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -722,6 +722,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
   }
 
   /* Resolved tone profile, shown as a small floating tag beside the pill so
@@ -729,6 +730,8 @@
      offsetting the pill capsule itself. Fades in softly so its appearance
      reads as the pill growing, not a new element popping in. */
   .pill-profile {
+    position: absolute;
+    left: calc(50% + 76px);
     font-size: 10.5px;
     font-weight: 500;
     letter-spacing: 0.02em;

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -83,55 +83,6 @@
 
   const BARS = 12;
 
-  // --- Content-fit window sizing -------------------------------------------
-  // The pill window's native size follows the visible content (capsule +
-  // profile label floating above it + expanded error text) so the transparent
-  // click-capture zone around the pill never exceeds the pill itself.
-  // Measured here (CSS px == logical points on the pill's monitor) and pushed
-  // to the backend, which resizes the window center-anchored horizontally and
-  // bottom-anchored vertically, so the pill never moves while it grows.
-  // `offsetWidth/offsetHeight` are layout dimensions, so the entrance/exit
-  // scale transforms don't pollute the measurement.
-  const PILL_PAD_W = 20; // shadow bleed margin (10px per side)
-  const PILL_PAD_H = 10; // shadow bleed margin (5px top + bottom)
-  const MIN_PILL_WINDOW_W = 92; // smallest capsule (recording) + PAD_W
-  const MIN_PILL_WINDOW_H = 44; // bare capsule + PAD_H
-  let clusterEl: HTMLDivElement | null = null;
-  let lastSentWidth = 0;
-  let lastSentHeight = 0;
-  // Deferred "final size" report: growth is sent immediately (so content is
-  // never clipped mid-transition), but shrinking waits for ~100ms of quiet —
-  // a shrinking pill's ResizeObserver fires every animation frame, and chasing
-  // it with a native resize per frame is exactly the flicker this avoids.
-  let settleTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function reportPillSize(width: number, height: number) {
-    const w = Math.max(Math.round(width + PILL_PAD_W), MIN_PILL_WINDOW_W);
-    const h = Math.max(Math.round(height + PILL_PAD_H), MIN_PILL_WINDOW_H);
-    if (w === lastSentWidth && h === lastSentHeight) return;
-    lastSentWidth = w;
-    lastSentHeight = h;
-    import('@tauri-apps/api/core')
-      .then(({ invoke }) => invoke('set_pill_size', { width: w, height: h }))
-      .catch(() => {});
-  }
-
-  function measureAndResize() {
-    if (!clusterEl) return;
-    const w = Math.max(Math.round(clusterEl.offsetWidth + PILL_PAD_W), MIN_PILL_WINDOW_W);
-    const h = Math.max(Math.round(clusterEl.offsetHeight + PILL_PAD_H), MIN_PILL_WINDOW_H);
-    if (w > lastSentWidth || h > lastSentHeight) {
-      reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
-    }
-    if (settleTimer) clearTimeout(settleTimer);
-    settleTimer = setTimeout(() => {
-      settleTimer = null;
-      if (clusterEl) reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
-    }, 100);
-  }
-
-  let pillResizeObserver: ResizeObserver | null = null;
-
   // Snap CSS-px lengths to a whole number of device pixels. On fractional DPI
   // scaling (e.g. 1.25×/1.5×) a hardcoded 3px bar maps to a fractional device
   // width, and Chromium rounds each bar's edges independently — so neighboring
@@ -355,10 +306,6 @@
         : ERROR_COLLAPSED_WIDTH;
       errWidth = errWidthNatural;
       errOpen = true;
-      // Eagerly size the native window to the target before the CSS width
-      // transition starts, so the growing error pill is never clipped while
-      // the ResizeObserver catch-up lags the transition.
-      reportPillSize(errWidthNatural, clusterEl?.offsetHeight ?? 34);
     };
 
     if (wasOpen) {
@@ -378,15 +325,6 @@
     // Arm the cross-monitor DPI watcher (defined at component scope above so
     // refreshDpr can re-arm it as the pill moves between displays).
     armDprWatch();
-
-    // Track the rendered content size so the native window stays snug around
-    // it. Fires on every width transition/animation frame of the pill, on
-    // label/stage text appearing, and on the initial idle mount (which
-    // pre-sizes the window to the minimum before the first reveal).
-    if (clusterEl && typeof ResizeObserver !== 'undefined') {
-      pillResizeObserver = new ResizeObserver(() => measureAndResize());
-      pillResizeObserver.observe(clusterEl);
-    }
 
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
@@ -574,12 +512,6 @@
 
     return () => {
       mounted = false;
-      if (settleTimer) {
-        clearTimeout(settleTimer);
-        settleTimer = null;
-      }
-      pillResizeObserver?.disconnect();
-      pillResizeObserver = null;
       mq?.removeEventListener('change', onDprChange);
       cancelAnimationFrame(rafId);
       if (errorTimer) clearTimeout(errorTimer);
@@ -657,10 +589,9 @@
 <!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
      has no bars of its own) inherits the DPI-snapped values for its width calc. -->
 <div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
-  <div class="pill-cluster" bind:this={clusterEl}>
-    {#if profileLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
-      <span class="pill-profile">{profileLabel}</span>
-    {/if}
+  {#if profileLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
+    <span class="pill-profile">{profileLabel}</span>
+  {/if}
 
   {#if state === 'recording'}
     <div class="pill recording" class:dying={dying}>
@@ -774,7 +705,6 @@
       {/if}
     </div>
   {/if}
-  </div>
 </div>
 
 <style>
@@ -794,18 +724,7 @@
     justify-content: center;
   }
 
-  /* Measured wrapper — the backend sizes the native window to this element's
-     size (see measureAndResize) so the transparent click-capture zone stays
-     as small as the visible content. Column layout: the profile label floats
-     above the capsule (centered) instead of pushing it off-center. */
-  .pill-cluster {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-  }
-
-  /* Resolved tone profile, shown as a small floating tag above the pill so
+  /* Resolved tone profile, shown as a small floating tag beside the pill so
      the otherwise-invisible style setting stays legible without crowding or
      offsetting the pill capsule itself. Fades in softly so its appearance
      reads as the pill growing, not a new element popping in. */

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -50,3 +50,8 @@ export function formatKeyLabel(code: string): string {
  * adjacent bottom-row keys, no Fn/Spotlight conflict). Windows keeps its chord.
  */
 export const defaultHotkey: string[] = isMac ? ['AltLeft', 'Space'] : ['ControlLeft', 'MetaLeft'];
+
+/** Platform label for the fixed copy-last-dictation shortcut. */
+export const copyLastHotkey: string[] = isMac
+	? ['AltLeft', 'MetaLeft', 'KeyC']
+	: ['ControlLeft', 'AltLeft', 'KeyC'];

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -81,10 +81,10 @@
   }
 
   // Filters are session-only. Page navigation unmounts Home (fresh state on
-  // return); Settings is a full-screen overlay that keeps Home mounted, so
-  // clear the filter there too and refresh the list behind it. A restart
-  // clears them naturally since nothing is persisted.
-  $: if (appStore.currentPage !== 'home' || appStore.settingsOpen) {
+  // return, no reload needed); Settings is a full-screen overlay that keeps
+  // Home mounted, so clear the filter there and refresh the list behind it.
+  // A restart clears them naturally since nothing is persisted.
+  $: if (appStore.settingsOpen) {
     if (resetHistoryFilters()) {
       load(true);
     }

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -56,6 +56,13 @@
 
   function handleAppFilterChange(app: string | null) {
     if (appFilter === app) return;
+    // A pending debounce would otherwise fire a stale search query right after
+    // this load — flush it so the filter change queries once with current state.
+    if (searchTimer) {
+      clearTimeout(searchTimer);
+      searchTimer = null;
+      debouncedSearch = search;
+    }
     appFilter = app;
     load(true);
   }
@@ -257,6 +264,10 @@
       if (cancelledTimer) {
         clearTimeout(cancelledTimer);
         cancelledTimer = null;
+      }
+      if (searchTimer) {
+        clearTimeout(searchTimer);
+        searchTimer = null;
       }
     };
   });

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -143,7 +143,13 @@
     } catch { /* clipboard not available in dev */ }
   }
 
+  // A monotonically increasing sequence number lets a superseded load()
+  // (e.g. a search debounce firing right after an app-filter change) detect
+  // that a newer request is in flight and discard its own stale result.
+  let loadSeq = 0;
+
   async function load(reset = true) {
+    const seq = ++loadSeq;
     const nextOffset = reset ? 0 : recents.length;
     try {
       const [r, s] = await Promise.all([
@@ -155,10 +161,12 @@
         }),
         reset ? invoke<Stats>('get_stats') : Promise.resolve(stats),
       ]);
+      if (seq !== loadSeq) return;
       recents = reset ? (r ?? []) : [...recents, ...(r ?? [])];
       stats = s;
       hasMoreHistory = (r?.length ?? 0) === HISTORY_PAGE_SIZE;
     } catch (err) {
+      if (seq !== loadSeq) return;
       console.error('Home load failed:', err);
       if (reset) {
         recents = [];

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -1,9 +1,15 @@
+<script context="module" lang="ts">
+  let copyTipShown = false;
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { fly } from 'svelte/transition';
+  import { expoOut } from 'svelte/easing';
   import { invoke, getVersion, listen } from '../tauri';
   import { appStore } from '../stores';
   import { saveSetting } from '../settings';
-  import { formatKeyLabel, defaultHotkey } from '../platform';
+  import { formatKeyLabel, defaultHotkey, copyLastHotkey } from '../platform';
   import { getGreeting, HISTORY_PAGE_SIZE, type Entry, type Stats } from './home/helpers';
   import HomeHero from './home/HomeHero.svelte';
   import UpdateBanner from './home/UpdateBanner.svelte';
@@ -15,6 +21,7 @@
   let hotkey = defaultHotkey;
   $: hk1 = formatKeyLabel(hotkey[0]);
   $: hk2 = formatKeyLabel(hotkey[1]);
+  $: copyLastLabel = copyLastHotkey.map(formatKeyLabel).join(' ');
 
   let copiedId: number | null = null;
   let currentVersion = '';
@@ -41,6 +48,23 @@
   let appFilter: string | null = null;
   let apps: string[] = [];
   let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  let showCopyTip = false;
+  let copyTipShowTimer: ReturnType<typeof setTimeout> | null = null;
+  let copyTipHideTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function dismissCopyTip() {
+    showCopyTip = false;
+    if (copyTipHideTimer) {
+      clearTimeout(copyTipHideTimer);
+      copyTipHideTimer = null;
+    }
+  }
+
+  function showCopyTipNow() {
+    if (copyTipHideTimer) clearTimeout(copyTipHideTimer);
+    showCopyTip = true;
+    copyTipHideTimer = setTimeout(dismissCopyTip, 6000);
+  }
 
   function handleSearchChange(value: string) {
     search = value;
@@ -78,6 +102,11 @@
       searchTimer = null;
     }
     return true;
+  }
+
+  function clearHistoryFilters() {
+    if (!resetHistoryFilters()) return;
+    load(true);
   }
 
   // Filters are session-only. Page navigation unmounts Home (fresh state on
@@ -140,6 +169,7 @@
       await navigator.clipboard.writeText(entry.clean_text);
       copiedId = entry.id;
       setTimeout(() => { copiedId = null; }, 1500);
+      showCopyTipNow();
     } catch { /* clipboard not available in dev */ }
   }
 
@@ -217,6 +247,11 @@
       .catch(() => { /* use platform default if setting unavailable */ });
     load();
 
+    if (!copyTipShown) {
+      copyTipShown = true;
+      copyTipShowTimer = setTimeout(showCopyTipNow, 1200);
+    }
+
     let mounted = true;
     const unlisteners: (() => void)[] = [];
 
@@ -288,6 +323,8 @@
         clearTimeout(searchTimer);
         searchTimer = null;
       }
+      if (copyTipShowTimer) clearTimeout(copyTipShowTimer);
+      if (copyTipHideTimer) clearTimeout(copyTipHideTimer);
     };
   });
 </script>
@@ -334,6 +371,7 @@
         {appFilter}
         onSearchChange={handleSearchChange}
         onAppFilterChange={handleAppFilterChange}
+        onClearFilters={clearHistoryFilters}
         onRetry={retryTranscription}
         onContinueCancelled={continueCancelled}
         onDismissCancelled={dismissCancelled}
@@ -348,6 +386,14 @@
     </div>
   </div>
 </div>
+
+{#if showCopyTip}
+  <div class="copy-tip-toast" role="status" transition:fly={{ y: 6, duration: 180, easing: expoOut }}>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18h6M10 22h4M12 2a6 6 0 0 0-4 10.5c.7.6 1 1.4 1 2.5h6c0-1.1.3-1.9 1-2.5A6 6 0 0 0 12 2Z" /></svg>
+    <span>Tip: press <kbd>{copyLastLabel}</kbd> anytime to copy your last transcription.</span>
+    <button class="toast-close ui-focus-ring" onclick={dismissCopyTip} aria-label="Dismiss tip">✕</button>
+  </div>
+{/if}
 
 <style>
   .content-inner {
@@ -379,6 +425,34 @@
   }
 
   .page-sub { color: var(--ink-mute); font-size: 12.5px; margin: 0 0 22px; }
+
+  .copy-tip-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 18px;
+    transform: translateX(-50%);
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: min(480px, calc(100vw - 32px));
+    padding: 9px 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    background: var(--bg-elev);
+    color: var(--ink-soft);
+    box-shadow: var(--shadow-popover);
+    font-size: 12.5px;
+  }
+  .copy-tip-toast kbd {
+    padding: 1px 5px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    background: var(--paper-2);
+    color: var(--ink);
+    font-family: var(--mono);
+    font-size: 11px;
+  }
 
   /* Flat stats */
   .stat-stack { display: flex; flex-direction: column; gap: 22px; }

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -453,6 +453,18 @@
     font-family: var(--mono);
     font-size: 11px;
   }
+  .copy-tip-toast .toast-close {
+    margin-left: 4px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--ink-mute);
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1;
+    opacity: 0.65;
+  }
+  .copy-tip-toast .toast-close:hover { opacity: 1; }
 
   /* Flat stats */
   .stat-stack { display: flex; flex-direction: column; gap: 22px; }

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -34,6 +34,44 @@
   let loadingMore = false;
   let hasMoreHistory = false;
 
+  // History search + app filter. Search is debounced; the app list comes from
+  // the backend so filtering stays in SQLite (pagination is preserved).
+  let search = '';
+  let debouncedSearch = '';
+  let appFilter: string | null = null;
+  let apps: string[] = [];
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function handleSearchChange(value: string) {
+    search = value;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      searchTimer = null;
+      if (debouncedSearch !== value) {
+        debouncedSearch = value;
+        load(true);
+      }
+    }, 120);
+  }
+
+  function handleAppFilterChange(app: string | null) {
+    if (appFilter === app) return;
+    appFilter = app;
+    load(true);
+  }
+
+  function clearHistoryFilters() {
+    if (search === '' && appFilter === null) return;
+    search = '';
+    debouncedSearch = '';
+    appFilter = null;
+    if (searchTimer) {
+      clearTimeout(searchTimer);
+      searchTimer = null;
+    }
+    load(true);
+  }
+
   async function retryTranscription() {
     if (retrying) return;
     retrying = true;
@@ -91,7 +129,12 @@
     const nextOffset = reset ? 0 : recents.length;
     try {
       const [r, s] = await Promise.all([
-        invoke<Entry[]>('get_recent', { limit: HISTORY_PAGE_SIZE, offset: nextOffset }),
+        invoke<Entry[]>('get_recent', {
+          limit: HISTORY_PAGE_SIZE,
+          offset: nextOffset,
+          search: debouncedSearch.trim() || undefined,
+          appName: appFilter ?? undefined,
+        }),
         reset ? invoke<Stats>('get_stats') : Promise.resolve(stats),
       ]);
       recents = reset ? (r ?? []) : [...recents, ...(r ?? [])];
@@ -140,6 +183,9 @@
 
   onMount(() => {
     getVersion().then(v => currentVersion = v);
+    invoke<string[] | null>('get_history_apps')
+      .then(list => { apps = list ?? []; })
+      .catch(() => { apps = []; });
     invoke<string[] | null>('get_setting', { key: 'hotkey' })
       .then(hk => { if (hk?.length === 2) hotkey = hk; })
       .catch(() => { /* use platform default if setting unavailable */ });
@@ -253,6 +299,12 @@
         {copiedId}
         {hk1}
         {hk2}
+        {search}
+        {apps}
+        {appFilter}
+        onSearchChange={handleSearchChange}
+        onAppFilterChange={handleAppFilterChange}
+        onClearFilters={clearHistoryFilters}
         onRetry={retryTranscription}
         onContinueCancelled={continueCancelled}
         onDismissCancelled={dismissCancelled}

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -67,8 +67,9 @@
     load(true);
   }
 
-  function clearHistoryFilters() {
-    if (search === '' && appFilter === null) return;
+  function resetHistoryFilters(): boolean {
+    const had = search !== '' || debouncedSearch !== '' || appFilter !== null;
+    if (!had) return false;
     search = '';
     debouncedSearch = '';
     appFilter = null;
@@ -76,7 +77,17 @@
       clearTimeout(searchTimer);
       searchTimer = null;
     }
-    load(true);
+    return true;
+  }
+
+  // Filters are session-only. Page navigation unmounts Home (fresh state on
+  // return); Settings is a full-screen overlay that keeps Home mounted, so
+  // clear the filter there too and refresh the list behind it. A restart
+  // clears them naturally since nothing is persisted.
+  $: if (appStore.currentPage !== 'home' || appStore.settingsOpen) {
+    if (resetHistoryFilters()) {
+      load(true);
+    }
   }
 
   async function retryTranscription() {
@@ -315,7 +326,6 @@
         {appFilter}
         onSearchChange={handleSearchChange}
         onAppFilterChange={handleAppFilterChange}
-        onClearFilters={clearHistoryFilters}
         onRetry={retryTranscription}
         onContinueCancelled={continueCancelled}
         onDismissCancelled={dismissCancelled}

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -31,7 +31,7 @@
   export let onCopy: (entry: Entry) => void;
 
   $: hasBanner = !!failedEntry || !!cancelledEntry;
-  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+  $: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
 
   function rowMeta(entry: Entry): string {
     const parts: string[] = [];

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -4,7 +4,9 @@
   import { expoOut } from 'svelte/easing';
   import { icons } from '../../icons';
   import { appStore } from '../../stores';
-  import { fmtDate, fmtTime, type Entry, type RenderItem } from './helpers';
+  import { fmtDuration } from '../insights/helpers';
+  import HistoryToolbar from './HistoryToolbar.svelte';
+  import { fmtDate, fmtTime, formatAppLabel, type Entry, type RenderItem } from './helpers';
 
   export let recents: Entry[];
   export let failedEntry: { created_at: string } | null;
@@ -17,6 +19,12 @@
   export let copiedId: number | null;
   export let hk1: string;
   export let hk2: string;
+  export let search: string;
+  export let apps: string[];
+  export let appFilter: string | null;
+  export let onSearchChange: (value: string) => void;
+  export let onAppFilterChange: (app: string | null) => void;
+  export let onClearFilters: () => void;
   export let onRetry: () => void;
   export let onContinueCancelled: () => void;
   export let onDismissCancelled: () => void;
@@ -24,6 +32,20 @@
   export let onCopy: (entry: Entry) => void;
 
   $: hasBanner = !!failedEntry || !!cancelledEntry;
+  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+
+  function rowMeta(entry: Entry): string {
+    const parts: string[] = [];
+    if (entry.app_name) parts.push(formatAppLabel(entry.app_name));
+    if (
+      typeof entry.duration_ms === 'number' &&
+      Number.isFinite(entry.duration_ms) &&
+      entry.duration_ms >= 0
+    ) {
+      parts.push(fmtDuration(entry.duration_ms));
+    }
+    return parts.join(' · ');
+  }
 
   let flatItems: RenderItem[] = [];
   $: {
@@ -56,7 +78,7 @@
   }
 
   const DEFAULT_HEADER_HEIGHT = 38;
-  const DEFAULT_ROW_HEIGHT = 58;
+  const DEFAULT_ROW_HEIGHT = 74;
 
   let container: HTMLElement | null = null;
   let listContainer: HTMLElement | null = null;
@@ -168,6 +190,10 @@
     container;
     listContainer;
     appStore.updateInfo;
+    // The toolbar's "Clear filters" button appears/disappears with filter
+    // state, which changes the list's vertical offset — recompute when it
+    // toggles, not just when history rows change.
+    filtersActive;
     // Depend on the entries directly, not the derived `hasBanner` boolean —
     // swapping one banner for the other keeps the boolean true, so the block
     // would otherwise not re-run and `listOffset` would go stale.
@@ -307,10 +333,27 @@
     </div>
   {/if}
 
+  <HistoryToolbar
+    {search}
+    {apps}
+    {appFilter}
+    {onSearchChange}
+    {onAppFilterChange}
+    {onClearFilters}
+  />
+
   {#if recents.length === 0 && !hasBanner}
-    <div class="empty-state">
-      No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
-    </div>
+    {#if filtersActive}
+      <div class="empty-state">
+        <p class="empty-h">No matches</p>
+        <p class="empty-sub">Nothing matches your current search and filters.</p>
+        <button class="btn-ghost" onclick={onClearFilters}>Clear filters</button>
+      </div>
+    {:else}
+      <div class="empty-state">
+        No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
+      </div>
+    {/if}
   {:else}
     <div bind:this={listContainer}>
       <div style="height: {topSpacerHeight}px;"></div>
@@ -322,7 +365,12 @@
         {:else if item.type === 'row'}
           <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
             <div class="day-time">{fmtTime(item.entry.created_at)}</div>
-            <div class="day-text">{item.entry.clean_text}</div>
+            <div class="day-main">
+              <div class="day-text">{item.entry.clean_text}</div>
+              {#if rowMeta(item.entry)}
+                <div class="day-meta">{rowMeta(item.entry)}</div>
+              {/if}
+            </div>
             <button
               class="copy-btn"
               class:copied={copiedId === item.entry.id}
@@ -425,6 +473,23 @@
     overflow-wrap: anywhere;
   }
 
+  .day-main {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .day-meta {
+    font-size: 10.5px;
+    color: var(--ink-faint);
+    letter-spacing: 0.01em;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .error-msg {
     color: var(--ink-mute);
     font-style: italic;
@@ -480,6 +545,28 @@
     font-size: 13px;
     color: var(--ink-mute);
     font-style: italic;
+  }
+
+  .empty-state .empty-h,
+  .empty-state .empty-sub {
+    font-style: normal;
+  }
+
+  .empty-h {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  .empty-sub {
+    font-size: 12.5px;
+    color: var(--ink-mute);
+    line-height: 1.5;
+    margin: 0 0 10px;
+    max-width: 360px;
   }
 
   .empty-state :global(kbd) {

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -24,7 +24,6 @@
   export let appFilter: string | null;
   export let onSearchChange: (value: string) => void;
   export let onAppFilterChange: (app: string | null) => void;
-  export let onClearFilters: () => void;
   export let onRetry: () => void;
   export let onContinueCancelled: () => void;
   export let onDismissCancelled: () => void;
@@ -339,7 +338,6 @@
     {appFilter}
     {onSearchChange}
     {onAppFilterChange}
-    {onClearFilters}
   />
 
   {#if recents.length === 0 && !hasBanner}
@@ -347,7 +345,6 @@
       <div class="empty-state">
         <p class="empty-h">No matches</p>
         <p class="empty-sub">Nothing matches your current search and filters.</p>
-        <button class="btn-ghost" onclick={onClearFilters}>Clear filters</button>
       </div>
     {:else}
       <div class="empty-state">

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -24,6 +24,7 @@
   export let appFilter: string | null;
   export let onSearchChange: (value: string) => void;
   export let onAppFilterChange: (app: string | null) => void;
+  export let onClearFilters: () => void;
   export let onRetry: () => void;
   export let onContinueCancelled: () => void;
   export let onDismissCancelled: () => void;
@@ -338,6 +339,7 @@
     {appFilter}
     {onSearchChange}
     {onAppFilterChange}
+    {onClearFilters}
   />
 
   {#if recents.length === 0 && !hasBanner}

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import Dropdown from '../../components/Dropdown.svelte';
+  import { cleanAppName } from '../../appMappings';
+  import { formatAppLabel } from './helpers';
+
+  export let search: string;
+  export let apps: string[];
+  export let appFilter: string | null;
+  export let onSearchChange: (value: string) => void;
+  export let onAppFilterChange: (app: string | null) => void;
+  export let onClearFilters: () => void;
+
+  let appDropdownOpen = false;
+
+  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+</script>
+
+<div class="history-toolbar">
+  <div class="history-search-group">
+    <div class="history-search">
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.6"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
+      </svg>
+      <input
+        class="ui-input ui-input--dense"
+        type="text"
+        placeholder="Search history or app…"
+        value={search}
+        oninput={(e) => onSearchChange(e.currentTarget.value)}
+        aria-label="Search history"
+      />
+      {#if search}
+        <button
+          class="clear-btn ui-focus-ring"
+          onclick={() => onSearchChange('')}
+          aria-label="Clear search"
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      {/if}
+    </div>
+
+    <div class="history-search-divider"></div>
+
+    <Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
+      <div class="ui-dropdown history-app-dropdown">
+        <button
+          class="btn-ghost ui-dropdown-trigger history-app-trigger"
+          aria-haspopup="listbox"
+          aria-expanded={appDropdownOpen}
+          aria-controls="history-app-menu"
+          onclick={() => (appDropdownOpen = !appDropdownOpen)}
+        >
+          <span>{appFilter ? cleanAppName(appFilter) : 'All apps'}</span>
+          <svg
+            class="ui-chevron"
+            class:open={appDropdownOpen}
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </button>
+        {#if appDropdownOpen}
+          <div
+            id="history-app-menu"
+            class="ui-dropdown-menu history-app-menu scroll-styled"
+            role="listbox"
+            aria-label="Filter history by app"
+          >
+            <button
+              class="ui-dropdown-option"
+              class:active={!appFilter}
+              role="option"
+              aria-selected={!appFilter}
+              onclick={() => onAppFilterChange(null)}
+            >
+              All apps
+            </button>
+            {#each apps as app}
+              <button
+                class="ui-dropdown-option"
+                class:active={appFilter === app}
+                role="option"
+                aria-selected={appFilter === app}
+                onclick={() => onAppFilterChange(app)}
+              >
+                {formatAppLabel(app)}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </Dropdown>
+  </div>
+
+  {#if filtersActive}
+    <button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>
+      Clear filters
+    </button>
+  {/if}
+</div>
+
+<style>
+  .history-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  /* The search input and the app dropdown are one visual unit: a single
+     bordered field whose orange focus ring wraps both, so focusing either
+     control highlights the whole bar instead of just the text box. */
+  .history-search-group {
+    flex: 1 1 260px;
+    min-width: 160px;
+    display: flex;
+    align-items: center;
+    height: 32px;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    color: var(--ink-mute);
+    transition:
+      border-color var(--ui-duration-fast) var(--ui-ease-out),
+      box-shadow var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .history-search-group:focus-within {
+    border-color: var(--accent);
+    box-shadow: var(--ui-focus-ring);
+  }
+
+  .history-search {
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    padding: 0 9px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+  .history-search .ui-input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: 1px solid transparent;
+  }
+  .history-search .ui-input:focus-visible {
+    outline: none;
+  }
+
+  .history-search-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--line);
+    flex-shrink: 0;
+  }
+
+  .clear-btn {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--ink-mute);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+  .clear-btn:hover {
+    color: var(--ink-strong);
+  }
+
+  .history-app-trigger {
+    height: 100%;
+    border: 0;
+    border-radius: 0 var(--r-sm) var(--r-sm) 0;
+    background: transparent;
+  }
+  .history-app-trigger:hover,
+  .history-app-trigger[aria-expanded='true'] {
+    background: var(--control-hover);
+  }
+
+  .history-app-menu {
+    width: max-content;
+    min-width: 180px;
+    max-width: 280px;
+  }
+
+  .clear-filters-btn {
+    height: 32px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 560px) {
+    .history-toolbar {
+      flex-wrap: wrap;
+    }
+    .history-search-group {
+      flex-basis: 100%;
+    }
+  }
+</style>

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -8,11 +8,8 @@
   export let appFilter: string | null;
   export let onSearchChange: (value: string) => void;
   export let onAppFilterChange: (app: string | null) => void;
-  export let onClearFilters: () => void;
 
   let appDropdownOpen = false;
-
-  $: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
 </script>
 
 <div class="history-toolbar">
@@ -121,12 +118,6 @@
       </div>
     </Dropdown>
   </div>
-
-  {#if filtersActive}
-    <button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>
-      Clear filters
-    </button>
-  {/if}
 </div>
 
 <style>
@@ -217,12 +208,6 @@
     width: max-content;
     min-width: 180px;
     max-width: 280px;
-  }
-
-  .clear-filters-btn {
-    height: 32px;
-    white-space: nowrap;
-    flex-shrink: 0;
   }
 
   @media (max-width: 560px) {

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -167,8 +167,6 @@
     outline: none;
   }
 
-	.history-search .ui-input:focus-visible { outline: none; }
-
   .clear-btn {
     background: transparent;
     border: 0;

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,19 +1,74 @@
 <script lang="ts">
-  import Dropdown from '../../components/Dropdown.svelte';
-  import { formatAppLabel } from './helpers';
+	import { tick } from 'svelte';
+	import { scale, slide } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import Dropdown from '../../components/Dropdown.svelte';
+	import { cleanAppName } from '../../appMappings';
+	import { formatAppLabel } from './helpers';
+	import { motionMs, MOTION_MS } from '../../motion';
 
   export let search: string;
   export let apps: string[] = [];
   export let appFilter: string | null;
-  export let onSearchChange: (value: string) => void;
-  export let onAppFilterChange: (app: string | null) => void;
+	export let onSearchChange: (value: string) => void;
+	export let onAppFilterChange: (app: string | null) => void;
+	export let onClearFilters: () => void;
 
-  let appDropdownOpen = false;
+	let appDropdownOpen = false;
+	let uiExpanded = false;
+	let groupEl: HTMLElement | null = null;
+	let inputEl: HTMLInputElement | null = null;
+
+	$: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
+	$: expanded = uiExpanded || filtersActive;
+
+	async function expandSearch() {
+		uiExpanded = true;
+		await tick();
+		inputEl?.focus();
+	}
+
+	function handleGroupFocusOut() {
+		requestAnimationFrame(() => {
+			if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
+			if (!filtersActive) uiExpanded = false;
+		});
+	}
 </script>
 
 <div class="history-toolbar">
-  <div class="history-search-group">
-    <div class="history-search">
+	<div class="history-app-anchor">
+		<Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
+			<div class="ui-dropdown history-app-dropdown">
+				<button
+					class="ui-dropdown-trigger ui-dropdown-trigger--compact"
+					aria-haspopup="listbox"
+					aria-expanded={appDropdownOpen}
+					aria-controls="history-app-menu"
+					onclick={() => (appDropdownOpen = !appDropdownOpen)}
+				>
+					<span>{appFilter ? cleanAppName(appFilter) : 'All apps'}</span>
+					<svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+				</button>
+				{#if appDropdownOpen}
+					<div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
+						<button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => { onAppFilterChange(null); appDropdownOpen = false; }}>All apps</button>
+						{#each apps as app}
+							<button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => { onAppFilterChange(app); appDropdownOpen = false; }}>{formatAppLabel(app)}</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</Dropdown>
+	</div>
+
+	<div class="history-search-group" class:expanded bind:this={groupEl} onfocusout={handleGroupFocusOut}>
+		{#if !expanded}
+			<button class="search-icon-btn ui-focus-ring" onclick={expandSearch} aria-label="Search history">
+				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+			</button>
+		{:else}
+		<div class="history-search">
       <svg
         width="13"
         height="13"
@@ -27,7 +82,7 @@
       >
         <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
       </svg>
-      <input
+		<input bind:this={inputEl}
         class="ui-input ui-input--dense"
         type="text"
         placeholder="Search history or app…"
@@ -35,7 +90,7 @@
         oninput={(e) => onSearchChange(e.currentTarget.value)}
         aria-label="Search history"
       />
-      {#if search}
+		{#if search}
         <button
           class="clear-btn ui-focus-ring"
           onclick={() => onSearchChange('')}
@@ -54,69 +109,14 @@
             <path d="M18 6 6 18M6 6l12 12" />
           </svg>
         </button>
-      {/if}
-    </div>
+		{/if}
+	</div>
+		{/if}
+	</div>
 
-    <div class="history-search-divider"></div>
-
-    <Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
-      <div class="ui-dropdown history-app-dropdown">
-        <button
-          class="btn-ghost ui-dropdown-trigger history-app-trigger"
-          aria-haspopup="listbox"
-          aria-expanded={appDropdownOpen}
-          aria-controls="history-app-menu"
-          onclick={() => (appDropdownOpen = !appDropdownOpen)}
-        >
-          <span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
-          <svg
-            class="ui-chevron"
-            class:open={appDropdownOpen}
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="m6 9 6 6 6-6" />
-          </svg>
-        </button>
-        {#if appDropdownOpen}
-          <div
-            id="history-app-menu"
-            class="ui-dropdown-menu history-app-menu scroll-styled"
-            role="listbox"
-            aria-label="Filter history by app"
-          >
-            <button
-              class="ui-dropdown-option"
-              class:active={!appFilter}
-              role="option"
-              aria-selected={!appFilter}
-              onclick={() => { onAppFilterChange(null); appDropdownOpen = false; }}
-            >
-              All apps
-            </button>
-            {#each apps as app}
-              <button
-                class="ui-dropdown-option"
-                class:active={appFilter === app}
-                role="option"
-                aria-selected={appFilter === app}
-                onclick={() => { onAppFilterChange(app); appDropdownOpen = false; }}
-              >
-                {formatAppLabel(app)}
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </Dropdown>
-  </div>
+	{#if filtersActive}
+		<button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters} transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>Clear filters</button>
+	{/if}
 </div>
 
 <style>
@@ -130,24 +130,23 @@
   /* The search input and the app dropdown are one visual unit: a single
      bordered field whose orange focus ring wraps both, so focusing either
      control highlights the whole bar instead of just the text box. */
-  .history-search-group {
-    flex: 1 1 260px;
-    min-width: 160px;
-    display: flex;
+	.history-app-anchor { flex-shrink: 0; }
+	.history-search-group {
+		flex: 0 0 32px;
+		min-width: 32px;
+		display: flex;
     align-items: center;
     height: 32px;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
+		background: transparent;
+		border: 1px solid transparent;
     border-radius: var(--r-sm);
     color: var(--ink-mute);
-    transition:
-      border-color var(--ui-duration-fast) var(--ui-ease-out),
-      box-shadow var(--ui-duration-fast) var(--ui-ease-out);
-  }
-  .history-search-group:focus-within {
-    border-color: var(--accent);
-    box-shadow: var(--ui-focus-ring);
-  }
+		margin-left: auto;
+		transition: flex-basis var(--ui-duration-base) var(--ui-ease-out), border-color var(--ui-duration-fast) var(--ui-ease-out), background-color var(--ui-duration-fast) var(--ui-ease-out);
+	}
+	.history-search-group.expanded { flex: 1 1 260px; min-width: 160px; max-width: 320px; background: var(--bg-elev); border-color: var(--line); overflow: visible; }
+	.search-icon-btn { all: unset; box-sizing: border-box; width: 32px; height: 32px; flex-shrink: 0; display: grid; place-items: center; cursor: pointer; color: var(--ink-mute); border-radius: var(--r-sm); }
+	.search-icon-btn:hover { color: var(--ink-strong); }
 
   .history-search {
     flex: 1;
@@ -168,12 +167,7 @@
     outline: none;
   }
 
-  .history-search-divider {
-    width: 1px;
-    height: 18px;
-    background: var(--line);
-    flex-shrink: 0;
-  }
+	.history-search .ui-input:focus-visible { outline: none; }
 
   .clear-btn {
     background: transparent;
@@ -192,29 +186,19 @@
     color: var(--ink-strong);
   }
 
-  .history-app-trigger {
-    height: 100%;
-    border: 0;
-    border-radius: 0 var(--r-sm) var(--r-sm) 0;
-    background: transparent;
-  }
-  .history-app-trigger:hover,
-  .history-app-trigger[aria-expanded='true'] {
-    background: var(--control-hover);
-  }
-
-  .history-app-menu {
+	.history-app-menu {
     width: max-content;
     min-width: 180px;
-    max-width: 280px;
-  }
+		max-width: 280px;
+		left: 0;
+		right: auto;
+	}
+	.clear-filters-btn { height: 32px; white-space: nowrap; flex-shrink: 0; }
 
   @media (max-width: 560px) {
     .history-toolbar {
       flex-wrap: wrap;
     }
-    .history-search-group {
-      flex-basis: 100%;
-    }
+		.history-search-group.expanded { flex-basis: 100%; max-width: none; }
   }
 </style>

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -103,6 +103,7 @@
 		{#if search}
         <button
           class="clear-btn ui-focus-ring"
+          onmousedown={(event) => event.preventDefault()}
           onclick={() => onSearchChange('')}
           aria-label="Clear search"
         >

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -3,7 +3,6 @@
 	import { scale, slide } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import Dropdown from '../../components/Dropdown.svelte';
-	import { cleanAppName } from '../../appMappings';
 	import { formatAppLabel } from './helpers';
 	import { motionMs, MOTION_MS } from '../../motion';
 
@@ -47,7 +46,7 @@
 					aria-controls="history-app-menu"
 					onclick={() => (appDropdownOpen = !appDropdownOpen)}
 				>
-					<span>{appFilter ? cleanAppName(appFilter) : 'All apps'}</span>
+					<span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
 					<svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
 				</button>
 				{#if appDropdownOpen}

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -6,20 +6,31 @@
 	import { formatAppLabel } from './helpers';
 	import { motionMs, MOTION_MS } from '../../motion';
 
-  export let search: string;
-  export let apps: string[] = [];
-  export let appFilter: string | null;
-	export let onSearchChange: (value: string) => void;
-	export let onAppFilterChange: (app: string | null) => void;
-	export let onClearFilters: () => void;
+	type Props = {
+		search: string;
+		apps?: string[];
+		appFilter: string | null;
+		onSearchChange: (value: string) => void;
+		onAppFilterChange: (app: string | null) => void;
+		onClearFilters: () => void;
+	};
 
-	let appDropdownOpen = false;
-	let uiExpanded = false;
-	let groupEl: HTMLElement | null = null;
-	let inputEl: HTMLInputElement | null = null;
+	let {
+		search,
+		apps = [],
+		appFilter,
+		onSearchChange,
+		onAppFilterChange,
+		onClearFilters,
+	}: Props = $props();
 
-	$: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
-	$: expanded = uiExpanded || filtersActive;
+	let appDropdownOpen = $state(false);
+	let uiExpanded = $state(false);
+	let groupEl = $state<HTMLElement | null>(null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	let filtersActive = $derived((search ?? '').trim().length > 0 || appFilter !== null);
+	let expanded = $derived(uiExpanded || filtersActive);
 
 	async function expandSearch() {
 		uiExpanded = true;

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import Dropdown from '../../components/Dropdown.svelte';
-  import { cleanAppName } from '../../appMappings';
   import { formatAppLabel } from './helpers';
 
   export let search: string;
-  export let apps: string[];
+  export let apps: string[] = [];
   export let appFilter: string | null;
   export let onSearchChange: (value: string) => void;
   export let onAppFilterChange: (app: string | null) => void;
@@ -69,7 +68,7 @@
           aria-controls="history-app-menu"
           onclick={() => (appDropdownOpen = !appDropdownOpen)}
         >
-          <span>{appFilter ? cleanAppName(appFilter) : 'All apps'}</span>
+          <span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
           <svg
             class="ui-chevron"
             class:open={appDropdownOpen}

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -12,7 +12,7 @@
 
   let appDropdownOpen = false;
 
-  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+  $: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
 </script>
 
 <div class="history-toolbar">
@@ -101,7 +101,7 @@
               class:active={!appFilter}
               role="option"
               aria-selected={!appFilter}
-              onclick={() => onAppFilterChange(null)}
+              onclick={() => { onAppFilterChange(null); appDropdownOpen = false; }}
             >
               All apps
             </button>
@@ -111,7 +111,7 @@
                 class:active={appFilter === app}
                 role="option"
                 aria-selected={appFilter === app}
-                onclick={() => onAppFilterChange(app)}
+                onclick={() => { onAppFilterChange(app); appDropdownOpen = false; }}
               >
                 {formatAppLabel(app)}
               </button>

--- a/src/lib/views/home/helpers.ts
+++ b/src/lib/views/home/helpers.ts
@@ -1,6 +1,13 @@
 import type { UpdateInfo } from '../../stores';
 
-export interface Entry { id: number; clean_text: string; words: number; created_at: string; }
+export interface Entry {
+  id: number;
+  clean_text: string;
+  words: number;
+  created_at: string;
+  app_name?: string | null;
+  duration_ms?: number;
+}
 export interface Stats { total_words: number; avg_wpm: number; day_streak: number; }
 
 export type RenderItem =
@@ -8,6 +15,18 @@ export type RenderItem =
   | { type: 'row'; key: string; entry: Entry };
 
 export const HISTORY_PAGE_SIZE = 100;
+
+/** Prettifies a stored lowercase executable name (e.g. "outlook.exe") for
+ * display ("Outlook"). Falls back to the raw value for anything odd. */
+export function formatAppLabel(appName: string): string {
+  const base = appName.trim().toLowerCase().replace(/\.exe$/, '');
+  if (!base) return appName;
+  return base
+    .split(/[._\-\s+]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
 
 export function getGreeting(): string {
   const now = new Date();

--- a/src/lib/views/home/helpers.ts
+++ b/src/lib/views/home/helpers.ts
@@ -16,10 +16,11 @@ export type RenderItem =
 
 export const HISTORY_PAGE_SIZE = 100;
 
-/** Prettifies a stored lowercase executable name (e.g. "outlook.exe") for
- * display ("Outlook"). Falls back to the raw value for anything odd. */
+/** Prettifies a stored lowercase executable name (e.g. "outlook.exe" on
+ * Windows or "slack.app" on macOS) for display ("Outlook" / "Slack"). Falls
+ * back to the raw value for anything odd. */
 export function formatAppLabel(appName: string): string {
-  const base = appName.trim().toLowerCase().replace(/\.exe$/, '');
+  const base = appName.trim().toLowerCase().replace(/\.(exe|app)$/, '');
   if (!base) return appName;
   return base
     .split(/[._\-\s+]+/)

--- a/tests/OnePyFone.py
+++ b/tests/OnePyFone.py
@@ -145,6 +145,7 @@ JS_TESTS = [
     ("integration/playwright-test-surface-dev.cjs",    "ui",      "Snippets, dictionary, style surfaces", {"retry": 1, "timeout_s": 120}),
     ("integration/playwright-test-offline-dev.cjs",    "ui",      "Offline toast in browser dev mode",    {"retry": 1, "timeout_s": 60}),
     ("integration/playwright-test-fullscreen-settings-dev.cjs", "ui", "Full-screen settings & rail morph", {"retry": 2, "timeout_s": 120}),
+    ("integration/playwright-test-history-filter-dev.cjs",       "ui", "History search & app filter",      {"retry": 1, "timeout_s": 90}),
 
     # ── SUITE: state ──────────────────────────────────────────────────────────
     ("smoke/playwright-test-state.cjs",                "state",     "Settings state persistence",       {"retry": 2, "timeout_s": 90}),

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -109,17 +109,21 @@ const historyMockWrap = function () {
       errors.push(`app filter wrong: ${JSON.stringify(byApp)}`);
     }
 
-    // No matches → clear empty state.
+    // No matches → empty state; reset via the search × and the dropdown's
+    // "All apps" option (there is deliberately no separate "Clear filters"
+    // button).
     await search.fill('zzzz nothing matches');
     await page.waitForTimeout(500);
     const noMatch = await page.locator('.empty-state .empty-h').innerText();
     if (noMatch !== 'No matches') errors.push(`empty state heading wrong: "${noMatch}"`);
-    // The toolbar's "Clear filters" resets everything; the empty-state button
-    // is a second, equivalent affordance.
-    await page.locator('.clear-filters-btn').click();
+    await page.getByRole('button', { name: 'Clear search' }).click();
+    await page.waitForTimeout(300);
+    await page.locator('.history-app-dropdown button').click();
+    await page.waitForTimeout(200);
+    await page.locator('#history-app-menu [role="option"]:has-text("All apps")').click();
     await page.waitForTimeout(500);
-    if ((await page.locator('.day-row').count()) !== 6) errors.push('clearing filters must restore all rows');
-    if ((await page.locator('.empty-state').count()) !== 0) errors.push('empty state must disappear after clearing filters');
+    if ((await page.locator('.day-row').count()) !== 6) errors.push('resetting to All apps must restore all rows');
+    if ((await page.locator('.empty-state').count()) !== 0) errors.push('empty state must disappear after resetting to All apps');
 
     // Pagination contract intact: "Load older" only when a full page is present
     // is exercised by the frozen smoke test; here just ensure no error surfaced.

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -1,0 +1,134 @@
+'use strict';
+
+// History search + app filter UX. Exercises the real Home/HistoryList/
+// HistoryToolbar against a filtering `get_recent`/`get_history_apps` mock so
+// the search → SQLite-arg wiring, the app dropdown, the combined filter, the
+// row metadata, and the "No matches" empty state are all covered end-to-end.
+
+const { chromium } = require('playwright');
+const { tauriMock } = require('../smoke/_tauri-mock.cjs');
+
+// Overrides the frozen smoke mock's history commands with a filtering variant
+// that carries app names + durations, so the frontend's real flow is exercised.
+const historyMockWrap = function () {
+  const entries = [
+    { id: 6, clean_text: 'Send the quarterly report to accounting', raw_text: 'send the quarterly report to accounting', words: 7, duration_ms: 8400, app_name: 'outlook.exe', created_at: '2026-05-31 08:05:00' },
+    { id: 5, clean_text: 'Refactor the login flow for the new design', raw_text: 'refactor the login flow', words: 9, duration_ms: 12200, app_name: 'code.exe', created_at: '2026-05-31 09:12:00' },
+    { id: 4, clean_text: 'Remind me to call the accountant tomorrow', raw_text: 'remind me to call the accountant', words: 7, duration_ms: 6100, app_name: 'outlook.exe', created_at: '2026-05-30 16:40:00' },
+    { id: 3, clean_text: 'Set up a meeting with the design team', raw_text: 'set up a meeting with the design team', words: 8, duration_ms: 7300, app_name: 'outlook.exe', created_at: '2026-05-30 10:00:00' },
+    { id: 2, clean_text: 'Rename the tests to match the new spec', raw_text: 'rename the tests', words: 8, duration_ms: 5600, app_name: 'code.exe', created_at: '2026-05-29 14:22:00' },
+    { id: 1, clean_text: 'Draft a response to the vendor', raw_text: 'draft a response to the vendor', words: 6, duration_ms: 4800, app_name: null, created_at: '2026-05-29 09:05:00' },
+  ];
+  const baseInvoke = window.__TAURI_INTERNALS__.invoke;
+  window.__TAURI_INTERNALS__.invoke = function (cmd, args) {
+    if (cmd === 'get_recent') {
+      const limit = Number(args?.limit ?? 100);
+      const offset = Number(args?.offset ?? 0);
+      const search = typeof args?.search === 'string' ? args.search.trim().toLowerCase() : '';
+      const appName = typeof args?.appName === 'string' ? args.appName : null;
+      let filtered = entries.filter((e) => {
+        if (search && !e.clean_text.toLowerCase().includes(search) && !e.raw_text.toLowerCase().includes(search)) {
+          return false;
+        }
+        if (appName && e.app_name !== appName) {
+          return false;
+        }
+        return true;
+      });
+      return Promise.resolve(filtered.slice(offset, offset + limit));
+    }
+    if (cmd === 'get_history_apps') {
+      return Promise.resolve(['code.exe', 'outlook.exe']);
+    }
+    return baseInvoke(cmd, args);
+  };
+};
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const errors = [];
+
+  page.on('pageerror', (err) => errors.push(`Page exception: ${err.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(`Console error: ${msg.text()}`);
+  });
+
+  await page.addInitScript(tauriMock, {});
+  await page.addInitScript(historyMockWrap);
+
+  try {
+    await page.goto('http://localhost:1420', { waitUntil: 'networkidle', timeout: 15_000 });
+    await page.locator('h1.page-h:has-text("Welcome back")').waitFor({ state: 'visible', timeout: 12_000 });
+
+    const search = page.getByRole('textbox', { name: 'Search history' });
+    await search.waitFor({ state: 'visible', timeout: 5_000 });
+
+    const dayRows = page.locator('.day-row');
+    const visibleCleanTexts = async () => {
+      await page.waitForTimeout(150);
+      return page.locator('.day-text').allInnerTexts();
+    };
+
+    // Row metadata: app label + compact duration under the text.
+    const metaFirst = await page.locator('.day-meta').first().innerText();
+    if (!/Outlook · \d+s/.test(metaFirst)) errors.push(`row meta wrong: "${metaFirst}"`);
+    // Row with no app but a duration still shows just the duration.
+    const metaNoApp = await page.locator('.day-row:has-text("Draft a response to the vendor") .day-meta').innerText();
+    if (metaNoApp !== '5s') errors.push(`no-app row meta wrong: "${metaNoApp}"`);
+    if ((await page.locator('.day-row').count()) !== 6) errors.push('all history rows should render unfiltered');
+
+    // Search: partial + case-insensitive, finds cleaned text.
+    await search.fill('quarterly');
+    await page.waitForTimeout(500);
+    const searched = await visibleCleanTexts();
+    if (searched.length !== 1 || !searched[0].includes('quarterly')) {
+      errors.push(`search "quarterly" wrong: ${JSON.stringify(searched)}`);
+    }
+
+    // Combined search + app filter.
+    await page.locator('.history-app-dropdown button').click();
+    await page.waitForTimeout(200);
+    await page.locator('#history-app-menu [role="option"]:has-text("Outlook")').click();
+    await page.waitForTimeout(500);
+    const combined = await visibleCleanTexts();
+    if (combined.length !== 1 || !combined[0].includes('accounting')) {
+      errors.push(`search+app combined wrong: ${JSON.stringify(combined)}`);
+    }
+
+    // App filter alone.
+    await page.getByRole('button', { name: 'Clear search' }).click();
+    await page.waitForTimeout(500);
+    const byApp = await visibleCleanTexts();
+    if (byApp.length !== 3 || !byApp.every((t) => /accounting|call the accountant|design team/.test(t))) {
+      errors.push(`app filter wrong: ${JSON.stringify(byApp)}`);
+    }
+
+    // No matches → clear empty state.
+    await search.fill('zzzz nothing matches');
+    await page.waitForTimeout(500);
+    const noMatch = await page.locator('.empty-state .empty-h').innerText();
+    if (noMatch !== 'No matches') errors.push(`empty state heading wrong: "${noMatch}"`);
+    // The toolbar's "Clear filters" resets everything; the empty-state button
+    // is a second, equivalent affordance.
+    await page.locator('.clear-filters-btn').click();
+    await page.waitForTimeout(500);
+    if ((await page.locator('.day-row').count()) !== 6) errors.push('clearing filters must restore all rows');
+    if ((await page.locator('.empty-state').count()) !== 0) errors.push('empty state must disappear after clearing filters');
+
+    // Pagination contract intact: "Load older" only when a full page is present
+    // is exercised by the frozen smoke test; here just ensure no error surfaced.
+    if (errors.length > 0) {
+      console.error('FAILURES:');
+      errors.forEach((e) => console.error('  ' + e));
+      await page.screenshot({ path: 'C:/Users/noah7/AppData/Local/Temp/opencode/history-filter-fail.png', fullPage: true });
+      process.exit(1);
+    }
+    console.log('PASS — history search, app filter, metadata, and clear-all work together.');
+  } catch (err) {
+    console.error('FAIL — test threw:', err.message);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -131,12 +131,13 @@ const historyMockWrap = function () {
       console.error('FAILURES:');
       errors.forEach((e) => console.error('  ' + e));
       await page.screenshot({ path: FAILURE_SCREENSHOT, fullPage: true });
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     console.log('PASS — history search, app filter, metadata, and clear-all work together.');
   } catch (err) {
     console.error('FAIL — test threw:', err.message);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await browser.close();
   }

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -66,6 +66,8 @@ const historyMockWrap = function () {
     await page.goto('http://localhost:1420', { waitUntil: 'networkidle', timeout: 15_000 });
     await page.locator('h1.page-h:has-text("Welcome back")').waitFor({ state: 'visible', timeout: 12_000 });
 
+    // Search is intentionally collapsed to a bare icon until it is needed.
+    await page.getByRole('button', { name: 'Search history' }).click();
     const search = page.getByRole('textbox', { name: 'Search history' });
     await search.waitFor({ state: 'visible', timeout: 5_000 });
 
@@ -124,6 +126,14 @@ const historyMockWrap = function () {
     await page.waitForTimeout(500);
     if ((await page.locator('.day-row').count()) !== 6) errors.push('resetting to All apps must restore all rows');
     if ((await page.locator('.empty-state').count()) !== 0) errors.push('empty state must disappear after resetting to All apps');
+
+    // The explicit clear action enters with a horizontal transition and resets
+    // both controls together.
+    await search.fill('accounting');
+    await page.waitForTimeout(500);
+    await page.getByRole('button', { name: 'Clear filters' }).click();
+    await page.waitForTimeout(500);
+    if ((await page.locator('.day-row').count()) !== 6) errors.push('Clear filters must restore all rows');
 
     // Pagination contract intact: "Load older" only when a full page is present
     // is exercised by the frozen smoke test; here just ensure no error surfaced.

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -1,5 +1,8 @@
 'use strict';
 
+const path = require('path');
+const os = require('os');
+
 // History search + app filter UX. Exercises the real Home/HistoryList/
 // HistoryToolbar against a filtering `get_recent`/`get_history_apps` mock so
 // the search → SQLite-arg wiring, the app dropdown, the combined filter, the
@@ -7,6 +10,8 @@
 
 const { chromium } = require('playwright');
 const { tauriMock } = require('../smoke/_tauri-mock.cjs');
+
+const FAILURE_SCREENSHOT = path.join(os.tmpdir(), 'verenu-history-filter-fail.png');
 
 // Overrides the frozen smoke mock's history commands with a filtering variant
 // that carries app names + durations, so the frontend's real flow is exercised.
@@ -25,7 +30,7 @@ const historyMockWrap = function () {
       const limit = Number(args?.limit ?? 100);
       const offset = Number(args?.offset ?? 0);
       const search = typeof args?.search === 'string' ? args.search.trim().toLowerCase() : '';
-      const appName = typeof args?.appName === 'string' ? args.appName : null;
+      const appName = typeof args?.appName === 'string' ? args.appName : (typeof args?.app_name === 'string' ? args.app_name : null);
       let filtered = entries.filter((e) => {
         if (search && !e.clean_text.toLowerCase().includes(search) && !e.raw_text.toLowerCase().includes(search)) {
           return false;
@@ -121,7 +126,7 @@ const historyMockWrap = function () {
     if (errors.length > 0) {
       console.error('FAILURES:');
       errors.forEach((e) => console.error('  ' + e));
-      await page.screenshot({ path: 'C:/Users/noah7/AppData/Local/Temp/opencode/history-filter-fail.png', fullPage: true });
+      await page.screenshot({ path: FAILURE_SCREENSHOT, fullPage: true });
       process.exit(1);
     }
     console.log('PASS — history search, app filter, metadata, and clear-all work together.');

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -112,8 +112,7 @@ const historyMockWrap = function () {
     }
 
     // No matches → empty state; reset via the search × and the dropdown's
-    // "All apps" option (there is deliberately no separate "Clear filters"
-    // button).
+    // "All apps" option before exercising the explicit Clear filters action.
     await search.fill('zzzz nothing matches');
     await page.waitForTimeout(500);
     const noMatch = await page.locator('.empty-state .empty-h').innerText();


### PR DESCRIPTION
## Problem

Once a user accumulates many dictations, History is just a flat paginated list with no way to find anything, and each row only shows the time and text. Meanwhile the dictation pill gives no feedback about what's happening while it processes, and the tone profile that silently shapes every dictation is invisible.

## What changed

**History search + app filter**
- Search input on History; matches case-insensitively and partially across the cleaned text, raw transcription, and app name (multi-term). Filtering happens in SQLite so pagination is preserved and the whole table never reaches the frontend.
- App filter dropdown (apps that actually have history, via a new `get_history_apps` command). Selecting a filter closes the menu; "All apps" resets it.
- Filters are session-only: they clear when you leave Home (Settings clears + refreshes the list behind it; page navigation resets via remount) or restart the app.
- A "No matches" empty state when filters return nothing.
- New `app_name` column on `transcriptions` (migration v13) populated at insert time with the foreground app; past rows simply have no app metadata.

**Row metadata**
- Each history row now shows `App · duration` (e.g. `Outlook · 8s`) as secondary text under the dictation, using data already stored; missing app/duration degrades gracefully.

**Dictation pill feedback**
- The pill now shows the resolved tone profile (e.g. `Casual`) subtly beside the recording/processing pill, emitted from the pipeline's own profile resolution (no second frontend resolution).
- Processing now shows real stages — `Transcribing…` → `Cleaning…` → `Pasting…` — driven by `pill-stage` events at the actual pipeline boundaries. `Cleaning` is only advertised when the cleanup LLM will actually run, and a short min-display prevents flicker on fast stages. All terminal states clear the stage.

## Verification

- `cargo test` (491 tests, incl. new search/filter/distinct-apps coverage) — pass
- `cargo clippy -D warnings` — clean
- `svelte-check` — 0 errors
- `npm test` fast profile (26 tests incl. new history-filter integration test, plus frozen pagination/contract smoke tests) — all pass
- Pill profile/stage states and toolbar verified in-browser

## Notes

- Old history entries (pre-v13) have no app metadata and appear under the unfiltered view.
- The integration test `playwright-test-history-filter-dev.cjs` is registered in `tests/OnePyFone.py`.
