### PR TITLE
Group History search and app filters into one control

### DIFF
--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,254 +1,216 @@
 <script lang="ts">
-	import { tick } from 'svelte';
-	import { scale, slide } from 'svelte/transition';
-	import { cubicOut } from 'svelte/easing';
-	import Dropdown from '../../components/Dropdown.svelte';
-	import { formatAppLabel } from './helpers';
-	import { motionMs, MOTION_MS } from '../../motion';
+  import { tick } from 'svelte';
+  import { scale, slide } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
+  import Dropdown from '../../components/Dropdown.svelte';
+  import { formatAppLabel } from './helpers';
+  import { motionMs, MOTION_MS } from '../../motion';
 
-	type Props = {
-		search: string;
-		apps?: string[];
-		appFilter: string | null;
-		onSearchChange: (value: string) => void;
-		onAppFilterChange: (app: string | null) => void;
-		onClearFilters: () => void;
-	};
+  type Props = {
+    search: string;
+    apps?: string[];
+    appFilter: string | null;
+    onSearchChange: (value: string) => void;
+    onAppFilterChange: (app: string | null) => void;
+    onClearFilters: () => void;
+  };
 
-	let {
-		search,
-		apps = [],
-		appFilter,
-		onSearchChange,
-		onAppFilterChange,
-		onClearFilters,
-	}: Props = $props();
+  let {
+    search,
+    apps = [],
+    appFilter,
+    onSearchChange,
+    onAppFilterChange,
+    onClearFilters,
+  }: Props = $props();
 
-	let appDropdownOpen = $state(false);
-	let uiExpanded = $state(false);
-	let groupEl = $state<HTMLElement | null>(null);
-	let inputEl = $state<HTMLInputElement | null>(null);
+  let appDropdownOpen = $state(false);
+  let uiExpanded = $state(false);
+  let groupEl = $state<HTMLElement | null>(null);
+  let inputEl = $state<HTMLInputElement | null>(null);
 
-	let filtersActive = $derived((search ?? '').trim().length > 0 || appFilter !== null);
-	let expanded = $derived(uiExpanded || filtersActive);
+  let filtersActive = $derived((search ?? '').trim().length > 0 || appFilter !== null);
+  let expanded = $derived(uiExpanded || filtersActive);
 
-	async function expandSearch() {
-		uiExpanded = true;
-		await tick();
-		inputEl?.focus();
-	}
+  async function expandSearch() {
+    uiExpanded = true;
+    await tick();
+    inputEl?.focus();
+  }
 
-	function selectAppFilter(app: string | null) {
-		appDropdownOpen = false;
-		onAppFilterChange(app);
-	}
+  function selectAppFilter(app: string | null) {
+    appDropdownOpen = false;
+    onAppFilterChange(app);
+  }
 
-	function handleGroupFocusOut() {
-		requestAnimationFrame(() => {
-			if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
-			if (!filtersActive) uiExpanded = false;
-		});
-	}
+  function handleGroupFocusOut() {
+    requestAnimationFrame(() => {
+      if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
+      if (!filtersActive) uiExpanded = false;
+    });
+  }
 </script>
 
 <div class="history-toolbar">
