### PR TITLE
Fix Insights range filtering and weekly chart

### DIFF
--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -354,10 +354,8 @@ fn query_totals(
             |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
         )?;
 
-    // Identical definition to query_stats (average of each clip's own wpm)
-    // so the Insights "All time" number matches the Home page exactly;
-    // scoped to the range here. Not total_words/total_duration — that
-    // aggregates differently and makes the two pages disagree.
+    // Identical definition to query_stats (average of each clip's own wpm),
+    // scoped to the selected Insights range.
     let avg_wpm: f64 = conn.query_row(
         "SELECT COALESCE(AVG(CAST(spoken_words AS REAL) * 60000.0 / duration_ms), 0.0)
          FROM transcriptions
@@ -373,12 +371,6 @@ fn query_totals(
          WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
            AND duration_ms > 0 AND spoken_words > 0",
         params![range_start, range_end],
-        |r| r.get(0),
-    )?;
-
-    let total_words: i64 = conn.query_row(
-        "SELECT COALESCE((SELECT total_words FROM lifetime_stats WHERE id = 1), 0)",
-        [],
         |r| r.get(0),
     )?;
 
@@ -404,7 +396,9 @@ fn query_totals(
     };
 
     Ok(InsightsTotals {
-        total_words,
+        // Insights is range-filtered. The lifetime counter is still used by
+        // the Home page, but it must not leak into a selected Insights range.
+        total_words: words_in_range,
         total_transcriptions,
         total_speaking_ms,
         avg_words_per_transcription,
@@ -806,6 +800,18 @@ mod tests {
         assert_eq!(insights.range_days, 0);
         assert_eq!(insights.totals.words_in_range, 4);
         assert_eq!(insights.totals.words_prev_range, 0);
+    }
+
+    #[test]
+    fn selected_range_total_words_excludes_older_transcriptions() {
+        let db = test_db();
+        insert_on_day(&db, 8, "older words", 10, 1000);
+        insert_on_day(&db, 2, "recent words", 4, 1000);
+
+        let insights = query_insights(&db, 7).expect("insights");
+
+        assert_eq!(insights.totals.total_words, 4);
+        assert_eq!(insights.totals.words_in_range, 4);
     }
 
     #[test]

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -925,7 +925,7 @@ function devInsights(days: number): unknown {
     range_days: days,
     generated_at: new Date().toISOString().slice(0, 19).replace('T', ' '),
     totals: {
-      total_words: wordsInRange + 218_400,
+      total_words: wordsInRange,
       total_transcriptions: transcriptions,
       total_speaking_ms: speakingMs,
       avg_words_per_transcription: transcriptions ? Math.round(wordsInRange / transcriptions) : 0,

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -18,30 +18,32 @@
   let status = $state<'loading' | 'loaded' | 'error'>('loading');
   let error = $state('');
   let rangeOpen = $state(false);
-  let displayVersion = $state(0);
 
   let fetchToken = 0;
   let mounted = false;
 
   const rangeLabel = $derived(RANGE_OPTIONS.find((o) => o.value === range)?.label ?? 'Last 30 days');
+  const dataRangeLabel = $derived(
+    RANGE_OPTIONS.find((o) => o.value === data?.range_days)?.label ?? rangeLabel,
+  );
   const isEmpty = $derived(!data || data.totals.total_transcriptions === 0);
 
-  async function load(opts?: { silent?: boolean }) {
+  async function load(opts?: { silent?: boolean; days?: InsightsRange }) {
     const token = ++fetchToken;
+    const requestedRange = opts?.days ?? range;
     if (!opts?.silent) {
       status = 'loading';
       error = '';
     }
     try {
-      const payload = await invoke<InsightsPayload>('get_insights', { days: range });
+      const payload = await invoke<InsightsPayload>('get_insights', { days: requestedRange });
       if (!mounted || token !== fetchToken) return;
-      data = payload ?? EMPTY_INSIGHTS;
+      if (payload && payload.range_days !== requestedRange) {
+        throw new Error(`Insights response used ${payload.range_days} days instead of ${requestedRange}.`);
+      }
+      data = payload ?? { ...EMPTY_INSIGHTS, range_days: requestedRange };
       status = 'loaded';
       error = '';
-      // Keep the previous range visible while its replacement loads, then
-      // give explicit range/manual refreshes one deliberate entry. Silent
-      // polling must update values in place so chart hover/focus state survives.
-      if (!opts?.silent) displayVersion += 1;
     } catch (err) {
       if (!mounted || token !== fetchToken) return;
       console.error('IPC get_insights failed:', err);
@@ -67,7 +69,7 @@
     rangeOpen = false;
     if (next === range) return;
     range = next;
-    load();
+    load({ days: next });
   }
 
   onMount(() => {
@@ -167,23 +169,23 @@
       <p class="empty-sub">Hold your hotkey and say something. Once you've dictated a few times, your streaks, speed, and cost estimates will show up here.</p>
     </div>
   {:else if data}
-    {#if status === 'error'}
-      <p class="fetch-status fetch-status-error" role="alert">Refresh failed: {error}</p>
-    {:else if status === 'loading'}
-      <p class="fetch-status" role="status" aria-live="polite">Refreshing insights…</p>
-    {/if}
+    <div class="insights-results-shell" class:refreshing={status === 'loading'} aria-busy={status === 'loading'}>
+      {#if status === 'loading'}
+        <p class="fetch-status refresh-status" role="status" aria-live="polite">Refreshing insights…</p>
+      {:else if status === 'error'}
+        <p class="fetch-status fetch-status-error" role="alert">Refresh failed: {error}</p>
+      {/if}
 
-    {#key displayVersion}
-      <div class="insights-results" in:fade={{ duration: motionMs(MOTION_MS.base) }}>
-        <HeroStats {data} {rangeLabel} />
+      <div class="insights-results">
+        <HeroStats {data} rangeLabel={dataRangeLabel} />
 
-        <DailyChart daily={data.daily} {rangeLabel} />
+        <DailyChart daily={data.daily} rangeLabel={dataRangeLabel} />
         <StreakHeatmap daily={data.streak_daily} streak={data.streak} historyStartedOn={data.history_started_on} />
         <HourStrip hourly={data.hourly} />
         <WordStats words={data.words} cleanup={data.cleanup} totals={data.totals} />
-        <CostBreakdown providers={data.providers} {rangeLabel} />
+        <CostBreakdown providers={data.providers} rangeLabel={dataRangeLabel} />
       </div>
-    {/key}
+    </div>
   {/if}
 </div>
 
@@ -221,7 +223,35 @@
   }
 
   .fetch-status { margin: 0 0 10px; font-size: 12px; color: var(--ink-mute); }
-  .fetch-status-error { color: var(--danger); }
+  .fetch-status-error {
+    position: absolute;
+    top: -22px;
+    inset-inline: 0;
+    margin: 0;
+    color: var(--danger);
+  }
+
+  .insights-results-shell {
+    position: relative;
+    min-width: 0;
+  }
+
+  .insights-results-shell.refreshing .insights-results {
+    visibility: hidden;
+  }
+
+  .refresh-status {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 24px;
+    margin: 0;
+    background: color-mix(in srgb, var(--paper) 88%, transparent);
+    pointer-events: none;
+  }
 
   /* Section shell for every child component. Owned here rather than repeated
      in each of them, so the page's visual weight has a single lever. These are

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -16,13 +16,10 @@
   const PAD_TOP = 12;
   const PAD_BOTTOM = 22;
 
-  /* Below this many points a line reads as noise — discrete bars are clearer. */
-  const BAR_THRESHOLD = 14;
-
   // Reduce rather than Math.max(...spread) — an all-time range can exceed the
   // call-stack limit for spread arguments on a very long daily series.
   const max = $derived(niceCeiling(daily.reduce((m, d) => Math.max(m, d.words), 0)));
-  const asBars = $derived(daily.length <= BAR_THRESHOLD);
+  const asBars = $derived(rangeLabel === 'Last 7 days');
   const plotH = H - PAD_TOP - PAD_BOTTOM;
 
   function x(i: number): number {
@@ -63,10 +60,31 @@
   );
 
   const barWidth = $derived(daily.length > 0 ? Math.min(28, (W / daily.length) * 0.55) : 0);
+  const BAR_RADIUS = 3;
+
+  function barPath(day: InsightsDay, i: number): string {
+    const left = x(i) - barWidth / 2;
+    const top = day.words > 0 ? y(day.words) : H - PAD_BOTTOM - 1;
+    const height = day.words > 0 ? Math.max(1, H - PAD_BOTTOM - y(day.words)) : 1;
+    const right = left + barWidth;
+    const bottom = top + height;
+    const radius = Math.min(BAR_RADIUS, barWidth / 2, height / 2);
+
+    return [
+      `M ${left} ${bottom}`,
+      `V ${top + radius}`,
+      `Q ${left} ${top} ${left + radius} ${top}`,
+      `H ${right - radius}`,
+      `Q ${right} ${top} ${right} ${top + radius}`,
+      `V ${bottom}`,
+      'Z',
+    ].join(' ');
+  }
 
   let hover = $state<number | null>(null);
   let hoverPos = $state<{ x: number; y: number } | null>(null);
   const active = $derived(hover !== null ? daily[hover] : null);
+  const latest = $derived(daily.length > 0 ? daily[daily.length - 1] : null);
 
   function onMove(event: PointerEvent) {
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
@@ -105,9 +123,9 @@
       {#if active}
         <span class="readout-num">{fmtNumber(active.words)}</span>
         <span class="readout-day">{fmtDayLong(active.day)}</span>
-      {:else}
-        <span class="readout-num"><AnimatedNumber value={total} /></span>
-        <span class="readout-day">total</span>
+      {:else if latest}
+        <span class="readout-num"><AnimatedNumber value={latest.words} /></span>
+        <span class="readout-day">{fmtDayLong(latest.day)}</span>
       {/if}
     </div>
   </header>
@@ -139,13 +157,11 @@
       />
       {#if asBars}
         {#each daily as d, i}
-          <rect
-            x={x(i) - barWidth / 2}
-            y={d.words > 0 ? y(d.words) : H - PAD_BOTTOM - 1}
-            width={barWidth}
-            height={d.words > 0 ? Math.max(1, H - PAD_BOTTOM - y(d.words)) : 1}
+          <path
+            d={barPath(d, i)}
+            class="bar-path"
             fill={hover === i ? 'var(--accent)' : 'color-mix(in srgb, var(--accent) 55%, transparent)'}
-          ><title>{fmtDayLong(d.day)} — {fmtNumber(d.words)} words</title></rect>
+          ><title>{fmtDayLong(d.day)} — {fmtNumber(d.words)} words</title></path>
         {/each}
       {:else}
         <path d={areaPath} fill="color-mix(in srgb, var(--accent) 18%, transparent)" mask="url(#{gradientId}-mask)" class="area-path" />
@@ -221,7 +237,7 @@
     margin-top: 2px;
   }
 
-  rect { transition: fill var(--ui-duration-fast) var(--ui-ease-out), y var(--ui-duration-base) var(--ui-ease-out), height var(--ui-duration-base) var(--ui-ease-out); }
+  .bar-path { transition: fill var(--ui-duration-fast) var(--ui-ease-out), d var(--ui-duration-base) var(--ui-ease-out); }
 
   /* Progressive enhancement: browsers that support animating `d` glide to a
      new shape when the range or a fresh dictation changes the data. */

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -80,7 +80,7 @@
     </p>
   </section>
 
-  <section class="tile tile-relative" aria-label="Total words dictated">
+  <section class="tile tile-relative" aria-label="Words dictated in selected range">
     {#if delta !== null}
       <span class="delta" class:down={delta < 0}>
         <svg class="delta-arrow" class:flip={delta < 0} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -92,7 +92,7 @@
     <div class="tile-head">
       <span class="big">{words.value}{#if words.suffix}<small>{words.suffix}</small>{/if}</span>
     </div>
-    <p class="tile-label">total words dictated</p>
+    <p class="tile-label">words dictated</p>
     <p class="tile-note">
       {#if books >= 1}
         <!-- Pluralize off the displayed amount: "1" is singular, but "1.5"
@@ -113,11 +113,11 @@
     </p>
   </section>
 
-  <section class="tile" aria-label="Fixes made by Verenu">
+  <section class="tile" aria-label="All-time fixes made by Verenu">
     <div class="tile-head">
       <span class="big"><AnimatedNumber value={data.cleanup.edits_applied} /></span>
     </div>
-    <p class="tile-label">fixes made by Verenu</p>
+    <p class="tile-label">all-time fixes made by Verenu</p>
     <div class="sub-rows">
       <div class="stat-line">
         <span class="stat-num"><AnimatedNumber value={data.cleanup.dictionary_fixes} /></span>

--- a/src/lib/views/insights/types.ts
+++ b/src/lib/views/insights/types.ts
@@ -9,7 +9,7 @@
 export type InsightsRange = 7 | 30 | 90 | 0; // 0 = all time
 
 export interface InsightsTotals {
-  /** Lifetime, from the lifetime_stats table — never shrinks with retention pruning. */
+  /** Total words in the selected Insights range. */
   total_words: number;
   total_transcriptions: number;
   total_speaking_ms: number;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that turns held-hotkey audio into local transcription, cleanup, and text injection.
> - The Insights subsystem combines the Svelte UI with Tauri analytics queries over local transcription data.
> - A range switch could leave old data visible under a new label, and the headline total read from the lifetime counter instead of the selected range.
> - The refresh remount also changed the result height during loading, which caused the page to jump.
> - The weekly daily chart needed a latest-day default and rounded bar tops without changing longer-range line charts.
> - This pull request keeps the selected range, returned data, and chart presentation synchronized.

## What Changed

- Validate that each Insights response matches the range requested by the user.
- Keep the result layout stable while a range refresh is in progress.
- Use range-scoped words for the Insights headline total and add a regression test for older transcriptions.
- Show the latest day by default in Words per day.
- Use rounded-top bars only for Last 7 days. Keep Last 30 days, Last 90 days, and All time as line charts.

## Verification

- `npm run check` passes with 0 errors and 0 warnings.
- `cargo test --manifest-path src-tauri/Cargo.toml insights` passes all 19 Insights tests.
- The supplied before screenshots were inspected locally. An after screenshot is not embedded because the configured upload helper is unavailable in this environment.

## Risks

- Low risk. No schema or migration changes. The backend change only corrects the selected-range total, while the other changes are limited to Insights loading and chart presentation.

> Checked `docs/ROADMAP.md`. The existing opt-in Analytics item is unrelated to this local Insights page fix.

## Model Used

- OpenAI GPT-5.6 via Codex, with tool use and extended reasoning.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes (focused Insights Rust test profile)
- [ ] Smoke tests pass (not run; existing build blocker remains in `src/lib/views/home/HistoryToolbar.svelte`)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (after upload unavailable)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (not applicable)
- [ ] Relevant documentation updated (not needed for this bug fix)
- [x] Risks documented above
