### PR TITLE
Make AI review findings fail CI

### DIFF
--- a/scripts/verenu-ai-review-logic.mjs
+++ b/scripts/verenu-ai-review-logic.mjs
@@ -1,5 +1,5 @@
-export const DEFAULT_MODEL = "gemini-3.6-flash-high";
-export const DEFAULT_FALLBACK_MODEL = "claude-sonnet-4.6";
+export const DEFAULT_MODEL = "gemini-3.7-flash-high";
+export const DEFAULT_FALLBACK_MODEL = "claude-sonnet-4-6";
 
 const FALLBACK_ERROR_PATTERNS = [
   /\b(?:model|engine)\b.{0,60}\b(?:not found|not available|unavailable|does not exist|unknown)\b/is,
@@ -35,8 +35,13 @@ export function fallbackReason(result) {
   if (!result || result.previewFailed || result.code === 0) return null;
 
   const output = `${result.stderr || ""}\n${result.stdout || ""}`;
-  if (/\b(?:quota|resource exhausted)\b/i.test(output)) return "quota";
-  if (/\b(?:rate[\s_-]?limit|too many requests|429)\b/i.test(output)) return "rate_limit";
+  // CLIProxy and the upstream Gemini API use underscore-delimited error
+  // codes such as RESOURCE_EXHAUSTED and QUOTA_EXHAUSTED. Normalize those
+  // separators before matching so a quota response without an explicit 429
+  // still reaches the next configured model.
+  const normalizedOutput = output.replace(/[_-]+/g, " ");
+  if (/\b(?:quota|resource exhausted|insufficient quota|daily limit|usage limit|out of extra usage|model cooldown|cooling down|capacity on this model)\b/i.test(normalizedOutput)) return "quota";
+  if (/\b(?:rate\s*limit|too many requests|429)\b/i.test(normalizedOutput)) return "rate_limit";
   if (FALLBACK_ERROR_PATTERNS.some((pattern) => pattern.test(output))) return "model_unavailable";
   return null;
 }
@@ -49,6 +54,15 @@ export function failureCategory(result) {
   if (!result || result.code === 0) return null;
   if (result?.previewFailed) return "preview_failed";
   return fallbackReason(result) || "review_failed";
+}
+
+export function reviewOutcome(findings) {
+  const count = Array.isArray(findings) ? findings.length : 0;
+  return {
+    count,
+    hasFindings: count > 0,
+    exitCode: count > 0 ? 1 : 0,
+  };
 }
 
 export function formatProgressSummary({ stage, model, fallbackModel, reason, mode, findings, headSha }) {
@@ -67,6 +81,11 @@ export function formatProgressSummary({ stage, model, fallbackModel, reason, mod
       {
         const findingCount = Number.isFinite(Number(findings)) ? Number(findings) : 0;
         return `✅ Verenu AI review complete${modelText}. Reviewed ${shaText} (${findingCount} finding${findingCount === 1 ? "" : "s"}).`;
+      }
+    case "findings":
+      {
+        const findingCount = Number.isFinite(Number(findings)) ? Number(findings) : 0;
+        return `❌ Verenu AI review found ${findingCount} finding${findingCount === 1 ? "" : "s"}. Reviewed ${shaText}${modelText}.`;
       }
     case "failed":
       return `❌ Verenu AI review failed (${SAFE_FAILURE_REASONS.has(reason) ? reason : "review_failed"}).`;

--- a/scripts/verenu-ai-review-logic.mjs
+++ b/scripts/verenu-ai-review-logic.mjs
@@ -1,12 +1,22 @@
 export const DEFAULT_MODEL = "gemini-3.7-flash-high";
 export const DEFAULT_FALLBACK_MODEL = "claude-sonnet-4-6";
 
+const LEGACY_MODEL_ALIASES = new Map([
+  ["gemini-3.6-flash-high", DEFAULT_MODEL],
+  ["claude-sonnet-4.6", DEFAULT_FALLBACK_MODEL],
+]);
+
 const FALLBACK_ERROR_PATTERNS = [
   /\b(?:model|engine)\b.{0,60}\b(?:not found|not available|unavailable|does not exist|unknown)\b/is,
   /\b(?:not found|not available|unavailable|does not exist|unknown)\b.{0,60}\b(?:model|engine)\b/is,
   /\bno available (?:model|engine)\b/i,
 ];
 const SAFE_FAILURE_REASONS = new Set(["quota", "rate_limit", "model_unavailable", "preview_failed", "review_failed", "setup_failed", "provider_not_configured"]);
+
+export function normalizeReviewModel(model, defaultModel) {
+  const configuredModel = String(model ?? "").trim();
+  return LEGACY_MODEL_ALIASES.get(configuredModel) || configuredModel || defaultModel;
+}
 
 export function selectReviewModels({
   apiKey,
@@ -17,7 +27,10 @@ export function selectReviewModels({
 } = {}) {
   if (!String(apiKey ?? '').trim()) return null;
 
-  const models = [...new Set([primaryModel, fallbackModel].map((model) => String(model || "").trim()).filter(Boolean))];
+  const models = [...new Set([
+    normalizeReviewModel(primaryModel, DEFAULT_MODEL),
+    normalizeReviewModel(fallbackModel, DEFAULT_FALLBACK_MODEL),
+  ].filter(Boolean))];
   if (models.length === 0) return null;
 
   const additionCount = Number(additions);

--- a/scripts/verenu-ai-review-logic.mjs
+++ b/scripts/verenu-ai-review-logic.mjs
@@ -55,7 +55,7 @@ export function fallbackReason(result) {
   const normalizedOutput = output.replace(/[_-]+/g, " ");
   if (/\b(?:quota|resource exhausted|insufficient quota|daily limit|usage limit|out of extra usage|model cooldown|cooling down|capacity on this model)\b/i.test(normalizedOutput)) return "quota";
   if (/\b(?:rate\s*limit|too many requests|429)\b/i.test(normalizedOutput)) return "rate_limit";
-  if (FALLBACK_ERROR_PATTERNS.some((pattern) => pattern.test(output))) return "model_unavailable";
+  if (FALLBACK_ERROR_PATTERNS.some((pattern) => pattern.test(normalizedOutput))) return "model_unavailable";
   return null;
 }
 

--- a/scripts/verenu-ai-review-logic.test.mjs
+++ b/scripts/verenu-ai-review-logic.test.mjs
@@ -7,6 +7,7 @@ import {
   failureCategory,
   fallbackReason,
   formatProgressSummary,
+  normalizeReviewModel,
   reviewOutcome,
   selectReviewModels,
   shouldFallback,
@@ -22,6 +23,16 @@ test("selectReviewModels returns Gemini then Claude defaults", () => {
       changedLines: 0,
     },
   );
+});
+
+test("legacy configured model names migrate to the current review models", () => {
+  assert.equal(normalizeReviewModel("gemini-3.6-flash-high", DEFAULT_MODEL), DEFAULT_MODEL);
+  assert.equal(normalizeReviewModel("claude-sonnet-4.6", DEFAULT_FALLBACK_MODEL), DEFAULT_FALLBACK_MODEL);
+  assert.deepEqual(selectReviewModels({
+    apiKey: "present",
+    primaryModel: "gemini-3.6-flash-high",
+    fallbackModel: "claude-sonnet-4.6",
+  }).models, [DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL]);
 });
 
 test("selectReviewModels preserves configured ordering and removes duplicates", () => {

--- a/scripts/verenu-ai-review-logic.test.mjs
+++ b/scripts/verenu-ai-review-logic.test.mjs
@@ -7,6 +7,7 @@ import {
   failureCategory,
   fallbackReason,
   formatProgressSummary,
+  reviewOutcome,
   selectReviewModels,
   shouldFallback,
 } from "./verenu-ai-review-logic.mjs";
@@ -53,10 +54,14 @@ test("selectReviewModels rejects blank API keys", () => {
 test("quota, rate-limit, and model-unavailable failures are fallback eligible", () => {
   const cases = [
     [{ code: 1, stderr: "RESOURCE_EXHAUSTED: quota exceeded" }, "quota"],
+    [{ code: 1, stderr: "status=RESOURCE_EXHAUSTED" }, "quota"],
+    [{ code: 1, stderr: "reason=QUOTA_EXHAUSTED" }, "quota"],
+    [{ code: 1, stderr: "insufficient_quota: daily limit reached" }, "quota"],
+    [{ code: 1, stderr: "model_cooldown: all credentials are cooling down" }, "quota"],
     [{ code: 1, stderr: "HTTP 429 too many requests" }, "rate_limit"],
-    [{ code: 1, stderr: "model gemini-3.6-flash-high not found" }, "model_unavailable"],
+    [{ code: 1, stderr: "model gemini-3.7-flash-high not found" }, "model_unavailable"],
     [{ code: 1, stderr: "no available model for this request" }, "model_unavailable"],
-    [{ code: 1, stderr: "model gemini-3.6-flash-high\nnot found" }, "model_unavailable"],
+    [{ code: 1, stderr: "model gemini-3.7-flash-high\nnot found" }, "model_unavailable"],
   ];
 
   for (const [result, reason] of cases) {
@@ -75,6 +80,11 @@ test("unrelated failures, preview failures, and successful reviews do not fallba
   assert.equal(failureCategory({ code: 0, stderr: "success" }), null);
 });
 
+test("clean reviews pass and reviews with findings fail", () => {
+  assert.deepEqual(reviewOutcome([]), { count: 0, hasFindings: false, exitCode: 0 });
+  assert.deepEqual(reviewOutcome([{ message: "bug" }]), { count: 1, hasFindings: true, exitCode: 1 });
+});
+
 test("progress summaries expose the expected review stages without provider details", () => {
   assert.match(formatProgressSummary({ stage: "preparing", mode: "normal" }), /^👀 Preparing/);
   assert.match(formatProgressSummary({ stage: "reviewing", model: DEFAULT_MODEL, headSha: "1234567890abcdef" }), /🔍 Reviewing `1234567`/);
@@ -83,6 +93,8 @@ test("progress summaries expose the expected review stages without provider deta
   assert.ok(quotaSwitch.includes(`\`${DEFAULT_MODEL}\` quota unavailable`));
   assert.ok(quotaSwitch.includes(`switching to \`${DEFAULT_FALLBACK_MODEL}\``));
   assert.match(formatProgressSummary({ stage: "switching", model: "custom-primary", fallbackModel: "custom-fallback", reason: "model_unavailable" }), /`custom-primary` unavailable, switching to `custom-fallback`/);
+  assert.match(formatProgressSummary({ stage: "complete", model: DEFAULT_MODEL, findings: 0, headSha: "1234567890abcdef" }), /0 findings/);
+  assert.match(formatProgressSummary({ stage: "findings", model: DEFAULT_MODEL, findings: 2, headSha: "1234567890abcdef" }), /found 2 findings/);
   assert.match(formatProgressSummary({ stage: "complete", model: DEFAULT_FALLBACK_MODEL, findings: 2, headSha: "1234567890abcdef" }), /✅ .*2 findings/);
   assert.equal(formatProgressSummary({ stage: "failed", reason: "quota exceeded for secret-token" }), "❌ Verenu AI review failed (review_failed).");
 });

--- a/scripts/verenu-ai-review-logic.test.mjs
+++ b/scripts/verenu-ai-review-logic.test.mjs
@@ -73,6 +73,7 @@ test("quota, rate-limit, and model-unavailable failures are fallback eligible", 
     [{ code: 1, stderr: "model gemini-3.7-flash-high not found" }, "model_unavailable"],
     [{ code: 1, stderr: "no available model for this request" }, "model_unavailable"],
     [{ code: 1, stderr: "model gemini-3.7-flash-high\nnot found" }, "model_unavailable"],
+    [{ code: 1, stderr: "MODEL_NOT_FOUND: gemini-3.7-flash-high" }, "model_unavailable"],
   ];
 
   for (const [result, reason] of cases) {

--- a/scripts/verenu-ai-review.mjs
+++ b/scripts/verenu-ai-review.mjs
@@ -35,6 +35,7 @@ import {
   failureCategory,
   fallbackReason,
   formatProgressSummary,
+  reviewOutcome,
   selectReviewModels,
   shouldFallback,
 } from "./verenu-ai-review-logic.mjs";
@@ -643,23 +644,29 @@ async function main() {
 
     const findings = parseOcrFindings(result.stdout);
     await postFindings(prNumber, pr, findings);
+    const outcome = reviewOutcome(findings);
+    const finalStage = outcome.hasFindings ? "findings" : "complete";
 
     stateComment = await updateProgress(
       prNumber,
       stateComment,
-      formatProgressSummary({ stage: "complete", model: activeModel, mode, findings: findings.length, headSha: pr.head.sha }),
+      formatProgressSummary({ stage: finalStage, model: activeModel, mode, findings: outcome.count, headSha: pr.head.sha }),
       {
         ...baseState,
         model: activeModel,
         attemptedModels: [...attemptedModels],
         fallbackUsed: activeModel !== selection.model,
-        status: "completed",
-        stage: "complete",
-        findings: findings.length,
+        status: outcome.hasFindings ? "failed" : "completed",
+        stage: finalStage,
+        findings: outcome.count,
         timestamp: new Date().toISOString(),
         completed: true,
       },
     );
+    if (outcome.hasFindings) {
+      console.error(`OCR review found ${outcome.count} finding${outcome.count === 1 ? "" : "s"}`);
+      process.exitCode = outcome.exitCode;
+    }
   } catch (err) {
     stateComment = await updateProgress(
       prNumber,


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The CI AI review workflow is the subsystem being changed.
> - The review workflow was still defaulting to Gemini 3.6 Flash, and quota failures did not reliably activate the Claude fallback. A review with findings also exited successfully when it posted comments.
> - This pull request updates the Gemini model, hardens quota/cooldown fallback detection, and makes the review result explicit: zero findings succeeds; one or more findings fails CI.
> - The benefit is that the review system uses the intended model routing and cannot silently pass a PR that has actionable findings.

## What Changed

- Replace `gemini-3.6-flash-high` with `gemini-3.7-flash-high`.
- Normalize the Claude fallback model identifier to `claude-sonnet-4-6`.
- Detect provider quota, rate-limit, capacity, and cooldown failures so Claude can take over when Gemini is unavailable.
- Report explicit `0 findings` completion for clean reviews.
- Mark reviews with findings as failed and exit with status 1 after posting the findings.
- Add focused regression coverage for routing, fallback detection, summaries, and exit status.

## Verification

- `node --test scripts/verenu-ai-review-logic.test.mjs`
- `git diff --check` on the changed files

## Risks

- The workflow will now correctly fail a PR when the AI reviewer reports findings; this is intentional and may expose existing findings that were previously treated as successful.
- Provider fallback still depends on the configured Claude credential being available to the workflow.

## Model Used

OpenAI Codex (GPT-5.6, tool-assisted)

## Checklist

- [x] I have read `CLAUDE.md` and followed the project conventions.
- [x] I have kept the change scoped to the requested CI review behavior.
- [x] I have added or updated focused regression coverage.
- [x] I have run the relevant verification commands.
