### PR TITLE
Prevent duplicate Vite dev servers during startup

### DIFF
--- a/scripts/vite-dev-server.mjs
+++ b/scripts/vite-dev-server.mjs
@@ -4,6 +4,8 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const DEV_PORT = 1420;
+const SERVER_PROBE_ATTEMPTS = 3;
+const SERVER_PROBE_TIMEOUT_MS = 3000;
 const DEV_URLS = [
   `http://127.0.0.1:${DEV_PORT}/`,
   `http://localhost:${DEV_PORT}/`,
@@ -39,9 +41,18 @@ child.on('exit', (code, signal) => {
 });
 
 async function findReachableServerUrl() {
-  for (const url of DEV_URLS) {
-    if (await isServerReachable(url)) {
-      return url;
+  // Vite can take a moment to answer while dependency optimization is in
+  // progress. A single short probe can miss an already-running server and
+  // then launch a second strictPort instance, which makes beforeDevCommand
+  // fail with "Port 1420 is already in use".
+  for (let attempt = 0; attempt < SERVER_PROBE_ATTEMPTS; attempt += 1) {
+    for (const url of DEV_URLS) {
+      if (await isServerReachable(url)) {
+        return url;
+      }
+    }
+    if (attempt < SERVER_PROBE_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
     }
   }
 
@@ -50,7 +61,7 @@ async function findReachableServerUrl() {
 
 async function isServerReachable(url) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 1000);
+  const timeout = setTimeout(() => controller.abort(), SERVER_PROBE_TIMEOUT_MS);
   try {
     const response = await fetch(url, {
       method: 'GET',


### PR DESCRIPTION
## Thinking Path

> - Verenu starts Vite through Tauri's `beforeDevCommand` during development.
> - The existing-server probe could time out while Vite was still optimizing dependencies.
> - The launcher then started a second strict-port server, which failed on port 1420.
> - A normal development restart should reuse a healthy server instead of failing during startup.
> - This change retries the probe and allows each request enough time for Vite to finish its initial work.
> - The result is limited to development-server startup behavior and does not change production requests.

## What Changed

- Retry existing Vite server detection up to three times with a 3-second request timeout and a short pause between attempts.
- Keep strict-port behavior unchanged when no healthy Verenu server is reachable.

## Verification

- `node scripts/vite-dev-server.mjs` reused `http://127.0.0.1:1420/`.
- `npm run check` passed with 0 errors and 0 warnings.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- No UI changes, so no screenshot was needed.

## Risks

- Low risk. This changes only the development-server health probe. It may wait briefly longer before spawning Vite when an existing server is slow, and it does not affect production builds.

## Model Used

- OpenAI Codex, GPT-5.6.

## Checklist

- [x] Thinking path explains the problem and why the change is needed.
- [x] Verification commands passed.
- [x] No API keys or credentials were added.
- [x] Risks are documented.
- [x] The change is limited to the requested fix.