-	<div class="history-search-group" class:expanded bind:this={groupEl} onfocusout={handleGroupFocusOut}>
-		{#if !expanded}
-			<button class="search-icon-btn ui-focus-ring" onclick={expandSearch} aria-label="Search history">
-				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
-			</button>
-		{:else}
-			<div class="history-search">
-				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
-				<input
-					bind:this={inputEl}
-					class="ui-input ui-input--dense"
-					type="text"
-					placeholder="Search history or appâ€¦"
-					value={search}
-					oninput={(event) => onSearchChange(event.currentTarget.value)}
-					aria-label="Search history"
-				/>
-				{#if search}
-					<button
-						class="clear-btn ui-focus-ring"
-						onmousedown={(event) => event.preventDefault()}
-						onclick={() => onSearchChange('')}
-						aria-label="Clear search"
-					>
-						<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
-					</button>
-				{/if}
-			</div>
+  <div class="history-search-group" class:expanded bind:this={groupEl} onfocusout={handleGroupFocusOut}>
+    {#if !expanded}
+      <button class="search-icon-btn ui-focus-ring" onclick={expandSearch} aria-label="Search history">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+      </button>
+    {:else}
+      <div class="history-search">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+        <input
+          bind:this={inputEl}
+          class="ui-input ui-input--dense"
+          type="text"
+          placeholder="Search history or app..."
+          value={search}
+          oninput={(event) => onSearchChange(event.currentTarget.value)}
+          aria-label="Search history"
+        />
+        {#if search}
+          <button class="clear-btn ui-focus-ring" onmousedown={(event) => event.preventDefault()} onclick={() => onSearchChange('')} aria-label="Clear search">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
+          </button>
+        {/if}
+      </div>
 
-			<div class="history-search-divider"></div>
+      <div class="history-search-divider"></div>
 
-			<Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
-				<div class="ui-dropdown history-app-dropdown">
-					<button
-						class="ui-dropdown-trigger ui-dropdown-trigger--compact history-app-trigger"
-						aria-haspopup="listbox"
-						aria-expanded={appDropdownOpen}
-						aria-controls="history-app-menu"
-						onclick={() => (appDropdownOpen = !appDropdownOpen)}
-					>
-						<span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
-						<svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
-					</button>
-					{#if appDropdownOpen}
-						<div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
-							<button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => selectAppFilter(null)}>All apps</button>
-							{#each apps as app}
-								<button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => selectAppFilter(app)}>{formatAppLabel(app)}</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
-			</Dropdown>
+      <Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
+        <div class="ui-dropdown history-app-dropdown">
+          <button
+            class="ui-dropdown-trigger ui-dropdown-trigger--compact history-app-trigger"
+            aria-haspopup="listbox"
+            aria-expanded={appDropdownOpen}
+            aria-controls="history-app-menu"
+            onclick={() => (appDropdownOpen = !appDropdownOpen)}
+          >
+            <span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
+            <svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+          </button>
+          {#if appDropdownOpen}
+            <div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
+              <button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => selectAppFilter(null)}>All apps</button>
+              {#each apps as app}
+                <button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => selectAppFilter(app)}>{formatAppLabel(app)}</button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </Dropdown>
 
-			{#if filtersActive}
-				<div class="clear-filters-wrap" transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>
-					<div class="history-search-divider"></div>
-					<button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>Clear filters</button>
-				</div>
-			{/if}
-		{/if}
-	</div>
+      {#if filtersActive}
+        <div class="clear-filters-wrap" transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>
+          <div class="history-search-divider"></div>
+          <button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>Clear filters</button>
+        </div>
+      {/if}
+    {/if}
+  </div>
 </div>
 
 <style>
-	.history-toolbar {
-		display: flex;
-		align-items: center;
-		margin-bottom: 12px;
-	}
+  .history-toolbar { display: flex; align-items: center; margin-bottom: 12px; }
 
-	.history-search-group {
-		flex: 0 0 32px;
-		min-width: 32px;
-		display: flex;
-		align-items: center;
-		height: 32px;
-		background: transparent;
-		border: 1px solid transparent;
-		border-radius: var(--r-sm);
-		color: var(--ink-mute);
-		margin-left: auto;
-		overflow: hidden;
-		transition:
-			flex-basis var(--ui-duration-base) var(--ui-ease-out),
-			border-color var(--ui-duration-fast) var(--ui-ease-out),
-			background-color var(--ui-duration-fast) var(--ui-ease-out);
-	}
+  .history-search-group {
+    flex: 0 0 32px;
+    min-width: 32px;
+    display: flex;
+    align-items: center;
+    height: 32px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--r-sm);
+    color: var(--ink-mute);
+    margin-left: auto;
+    overflow: hidden;
+    transition:
+      flex-basis var(--ui-duration-base) var(--ui-ease-out),
+      border-color var(--ui-duration-fast) var(--ui-ease-out),
+      background-color var(--ui-duration-fast) var(--ui-ease-out);
+  }
 
-	.history-search-group.expanded {
-		flex: 1 1 260px;
-		min-width: 160px;
-		max-width: 460px;
-		background: var(--bg-elev);
-		border-color: var(--line);
-		overflow: visible;
-	}
+  .history-search-group.expanded {
+    flex: 1 1 260px;
+    min-width: 160px;
+    max-width: 460px;
+    background: var(--bg-elev);
+    border-color: var(--line);
+    overflow: visible;
+  }
 
-	.search-icon-btn {
-		all: unset;
-		box-sizing: border-box;
-		width: 32px;
-		height: 32px;
-		flex-shrink: 0;
-		display: grid;
-		place-items: center;
-		cursor: pointer;
-		color: var(--ink-mute);
-		border-radius: var(--r-sm);
-		transition: color var(--ui-duration-fast) var(--ui-ease-out);
-	}
+  .search-icon-btn {
+    all: unset;
+    box-sizing: border-box;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    color: var(--ink-mute);
+    border-radius: var(--r-sm);
+    transition: color var(--ui-duration-fast) var(--ui-ease-out);
+  }
 
-	.search-icon-btn:hover { color: var(--ink-strong); }
+  .search-icon-btn:hover { color: var(--ink-strong); }
 
-	.history-search {
-		flex: 1;
-		min-width: 0;
-		height: 100%;
-		padding: 0 9px;
-		display: flex;
-		align-items: center;
-		gap: 7px;
-	}
+  .history-search {
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    padding: 0 9px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
 
-	.history-search .ui-input {
-		flex: 1;
-		min-width: 0;
-		background: transparent;
-		border: 1px solid transparent;
-	}
+  .history-search .ui-input { flex: 1; min-width: 0; background: transparent; border: 1px solid transparent; }
+  .history-search .ui-input:focus-visible { outline: none; }
 
-	.history-search .ui-input:focus-visible { outline: none; }
+  .history-search-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--line);
+    flex-shrink: 0;
+  }
 
-	.history-search-divider {
-		width: 1px;
-		height: 18px;
-		background: var(--line);
-		flex-shrink: 0;
-	}
+  .clear-btn {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--ink-mute);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
 
-	.clear-btn {
-		background: transparent;
-		border: 0;
-		padding: 0;
-		color: var(--ink-mute);
-		cursor: pointer;
-		display: grid;
-		place-items: center;
-		width: 16px;
-		height: 16px;
-		border-radius: 4px;
-		flex-shrink: 0;
-	}
+  .clear-btn:hover { color: var(--ink-strong); }
 
-	.clear-btn:hover { color: var(--ink-strong); }
+  .history-app-trigger { border-color: transparent; background: transparent; flex-shrink: 0; }
+  .history-app-trigger:hover,
+  .history-app-trigger[aria-expanded='true'] { background: var(--control-hover); border-color: transparent; }
 
-	.history-app-trigger {
-		border-color: transparent;
-		background: transparent;
-		flex-shrink: 0;
-	}
+  .history-app-menu { width: max-content; min-width: 180px; max-width: 280px; }
 
-	.history-app-trigger:hover,
-	.history-app-trigger[aria-expanded='true'] {
-		background: var(--control-hover);
-		border-color: transparent;
-	}
+  .clear-filters-wrap { display: flex; align-items: center; height: 100%; flex-shrink: 0; }
 
-	.history-app-menu {
-		width: max-content;
-		min-width: 180px;
-		max-width: 280px;
-	}
+  .clear-filters-btn {
+    height: 100%;
+    padding: 0 12px;
+    border-color: transparent;
+    border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  }
 
-	.clear-filters-wrap {
-		display: flex;
-		align-items: center;
-		height: 100%;
-		flex-shrink: 0;
-	}
+  .clear-filters-btn:hover { background: var(--control-hover); border-color: transparent; }
 
-	.clear-filters-btn {
-		height: 100%;
-		padding: 0 12px;
-		border-color: transparent;
-		border-radius: 0 var(--r-sm) var(--r-sm) 0;
-	}
-
-	.clear-filters-btn:hover {
-		background: var(--control-hover);
-		border-color: transparent;
-	}
-
-	@media (max-width: 560px) {
-		.history-search-group.expanded {
-			flex-basis: 100%;
-			max-width: none;
-		}
-	}
+  @media (max-width: 560px) {
+    .history-search-group.expanded { flex-basis: 100%; max-width: none; }
+  }
 </style>

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -53,10 +53,21 @@
 
   function handleGroupFocusOut() {
     requestAnimationFrame(() => {
-      if (preserveExpanded) return;
-      if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
-      if (!filtersActive) uiExpanded = false;
+      if (preserveExpanded) {
+        // Some browsers finish the pointer transition after the replacement
+        // frame, briefly leaving body as the active element. Give the input a
+        // short settling window before deciding the group was really exited.
+        setTimeout(collapseIfFocusLeft, 300);
+        return;
+      }
+      collapseIfFocusLeft();
     });
+  }
+
+  function collapseIfFocusLeft() {
+    if (filtersActive) return;
+    if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
+    uiExpanded = false;
   }
 </script>
 

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -26,6 +26,7 @@
 
   let appDropdownOpen = $state(false);
   let uiExpanded = $state(false);
+  let preserveExpanded = $state(false);
   let groupEl = $state<HTMLElement | null>(null);
   let inputEl = $state<HTMLInputElement | null>(null);
 
@@ -33,9 +34,16 @@
   let expanded = $derived(uiExpanded || filtersActive);
 
   async function expandSearch() {
+    // Replacing the focused icon button with the input emits focusout before
+    // the new input can receive focus. Keep the group open through that one
+    // DOM transition so keyboard and automation users can type immediately.
+    preserveExpanded = true;
     uiExpanded = true;
     await tick();
     inputEl?.focus();
+    requestAnimationFrame(() => {
+      preserveExpanded = false;
+    });
   }
 
   function selectAppFilter(app: string | null) {
@@ -45,6 +53,7 @@
 
   function handleGroupFocusOut() {
     requestAnimationFrame(() => {
+      if (preserveExpanded) return;
       if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
       if (!filtersActive) uiExpanded = false;
     });

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -29,6 +29,7 @@
   let preserveExpanded = $state(false);
   let groupEl = $state<HTMLElement | null>(null);
   let inputEl = $state<HTMLInputElement | null>(null);
+  let appTriggerEl = $state<HTMLButtonElement | null>(null);
 
   let filtersActive = $derived((search ?? '').trim().length > 0 || appFilter !== null);
   let expanded = $derived(uiExpanded || filtersActive);
@@ -46,9 +47,15 @@
     });
   }
 
-  function selectAppFilter(app: string | null) {
+  async function selectAppFilter(app: string | null) {
+    preserveExpanded = true;
     appDropdownOpen = false;
     onAppFilterChange(app);
+    await tick();
+    appTriggerEl?.focus();
+    requestAnimationFrame(() => {
+      preserveExpanded = false;
+    });
   }
 
   function handleGroupFocusOut() {
@@ -101,6 +108,7 @@
       <Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
         <div class="ui-dropdown history-app-dropdown">
           <button
+            bind:this={appTriggerEl}
             class="ui-dropdown-trigger ui-dropdown-trigger--compact history-app-trigger"
             aria-haspopup="listbox"
             aria-expanded={appDropdownOpen}

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -38,6 +38,11 @@
 		inputEl?.focus();
 	}
 
+	function selectAppFilter(app: string | null) {
+		appDropdownOpen = false;
+		onAppFilterChange(app);
+	}
+
 	function handleGroupFocusOut() {
 		requestAnimationFrame(() => {
 			if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
@@ -47,167 +52,203 @@
 </script>
 
 <div class="history-toolbar">
-	<div class="history-app-anchor">
-		<Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
-			<div class="ui-dropdown history-app-dropdown">
-				<button
-					class="ui-dropdown-trigger ui-dropdown-trigger--compact"
-					aria-haspopup="listbox"
-					aria-expanded={appDropdownOpen}
-					aria-controls="history-app-menu"
-					onclick={() => (appDropdownOpen = !appDropdownOpen)}
-				>
-					<span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
-					<svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
-				</button>
-				{#if appDropdownOpen}
-					<div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
-						<button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => { onAppFilterChange(null); appDropdownOpen = false; }}>All apps</button>
-						{#each apps as app}
-							<button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => { onAppFilterChange(app); appDropdownOpen = false; }}>{formatAppLabel(app)}</button>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		</Dropdown>
-	</div>
-
 	<div class="history-search-group" class:expanded bind:this={groupEl} onfocusout={handleGroupFocusOut}>
 		{#if !expanded}
 			<button class="search-icon-btn ui-focus-ring" onclick={expandSearch} aria-label="Search history">
 				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
 			</button>
 		{:else}
-		<div class="history-search">
-      <svg
-        width="13"
-        height="13"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.6"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
-      >
-        <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
-      </svg>
-		<input bind:this={inputEl}
-        class="ui-input ui-input--dense"
-        type="text"
-        placeholder="Search history or app…"
-        value={search}
-        oninput={(e) => onSearchChange(e.currentTarget.value)}
-        aria-label="Search history"
-      />
-		{#if search}
-        <button
-          class="clear-btn ui-focus-ring"
-          onmousedown={(event) => event.preventDefault()}
-          onclick={() => onSearchChange('')}
-          aria-label="Clear search"
-        >
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            aria-hidden="true"
-          >
-            <path d="M18 6 6 18M6 6l12 12" />
-          </svg>
-        </button>
-		{/if}
-	</div>
-		{/if}
-	</div>
+			<div class="history-search">
+				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+				<input
+					bind:this={inputEl}
+					class="ui-input ui-input--dense"
+					type="text"
+					placeholder="Search history or appâ€¦"
+					value={search}
+					oninput={(event) => onSearchChange(event.currentTarget.value)}
+					aria-label="Search history"
+				/>
+				{#if search}
+					<button
+						class="clear-btn ui-focus-ring"
+						onmousedown={(event) => event.preventDefault()}
+						onclick={() => onSearchChange('')}
+						aria-label="Clear search"
+					>
+						<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
+					</button>
+				{/if}
+			</div>
 
-	{#if filtersActive}
-		<button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters} transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>Clear filters</button>
-	{/if}
+			<div class="history-search-divider"></div>
+
+			<Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
+				<div class="ui-dropdown history-app-dropdown">
+					<button
+						class="ui-dropdown-trigger ui-dropdown-trigger--compact history-app-trigger"
+						aria-haspopup="listbox"
+						aria-expanded={appDropdownOpen}
+						aria-controls="history-app-menu"
+						onclick={() => (appDropdownOpen = !appDropdownOpen)}
+					>
+						<span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
+						<svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+					</button>
+					{#if appDropdownOpen}
+						<div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
+							<button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => selectAppFilter(null)}>All apps</button>
+							{#each apps as app}
+								<button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => selectAppFilter(app)}>{formatAppLabel(app)}</button>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</Dropdown>
+
+			{#if filtersActive}
+				<div class="clear-filters-wrap" transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>
+					<div class="history-search-divider"></div>
+					<button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>Clear filters</button>
+				</div>
+			{/if}
+		{/if}
+	</div>
 </div>
 
 <style>
-  .history-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 16px;
-  }
+	.history-toolbar {
+		display: flex;
+		align-items: center;
+		margin-bottom: 12px;
+	}
 
-  /* The search input and the app dropdown are one visual unit: a single
-     bordered field whose orange focus ring wraps both, so focusing either
-     control highlights the whole bar instead of just the text box. */
-	.history-app-anchor { flex-shrink: 0; }
 	.history-search-group {
 		flex: 0 0 32px;
 		min-width: 32px;
 		display: flex;
-    align-items: center;
-    height: 32px;
+		align-items: center;
+		height: 32px;
 		background: transparent;
 		border: 1px solid transparent;
-    border-radius: var(--r-sm);
-    color: var(--ink-mute);
+		border-radius: var(--r-sm);
+		color: var(--ink-mute);
 		margin-left: auto;
-		transition: flex-basis var(--ui-duration-base) var(--ui-ease-out), border-color var(--ui-duration-fast) var(--ui-ease-out), background-color var(--ui-duration-fast) var(--ui-ease-out);
+		overflow: hidden;
+		transition:
+			flex-basis var(--ui-duration-base) var(--ui-ease-out),
+			border-color var(--ui-duration-fast) var(--ui-ease-out),
+			background-color var(--ui-duration-fast) var(--ui-ease-out);
 	}
-	.history-search-group.expanded { flex: 1 1 260px; min-width: 160px; max-width: 320px; background: var(--bg-elev); border-color: var(--line); overflow: visible; }
-	.search-icon-btn { all: unset; box-sizing: border-box; width: 32px; height: 32px; flex-shrink: 0; display: grid; place-items: center; cursor: pointer; color: var(--ink-mute); border-radius: var(--r-sm); }
+
+	.history-search-group.expanded {
+		flex: 1 1 260px;
+		min-width: 160px;
+		max-width: 460px;
+		background: var(--bg-elev);
+		border-color: var(--line);
+		overflow: visible;
+	}
+
+	.search-icon-btn {
+		all: unset;
+		box-sizing: border-box;
+		width: 32px;
+		height: 32px;
+		flex-shrink: 0;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		color: var(--ink-mute);
+		border-radius: var(--r-sm);
+		transition: color var(--ui-duration-fast) var(--ui-ease-out);
+	}
+
 	.search-icon-btn:hover { color: var(--ink-strong); }
 
-  .history-search {
-    flex: 1;
-    min-width: 0;
-    height: 100%;
-    padding: 0 9px;
-    display: flex;
-    align-items: center;
-    gap: 7px;
-  }
-  .history-search .ui-input {
-    flex: 1;
-    min-width: 0;
-    background: transparent;
-    border: 1px solid transparent;
-  }
-  .history-search .ui-input:focus-visible {
-    outline: none;
-  }
+	.history-search {
+		flex: 1;
+		min-width: 0;
+		height: 100%;
+		padding: 0 9px;
+		display: flex;
+		align-items: center;
+		gap: 7px;
+	}
 
-  .clear-btn {
-    background: transparent;
-    border: 0;
-    padding: 0;
-    color: var(--ink-mute);
-    cursor: pointer;
-    display: grid;
-    place-items: center;
-    width: 16px;
-    height: 16px;
-    border-radius: 4px;
-    flex-shrink: 0;
-  }
-  .clear-btn:hover {
-    color: var(--ink-strong);
-  }
+	.history-search .ui-input {
+		flex: 1;
+		min-width: 0;
+		background: transparent;
+		border: 1px solid transparent;
+	}
+
+	.history-search .ui-input:focus-visible { outline: none; }
+
+	.history-search-divider {
+		width: 1px;
+		height: 18px;
+		background: var(--line);
+		flex-shrink: 0;
+	}
+
+	.clear-btn {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		color: var(--ink-mute);
+		cursor: pointer;
+		display: grid;
+		place-items: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 4px;
+		flex-shrink: 0;
+	}
+
+	.clear-btn:hover { color: var(--ink-strong); }
+
+	.history-app-trigger {
+		border-color: transparent;
+		background: transparent;
+		flex-shrink: 0;
+	}
+
+	.history-app-trigger:hover,
+	.history-app-trigger[aria-expanded='true'] {
+		background: var(--control-hover);
+		border-color: transparent;
+	}
 
 	.history-app-menu {
-    width: max-content;
-    min-width: 180px;
+		width: max-content;
+		min-width: 180px;
 		max-width: 280px;
-		left: 0;
-		right: auto;
 	}
-	.clear-filters-btn { height: 32px; white-space: nowrap; flex-shrink: 0; }
 
-  @media (max-width: 560px) {
-    .history-toolbar {
-      flex-wrap: wrap;
-    }
-		.history-search-group.expanded { flex-basis: 100%; max-width: none; }
-  }
+	.clear-filters-wrap {
+		display: flex;
+		align-items: center;
+		height: 100%;
+		flex-shrink: 0;
+	}
+
+	.clear-filters-btn {
+		height: 100%;
+		padding: 0 12px;
+		border-color: transparent;
+		border-radius: 0 var(--r-sm) var(--r-sm) 0;
+	}
+
+	.clear-filters-btn:hover {
+		background: var(--control-hover);
+		border-color: transparent;
+	}
+
+	@media (max-width: 560px) {
+		.history-search-group.expanded {
+			flex-basis: 100%;
+			max-width: none;
+		}
+	}
 </style>

--- a/src/lib/views/home/HomeHero.svelte
+++ b/src/lib/views/home/HomeHero.svelte
@@ -10,7 +10,7 @@
     </h2>
     <p class="hero-photo-sub">
       Verenu works in any app. Try it in
-      <em class="hero-em">email, messages, docs</em> — or anywhere else.
+      <em class="hero-em">email, messages, docs</em> â€” or anywhere else.
     </p>
   </div>
 </div>
@@ -20,7 +20,7 @@
     position: relative;
     border-radius: var(--r-lg);
     overflow: hidden;
-    margin-bottom: 22px;
+    margin-bottom: 16px;
     height: clamp(112px, 14vw, 160px);
     background: var(--arm-950);
   }

--- a/src/lib/views/home/HomeHero.svelte
+++ b/src/lib/views/home/HomeHero.svelte
@@ -10,7 +10,7 @@
     </h2>
     <p class="hero-photo-sub">
       Verenu works in any app. Try it in
-      <em class="hero-em">email, messages, docs</em> â€” or anywhere else.
+      <em class="hero-em">email, messages, docs</em> &mdash; or anywhere else.
     </p>
   </div>
 </div>
@@ -34,11 +34,7 @@
     pointer-events: none;
   }
 
-  .hero-photo-content {
-    position: relative;
-    padding: 22px 28px;
-    max-width: min(520px, 100%);
-  }
+  .hero-photo-content { position: relative; padding: 22px 28px; max-width: min(520px, 100%); }
 
   .hero-photo-title {
     font-family: var(--serif);
@@ -75,12 +71,7 @@
   }
 
   @media (max-width: 720px) {
-    .hero-photo-content {
-      padding: 18px 20px;
-    }
-
-    .hero-photo-title {
-      font-size: 20px;
-    }
+    .hero-photo-content { padding: 18px 20px; }
+    .hero-photo-title { font-size: 20px; }
   }
 </style>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a local-first Home history view.
> - The relevant subsystem is the Home UI, specifically the History toolbar.
> - Search, app filtering, and clear filters were split across visually competing controls.
> - The grouped layout needs to keep those actions together without nested rounded buttons.
> - This pull request places the app filter inside the expandable search control, animates the clear-filters space, and tightens the Home spacing.
> - The benefit is a smaller, more consistent toolbar that matches the shared dropdown treatment.

## What Changed

- Group the search icon, history search field, app filter, and clear-filters action in one right-aligned control.
- Use the shared compact dropdown classes and format selected app labels the same way as menu options.
- Animate the clear-filters segment into the layout and render it as a flush divider-separated action instead of a rounded button inside the rounded search field.
- Reduce the gap below the Home hero so the history content starts sooner.

## Verification

- `npm run check` passes with 0 Svelte errors and warnings.
- Checked `docs/ROADMAP.md`; no overlapping History toolbar work is listed.
- The dev server starts on port 1420. Automated preview snapshot timed out, so the final GitHub check should include a manual visual pass through collapsed, expanded, filtered, and dropdown-open states.

## Risks

- Low risk. This changes only Home toolbar layout and local presentation styles. No backend, persistence, secrets, or dictation pipeline behavior changes.

## Model Used

- OpenAI GPT-5.6, Codex tool use and repository inspection.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`
- [x] `npm run check` passes
- [ ] Smoke tests pass
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above