### PR TITLE
Add LLM-powered post-dictation repair flow

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -84,9 +84,16 @@ pub async fn start_input_recording(
     match start_result {
         Ok(()) => Ok(()),
         Err(e) => {
-            let msg = format!("Failed to start recording: {e}");
+            // The returned error is the only surface the caller shows (inline
+            // mic-button message / setup TryIt step). Emitting verenu:error
+            // here too would show the same failure twice — a toast on top of
+            // the inline message. The hotkey path that has no caller-facing
+            // surface emits its own event in pipeline::session instead.
+            let msg = format!(
+                "Failed to start recording: {}",
+                crate::api::user_facing_message(&e)
+            );
             crate::pipeline::hide_pill(&app);
-            app.emit("verenu:error", msg.clone()).ok();
             Err(msg)
         }
     }
@@ -145,9 +152,13 @@ pub async fn start_setup_try_recording(
     match start_result {
         Ok(()) => Ok(()),
         Err(e) => {
-            let msg = format!("Failed to start recording: {e}");
+            // Single-surface rule: the caller (setup TryIt step) shows the
+            // returned error inline; no duplicate verenu:error toast here.
+            let msg = format!(
+                "Failed to start recording: {}",
+                crate::api::user_facing_message(&e)
+            );
             crate::pipeline::hide_pill(&app);
-            app.emit("verenu:error", msg.clone()).ok();
             Err(msg)
         }
     }
@@ -311,7 +322,113 @@ pub async fn stop_and_transcribe_input(
 ) -> Result<String, String> {
     pipeline::transcribe_input_only(app, state.inner().clone())
         .await
-        .map_err(|e| e.to_string())
+        // Sanitize before crossing IPC: the raw error can embed provider
+        // response bodies or the AUTH_401 wire format, which must not reach
+        // the inline mic-button message.
+        .map_err(|e| crate::api::user_facing_error(&e))
+}
+
+#[tauri::command]
+pub async fn start_repair_complaint_recording(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    pipeline::reserve_starting(state.inner())?;
+    pipeline::start_recording_session_ex(
+        &app,
+        state.inner(),
+        "repair_recording",
+        false,
+        None,
+        pipeline::RecordingStartOptions {
+            show_recording_pill: true,
+            emit_globally: false,
+            start_cue_delay_ms: None,
+        },
+    )
+}
+
+#[tauri::command]
+pub async fn stop_repair_complaint_recording(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    crate::core::hotkey::set_handless_active(false);
+    tauri::async_runtime::spawn(pipeline::finish_complaint_recording(
+        app.clone(),
+        state.inner().clone(),
+    ));
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn repair_positive_feedback(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    pipeline::clear_repair(state.inner());
+    pipeline::hide_pill(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn repair_enter_input(
+    app: AppHandle,
+    _state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    pipeline::enter_repair_input(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn repair_cancel(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    // A stale pill event must never stop a newer normal dictation. A repair
+    // session is cleared synchronously when a new dictation reserves its
+    // lifecycle, so only discard an active microphone session while repair
+    // still owns the transient state.
+    let owns_repair = state
+        .inner()
+        .lock()
+        .map(|locked| locked.repair.is_some())
+        .unwrap_or(false);
+    if owns_repair {
+        pipeline::clear_repair(state.inner());
+        pipeline::discard_recording(&app, state.inner()).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn repair_analyze(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+    complaint: String,
+) -> Result<(), String> {
+    pipeline::diagnose_repair(app.clone(), state.inner().clone(), complaint)
+        .await
+        .map_err(|error| {
+            let message = crate::api::user_facing_error(&error);
+            pipeline::emit_repair_error(&app, &message);
+            message
+        })
+}
+
+#[tauri::command]
+pub async fn repair_apply(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+    proposal_id: u64,
+) -> Result<String, String> {
+    pipeline::apply_repair(app.clone(), state.inner().clone(), proposal_id)
+        .await
+        .map_err(|error| {
+            let message = crate::api::user_facing_error(&error);
+            pipeline::emit_repair_error(&app, &message);
+            message
+        })
 }
 
 #[tauri::command]
@@ -461,16 +578,16 @@ pub fn set_pill_size(
 
     // Upper bounds are backstops against a bad frontend measurement, not the
     // expected size — they must clear the largest real layout, which is the
-    // error card: it wraps at a fixed column width and grows upward for up to
-    // seven lines, so it needs far more vertical room than the single-line
-    // capsule every other state uses.
+    // repair error/proposal card: its message text is provider-supplied and
+    // effectively unbounded in length, so it needs far more vertical room
+    // than the single-line capsule every other state uses.
     let width_points = if width.is_finite() {
         width.clamp(60.0, 440.0).round()
     } else {
         60.0
     };
     let height_points = if height.is_finite() {
-        height.clamp(44.0, 260.0).round()
+        height.clamp(44.0, 420.0).round()
     } else {
         44.0
     };

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -30,6 +30,7 @@ enum SettingKind {
     SoundEffectsVolume,
     AppMappings,
     Hotkey,
+    RepairHotkey,
     ClipboardPhrase,
 }
 
@@ -120,6 +121,7 @@ const SETTING_SPECS: &[SettingSpec] = &[
     ),
     setting_spec(store::CLEANUP_ENABLED, SettingKind::Bool, true, true),
     setting_spec(store::HOTKEY, SettingKind::Hotkey, true, true),
+    setting_spec(store::REPAIR_HOTKEY, SettingKind::RepairHotkey, true, true),
     setting_spec(
         store::MICROPHONE_DEVICE,
         SettingKind::StringOrNull,
@@ -324,6 +326,19 @@ pub fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), Stri
                 && keys[1].as_str().is_none_or(|second| {
                     second.is_empty() || crate::core::hotkey::is_known_key_code(second)
                 })
+        }),
+        // Two modifiers + one regular trigger key (default Ctrl+Alt+Z) — see
+        // core::hotkey::win's REPAIR_MOD1 doc comment for why a modifier-only
+        // combo isn't allowed. Unlike the main hotkey, all three slots empty
+        // is also valid: it disables the feature rather than requiring one
+        // be bound (the built-in Ctrl+Alt+Z default needs no setting saved).
+        SettingKind::RepairHotkey => value.as_array().is_some_and(|keys| {
+            keys.len() == 3
+                && keys.iter().all(serde_json::Value::is_string)
+                && (keys.iter().all(|k| k.as_str() == Some(""))
+                    || keys.iter().all(|k| {
+                        k.as_str().is_some_and(crate::core::hotkey::is_known_key_code)
+                    }))
         }),
     };
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -14,35 +14,13 @@ pub fn frontend_ready(
     readiness: tauri::State<'_, crate::FrontendReadiness>,
 ) -> Result<(), String> {
     match window.label() {
-        "main" => readiness.main.store(true, std::sync::atomic::Ordering::Release),
-        "pill" => readiness.pill.store(true, std::sync::atomic::Ordering::Release),
+        "main" => readiness
+            .main
+            .store(true, std::sync::atomic::Ordering::Release),
+        "pill" => readiness
+            .pill
+            .store(true, std::sync::atomic::Ordering::Release),
         label => return Err(format!("Unknown frontend window: {label}")),
-    }
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn show_main(app: AppHandle) -> Result<(), String> {
-    if let Some(w) = app.get_webview_window("main") {
-        #[cfg(target_os = "macos")]
-        {
-            crate::system::mac_app::set_regular_activation_policy_on_main_thread(&app);
-            crate::system::mac_app::activate_current_app_on_main_thread(&app);
-        }
-        w.show().ok();
-        w.set_focus().ok();
-    }
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn hide_main(app: AppHandle) -> Result<(), String> {
-    if let Some(w) = app.get_webview_window("main") {
-        #[cfg(target_os = "macos")]
-        {
-            crate::system::mac_app::set_accessory_activation_policy_on_main_thread(&app);
-        }
-        w.hide().ok();
     }
     Ok(())
 }
@@ -142,6 +120,43 @@ pub async fn save_hotkey(app: AppHandle, key1: String, key2: String) -> Result<(
     let settings = store::settings_handle(&app)?;
     run_blocking("save_hotkey", move || {
         settings.save_value(store::HOTKEY, serde_json::json!([key1, key2]))
+    })
+    .await
+}
+
+/// Two modifiers (key1, key2) plus one regular trigger key (key3) — see the
+/// doc comment on `REPAIR_MOD1` in core::hotkey::win for why a modifier-only
+/// combo isn't allowed here.
+#[tauri::command]
+pub async fn check_repair_hotkey(key1: String, key2: String, key3: String) -> Result<bool, String> {
+    let _ = &key2;
+    Ok(crate::core::hotkey::is_hotkey_available(&key1, &key3))
+}
+
+/// Same shape as `save_hotkey`, but all three slots empty is a valid "unset"
+/// state (disables the repair-open hotkey rather than requiring one be bound
+/// — Ctrl+Alt+Z remains the working default until the user changes it).
+#[tauri::command]
+pub async fn save_repair_hotkey(app: AppHandle, key1: String, key2: String, key3: String) -> Result<(), String> {
+    let unset = key1.is_empty() && key2.is_empty() && key3.is_empty();
+    let vk1 = crate::core::hotkey::map_code_to_vk(&key1);
+    let vk2 = crate::core::hotkey::map_code_to_vk(&key2);
+    let vk3 = crate::core::hotkey::map_code_to_vk(&key3);
+    if !unset {
+        if vk1 == 0 {
+            return Err(format!("Unrecognized key code: {key1}"));
+        }
+        if vk2 == 0 {
+            return Err(format!("Unrecognized key code: {key2}"));
+        }
+        if vk3 == 0 {
+            return Err(format!("Unrecognized key code: {key3}"));
+        }
+    }
+    crate::core::hotkey::update_repair_keys(vk1, vk2, vk3);
+    let settings = store::settings_handle(&app)?;
+    run_blocking("save_repair_hotkey", move || {
+        settings.save_value(store::REPAIR_HOTKEY, serde_json::json!([key1, key2, key3]))
     })
     .await
 }
@@ -342,7 +357,9 @@ fn run_launchctl(args: &[&str]) -> Result<(), String> {
         format!("exit status {}", output.status)
     };
 
-    Err(format!("launchctl {:?} failed: {detail}", args))
+    // Deliberately no `{:?}` of args: the service target embeds the local
+    // plist path. stderr/stdout keep the diagnostic value for the user.
+    Err(format!("launchctl failed: {detail}"))
 }
 
 // ---------- connectivity ----------
@@ -393,16 +410,6 @@ async fn native_connectivity_check() -> Option<bool> {
 // ---------- developer logs ----------
 
 #[tauri::command]
-pub fn log_frontend(level: String, message: String) {
-    let message = crate::system::logger::sanitize_frontend_log_message(&message);
-    match level.as_str() {
-        "warn" => log::warn!("fe: {message}"),
-        "error" => log::error!("fe: {message}"),
-        _ => log::info!("fe: {message}"),
-    }
-}
-
-#[tauri::command]
 pub fn get_recent_logs(limit: Option<usize>) -> Vec<String> {
     crate::system::logger::recent(limit)
 }
@@ -446,10 +453,7 @@ pub fn notify_provider_and_global_message(
 }
 
 #[tauri::command]
-pub fn test_notifications(
-    app: AppHandle,
-    notification_type: Option<String>,
-) -> Result<(), String> {
+pub fn test_notifications(app: AppHandle, notification_type: Option<String>) -> Result<(), String> {
     crate::system::notify::notify_test_notification(
         &app,
         notification_type.as_deref().unwrap_or("update"),

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -101,6 +101,18 @@ static MANAGER: OnceLock<GlobalHotKeyManager> = OnceLock::new();
 static CURRENT_HOTKEY: Mutex<Option<HotKey>> = Mutex::new(None);
 static MAIN_HOTKEY_ID: AtomicU32 = AtomicU32::new(0);
 static ESCAPE_HOTKEY: OnceLock<HotKey> = OnceLock::new();
+
+// User-configurable "open the repair complaint box" hotkey: two modifiers
+// plus one regular trigger key, default Ctrl+Alt+Z. Matches the Windows
+// backend's shape (see its REPAIR_MOD1 doc comment for why a modifier-only
+// combo is disallowed there) even though Carbon's RegisterEventHotKey was
+// never at risk of that specific bug itself.
+static REPAIR_KEY1: AtomicU32 = AtomicU32::new(ID_CONTROL);
+static REPAIR_KEY2: AtomicU32 = AtomicU32::new(ID_ALT);
+static REPAIR_KEY3: AtomicU32 = AtomicU32::new(REGULAR_BASE + 6); // KeyZ
+static CURRENT_REPAIR_HOTKEY: Mutex<Option<HotKey>> = Mutex::new(None);
+static REPAIR_HOTKEY_ID: AtomicU32 = AtomicU32::new(0);
+static REPAIR_OPEN_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 // ⌥⌘C: always-registered fallback to re-copy the last dictation, in case
 // paste failed in a way the pipeline's own detection missed. Unlike Escape
 // this is registered permanently at startup, not just while recording.
@@ -118,11 +130,6 @@ fn now_ms() -> u64 {
 
 // --- public contract -------------------------------------------------------
 
-/// Synthetic-paste suppression was only needed to keep the old keystroke tap
-/// from recording our own Cmd+V into the injection history. Without the tap this
-/// is a no-op (kept to satisfy the shared cross-platform contract).
-pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
-
 /// There's no Windows key on macOS — kept to satisfy the shared contract.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub fn is_win_key_down() -> bool {
@@ -138,6 +145,13 @@ pub fn update_keys(k1: u32, k2: u32) {
     KEY2.store(k2, Ordering::SeqCst);
     reset_chord_state();
     register_main_hotkey();
+}
+
+pub fn update_repair_keys(k1: u32, k2: u32, k3: u32) {
+    REPAIR_KEY1.store(k1, Ordering::SeqCst);
+    REPAIR_KEY2.store(k2, Ordering::SeqCst);
+    REPAIR_KEY3.store(k3, Ordering::SeqCst);
+    register_repair_hotkey();
 }
 
 pub fn reset_chord_state() {
@@ -361,9 +375,19 @@ fn modifier_id_to_mods(id: u32) -> Option<Modifiers> {
 /// Resolve the two private key ids into a single registrable `HotKey`, or `None`
 /// if there is no real trigger key (e.g. a modifier-only combination).
 fn build_hotkey(k1: u32, k2: u32) -> Option<HotKey> {
+    build_hotkey_from(&[k1, k2])
+}
+
+/// Same as `build_hotkey` but over an arbitrary number of ids — used by the
+/// repair-open hotkey, which is 2 modifiers + 1 trigger key. Already rejects
+/// a modifier-only combination (returns `None` since `code` stays unset), so
+/// unlike the Windows backend's low-level key hook, Carbon's
+/// `RegisterEventHotKey` was never at risk of intercepting a bare modifier
+/// press on its own — it only ever fires on the complete registered combo.
+fn build_hotkey_from(ids: &[u32]) -> Option<HotKey> {
     let mut mods = Modifiers::empty();
     let mut code: Option<Code> = None;
-    for id in [k1, k2] {
+    for id in ids.iter().copied() {
         if id == 0 {
             continue;
         }
@@ -437,6 +461,36 @@ fn register_main_hotkey() {
     }
 }
 
+fn register_repair_hotkey() {
+    let Some(mgr) = MANAGER.get() else {
+        return;
+    };
+    let hk = build_hotkey_from(&[
+        REPAIR_KEY1.load(Ordering::SeqCst),
+        REPAIR_KEY2.load(Ordering::SeqCst),
+        REPAIR_KEY3.load(Ordering::SeqCst),
+    ]);
+    let Ok(mut cur) = CURRENT_REPAIR_HOTKEY.lock() else {
+        return;
+    };
+    if let Some(prev) = cur.take() {
+        let _ = mgr.unregister(prev);
+        REPAIR_HOTKEY_ID.store(0, Ordering::SeqCst);
+    }
+    let Some(hk) = hk else {
+        // Unconfigured or unregistrable — leave nothing registered rather
+        // than falling back to a combo the user never chose.
+        return;
+    };
+    match mgr.register(hk) {
+        Ok(()) => {
+            *cur = Some(hk);
+            REPAIR_HOTKEY_ID.store(hk.id(), Ordering::SeqCst);
+        }
+        Err(e) => log::warn!("hotkey: failed to register repair-open hotkey: {e}"),
+    }
+}
+
 fn register_copy_last_hotkey() {
     let Some(mgr) = MANAGER.get() else {
         return;
@@ -492,6 +546,14 @@ fn handle_hotkey_event(ev: GlobalHotKeyEvent) {
     if COPY_LAST_HOTKEY.get().is_some_and(|h| h.id() == ev.id) {
         if matches!(ev.state, HotKeyState::Pressed) {
             if let Some(cb) = COPY_LAST_CB.get() {
+                cb();
+            }
+        }
+        return;
+    }
+    if REPAIR_HOTKEY_ID.load(Ordering::SeqCst) != 0 && ev.id == REPAIR_HOTKEY_ID.load(Ordering::SeqCst) {
+        if matches!(ev.state, HotKeyState::Pressed) {
+            if let Some(cb) = REPAIR_OPEN_CB.get() {
                 cb();
             }
         }
@@ -566,13 +628,15 @@ fn on_escape_pressed() {
 
 // --- start -----------------------------------------------------------------
 
-pub fn start<P, R, H, C, E, L>(
+#[allow(clippy::too_many_arguments)]
+pub fn start<P, R, H, C, E, L, O>(
     on_press: P,
     on_release: R,
     on_handless: H,
     on_cancel: C,
     on_escape: E,
     on_copy_last: L,
+    on_repair_open: O,
 ) -> Result<std::thread::JoinHandle<()>, String>
 where
     P: Fn() + Send + Sync + 'static,
@@ -581,6 +645,7 @@ where
     C: Fn() + Send + Sync + 'static,
     E: Fn() + Send + Sync + 'static,
     L: Fn() + Send + Sync + 'static,
+    O: Fn() + Send + Sync + 'static,
 {
     if MANAGER.get().is_some() {
         log::warn!("hotkey: global hotkey manager already initialized");
@@ -593,6 +658,7 @@ where
     let _ = CANCEL_CB.set(Box::new(on_cancel));
     let _ = ESCAPE_CB.set(Box::new(on_escape));
     let _ = COPY_LAST_CB.set(Box::new(on_copy_last));
+    let _ = REPAIR_OPEN_CB.set(Box::new(on_repair_open));
 
     // Created here (on the main thread, from Tauri `setup`) because the crate
     // installs its Carbon event handler on the application event target, which
@@ -605,6 +671,7 @@ where
     }
     register_main_hotkey();
     register_copy_last_hotkey();
+    register_repair_hotkey();
 
     // Drain hotkey events on a background thread; the receiver is a process-wide
     // channel fed by the Carbon handler, so it is safe to poll off-thread.

--- a/src-tauri/src/core/hotkey/mod.rs
+++ b/src-tauri/src/core/hotkey/mod.rs
@@ -5,13 +5,82 @@
 //!   `start(on_press, on_release, on_handless, on_cancel, on_escape, on_copy_last)`,
 //!   `update_keys`, `map_code_to_vk`, `is_hotkey_available`,
 //!   `reset_chord_state`, `set_handless_active`,
-//!   `begin_synthetic_paste_suppression`, `is_win_key_down`,
+//!   `is_win_key_down`,
 //!   `force_release_win_key`.
 //!
-//! Windows uses a `WH_KEYBOARD_LL` hook; macOS uses a `CGEventTap`. The numeric
+//! Windows uses a `WH_KEYBOARD_LL` hook; macOS uses Carbon `RegisterEventHotKey`
+//! via the `global-hotkey` crate. The numeric
 //! key ids produced by `map_code_to_vk` are platform-private — only the matching
 //! backend interprets them — so the two implementations never need to agree on a
 //! shared numbering.
+
+/// Whether `code` (a JS `KeyboardEvent.code`) is a key the backend can map to a
+/// real key on either supported platform. Platform-independent: mirrors the
+/// union of codes accepted by the Windows and macOS `map_code_to_vk`
+/// implementations, so a hotkey that validates here will register on at least
+/// one of them.
+///
+/// Used by the generic `save_setting`/`import_data` path, which must not let a
+/// hand-edited or imported settings.json silently disable the dictation hotkey
+/// by storing a code no backend recognizes (e.g. `["Foo", "Bar"]` — the startup
+/// hook would then map both to VK 0 and never fire).
+pub fn is_known_key_code(code: &str) -> bool {
+    match code {
+        "" => false,
+        "ShiftLeft" | "ShiftRight" | "ControlLeft" | "ControlRight" => true,
+        "AltLeft" | "AltRight" | "MetaLeft" | "MetaRight" | "Fn" => true,
+        "Space" | "Escape" | "Enter" | "Backspace" | "Tab" | "CapsLock" => true,
+        "Minus" | "Equal" | "BracketLeft" | "BracketRight" | "Backslash" => true,
+        "Semicolon" | "Quote" | "Comma" | "Period" | "Slash" | "Backquote" => true,
+        "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight" => true,
+        "Insert" | "Delete" | "Home" | "End" | "PageUp" | "PageDown" => true,
+        _ if code.starts_with("Key")
+            && code.len() == 4
+            && code.as_bytes()[3].is_ascii_uppercase() =>
+        {
+            true
+        }
+        _ if code.starts_with("Digit")
+            && code.len() == 6
+            && code.as_bytes()[5].is_ascii_digit() =>
+        {
+            true
+        }
+        _ if code.starts_with('F') && code.len() > 1 => code[1..]
+            .parse::<u32>()
+            .is_ok_and(|n| (1..=12).contains(&n)),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod known_key_code_tests {
+    use super::is_known_key_code;
+
+    #[test]
+    fn recognizes_supported_hotkey_codes() {
+        for code in [
+            "ControlLeft",
+            "MetaLeft",
+            "AltLeft",
+            "ShiftLeft",
+            "Space",
+            "Fn",
+            "F5",
+            "KeyA",
+            "Digit7",
+        ] {
+            assert!(is_known_key_code(code), "{code} should be known");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_and_malformed_codes() {
+        for code in ["Foo", "Bar", "Control", "Key", "F13", "Digit10", "", "meta"] {
+            assert!(!is_known_key_code(code), "{code:?} should be rejected");
+        }
+    }
+}
 
 #[cfg(windows)]
 mod win;
@@ -31,11 +100,11 @@ mod noop {
         true
     }
     pub fn update_keys(_k1: u32, _k2: u32) {}
+    pub fn update_repair_keys(_k1: u32, _k2: u32, _k3: u32) {}
     pub fn reset_chord_state() {}
     pub fn set_handless_active(_v: bool) {}
     pub fn set_processing_generation(_generation: u64) {}
     pub fn clear_processing_generation(_expected_generation: u64) {}
-    pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
     pub fn is_win_key_down() -> bool {
         false
     }
@@ -46,13 +115,15 @@ mod noop {
     pub fn map_code_to_vk(_code: &str) -> u32 {
         0
     }
-    pub fn start<P, R, H, C, E, L>(
+    #[allow(clippy::too_many_arguments)]
+    pub fn start<P, R, H, C, E, L, O>(
         _on_press: P,
         _on_release: R,
         _on_handless: H,
         _on_cancel: C,
         _on_escape: E,
         _on_copy_last: L,
+        _on_repair_open: O,
     ) -> Result<std::thread::JoinHandle<()>, String>
     where
         P: Fn() + Send + Sync + 'static,
@@ -61,6 +132,7 @@ mod noop {
         C: Fn() + Send + Sync + 'static,
         E: Fn() + Send + Sync + 'static,
         L: Fn() + Send + Sync + 'static,
+        O: Fn() + Send + Sync + 'static,
     {
         Ok(std::thread::spawn(|| {}))
     }

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -538,9 +538,6 @@ pub fn caps_lock_is_on() -> bool {
     CAPS_LOCK_ON.load(Ordering::SeqCst)
 }
 
-#[allow(dead_code)]
-pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
-
 /// Live OS-level check (not our own bookkeeping) — true if Windows currently
 /// thinks either Win key is held. Reuses the same `GetAsyncKeyState` primitive
 /// `modifier_held` already uses for Win (VK 91/92, no generic VK_WIN).
@@ -675,6 +672,30 @@ static ESCAPE_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::
 static COPY_LAST_KEY_DOWN: AtomicBool = AtomicBool::new(false);
 static COPY_LAST_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 
+// User-configurable "open the repair complaint box" hotkey. Two modifiers
+// plus one regular trigger key (default Ctrl+Alt+Z) — deliberately NOT a
+// two-key modifier-only chord like the main hotkey. An earlier version let
+// this be set to e.g. Ctrl+Alt alone and suppressed (return LRESULT(1))
+// *either* configured key's own down/up the moment it matched, before the
+// main chord's ChordStateMachine ever saw it — so a bare Ctrl press (half of
+// the default main hotkey) got eaten outright, breaking dictation entirely.
+// This mirrors the existing Ctrl+Alt+C copy-last shortcut instead: only the
+// trigger key's own event is ever intercepted, and only once GetAsyncKeyState
+// confirms both modifiers are already down — bare Ctrl/Alt presses, and every
+// other shortcut built on them (including the main hotkey), are untouched.
+static REPAIR_MOD1: AtomicU32 = AtomicU32::new(162); // Ctrl
+static REPAIR_MOD2: AtomicU32 = AtomicU32::new(164); // Alt
+static REPAIR_TRIGGER: AtomicU32 = AtomicU32::new(0x5A); // 'Z'
+static REPAIR_TRIGGER_DOWN: AtomicBool = AtomicBool::new(false);
+static REPAIR_OPEN_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
+
+pub fn update_repair_keys(mod1: u32, mod2: u32, trigger: u32) {
+    REPAIR_MOD1.store(mod1, Ordering::SeqCst);
+    REPAIR_MOD2.store(mod2, Ordering::SeqCst);
+    REPAIR_TRIGGER.store(trigger, Ordering::SeqCst);
+    REPAIR_TRIGGER_DOWN.store(false, Ordering::SeqCst);
+}
+
 unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     if code == HC_ACTION as i32 {
         let kb = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
@@ -692,6 +713,27 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
         let is_key1 = vk_matches(vk, k1);
         let is_down = msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN;
         let is_up = msg == WM_KEYUP || msg == WM_SYSKEYUP;
+
+        // Repair-open hotkey (Ctrl+Alt+Z by default): only the trigger key's
+        // own event is ever intercepted, exactly like the Ctrl+Alt+C
+        // copy-last shortcut below — bare modifier presses are never touched,
+        // so this can never eat half of the main hotkey (see the doc comment
+        // on REPAIR_MOD1 for the bug this replaced).
+        if vk == REPAIR_TRIGGER.load(Ordering::Relaxed) && (is_down || is_up) {
+            let mods_held = modifier_held(REPAIR_MOD1.load(Ordering::Relaxed))
+                && modifier_held(REPAIR_MOD2.load(Ordering::Relaxed));
+            if is_down && mods_held {
+                if !REPAIR_TRIGGER_DOWN.swap(true, Ordering::SeqCst) {
+                    if let Some(cb) = REPAIR_OPEN_CB.get() {
+                        cb();
+                    }
+                }
+                return LRESULT(1);
+            }
+            if is_up && REPAIR_TRIGGER_DOWN.swap(false, Ordering::SeqCst) && mods_held {
+                return LRESULT(1);
+            }
+        }
 
         if RESET_REQUESTED.swap(false, Ordering::SeqCst) {
             CHORD_MACHINE.with(|m| m.borrow_mut().reset_gesture_state());
@@ -1150,13 +1192,15 @@ mod chord_tests {
     }
 }
 
-pub fn start<P, R, H, C, E, L>(
+#[allow(clippy::too_many_arguments)]
+pub fn start<P, R, H, C, E, L, O>(
     on_press: P,
     on_release: R,
     on_handless: H,
     on_cancel: C,
     on_escape: E,
     on_copy_last: L,
+    on_repair_open: O,
 ) -> Result<std::thread::JoinHandle<()>, String>
 where
     P: Fn() + Send + Sync + 'static,
@@ -1165,6 +1209,7 @@ where
     C: Fn() + Send + Sync + 'static,
     E: Fn() + Send + Sync + 'static,
     L: Fn() + Send + Sync + 'static,
+    O: Fn() + Send + Sync + 'static,
 {
     let _ = PRESS_CB.set(Box::new(on_press));
     let _ = RELEASE_CB.set(Box::new(on_release));
@@ -1172,6 +1217,7 @@ where
     let _ = CANCEL_CB.set(Box::new(on_cancel));
     let _ = ESCAPE_CB.set(Box::new(on_escape));
     let _ = COPY_LAST_CB.set(Box::new(on_copy_last));
+    let _ = REPAIR_OPEN_CB.set(Box::new(on_repair_open));
 
     // Verify the hook can be installed before spawning the thread so the caller
     // gets a synchronous error instead of a silent panic on a background thread.

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -1,7 +1,7 @@
 //! Dictionary entries, auto-learn events/candidates, and pending corrections.
 
 use anyhow::Result;
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use super::*;
@@ -63,31 +63,55 @@ pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
     Ok(rows)
 }
 
+pub fn query_dictionary_for_context(db: &Db, context_id: i64) -> Result<Vec<DictionaryEntry>> {
+    let conn = lock_conn(db)?;
+    let mut stmt = conn.prepare(
+        "SELECT d.id, d.term, d.mistake, d.auto_learned, d.correction_count,
+                d.confidence_tier, d.last_seen_at, d.created_at
+         FROM dictionary d
+         INNER JOIN dictionary_contexts dc ON dc.dictionary_id = d.id
+         WHERE dc.context_id = ?1
+         ORDER BY d.created_at DESC",
+    )?;
+    let rows = stmt
+        .query_map(params![context_id], |r| {
+            Ok(DictionaryEntry {
+                id: r.get(0)?,
+                term: r.get(1)?,
+                mistake: r.get(2)?,
+                auto_learned: r.get::<_, i64>(3)? != 0,
+                correction_count: r.get(4)?,
+                confidence_tier: r.get(5)?,
+                last_seen_at: r.get(6)?,
+                created_at: r.get(7)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
 #[cfg(test)]
 pub fn insert_dictionary_entry(db: &Db, term: &str, mistake: Option<&str>) -> Result<()> {
-    let normalized_term = require_nonempty_trimmed("Term", term)?;
-    let normalized_mistake = normalize_optional_trimmed(mistake);
-    validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
-    if let Some(mistake) = normalized_mistake.as_deref() {
-        validate_char_limit(
-            "Often mistranscribed as",
-            mistake,
-            DICTIONARY_ENTRY_CHAR_LIMIT,
-        )?;
-    }
-
-    let conn = lock_conn(db)?;
-    conn.execute(
-        "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
-        params![normalized_term, normalized_mistake],
-    )?;
+    insert_dictionary_entry_returning(db, term, mistake, None)?;
     Ok(())
 }
 
+/// Creates a dictionary entry, or — when `context_id` names a specific
+/// (non-Everywhere) context and the term already exists elsewhere — links the
+/// existing entry into that context instead of failing on the term's UNIQUE
+/// constraint. Only errors on a duplicate when the entry is already assigned
+/// to that same context; a term already scoped to a *different* context is
+/// fair game to also assign here, since a term can belong to more than one
+/// context at once (see `dictionary_contexts`).
+///
+/// `context_id: None` (used by the legacy standalone Dictionary page and bulk
+/// import) keeps the original strict behavior: duplicate terms always fail,
+/// and new entries land in Everywhere.
 pub fn insert_dictionary_entry_returning(
     db: &Db,
     term: &str,
     mistake: Option<&str>,
+    context_id: Option<i64>,
 ) -> Result<CreatedRecordMeta> {
     let normalized_term = require_nonempty_trimmed("Term", term)?;
     let normalized_mistake = normalize_optional_trimmed(mistake);
@@ -96,20 +120,156 @@ pub fn insert_dictionary_entry_returning(
         validate_char_limit("Often mistranscribed as", m, DICTIONARY_ENTRY_CHAR_LIMIT)?;
     }
 
-    // Insert and read last_insert_rowid under a single lock to prevent another
-    // thread's insert racing between the two acquisitions and returning the wrong id.
-    let conn = lock_conn(db)?;
-    conn.execute(
+    // Insert, assign, and read last_insert_rowid under a single lock to prevent
+    // another thread's insert racing between the two acquisitions.
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+    let target_context = context_id.filter(|id| *id != everywhere_id);
+
+    if let Some(target_context) = target_context {
+        let existing: Option<i64> = tx
+            .query_row(
+                "SELECT id FROM dictionary WHERE term = ?1",
+                params![normalized_term],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(id) = existing {
+            let already_in_context: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2)",
+                params![target_context, id],
+                |row| row.get(0),
+            )?;
+            if already_in_context {
+                anyhow::bail!("\"{normalized_term}\" is already in this context");
+            }
+            tx.execute(
+                "UPDATE dictionary SET mistake = ?2 WHERE id = ?1",
+                params![id, normalized_mistake],
+            )?;
+            tx.execute(
+                "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+                params![target_context, id],
+            )?;
+            let created_at = tx.query_row(
+                "SELECT created_at FROM dictionary WHERE id=?1",
+                params![id],
+                |r| r.get(0),
+            )?;
+            tx.commit()?;
+            return Ok(CreatedRecordMeta { id, created_at });
+        }
+    }
+
+    tx.execute(
         "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
         params![normalized_term, normalized_mistake],
     )?;
-    let id = conn.last_insert_rowid();
-    let created_at = conn.query_row(
+    let id = tx.last_insert_rowid();
+    tx.execute(
+        "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+        params![target_context.unwrap_or(everywhere_id), id],
+    )?;
+    let created_at = tx.query_row(
         "SELECT created_at FROM dictionary WHERE id=?1",
         params![id],
         |r| r.get(0),
     )?;
+    tx.commit()?;
     Ok(CreatedRecordMeta { id, created_at })
+}
+
+/// Applies a user-approved repair as one database transaction. The expected
+/// values are checked while the same connection is locked, so a concurrent
+/// auto-learn or settings UI update cannot be silently overwritten.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_dictionary_repair(
+    db: &Db,
+    operation: &str,
+    dictionary_id: Option<i64>,
+    term: Option<&str>,
+    mistake: Option<&str>,
+    context_id: i64,
+    expected_term: Option<&str>,
+    expected_mistake: Option<&str>,
+) -> Result<i64> {
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let context_exists: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM contexts WHERE id = ?1",
+        params![context_id],
+        |row| row.get(0),
+    )?;
+    if context_exists == 0 {
+        anyhow::bail!("Repair scope does not exist")
+    }
+
+    let id = match operation {
+        "add" => {
+            let term = require_nonempty_trimmed("Term", term.unwrap_or_default())?;
+            let mistake = require_nonempty_trimmed("Often mistranscribed as", mistake.unwrap_or_default())?;
+            validate_char_limit("Term", &term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+            validate_char_limit("Often mistranscribed as", &mistake, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+            tx.execute(
+                "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
+                params![term, mistake],
+            )?;
+            tx.last_insert_rowid()
+        }
+        "update" => {
+            let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("Missing dictionary target"))?;
+            let current: (String, Option<String>) = tx.query_row(
+                "SELECT term, mistake FROM dictionary WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            if Some(current.0.as_str()) != expected_term || current.1.as_deref() != expected_mistake {
+                anyhow::bail!("Dictionary entry changed while you were reviewing it")
+            }
+            let term = require_nonempty_trimmed("Term", term.unwrap_or_default())?;
+            validate_char_limit("Term", &term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+            let normalized_mistake = normalize_optional_trimmed(mistake);
+            if let Some(value) = normalized_mistake.as_deref() {
+                validate_char_limit("Often mistranscribed as", value, DICTIONARY_ENTRY_CHAR_LIMIT)?;
+            }
+            let changed = tx.execute(
+                "UPDATE dictionary SET term = ?1, mistake = ?2 WHERE id = ?3",
+                params![term, normalized_mistake, id],
+            )?;
+            if changed != 1 {
+                anyhow::bail!("Dictionary entry no longer exists")
+            }
+            id
+        }
+        "remove" => {
+            let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("Missing dictionary target"))?;
+            let current: (String, Option<String>) = tx.query_row(
+                "SELECT term, mistake FROM dictionary WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            if Some(current.0.as_str()) != expected_term || current.1.as_deref() != expected_mistake {
+                anyhow::bail!("Dictionary entry changed while you were reviewing it")
+            }
+            tx.execute("DELETE FROM dictionary_contexts WHERE dictionary_id = ?1", params![id])?;
+            if tx.execute("DELETE FROM dictionary WHERE id = ?1", params![id])? != 1 {
+                anyhow::bail!("Dictionary entry no longer exists")
+            }
+            id
+        }
+        _ => anyhow::bail!("Unsupported dictionary repair operation"),
+    };
+
+    if operation != "remove" {
+        tx.execute("DELETE FROM dictionary_contexts WHERE dictionary_id = ?1", params![id])?;
+        tx.execute(
+            "INSERT INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+            params![context_id, id],
+        )?;
+    }
+    tx.commit()?;
+    Ok(id)
 }
 
 /// Ensures the dictionary's "Verenu" entry (if any) lists every known
@@ -216,6 +376,12 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
                 "INSERT INTO dictionary (term, mistake, confidence_tier) VALUES ('Verenu', ?1, 'manual')",
                 params![KNOWN_VARIANTS.join(", ")],
             )?;
+            let id = tx.last_insert_rowid();
+            let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+            tx.execute(
+                "INSERT INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+                params![everywhere_id, id],
+            )?;
             tx.execute(
                 "INSERT INTO seeded_defaults (key) VALUES (?1)",
                 params![MARKER],
@@ -248,9 +414,16 @@ pub fn insert_dictionary_entry_from_backup_conn(
          VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
         params![normalized_term, normalized_mistake, auto_learned as i64, correction_count, confidence_tier],
     )?;
+    let id = conn.last_insert_rowid();
+    let everywhere_id = ensure_everywhere_context_conn(conn)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+        params![everywhere_id, id],
+    )?;
     Ok(())
 }
 
+#[cfg(test)]
 pub fn insert_dictionary_entry_auto_learned(
     db: &Db,
     term: &str,
@@ -279,6 +452,16 @@ pub fn insert_dictionary_entry_auto_learned(
          WHERE dictionary.auto_learned = 1 \
            AND COALESCE(dictionary.mistake, '') = COALESCE(excluded.mistake, '')",
         params![normalized_term, normalized_mistake, confidence_tier],
+    )?;
+    let id: i64 = conn.query_row(
+        "SELECT id FROM dictionary WHERE term = ?1",
+        params![normalized_term],
+        |r| r.get(0),
+    )?;
+    let everywhere_id = ensure_everywhere_context_conn(&conn)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+        params![everywhere_id, id],
     )?;
     Ok(changed > 0)
 }
@@ -334,15 +517,145 @@ pub fn upsert_auto_learn_candidate(
     .map_err(Into::into)
 }
 
-pub fn mark_auto_learn_candidate_promoted(db: &Db, wrong: &str, correct: &str) -> Result<()> {
-    let conn = lock_conn(db)?;
-    conn.execute(
-        "UPDATE auto_learn_candidates
-         SET promoted_at = datetime('now')
-         WHERE wrong_word = ?1 AND correct_word = ?2",
+/// Outcome of an [`auto_learn_promote`] attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoLearnPromoteResult {
+    /// The pair was promoted to the dictionary (or its existing auto-learned
+    /// entry was reinforced) and the candidate's `promoted_at` gate claimed.
+    Promoted,
+    /// Pending-correction count hasn't reached the threshold yet. The pending
+    /// row was recorded so the next session counts toward the threshold.
+    BelowThreshold { pending_count: i64 },
+    /// A manual dictionary entry for the same term blocks auto-learn. The
+    /// candidate gate was NOT claimed, so removing the manual entry later lets
+    /// the pair be learned anew.
+    Blocked,
+    /// A concurrent monitor (or a rejection that already purged the candidate)
+    /// won the promotion claim first. The pair must not promote again.
+    AlreadyPromoted,
+}
+
+/// Atomically records a pending correction, checks the promotion threshold,
+/// claims the candidate's `promoted_at` gate, and promotes the pair into the
+/// dictionary — all in one transaction under the single DB lock.
+///
+/// Auto-learn monitors are intentionally concurrent (one per dictation), and
+/// two monitors can observe the same `(wrong, correct)` pair within the same
+/// 2-day window. Previously the pending-count read and the dictionary upsert
+/// were separate lock acquisitions, so two monitors could BOTH pass the
+/// threshold and BOTH "promote" the same pair — double `promoted` events and
+/// an inflated `correction_count`. A rejection monitor could also delete the
+/// entry/candidate in the gap, and the in-flight promotion would re-create the
+/// rejected entry. `promoted_at` is the single promotion gate: it is claimed
+/// here (atomically, `IS NULL` guard) and only cleared by the rejection /
+/// manual-delete paths, which purge the candidate row entirely.
+pub fn auto_learn_promote(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    confidence_tier: &str,
+    pending_retention_days: i64,
+    threshold: i64,
+) -> Result<AutoLearnPromoteResult> {
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+
+    tx.execute(
+        "INSERT INTO pending_corrections (wrong_word, correct_word) VALUES (?1, ?2)",
         params![wrong, correct],
     )?;
-    Ok(())
+
+    let pending_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM pending_corrections
+         WHERE wrong_word = ?1 AND correct_word = ?2
+           AND created_at >= datetime('now', ?3)",
+        params![
+            wrong,
+            correct,
+            format!("-{} days", pending_retention_days.max(1))
+        ],
+        |r| r.get(0),
+    )?;
+
+    if pending_count < threshold.max(1) {
+        tx.commit()?;
+        return Ok(AutoLearnPromoteResult::BelowThreshold { pending_count });
+    }
+
+    // A manual entry must block auto-learn WITHOUT claiming the candidate, so
+    // that deleting the manual entry later allows the pair to be learned anew.
+    let manual_exists: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM dictionary WHERE term = ?1 AND auto_learned = 0",
+        params![correct],
+        |r| r.get(0),
+    )?;
+    if manual_exists > 0 {
+        tx.commit()?;
+        return Ok(AutoLearnPromoteResult::Blocked);
+    }
+
+    // Atomic claim on the candidate. 0 rows means the candidate is already
+    // promoted (a concurrent monitor won the race) or was purged by a
+    // rejection / manual delete — either way this pair must not promote again.
+    let claimed = tx.execute(
+        "UPDATE auto_learn_candidates
+         SET promoted_at = datetime('now')
+         WHERE wrong_word = ?1 AND correct_word = ?2
+           AND promoted_at IS NULL",
+        params![wrong, correct],
+    )?;
+    if claimed == 0 {
+        tx.commit()?;
+        return Ok(AutoLearnPromoteResult::AlreadyPromoted);
+    }
+
+    // Promote into the dictionary. An existing auto-learned entry for the same
+    // pair (a later learning window) increments its lifetime correction count;
+    // a manual entry was already excluded above, and an auto-learned entry for
+    // a DIFFERENT mistake can't be matched (RETURNING yields no row).
+    let promoted: Option<i64> = tx
+        .query_row(
+            "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier)
+             VALUES (?1, ?2, 1, 1, ?3)
+             ON CONFLICT(term) DO UPDATE SET
+               correction_count = correction_count + 1,
+               confidence_tier = ?3,
+               last_seen_at = datetime('now')
+             WHERE dictionary.auto_learned = 1
+               AND COALESCE(dictionary.mistake, '') = COALESCE(?2, '')
+             RETURNING id",
+            params![correct, wrong, confidence_tier],
+            |r| r.get(0),
+        )
+        .optional()?;
+
+    if promoted.is_none() {
+        // An auto-learned entry for a DIFFERENT mistake won the upsert's
+        // conflict clause. Release the claimed gate so this pair can still be
+        // learned once that entry is removed — otherwise the claim would burn
+        // the pair's last chance permanently while reporting Blocked.
+        tx.execute(
+            "UPDATE auto_learn_candidates SET promoted_at = NULL
+             WHERE wrong_word = ?1 AND correct_word = ?2",
+            params![wrong, correct],
+        )?;
+        tx.commit()?;
+        return Ok(AutoLearnPromoteResult::Blocked);
+    }
+
+    let dictionary_id: i64 = tx.query_row(
+        "SELECT id FROM dictionary WHERE term = ?1",
+        params![correct],
+        |r| r.get(0),
+    )?;
+    tx.execute(
+        "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+        params![everywhere_id, dictionary_id],
+    )?;
+
+    tx.commit()?;
+    Ok(AutoLearnPromoteResult::Promoted)
 }
 
 pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> {
@@ -400,6 +713,7 @@ pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLea
     Ok(rows)
 }
 
+#[cfg(test)]
 pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
@@ -409,6 +723,7 @@ pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<
     Ok(())
 }
 
+#[cfg(test)]
 pub fn count_pending_corrections_recent(
     db: &Db,
     wrong: &str,
@@ -434,6 +749,28 @@ pub fn prune_pending_corrections(db: &Db, max_age_days: i64) -> Result<usize> {
         params![format!("-{} days", max_age_days.max(1))],
     )?;
     Ok(changed)
+}
+
+/// Bounded retention for the auto-learn bookkeeping tables, so they cannot
+/// grow without limit on long-lived installs: monitor/promotion audit events
+/// are pruned after 30 days, and candidate rows that have not been seen in 90
+/// days (promoted or not) are dropped — a candidate that is still alive after
+/// 90 days of inactivity has outlived its learning window. Rejection and
+/// manual-delete already purge their own rows; this catches everything else.
+/// Called at startup alongside the cleanup-cache prune.
+pub fn prune_auto_learn_retention(db: &Db) -> Result<usize> {
+    let conn = lock_conn(db)?;
+    let events = conn.execute(
+        "DELETE FROM auto_learn_events \
+         WHERE created_at < datetime('now', '-30 days')",
+        [],
+    )?;
+    let candidates = conn.execute(
+        "DELETE FROM auto_learn_candidates \
+         WHERE last_seen_at < datetime('now', '-90 days')",
+        [],
+    )?;
+    Ok(events + candidates)
 }
 
 pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&str>) -> Result<()> {
@@ -472,6 +809,10 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
 
     let changed = tx.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
     require_row_changed(changed, "Dictionary entry", id)?;
+    tx.execute(
+        "DELETE FROM dictionary_contexts WHERE dictionary_id = ?1",
+        params![id],
+    )?;
 
     // If this was an auto-learned entry, remove its pending corrections and
     // candidates so the auto-learn system cannot immediately re-promote it.

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -190,6 +190,7 @@ pub const DUAL_TRANSCRIPTION_ENABLED: &str = "dual_transcription_enabled";
 pub const CLEANUP_FALLBACK_MODELS: &str = "cleanup_fallback_models";
 pub const CLEANUP_ENABLED: &str = "cleanup_enabled";
 pub const HOTKEY: &str = "hotkey";
+pub const REPAIR_HOTKEY: &str = "repair_hotkey";
 pub const MICROPHONE_DEVICE: &str = "microphone_device";
 pub const DEFAULT_TONE: &str = "default_tone";
 pub const CLEANUP_INTENSITY: &str = "cleanup_intensity";
@@ -220,6 +221,10 @@ pub const VERENU_SERVICE_CHECKS_ENABLED: &str = "verenu_service_checks_enabled";
 pub const HISTORY_RETENTION: &str = "history_retention";
 pub const AUTOSTART_ENABLED: &str = "autostart_enabled";
 pub const CAPS_LOCK_UPPERCASE: &str = "caps_lock_uppercase_enabled";
+pub const CLIPBOARD_PHRASE_ENABLED: &str = "clipboard_phrase_enabled";
+pub const CLIPBOARD_PHRASE: &str = "clipboard_phrase";
+pub const LEGACY_FEATURES_ENABLED: &str = "legacy_features_enabled";
+pub const DEFAULT_CLIPBOARD_PHRASE: &str = "paste clipboard here";
 pub const LOCAL_MODEL_MEMORY_POLICY: &str = "local_model_memory_policy";
 
 pub const DEFAULT_TONES: &[&str] = &["casual", "formal", "very_casual"];
@@ -262,7 +267,7 @@ pub fn history_retention_days(value: &str) -> Option<i64> {
 // ---------- pipeline config ----------
 
 /// All settings values needed by run_pipeline, loaded in one place.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PipelineConfig {
     pub transcription_provider: String,
     pub transcription_language: String,
@@ -284,6 +289,8 @@ pub struct PipelineConfig {
     pub contextual_caps_enabled: bool,
     pub auto_spacing_enabled: bool,
     pub caps_lock_uppercase_enabled: bool,
+    pub clipboard_phrase_enabled: bool,
+    pub clipboard_phrase: String,
     pub macos_clipboard_sniff_enabled: bool,
     pub advanced_model_ui: bool,
     pub local_model_memory_policy: String,
@@ -585,6 +592,16 @@ pub fn load_pipeline_config(store: &SettingsSnapshot) -> PipelineConfig {
             .get(CAPS_LOCK_UPPERCASE)
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
+        clipboard_phrase_enabled: store
+            .get(CLIPBOARD_PHRASE_ENABLED)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        clipboard_phrase: store
+            .get(CLIPBOARD_PHRASE)
+            .and_then(|v| v.as_str())
+            .map(normalize_clipboard_phrase)
+            .filter(|v| is_valid_clipboard_phrase(v))
+            .unwrap_or_else(|| DEFAULT_CLIPBOARD_PHRASE.to_string()),
         macos_clipboard_sniff_enabled: store
             .get(MACOS_CLIPBOARD_SNIFF)
             .and_then(|v| v.as_bool())
@@ -600,6 +617,15 @@ pub fn load_pipeline_config(store: &SettingsSnapshot) -> PipelineConfig {
             is_supported_local_model_memory_policy,
         ),
     }
+}
+
+pub fn normalize_clipboard_phrase(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub fn is_valid_clipboard_phrase(value: &str) -> bool {
+    let count = value.chars().count();
+    (5..=80).contains(&count) && value.chars().any(char::is_alphanumeric)
 }
 
 pub const DEFAULT_MIC_GAIN: f32 = 3.5;
@@ -739,10 +765,8 @@ mod tests {
         let empty = SettingsSnapshot::from_pairs([]);
         assert_eq!(load_audio_config(&empty).sound_effects_volume, 1.0);
 
-        let disabled = SettingsSnapshot::from_pairs([(
-            PLAY_START_STOP_SOUNDS.to_string(),
-            json!(false),
-        )]);
+        let disabled =
+            SettingsSnapshot::from_pairs([(PLAY_START_STOP_SOUNDS.to_string(), json!(false))]);
         assert_eq!(load_audio_config(&disabled).sound_effects_volume, 0.0);
 
         let explicit_volume = SettingsSnapshot::from_pairs([

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -385,6 +385,22 @@ fn main() {
                         }
                     }
                 }
+                if let Some(val) = settings.get(crate::data::store::REPAIR_HOTKEY) {
+                    if let Some(arr) = val.as_array() {
+                        if arr.len() == 3 {
+                            if let (Some(k1), Some(k2), Some(k3)) =
+                                (arr[0].as_str(), arr[1].as_str(), arr[2].as_str())
+                            {
+                                if !k1.is_empty() || !k2.is_empty() || !k3.is_empty() {
+                                    let vk1 = crate::core::hotkey::map_code_to_vk(k1);
+                                    let vk2 = crate::core::hotkey::map_code_to_vk(k2);
+                                    let vk3 = crate::core::hotkey::map_code_to_vk(k3);
+                                    crate::core::hotkey::update_repair_keys(vk1, vk2, vk3);
+                                }
+                            }
+                        }
+                    }
+                }
                 let retention_value = settings.get(crate::data::store::HISTORY_RETENTION);
                 let retention = retention_value
                     .as_ref()
@@ -587,6 +603,8 @@ fn main() {
             system::windows_titlebar::get_native_titlebar_metrics,
             commands::save_hotkey,
             commands::check_hotkey,
+            commands::save_repair_hotkey,
+            commands::check_repair_hotkey,
             commands::save_api_key,
             commands::delete_api_key,
             commands::get_api_key_status,

--- a/src-tauri/src/pipeline/gates.rs
+++ b/src-tauri/src/pipeline/gates.rs
@@ -270,7 +270,13 @@ pub(super) fn strip_trailing_hallucination(text: &str) -> String {
         if !hard_boundary {
             continue;
         }
-        let tail = lower[idx + pattern.len()..].trim();
+        // A transcription may preserve the prompt's final punctuation, so
+        // punctuation-only tails are still an exact trailing prompt echo.
+        // Keep real words meaningful for the glossary corroboration check.
+        let tail = lower[idx + pattern.len()..]
+            .trim()
+            .trim_matches(|ch: char| ch.is_ascii_punctuation())
+            .trim();
         let corroborated = tail.is_empty()
             || GLOSSARY_TERMS.iter().any(|term| tail.contains(term))
             || TRAILING_PATTERNS.iter().any(|p| tail.contains(p));

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::api::{auto_learn, cleanup, prompts, transcription, ProviderId};
-use crate::core::{injection, window_context};
+use crate::core::{browser_probe, context, injection, window_context};
 use crate::data::{db, dictionary, snippets, store};
 use crate::media::audio;
 use crate::system::apps::AppMapping;
@@ -14,6 +14,7 @@ use chrono::{DateTime, Duration, NaiveDateTime, SecondsFormat, Utc};
 
 mod cache;
 mod chains;
+mod clipboard_phrase;
 mod finalize;
 #[cfg(any(test, debug_assertions))]
 mod fixture;
@@ -21,6 +22,7 @@ mod gates;
 mod pill;
 mod pill_animation;
 mod pill_position;
+mod repair;
 mod session;
 mod stages;
 mod state;
@@ -36,17 +38,18 @@ pub use fixture::{
 use gates::{
     effective_recording_rms, has_spoken_content, is_transcription_hallucination,
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
-    silence_floor_gate_rms, strip_hallucinated_suffix,
+    silence_floor_gate_rms, strip_hallucinated_suffix, strip_trailing_hallucination,
     MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
-    emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
+    emit_pill_profile, emit_pill_stage, hide_pill, pill_wants_repair_focus, show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
 };
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
 pub use session::*;
+pub(crate) use repair::*;
 use stages::*;
 pub use state::*;
 
@@ -129,6 +132,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
             },
             &language,
             &model,
+            0,
         )
         .await
         {
@@ -140,7 +144,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
             Err(e) => {
                 let retryable = crate::api::is_retryable_provider_error(&e);
                 log::warn!(
-                    "pipeline: transcription provider failed provider={} model={} retryable={} error={}",
+                    "pipeline: transcription provider failed gen=0 provider={} model={} retryable={} error={}",
                     provider_id,
                     model,
                     retryable,
@@ -162,7 +166,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
     match transcribed {
         Some(text) => {
             let normalized = normalize_transcription_math_artifacts(&text);
-            let normalized = strip_hallucinated_suffix(&normalized);
+            let normalized = strip_trailing_hallucination(&strip_hallucinated_suffix(&normalized));
             let normalized = crate::system::text::collapse_degenerate_word_runs(&normalized);
             if !has_spoken_content(&normalized) || is_transcription_hallucination(&normalized) {
                 hide_pill(&app);
@@ -253,7 +257,36 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         .or_else(window_context::get_active_process_name)
         .unwrap_or_else(|| "unknown".into())
         .to_lowercase();
-    log::info!("pipeline: start target_id={}", target.id);
+    let db_handle = app.state::<DbHandle>().inner().clone();
+    // Only probe the address bar when the foreground app is actually a
+    // browser — the UIA tree walk is comparatively costly and meaningless
+    // for any other window. Best-effort: a probe failure just means the
+    // context resolves by exe alone, same as before this feature existed.
+    let browser_domain = if window_context::is_browser_exe(&process_name) {
+        browser_probe::read_active_browser_domain()
+    } else {
+        None
+    };
+    let resolved_context = match context::resolve_context(&db_handle, &process_name, browser_domain.as_deref())
+    {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            log::warn!("pipeline: context resolution failed, using Everywhere error={error}");
+            db::Context {
+                id: db::EVERYWHERE_CONTEXT_ID,
+                name: "Everywhere".to_string(),
+                is_everywhere: true,
+                icon: None,
+                tone: None,
+                cleanup_intensity: None,
+                color: None,
+                created_at: String::new(),
+                updated_at: String::new(),
+            }
+        }
+    };
+    let context_id = resolved_context.id;
+    log::info!("pipeline: start gen={generation} target_id={}", target.id);
 
     // Mark the session inactive before unmuting or waiting on stop() so the
     // delayed mute helper cannot wake up and re-mute the system mid-shutdown.
@@ -354,7 +387,8 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     }
 
     let stage_config = std::time::Instant::now();
-    let Some((cfg, profile, app_context)) = open_config_and_context(&app, &process_name).await
+    let Some((cfg, profile, app_context)) =
+        open_config_and_context(&app, &process_name, Some(&resolved_context)).await
     else {
         // open_config_and_context already shows its own error/pill on
         // failure — no separate emit_pipeline_failed here (matches its
@@ -362,6 +396,9 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         state::leave_processing_if_owned(&state, generation);
         return;
     };
+    // The profile is now resolved — surface it so the pill can show which
+    // style applies to this dictation (same value emitted at record start).
+    emit_pill_profile(&app, &profile);
     log::debug!(
         "pipeline: config t_provider={} c_provider={} t_model={} c_model={} cleanup_enabled={} intensity={} app_context_hint={} profile={}",
         cfg.transcription_provider,
@@ -391,6 +428,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
             captured_at: retry_captured_at,
             target,
             process_name: process_name.clone(),
+            context_id,
             profile: profile.clone(),
             app_context: app_context.clone(),
             caps_lock_on,
@@ -420,6 +458,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
             }
         },
         _ = wait_for_cancel(&mut cancel_rx) => {
+            log::info!("pipeline: cancelled gen={generation} (awaiting VAD gate)");
             state::leave_processing_if_owned(&state, generation);
             return;
         }
@@ -436,10 +475,15 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         return;
     }
 
+    // Stage already emitted right after entering "processing" above (see
+    // comment there) — this Instant is purely for the timing log below.
     let stage_transcribe = std::time::Instant::now();
     let transcribe_race = tokio::select! {
-        r = run_transcription(&app, &captured_audio, &cfg) => Some(r),
-        _ = wait_for_cancel(&mut cancel_rx) => None,
+        r = run_transcription(&app, &captured_audio, &cfg, generation) => Some(r),
+        _ = wait_for_cancel(&mut cancel_rx) => {
+            log::info!("pipeline: cancelled gen={generation} (during transcription)");
+            None
+        }
     };
     let Some(transcribe_outcome) = transcribe_race else {
         state::leave_processing_if_owned(&state, generation);
@@ -460,7 +504,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     {
         raw
     } else {
-        strip_hallucinated_suffix(&raw)
+        strip_trailing_hallucination(&strip_hallucinated_suffix(&raw))
     };
     if raw.chars().count() != raw_chars_before_strip {
         log::warn!(
@@ -528,10 +572,31 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         return;
     }
 
+    let (raw_for_cleanup, clipboard_plan, clipboard_warning) =
+        prepare_clipboard_phrase(&cfg, &raw).await;
+    let clipboard_instruction = clipboard_plan.as_ref().map(clipboard_phrase::cleanup_instruction);
+
     let stage_cleanup = std::time::Instant::now();
+    // Only advertise the cleaning stage when the cleanup LLM will actually run
+    // (cleanup enabled + intensity + a key in the chain). When cleanup is off
+    // the cleanup call resolves to local snippet/dictionary work that is
+    // effectively instant, so advertising it would just flash the label.
+    let cleanup_will_run_llm = should_run_cleanup_llm(
+        cfg.cleanup_enabled,
+        has_cleanup_key_in_chain(&cfg),
+        true,
+        &cfg.cleanup_intensity,
+        &profile,
+    );
+    if cleanup_will_run_llm {
+        emit_pill_stage(&app, "cleaning");
+    }
     let cleanup_race = tokio::select! {
-        r = run_cleanup_and_snippets(&app, &raw, alternate.as_ref(), &cfg, &profile, app_context.as_deref()) => Some(r),
-        _ = wait_for_cancel(&mut cancel_rx) => None,
+        r = run_cleanup_and_snippets(&app, &raw_for_cleanup, alternate.as_ref(), &cfg, &profile, app_context.as_deref(), context_id, clipboard_instruction.as_deref(), generation) => Some(r),
+        _ = wait_for_cancel(&mut cancel_rx) => {
+            log::info!("pipeline: cancelled gen={generation} (during cleanup)");
+            None
+        }
     };
     let Some(cleanup_outcome) = cleanup_race else {
         state::leave_processing_if_owned(&state, generation);
@@ -566,6 +631,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // finalize (see core/injection's serialized critical section). Failure
     // here means an interrupt/Escape branch already took ownership of this
     // generation; abandon without inserting anything.
+    emit_pill_stage(&app, "pasting");
     if !state::enter_finalizing(&state, generation) {
         return;
     }
@@ -577,6 +643,8 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         PipelineCompletionContext {
             raw: &raw,
             final_text_before_dict: &final_text,
+            clipboard_plan: clipboard_plan.as_ref(),
+            clipboard_warning,
             dict_entries: &dict_entries,
             duration_ms: captured_audio.duration_ms,
             api_used: &api_used,
@@ -588,6 +656,8 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
             captured_at: retry_captured_at,
             event_only,
             caps_lock_on,
+            context: Some(&resolved_context),
+            browser_domain,
         },
     )
     .await
@@ -599,11 +669,45 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     state::leave_finalizing(&state, generation);
 
     log::info!(
-        "pipeline: completed words={} duration_ms={} elapsed_ms={}",
+        "pipeline: completed gen={generation} words={} duration_ms={} elapsed_ms={}",
         words,
         captured_audio.duration_ms,
         started_at.elapsed().as_millis()
     );
+}
+
+async fn prepare_clipboard_phrase(
+    cfg: &store::PipelineConfig,
+    raw: &str,
+) -> (
+    String,
+    Option<clipboard_phrase::ClipboardPhrasePlan>,
+    Option<&'static str>,
+) {
+    if !cfg.clipboard_phrase_enabled
+        || clipboard_phrase::replace_phrase_with_marker(raw, &cfg.clipboard_phrase, String::new()).is_none()
+    {
+        return (raw.to_string(), None, None);
+    }
+
+    match injection::read_current_clipboard_text().await.filter(|text| !text.trim().is_empty()) {
+        Some(text) => match clipboard_phrase::replace_phrase_with_marker(
+            raw,
+            &cfg.clipboard_phrase,
+            text,
+        ) {
+            Some(plan) => (plan.pre_cleanup.clone(), Some(plan), None),
+            None => {
+                log::debug!("pipeline: clipboard phrase match disappeared before planning");
+                (raw.to_string(), None, None)
+            }
+        }
+        None => (
+            clipboard_phrase::remove_phrase(raw, &cfg.clipboard_phrase),
+            None,
+            Some("No text in clipboard"),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -662,9 +766,14 @@ pub async fn retry_transcription_impl(
     }
 
     let mapping = resolve_app_mapping(Some(&settings_store), &capture.process_name);
-    capture.profile = apply_app_style_overrides(&mut cfg, mapping.as_ref());
+    let db_handle = app.state::<DbHandle>().inner().clone();
+    let context = db::query_context(&db_handle, capture.context_id).ok();
+    capture.profile = apply_app_style_overrides(&mut cfg, mapping.as_ref(), context.as_ref());
+    emit_pill_profile(app, &capture.profile);
 
-    let Some((raw_unorm, api_used, alternate)) = run_transcription(app, &capture.audio, &cfg).await
+    emit_pill_stage(app, "transcribing");
+    let Some((raw_unorm, api_used, alternate)) =
+        run_transcription(app, &capture.audio, &cfg, 0).await
     else {
         hide_pill(app);
         anyhow::bail!("Retry transcription failed");
@@ -676,7 +785,7 @@ pub async fn retry_transcription_impl(
     {
         raw
     } else {
-        strip_hallucinated_suffix(&raw)
+        strip_trailing_hallucination(&strip_hallucinated_suffix(&raw))
     };
     let raw = crate::system::text::collapse_degenerate_word_runs(&raw);
     if !has_spoken_content(&raw) || is_transcription_hallucination(&raw) {
@@ -687,14 +796,29 @@ pub async fn retry_transcription_impl(
         hide_pill(app);
         anyhow::bail!("Recording was too quiet — nothing was transcribed");
     }
+    if should_run_cleanup_llm(
+        cfg.cleanup_enabled,
+        has_cleanup_key_in_chain(&cfg),
+        true,
+        &cfg.cleanup_intensity,
+        &capture.profile,
+    ) {
+        emit_pill_stage(app, "cleaning");
+    }
+    let (raw_for_cleanup, clipboard_plan, clipboard_warning) =
+        prepare_clipboard_phrase(&cfg, &raw).await;
+    let clipboard_instruction = clipboard_plan.as_ref().map(clipboard_phrase::cleanup_instruction);
     let Some((final_text, dict_entries, cleanup_cache_key, cleanup_api_used)) =
         run_cleanup_and_snippets(
             app,
-            &raw,
+            &raw_for_cleanup,
             alternate.as_ref(),
             &cfg,
             &capture.profile,
             capture.app_context.as_deref(),
+            capture.context_id,
+            clipboard_instruction.as_deref(),
+            0,
         )
         .await
     else {
@@ -707,12 +831,15 @@ pub async fn retry_transcription_impl(
         format!("{api_used};cleanup={cleanup_api_used}")
     };
 
+    emit_pill_stage(app, "pasting");
     finalize_pipeline_completion(
         app,
         state,
         PipelineCompletionContext {
             raw: &raw,
             final_text_before_dict: &final_text,
+            clipboard_plan: clipboard_plan.as_ref(),
+            clipboard_warning,
             dict_entries: &dict_entries,
             duration_ms: capture.audio.duration_ms,
             api_used: &api_used,
@@ -724,6 +851,8 @@ pub async fn retry_transcription_impl(
             captured_at: capture.captured_at,
             event_only: false,
             caps_lock_on: capture.caps_lock_on,
+            context: None,
+            browser_domain: None,
         },
     )
     .await

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -6,6 +6,7 @@
 use super::SharedState;
 use crate::pipeline::pill_position::PillPlacement;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 
 /// Initial window size at creation. Kept in step with the state defaults so
@@ -40,6 +41,41 @@ static PILL_VISUALLY_ACTIVE: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "windows")]
 static PILL_PLACED_ONCE: AtomicBool = AtomicBool::new(false);
 
+/// Holds a resolved tone-profile label until the reveal that should carry it
+/// actually runs. `show_pill`'s cross-monitor move animates the window into
+/// place and only calls `reveal_pill` (which emits `pill-state`) once that
+/// tween lands, deferred well past the moment the caller finishes its own
+/// synchronous call — a profile emitted directly at the call site could land
+/// either before or after that deferred `pill-state`, and the frontend
+/// unconditionally clears `profileLabel` on `pill-state: recording`, so a
+/// profile that beat it there got silently wiped. Queuing it here and only
+/// emitting it from inside `reveal_pill`, right after `pill-state`, makes the
+/// ordering correct regardless of which path a given reveal takes.
+static PENDING_PILL_PROFILE: Mutex<Option<String>> = Mutex::new(None);
+
+/// Queues a tone-profile label to ride along with whichever reveal happens
+/// next, instead of emitting it immediately (see `PENDING_PILL_PROFILE`).
+pub(crate) fn queue_pill_profile(profile: &str) {
+    if let Ok(mut slot) = PENDING_PILL_PROFILE.lock() {
+        *slot = Some(profile.to_string());
+    }
+}
+
+/// Whether the pill *should* currently hold real OS keyboard focus, per our
+/// own state machine — not whether Windows actually still reports it
+/// focused. `set_pill_focusable(false)` only flips `WS_EX_NOACTIVATE` back
+/// on to block *future* activation; Windows does not auto-return focus to
+/// whatever was focused before we took it, so `pill.is_focused()` can keep
+/// reading true long after the repair UI that needed it has closed. The
+/// hotkey's "is the repair pill the thing I'm dictating into right now"
+/// check (app_hotkey.rs) needs this deterministic flag instead, or a stale
+/// true reading there routes an unrelated dictation into the repair pill.
+static PILL_WANTS_REPAIR_FOCUS: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn pill_wants_repair_focus() -> bool {
+    PILL_WANTS_REPAIR_FOCUS.load(Ordering::SeqCst)
+}
+
 fn create_pill_if_needed(app: &AppHandle) {
     if app.get_webview_window("pill").is_some() {
         return;
@@ -57,7 +93,64 @@ fn create_pill_if_needed(app: &AppHandle) {
         .focused(false)
         .build()
     {
-        Ok(pill) => harden_pill_window(&pill),
+        Ok(pill) => {
+            // Keep the WebView client area transparent even when Windows
+            // switches the window from click-through to interactive. Without
+            // an explicit native colour, WebView2 can briefly repaint the
+            // newly interactive surface as an opaque rectangle around the
+            // capsule.
+            pill.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0))).ok();
+            harden_pill_window(&pill);
+
+            // The repair pill actively steals OS keyboard focus while
+            // waiting on typed input (see set_pill_focusable), but never had
+            // any way to notice the user giving up on it by simply clicking
+            // into a different app's text box — Windows doesn't return focus
+            // on its own, so the pill kept it, and a normal dictation
+            // afterward silently pasted into the still-focused repair
+            // textarea instead of wherever the user actually clicked. React
+            // to losing OS focus the same way the X button/click-away/Escape
+            // already do: abandon the repair session outright.
+            //
+            // Debounced, not immediate: growing the textarea's content
+            // resizes the native window (see measureAndResize/set_pill_size),
+            // and that resize was itself observed to raise a transient
+            // Focused(false)/(true) blip with no real user action behind it —
+            // acting on it immediately cancelled an in-progress complaint out
+            // from under the user while they were still typing. Waiting a
+            // beat and rechecking real focus catches only a genuine
+            // click-away; a resize-induced blip has already resolved by then.
+            let app_for_blur = app.clone();
+            pill.on_window_event(move |event| {
+                if !matches!(event, tauri::WindowEvent::Focused(false)) {
+                    return;
+                }
+                if !pill_wants_repair_focus() {
+                    return;
+                }
+                let app_for_check = app_for_blur.clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    if !pill_wants_repair_focus() {
+                        return; // resolved (applied/cancelled/expired) in the meantime
+                    }
+                    let Some(pill) = app_for_check.get_webview_window("pill") else {
+                        return;
+                    };
+                    if pill.is_focused().unwrap_or(true) {
+                        return; // focus came back — the blur was transient
+                    }
+                    let Some(state) = app_for_check.try_state::<SharedState>() else {
+                        return;
+                    };
+                    let has_repair_session = state.inner().lock().is_ok_and(|st| st.repair.is_some());
+                    if has_repair_session {
+                        super::clear_repair(state.inner());
+                        hide_pill(&app_for_check);
+                    }
+                });
+            });
+        }
         Err(err) => log::warn!("Failed to create dictation pill window: {err}"),
     }
 }
@@ -66,6 +159,10 @@ fn create_pill_if_needed(app: &AppHandle) {
 fn harden_pill_window<R: Runtime>(pill: &WebviewWindow<R>) {
     use windows::Win32::{
         Foundation::{GetLastError, SetLastError, WIN32_ERROR},
+        Graphics::Dwm::{
+            DwmSetWindowAttribute, DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE,
+            DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
+        },
         UI::WindowsAndMessaging::{
             GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, HWND_TOPMOST,
             SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, WS_EX_APPWINDOW,
@@ -78,6 +175,24 @@ fn harden_pill_window<R: Runtime>(pill: &WebviewWindow<R>) {
     };
 
     unsafe {
+        // Windows 11 draws its own accent-colored active-window border and
+        // rounded-corner frame around any top-level window once it becomes
+        // focused — which the repair-input state does deliberately for text
+        // entry. Left alone, that native frame shows up as a pale rounded
+        // outline larger than (and misaligned with) the custom-drawn card,
+        // since it sits outside the transparent WebView content entirely.
+        let _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_BORDER_COLOR,
+            &DWMWA_COLOR_NONE as *const _ as *const _,
+            std::mem::size_of_val(&DWMWA_COLOR_NONE) as u32,
+        );
+        let _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_WINDOW_CORNER_PREFERENCE,
+            &DWMWCP_DONOTROUND as *const _ as *const _,
+            std::mem::size_of_val(&DWMWCP_DONOTROUND) as u32,
+        );
         SetLastError(WIN32_ERROR(0));
         let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
         if current == 0 {
@@ -228,9 +343,30 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     // Click-through for passive states so nothing behind the pill is blocked.
     // Handsfree, error (Retry), and cancelled (Undo/Dismiss) all have real
     // buttons that need real cursor events.
-    let has_clickable_buttons =
-        matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed" | "copied");
+    let has_clickable_buttons = matches!(
+        state,
+        "handsfree"
+            | "error"
+            | "cancelled"
+            | "paste_failed"
+            | "copied"
+            | "feedback_prompt"
+            | "repair_input"
+            | "repair_recording"
+            | "repair_processing"
+            | "repair_proposal"
+            | "repair_applying"
+            | "repair_error"
+            | "repair_done"
+    );
     pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
+    // Re-assert every reveal, not just once at window creation: WebView2 has
+    // been observed repainting its surface opaque again when the window
+    // flips between click-through and interactive (exactly what toggling
+    // set_ignore_cursor_events above does for every repair-flow state), which
+    // showed up as whatever sits behind the pill flashing through for a
+    // frame — e.g. clicking "Not good"/"Good" on the feedback card.
+    pill.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0))).ok();
 
     // Show the window before emitting state so WebView2 is active when it
     // receives the event. WebView2 suspends event processing while hidden;
@@ -262,6 +398,15 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     #[cfg(not(target_os = "windows"))]
     pill.show().ok();
 
+    // Must run after the SW_SHOWNOACTIVATE show above, not before: that call
+    // explicitly leaves the current foreground window untouched, which was
+    // silently undoing the focus grab below when this ran first — repair_input
+    // needs real keyboard focus so typed/pasted text lands in the textarea
+    // instead of whatever app last had it.
+    let wants_focus = matches!(state, "repair_input" | "repair_proposal" | "repair_error");
+    PILL_WANTS_REPAIR_FOCUS.store(wants_focus, Ordering::SeqCst);
+    set_pill_focusable(pill, wants_focus);
+
     // macOS: `show()` (orderFront:) is ignored for a background app, so the
     // pill only appeared when Verenu was frontmost. Force it above the
     // active app's windows without stealing focus. AppKit window calls must
@@ -284,6 +429,102 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
         pill.emit("pill-error", msg).ok();
     }
     pill.emit("pill-state", state).ok();
+
+    // Must fire after pill-state (see PENDING_PILL_PROFILE) — this is the
+    // one place every reveal path (immediate or animated) actually
+    // converges, so it's the only point where the ordering is guaranteed.
+    if let Some(profile) = PENDING_PILL_PROFILE.lock().ok().and_then(|mut slot| slot.take()) {
+        pill.emit("pill-profile", profile).ok();
+    }
+}
+
+fn set_pill_focusable<R: Runtime>(pill: &WebviewWindow<R>, focusable: bool) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Graphics::Dwm::{
+            DwmSetWindowAttribute, DWMWA_BORDER_COLOR, DWMWA_COLOR_NONE,
+            DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
+        };
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, SWP_FRAMECHANGED,
+            SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, WS_EX_NOACTIVATE,
+        };
+        if let Ok(hwnd) = pill.hwnd() {
+            unsafe {
+                let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+                let desired = if focusable {
+                    current & !(WS_EX_NOACTIVATE.0 as isize)
+                } else {
+                    current | WS_EX_NOACTIVATE.0 as isize
+                };
+                if desired != current {
+                    let _ = SetWindowLongPtrW(hwnd, GWL_EXSTYLE, desired);
+                    let _ = SetWindowPos(
+                        hwnd,
+                        None,
+                        0,
+                        0,
+                        0,
+                        0,
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+                    );
+                    // SWP_FRAMECHANGED makes DWM recompute the non-client frame,
+                    // which has been observed to redraw the native active-window
+                    // border even though harden_pill_window() already suppressed
+                    // it once at window creation — re-assert it here so becoming
+                    // focusable (the repair-input path) never brings it back.
+                    let _ = DwmSetWindowAttribute(
+                        hwnd,
+                        DWMWA_BORDER_COLOR,
+                        &DWMWA_COLOR_NONE as *const _ as *const _,
+                        std::mem::size_of_val(&DWMWA_COLOR_NONE) as u32,
+                    );
+                    let _ = DwmSetWindowAttribute(
+                        hwnd,
+                        DWMWA_WINDOW_CORNER_PREFERENCE,
+                        &DWMWCP_DONOTROUND as *const _ as *const _,
+                        std::mem::size_of_val(&DWMWCP_DONOTROUND) as u32,
+                    );
+                }
+            }
+        }
+    }
+    if focusable {
+        // `WebviewWindow::set_focus()` alone was not reliably stealing OS
+        // keyboard focus from whatever app was previously foreground — plain
+        // SetFocus() only works within the calling thread's own input queue,
+        // and Windows blocks a background process from calling
+        // SetForegroundWindow() on its own. Attaching this thread's input
+        // queue to the current foreground thread first is the standard
+        // workaround, so typed/pasted text actually lands in the repair
+        // textarea instead of whatever window last had focus.
+        #[cfg(target_os = "windows")]
+        {
+            use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+            use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+            use windows::Win32::UI::WindowsAndMessaging::{
+                BringWindowToTop, GetForegroundWindow, GetWindowThreadProcessId,
+                SetForegroundWindow,
+            };
+            if let Ok(hwnd) = pill.hwnd() {
+                unsafe {
+                    let foreground = GetForegroundWindow();
+                    let current_thread = GetCurrentThreadId();
+                    let foreground_thread = GetWindowThreadProcessId(foreground, None);
+                    let attached = foreground_thread != 0
+                        && foreground_thread != current_thread
+                        && AttachThreadInput(current_thread, foreground_thread, true).as_bool();
+                    let _ = SetForegroundWindow(hwnd);
+                    let _ = BringWindowToTop(hwnd);
+                    let _ = SetFocus(Some(hwnd));
+                    if attached {
+                        let _ = AttachThreadInput(current_thread, foreground_thread, false);
+                    }
+                }
+            }
+        }
+        pill.set_focus().ok();
+    }
 }
 
 fn next_pill_placement<R: Runtime>(
@@ -396,6 +637,19 @@ pub(crate) fn emit_pill_stage(app: &AppHandle, stage: &str) {
     }
 }
 
+/// Emits the resolved tone profile (e.g. "casual") to the pill window so it
+/// can show which style will apply to the current dictation. Emitted from the
+/// pipeline itself — the frontend never re-resolves it.
+pub(crate) fn emit_pill_profile(app: &AppHandle, profile: &str) {
+    match app.get_webview_window("pill") {
+        Some(pill) => {
+            let sent = pill.emit("pill-profile", profile).is_ok();
+            log::debug!("pill: profile={profile} sent={sent}");
+        }
+        None => log::debug!("pill: profile={profile} sent=false (no pill window)"),
+    }
+}
+
 pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {
     log::error!("pipeline error: {msg}");
     app.emit("verenu:error", msg).ok();
@@ -406,6 +660,12 @@ pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {
     // its own state before reverting to idle, avoiding a race where a new
     // recording session's pill gets hidden by this error's timeout.
     show_pill_msg(app, "error", Some(msg));
+}
+
+/// A delivered dictation can still have a clipboard-phrase warning. This is
+/// deliberately passive: the text already reached its destination.
+pub(crate) fn show_clipboard_warning_pill(app: &AppHandle, msg: &str) {
+    show_pill_msg(app, "clipboard_warning", Some(msg));
 }
 
 /// Shows the pill in error state for a quality-gate rejection without

--- a/src-tauri/src/pipeline/repair.rs
+++ b/src-tauri/src/pipeline/repair.rs
@@ -1,0 +1,786 @@
+//! Transient, approval-gated post-dictation repair flow.
+//!
+//! The model only proposes a closed typed action. This module owns the safe
+//! input snapshot, deterministic validation, and the final mutation.
+
+use super::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const COMPLAINT_LIMIT: usize = 2_000;
+const SHORT_TEXT_LIMIT: usize = 3_000;
+const EXCERPT_LIMIT: usize = 3_000;
+// The JSON action shape itself never needs more than ~60-80 tokens; the rest
+// of the old 320-token budget just gave a misbehaving model room to ramble
+// inside a JSON string field (term/mistake), which then overflowed the fixed-
+// width proposal card with no way to scroll. Trimming the ceiling makes that
+// structurally harder, on top of the display-side truncation in `summary()`.
+const REPAIR_MAX_OUTPUT_TOKENS: u32 = 120;
+/// Display-only cap on a proposal's interpolated term/mistake text (see
+/// `truncate_for_display`) — never applied to what's actually written to the
+/// dictionary, only to the summary shown in the fixed-width proposal card.
+const DISPLAY_TEXT_LIMIT: usize = 60;
+const REPAIR_TIMEOUT_SECS: u64 = 45;
+const NO_SAFE_REPAIR_MESSAGE: &str = "I couldn't map this to a safe Verenu setting. Try speaking a little closer to the microphone and a little slower. If you want a reusable phrase, add a vocabulary item or snippet manually in Verenu.";
+
+static REPAIR_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RepairSettings {
+    pub cleanup_enabled: bool,
+    pub cleanup_intensity: String,
+    pub default_tone: String,
+    pub contextual_caps_enabled: bool,
+    pub auto_spacing_enabled: bool,
+    pub caps_lock_uppercase_enabled: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RepairSnapshot {
+    pub id: u64,
+    pub raw: String,
+    pub cleaned: String,
+    pub delivered_private: String,
+    pub process_name: String,
+    pub browser_domain: Option<String>,
+    pub context_id: i64,
+    pub context_name: String,
+    pub dictionary: Vec<db::DictionaryEntry>,
+    pub settings: RepairSettings,
+}
+
+#[derive(Clone, Debug)]
+pub struct RepairSession {
+    pub snapshot: RepairSnapshot,
+    pub proposal: Option<ValidatedProposal>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RepairProposalView {
+    pub id: u64,
+    pub summary: String,
+    pub scope: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedProposal {
+    pub id: u64,
+    action: RepairAction,
+    pub summary: String,
+    pub scope: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ModelProposal {
+    status: String,
+    action: Option<RepairAction>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+enum RepairAction {
+    #[serde(rename = "dictionary")]
+    Dictionary {
+        operation: DictionaryOperation,
+        dictionary_id: Option<i64>,
+        term: Option<String>,
+        mistake: Option<String>,
+        scope: DictionaryScope,
+        expected_term: Option<String>,
+        expected_mistake: Option<String>,
+    },
+    #[serde(rename = "setting")]
+    Setting {
+        key: String,
+        value: Value,
+        expected_value: Value,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DictionaryOperation {
+    Add,
+    Update,
+    Remove,
+}
+
+/// Semantic scope choice instead of a raw context id: the model has no
+/// reliable way to know the numeric id of "the app this dictation happened
+/// in" (it's never shown one), so it used to have to guess — sometimes
+/// landing on an arbitrary/invalid number, sometimes drifting to Everywhere
+/// by default. Resolving the actual id deterministically from the snapshot
+/// (see `resolve_scope_id`) makes "assign it to the app's context group"
+/// reliable instead of a guess, and makes an out-of-range scope structurally
+/// impossible rather than something validation has to catch.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum DictionaryScope {
+    Context,
+    Everywhere,
+}
+
+fn resolve_scope_id(snapshot: &RepairSnapshot, scope: DictionaryScope) -> i64 {
+    match scope {
+        DictionaryScope::Context => snapshot.context_id,
+        DictionaryScope::Everywhere => db::EVERYWHERE_CONTEXT_ID,
+    }
+}
+
+/// Caps a string to `DISPLAY_TEXT_LIMIT` chars (never mid-character-boundary)
+/// for the proposal card, which has no scrollbar and a bounded native window
+/// height — display-only, never applied to the value actually written to the
+/// dictionary or a setting.
+fn truncate_for_display(text: &str) -> std::borrow::Cow<'_, str> {
+    if text.chars().count() <= DISPLAY_TEXT_LIMIT {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut truncated: String = text.chars().take(DISPLAY_TEXT_LIMIT).collect();
+    truncated.push('…');
+    std::borrow::Cow::Owned(truncated)
+}
+
+impl RepairAction {
+    fn summary(&self, snapshot: &RepairSnapshot) -> anyhow::Result<(String, String)> {
+        match self {
+            Self::Dictionary {
+                operation,
+                dictionary_id,
+                term,
+                mistake,
+                scope,
+                ..
+            } => {
+                let scope_name = scope_name(snapshot, resolve_scope_id(snapshot, *scope))?;
+                let summary = match operation {
+                    DictionaryOperation::Add => format!(
+                        "Add vocabulary item: {} -> {}",
+                        truncate_for_display(mistake.as_deref().unwrap_or("spoken form")),
+                        truncate_for_display(term.as_deref().unwrap_or("new term"))
+                    ),
+                    DictionaryOperation::Update => {
+                        let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("missing vocabulary target"))?;
+                        let current = snapshot.dictionary.iter().find(|e| e.id == id).ok_or_else(|| anyhow::anyhow!("unknown vocabulary target"))?;
+                        format!(
+                            "Vocabulary item: {} -> {}",
+                            truncate_for_display(current.mistake.as_deref().unwrap_or(&current.term)),
+                            truncate_for_display(term.as_deref().unwrap_or(&current.term))
+                        )
+                    }
+                    DictionaryOperation::Remove => {
+                        let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("missing vocabulary target"))?;
+                        let current = snapshot.dictionary.iter().find(|e| e.id == id).ok_or_else(|| anyhow::anyhow!("unknown vocabulary target"))?;
+                        format!("Remove vocabulary item {}", truncate_for_display(&current.term))
+                    }
+                };
+                Ok((summary, format!("Apply in: {scope_name}")))
+            }
+            Self::Setting { key, value, expected_value } => {
+                let label = setting_label(key).ok_or_else(|| anyhow::anyhow!("unsupported setting"))?;
+                Ok((
+                    format!(
+                        "{label}: {} -> {}",
+                        truncate_for_display(&display_value(expected_value)),
+                        truncate_for_display(&display_value(value))
+                    ),
+                    "Apply globally".into(),
+                ))
+            }
+        }
+    }
+}
+
+fn setting_label(key: &str) -> Option<&'static str> {
+    Some(match key {
+        store::CLEANUP_ENABLED => "Automatic cleanup",
+        store::CLEANUP_INTENSITY => "Cleanup intensity",
+        store::DEFAULT_TONE => "Default tone",
+        store::CONTEXTUAL_CAPS => "Contextual capitalization",
+        store::AUTO_SPACING => "Automatic spacing",
+        store::CAPS_LOCK_UPPERCASE => "Caps Lock uppercase",
+        _ => return None,
+    })
+}
+
+fn display_value(value: &Value) -> String {
+    value.as_str().map(str::to_owned).unwrap_or_else(|| value.to_string())
+}
+
+fn scope_name(snapshot: &RepairSnapshot, context_id: i64) -> anyhow::Result<String> {
+    if context_id == db::EVERYWHERE_CONTEXT_ID {
+        Ok("Everywhere".into())
+    } else if context_id == snapshot.context_id {
+        Ok(snapshot.context_name.clone())
+    } else {
+        anyhow::bail!("scope is not the current context or Everywhere")
+    }
+}
+
+fn current_setting(snapshot: &RepairSnapshot, key: &str) -> Option<Value> {
+    Some(match key {
+        store::CLEANUP_ENABLED => json!(snapshot.settings.cleanup_enabled),
+        store::CLEANUP_INTENSITY => json!(snapshot.settings.cleanup_intensity),
+        store::DEFAULT_TONE => json!(snapshot.settings.default_tone),
+        store::CONTEXTUAL_CAPS => json!(snapshot.settings.contextual_caps_enabled),
+        store::AUTO_SPACING => json!(snapshot.settings.auto_spacing_enabled),
+        store::CAPS_LOCK_UPPERCASE => json!(snapshot.settings.caps_lock_uppercase_enabled),
+        _ => return None,
+    })
+}
+
+fn config_setting(cfg: &store::PipelineConfig, key: &str) -> Option<Value> {
+    Some(match key {
+        store::CLEANUP_ENABLED => json!(cfg.cleanup_enabled),
+        store::CLEANUP_INTENSITY => json!(cfg.cleanup_intensity),
+        store::DEFAULT_TONE => json!(cfg.default_tone),
+        store::CONTEXTUAL_CAPS => json!(cfg.contextual_caps_enabled),
+        store::AUTO_SPACING => json!(cfg.auto_spacing_enabled),
+        store::CAPS_LOCK_UPPERCASE => json!(cfg.caps_lock_uppercase_enabled),
+        _ => return None,
+    })
+}
+
+fn supports_complaint(snapshot: &RepairSnapshot, complaint: &str, action: &RepairAction) -> bool {
+    let complaint_lower = complaint.to_lowercase();
+    let evidence = format!("{} {} {}", complaint_lower, snapshot.raw, snapshot.delivered_private).to_lowercase();
+    match action {
+        // The real anti-hallucination guard is the substring checks below: both
+        // the proposed correct term and the proposed mistake must actually
+        // appear in what the user said or what was transcribed. An earlier
+        // keyword allowlist ("said"/"wrote"/"transcribed"/...) additionally
+        // required one of those exact words in the complaint, which rejected
+        // completely ordinary phrasing like "X became Y" or "X should be
+        // Y" — including the app's own placeholder example — so it's gone.
+        RepairAction::Dictionary { term, mistake, .. } => {
+            term.as_deref().is_some_and(|v| !v.trim().is_empty() && evidence.contains(&v.to_lowercase()))
+                && mistake.as_deref().is_some_and(|v| !v.trim().is_empty() && evidence.contains(&v.to_lowercase()))
+        }
+        RepairAction::Setting { key, .. } => match key.as_str() {
+            store::AUTO_SPACING => complaint_lower.contains("spacing") || complaint_lower.contains("space before"),
+            store::CAPS_LOCK_UPPERCASE | store::CONTEXTUAL_CAPS => complaint_lower.contains("caps") || complaint_lower.contains("capital") || complaint_lower.contains("uppercase"),
+            store::DEFAULT_TONE => complaint_lower.contains("tone") || complaint_lower.contains("formal") || complaint_lower.contains("casual"),
+            store::CLEANUP_INTENSITY => complaint_lower.contains("cleanup") || complaint_lower.contains("formatting") || complaint_lower.contains("too aggressive"),
+            store::CLEANUP_ENABLED => complaint_lower.contains("cleanup") || complaint_lower.contains("automatic cleanup"),
+            _ => false,
+        },
+    }
+}
+
+fn same_word(left: &str, right: &str) -> bool {
+    left.trim().eq_ignore_ascii_case(right.trim())
+}
+
+fn validate_action(snapshot: &RepairSnapshot, complaint: &str, action: RepairAction) -> anyhow::Result<ValidatedProposal> {
+    if !supports_complaint(snapshot, complaint, &action) {
+        anyhow::bail!("No safe repair could be mapped to the observed text")
+    }
+
+    match &action {
+        RepairAction::Dictionary {
+            operation,
+            dictionary_id,
+            term,
+            mistake,
+            scope,
+            expected_term,
+            expected_mistake,
+        } => {
+            scope_name(snapshot, resolve_scope_id(snapshot, *scope))?;
+            match operation {
+                DictionaryOperation::Add => {
+                    if dictionary_id.is_some() || term.as_deref().unwrap_or("").trim().is_empty() || mistake.as_deref().unwrap_or("").trim().is_empty() {
+                        anyhow::bail!("invalid dictionary add")
+                    }
+                    if same_word(term.as_deref().unwrap_or(""), mistake.as_deref().unwrap_or("")) {
+                        anyhow::bail!("dictionary add is a no-op")
+                    }
+                }
+                DictionaryOperation::Update => {
+                    let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("missing dictionary target"))?;
+                    let current = snapshot.dictionary.iter().find(|e| e.id == id).ok_or_else(|| anyhow::anyhow!("unknown dictionary target"))?;
+                    if expected_term.as_deref() != Some(current.term.as_str()) || expected_mistake.as_deref() != current.mistake.as_deref() {
+                        anyhow::bail!("dictionary entry changed")
+                    }
+                    if term.as_deref().unwrap_or("").trim().is_empty() {
+                        anyhow::bail!("invalid dictionary update")
+                    }
+                    if same_word(term.as_deref().unwrap_or(""), current.term.as_str())
+                        && mistake.as_deref().is_none_or(|value| current.mistake.as_deref().is_some_and(|old| same_word(value, old)))
+                    {
+                        anyhow::bail!("dictionary update is a no-op")
+                    }
+                }
+                DictionaryOperation::Remove => {
+                    let id = dictionary_id.ok_or_else(|| anyhow::anyhow!("missing dictionary target"))?;
+                    let current = snapshot.dictionary.iter().find(|e| e.id == id).ok_or_else(|| anyhow::anyhow!("unknown dictionary target"))?;
+                    if expected_term.as_deref() != Some(current.term.as_str()) || expected_mistake.as_deref() != current.mistake.as_deref() {
+                        anyhow::bail!("dictionary entry changed")
+                    }
+                }
+            }
+        }
+        RepairAction::Setting { key, value, expected_value } => {
+            if setting_label(key).is_none() || current_setting(snapshot, key).as_ref() != Some(expected_value) {
+                anyhow::bail!("setting is not allowlisted or changed")
+            }
+            if matches!(key.as_str(), store::CLEANUP_INTENSITY) && !value.as_str().is_some_and(store::is_supported_cleanup_intensity) {
+                anyhow::bail!("invalid cleanup intensity")
+            }
+            if matches!(key.as_str(), store::DEFAULT_TONE) && !value.as_str().is_some_and(store::is_supported_default_tone) {
+                anyhow::bail!("invalid tone")
+            }
+            if matches!(key.as_str(), store::CLEANUP_ENABLED | store::CONTEXTUAL_CAPS | store::AUTO_SPACING | store::CAPS_LOCK_UPPERCASE) && !value.is_boolean() {
+                anyhow::bail!("setting requires boolean")
+            }
+        }
+    }
+    let (summary, scope) = action.summary(snapshot)?;
+    Ok(ValidatedProposal { id: REPAIR_ID.fetch_add(1, Ordering::Relaxed), action, summary, scope })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn begin_feedback(
+    app: &AppHandle,
+    state: &SharedState,
+    raw: &str,
+    cleaned: &str,
+    delivered_private: &str,
+    process_name: String,
+    browser_domain: Option<String>,
+    context: &db::Context,
+    dictionary: &[db::DictionaryEntry],
+    cfg: &store::PipelineConfig,
+) {
+    let snapshot = RepairSnapshot {
+        id: REPAIR_ID.fetch_add(1, Ordering::Relaxed),
+        raw: raw.to_string(),
+        cleaned: cleaned.to_string(),
+        delivered_private: delivered_private.to_string(),
+        process_name,
+        browser_domain,
+        context_id: context.id,
+        context_name: context.name.clone(),
+        dictionary: dictionary.to_vec(),
+        settings: RepairSettings {
+            cleanup_enabled: cfg.cleanup_enabled,
+            cleanup_intensity: cfg.cleanup_intensity.clone(),
+            default_tone: cfg.default_tone.clone(),
+            contextual_caps_enabled: cfg.contextual_caps_enabled,
+            auto_spacing_enabled: cfg.auto_spacing_enabled,
+            caps_lock_uppercase_enabled: cfg.caps_lock_uppercase_enabled,
+        },
+    };
+    if let Ok(mut locked) = state.lock() {
+        locked.repair = Some(RepairSession { snapshot, proposal: None });
+    }
+    super::show_pill(app, "feedback_prompt");
+}
+
+pub(crate) fn clear(state: &SharedState) {
+    if let Ok(mut locked) = state.lock() {
+        locked.repair = None;
+    }
+}
+
+pub(crate) fn enter_input(app: &AppHandle) {
+    super::show_pill(app, "repair_input");
+}
+
+pub(crate) fn enter_repair_input(app: &AppHandle) {
+    enter_input(app);
+}
+
+pub(crate) fn emit_repair_error(app: &AppHandle, message: &str) {
+    emit_error(app, message);
+}
+
+pub(crate) async fn diagnose_repair(app: AppHandle, state: SharedState, complaint: String) -> anyhow::Result<()> {
+    diagnose(app, state, complaint).await
+}
+
+/// Transcribes whatever was just recorded as the repair complaint and hands
+/// control back to the input card. Shared by the explicit dictate flow and
+/// the global hotkey path (pressing the normal record hotkey while the
+/// repair-input pill is open dictates into it directly, same as any other
+/// target) — both end a repair-complaint recording the same way.
+pub(crate) async fn finish_complaint_recording(app: AppHandle, state: SharedState) {
+    match super::transcribe_input_only(app.clone(), state).await {
+        Ok(text) => {
+            app.emit("repair-complaint-result", &text).ok();
+            enter_repair_input(&app);
+        }
+        Err(error) => emit_repair_error(&app, &crate::api::user_facing_error(&error)),
+    }
+}
+
+pub(crate) async fn apply_repair(app: AppHandle, state: SharedState, proposal_id: u64) -> anyhow::Result<String> {
+    apply(app, state, proposal_id).await
+}
+
+pub(crate) fn clear_repair(state: &SharedState) {
+    clear(state);
+}
+
+pub(crate) fn emit_error(app: &AppHandle, message: &str) {
+    app.emit("repair-error", message).ok();
+    super::show_pill(app, "repair_error");
+}
+
+fn bounded_excerpt(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= SHORT_TEXT_LIMIT {
+        return text.to_string();
+    }
+    let side = EXCERPT_LIMIT / 2;
+    chars[..side].iter().chain(chars[chars.len() - side..].iter()).collect()
+}
+
+fn safe_text(text: &str, limit: usize) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\t'))
+        .take(limit)
+        .collect()
+}
+
+/// Returns a bounded window around the first changed span in `text` compared
+/// with `reference`. This keeps the model focused on the transformation that
+/// the user is reporting instead of sending an entire long dictation.
+fn diff_excerpt(text: &str, reference: &str) -> String {
+    let text_chars: Vec<char> = text.chars().collect();
+    if text_chars.len() <= SHORT_TEXT_LIMIT {
+        return text.to_string();
+    }
+    let reference_chars: Vec<char> = reference.chars().collect();
+    let prefix = text_chars
+        .iter()
+        .zip(reference_chars.iter())
+        .take_while(|(left, right)| left == right)
+        .count();
+    let suffix_limit = text_chars.len().saturating_sub(prefix);
+    let suffix = text_chars
+        .iter()
+        .rev()
+        .zip(reference_chars.iter().rev())
+        .take(suffix_limit)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let changed_end = text_chars.len().saturating_sub(suffix);
+    if prefix == text_chars.len() {
+        return bounded_excerpt(text);
+    }
+    let context = 1_000;
+    let mut start = prefix.saturating_sub(context);
+    let mut end = (changed_end + context).min(text_chars.len());
+    if end.saturating_sub(start) > EXCERPT_LIMIT {
+        end = (start + EXCERPT_LIMIT).min(text_chars.len());
+        start = end.saturating_sub(EXCERPT_LIMIT);
+    }
+    let mut excerpt: String = text_chars[start..end].iter().collect();
+    if start > 0 {
+        excerpt.insert(0, '…');
+    }
+    if end < text_chars.len() {
+        excerpt.push('…');
+    }
+    excerpt
+}
+
+fn model_input(snapshot: &RepairSnapshot, complaint: &str) -> String {
+    let complaint = safe_text(complaint, COMPLAINT_LIMIT);
+    let raw = safe_text(&diff_excerpt(&snapshot.raw, &snapshot.cleaned), SHORT_TEXT_LIMIT);
+    let cleaned = safe_text(&diff_excerpt(&snapshot.cleaned, &snapshot.raw), SHORT_TEXT_LIMIT);
+    let delivered = safe_text(&diff_excerpt(&snapshot.delivered_private, &snapshot.cleaned), SHORT_TEXT_LIMIT);
+    let dictionary = snapshot
+        .dictionary
+        .iter()
+        .take(16)
+        .map(|entry| format!("{}|{}|{}", entry.id, safe_text(&entry.term, 80), entry.mistake.as_deref().map(|value| safe_text(value, 80)).unwrap_or_default()))
+        .collect::<Vec<_>>()
+        .join(";");
+    format!(
+        "Complaint:{complaint}\nRaw:{raw}\nCleaned:{cleaned}\nDelivered:{delivered}\nTarget:{}|{}|{}\nDictionary(id|term|mistake):{dictionary}\nSettings:cleanup_enabled={}|cleanup_intensity={}|tone={}|contextual_caps={}|spacing={}|caps_lock_uppercase={}",
+        safe_text(&snapshot.process_name, 80),
+        safe_text(snapshot.browser_domain.as_deref().unwrap_or("none"), 120),
+        safe_text(&snapshot.context_name, 80),
+        snapshot.settings.cleanup_enabled,
+        safe_text(&snapshot.settings.cleanup_intensity, 24),
+        safe_text(&snapshot.settings.default_tone, 24),
+        snapshot.settings.contextual_caps_enabled,
+        snapshot.settings.auto_spacing_enabled,
+        snapshot.settings.caps_lock_uppercase_enabled,
+    )
+}
+
+const REPAIR_SYSTEM_PROMPT: &str = r#"You read one user complaint about a Verenu dictation and decide whether it describes a specific, fixable mistake. Return JSON only, no markdown, exactly one of:
+{"status":"unsupported","action":null}
+{"status":"proposed","action":{"kind":"dictionary","operation":"add|update|remove","dictionary_id":null or number,"term":string or null,"mistake":string or null,"scope":"context"|"everywhere","expected_term":string or null,"expected_mistake":string or null}}
+{"status":"proposed","action":{"kind":"setting","key":"cleanup_enabled|cleanup_intensity|default_tone|contextual_caps_enabled|auto_spacing_enabled|caps_lock_uppercase_enabled","value":boolean or string,"expected_value":boolean or string}}
+
+The complaint is itself often dictated, so it can carry small transcription typos or odd spacing (e.g. "oout" instead of "out") — read past those to what the user actually means, the same way you'd read past a typo in any message. Do not reject a complaint just because a word in it is spelled oddly.
+
+DICTIONARY fix: needs two things named anywhere in the complaint, in any order or phrasing — the word the user actually meant (term) and the word Verenu produced instead (mistake). Both may be informal, invented, or nonsense-sounding (names, slang, made-up words, nicknames) — that alone is not "noise," it's just an unusual word. "Noise" means the complaint never actually names what was meant, e.g. "that was totally wrong" with no words given. Do not require the user to say "dictionary," "vocabulary," or "reusable rule" — any phrasing that names both words is enough evidence.
+Examples (term / mistake):
+- "yaba became pooo poo" -> term "yaba", mistake "pooo poo"
+- "I wanted to say yaba bop but it came oout as yaba boo" -> term "yaba bop", mistake "yaba boo" (typo "oout" ignored)
+- "it heard pool request instead of pull request" -> term "pull request", mistake "pool request" ("heard X instead of Y" means X is the mistake)
+- "pool request should have been pull request" -> term "pull request", mistake "pool request"
+- "that was totally wrong" -> unsupported, no specific words named
+- "stop capitalizing randomly" -> not a dictionary fix, see setting example below
+
+SETTING fix: only for the six keys listed above, only when the complaint clearly describes that exact behavior (too aggressive cleanup, wrong tone, spacing before punctuation, random capitalization, Caps Lock typing uppercase). Never invent a setting, context, dictionary target, or snippet, and never propose a snippet. Never fix ordinary grammar or a no-op such as "the" -> "the".
+
+Use only the supplied dictionary ids for update/remove. For a dictionary action, default scope to "context" (the app this dictation happened in) — only use "everywhere" when the complaint itself says the mistake happens in general, everywhere, or across apps. term and mistake are single words or short phrases (a few words at most) — never a sentence, never the full complaint restated. Do not include extra fields."#;
+
+async fn diagnose_with_model(app: &AppHandle, cfg: &store::PipelineConfig, input: &str) -> anyhow::Result<String> {
+    let mut chain = Vec::new();
+    if let Some((provider, model)) = store::parse_model_id(&cfg.cleanup_default_model) {
+        chain.push((provider, model));
+    }
+    for id in &cfg.cleanup_fallback_models {
+        if let Some((provider, model)) = store::parse_model_id(id) {
+            if !chain.iter().any(|(p, m)| p == &provider && m == &model) {
+                chain.push((provider, model));
+            }
+        }
+    }
+    let mut last_error = None;
+    for (provider, model) in chain {
+        let is_local = provider == store::LOCAL;
+        let key = cfg.key_for(&provider);
+        if !is_local && key.is_empty() {
+            continue;
+        }
+        let result = if is_local {
+            let manager = app.state::<crate::local_llm::LocalLlmManager>().inner().clone();
+            manager.cleanup_with_prompt(app, &model, input, REPAIR_SYSTEM_PROMPT, REPAIR_MAX_OUTPUT_TOKENS).await
+        } else {
+            cleanup::structured_request(input, ProviderId::from_str(&provider), key, &model, REPAIR_SYSTEM_PROMPT, REPAIR_MAX_OUTPUT_TOKENS, 0).await
+        };
+        match result {
+            Ok(value) if !value.trim().is_empty() => return Ok(value),
+            Ok(_) => last_error = Some(anyhow::anyhow!("repair provider returned empty output")),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("No configured repair-capable provider/model")))
+}
+
+pub(crate) async fn diagnose(app: AppHandle, state: SharedState, complaint: String) -> anyhow::Result<()> {
+    let complaint = complaint.trim().chars().take(COMPLAINT_LIMIT).collect::<String>();
+    if complaint.is_empty() {
+        anyhow::bail!("Tell Verenu what went wrong first")
+    }
+    let snapshot = state.lock().map_err(|_| anyhow::anyhow!("Repair state lock was poisoned"))?.repair.as_ref().ok_or_else(|| anyhow::anyhow!("Repair session expired"))?.snapshot.clone();
+    super::show_pill(&app, "repair_processing");
+
+    let settings = store::settings_snapshot(&app).map_err(anyhow::Error::msg)?;
+    let cfg = store::load_pipeline_config(&settings);
+    let output = tokio::time::timeout(std::time::Duration::from_secs(REPAIR_TIMEOUT_SECS), diagnose_with_model(&app, &cfg, &model_input(&snapshot, &complaint)))
+        .await
+        .map_err(|_| anyhow::anyhow!("Repair diagnosis timed out"))?
+        .inspect_err(|e| log::warn!("repair: model call failed: {e}"))?;
+    let parsed = parse_model_proposal(&output).map_err(|e| {
+        log::warn!("repair: could not parse model output as JSON: {e}");
+        anyhow::anyhow!(NO_SAFE_REPAIR_MESSAGE)
+    })?;
+    let proposal = if parsed.status != "proposed" {
+        log::debug!("repair: model returned status={}", parsed.status);
+        anyhow::bail!(NO_SAFE_REPAIR_MESSAGE)
+    } else {
+        validate_action(&snapshot, &complaint, parsed.action.ok_or_else(|| anyhow::anyhow!(NO_SAFE_REPAIR_MESSAGE))?)
+            .map_err(|e| {
+                log::warn!("repair: proposal failed validation: {e}");
+                anyhow::anyhow!(NO_SAFE_REPAIR_MESSAGE)
+            })?
+    };
+    let view = RepairProposalView { id: proposal.id, summary: proposal.summary.clone(), scope: proposal.scope.clone() };
+    {
+        let mut locked = state.lock().map_err(|_| anyhow::anyhow!("Repair state lock was poisoned"))?;
+        let session = locked.repair.as_mut().ok_or_else(|| anyhow::anyhow!("Repair session expired"))?;
+        if session.snapshot.id != snapshot.id {
+            anyhow::bail!("Repair session was replaced by a newer dictation")
+        }
+        session.proposal = Some(proposal);
+    }
+    app.emit("repair-proposal", &view).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    super::show_pill(&app, "repair_proposal");
+    Ok(())
+}
+
+fn parse_model_proposal(output: &str) -> anyhow::Result<ModelProposal> {
+    if let Ok(value) = serde_json::from_str::<ModelProposal>(output.trim()) {
+        return Ok(value);
+    }
+    let fenced = output.split("```").nth(1).unwrap_or("").trim_start_matches("json").trim();
+    serde_json::from_str::<ModelProposal>(fenced).map_err(|_| anyhow::anyhow!("Repair response was not valid structured output"))
+}
+
+pub(crate) async fn apply(app: AppHandle, state: SharedState, proposal_id: u64) -> anyhow::Result<String> {
+    let session = state.lock().map_err(|_| anyhow::anyhow!("Repair state lock was poisoned"))?.repair.clone().ok_or_else(|| anyhow::anyhow!("Repair session expired"))?;
+    let proposal = session.proposal.ok_or_else(|| anyhow::anyhow!("No repair proposal is awaiting approval"))?;
+    if proposal.id != proposal_id {
+        anyhow::bail!("Repair proposal is stale")
+    }
+    let result = match proposal.action {
+        RepairAction::Dictionary { operation, dictionary_id, term, mistake, scope, expected_term, expected_mistake } => {
+            let scope_context_id = resolve_scope_id(&session.snapshot, scope);
+            let db = app.state::<crate::DbHandle>().inner().clone();
+            let operation_name = match operation {
+                DictionaryOperation::Add => "add",
+                DictionaryOperation::Update => "update",
+                DictionaryOperation::Remove => "remove",
+            };
+            let id = tokio::task::spawn_blocking(move || db::apply_dictionary_repair(&db, operation_name, dictionary_id, term.as_deref(), mistake.as_deref(), scope_context_id, expected_term.as_deref(), expected_mistake.as_deref())).await.map_err(|e| anyhow::anyhow!(e.to_string()))??;
+            format!("Vocabulary item applied (entry {id})")
+        }
+        RepairAction::Setting { key, value, expected_value } => {
+            let settings = store::settings_handle(&app).map_err(anyhow::Error::msg)?;
+            let key_for_thread = key.clone();
+            let value_for_thread = value.clone();
+            let expected_for_thread = expected_value.clone();
+            tokio::task::spawn_blocking(move || {
+                let snapshot = settings.snapshot().map_err(anyhow::Error::msg)?;
+                let cfg = store::load_pipeline_config(&snapshot);
+                let current = config_setting(&cfg, &key_for_thread).unwrap_or(Value::Null);
+                if current != expected_for_thread {
+                    anyhow::bail!("Setting changed while you were reviewing it")
+                }
+                crate::commands::validate_setting(&key_for_thread, &value_for_thread).map_err(anyhow::Error::msg)?;
+                settings.save_value(key_for_thread, value_for_thread).map_err(anyhow::Error::msg)
+            }).await.map_err(|e| anyhow::anyhow!(e.to_string()))??;
+            format!("{} updated", setting_label(&key).unwrap_or("Setting"))
+        }
+    };
+    clear(&state);
+    super::show_pill(&app, "repair_done");
+    app.emit("repair-applied", &result).ok();
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot() -> RepairSnapshot {
+        RepairSnapshot {
+            id: 1,
+            raw: "I said pull request and it wrote pool request".into(),
+            cleaned: "I said pull request and it wrote pool request".into(),
+            delivered_private: "I said pull request and it wrote pool request".into(),
+            process_name: "code.exe".into(),
+            browser_domain: None,
+            context_id: 7,
+            context_name: "Development".into(),
+            dictionary: vec![db::DictionaryEntry {
+                id: 3,
+                term: "pull request".into(),
+                mistake: Some("pool request".into()),
+                auto_learned: false,
+                correction_count: 0,
+                confidence_tier: "manual".into(),
+                last_seen_at: None,
+                created_at: "".into(),
+            }],
+            settings: RepairSettings {
+                cleanup_enabled: true,
+                cleanup_intensity: "balanced".into(),
+                default_tone: "casual".into(),
+                contextual_caps_enabled: true,
+                auto_spacing_enabled: true,
+                caps_lock_uppercase_enabled: false,
+            },
+        }
+    }
+
+    #[test]
+    fn diff_excerpt_keeps_changed_region_bounded() {
+        let reference = "a".repeat(8_000);
+        let mut text = reference.clone();
+        text.replace_range(4_000..4_001, "b");
+        let excerpt = diff_excerpt(&text, &reference);
+        assert!(excerpt.chars().count() <= EXCERPT_LIMIT + 2);
+        assert!(excerpt.contains('b'));
+        assert!(excerpt.starts_with('…'));
+        assert!(excerpt.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_for_display_caps_long_text_but_leaves_short_text_alone() {
+        assert_eq!(truncate_for_display("pull request"), "pull request");
+        let long = "a".repeat(DISPLAY_TEXT_LIMIT + 20);
+        let truncated = truncate_for_display(&long);
+        assert_eq!(truncated.chars().count(), DISPLAY_TEXT_LIMIT + 1); // +1 for the ellipsis
+        assert!(truncated.ends_with('…'));
+    }
+
+    #[test]
+    fn strict_parser_rejects_unknown_fields_and_unauthorized_settings() {
+        assert!(parse_model_proposal(
+            r#"{"status":"proposed","extra":true,"action":null}"#,
+        )
+        .is_err());
+
+        let action: RepairAction = serde_json::from_str(
+            r#"{"kind":"setting","key":"api_key","value":true,"expected_value":false}"#,
+        )
+        .unwrap();
+        assert!(validate_action(&snapshot(), "turn off cleanup", action).is_err());
+    }
+
+    #[test]
+    fn dictionary_scope_is_a_closed_enum_not_an_arbitrary_id() {
+        // The model is never shown a numeric context id (it has no reliable
+        // way to know one), so scope is a semantic choice resolved
+        // deterministically from the snapshot instead of a raw id the model
+        // could guess wrong or hallucinate — any value outside
+        // context/everywhere fails to parse at all, rather than needing a
+        // runtime validity check.
+        assert!(serde_json::from_str::<RepairAction>(
+            r#"{"kind":"dictionary","operation":"add","dictionary_id":null,"term":"pull request","mistake":"pool request","scope":"some_other_app","expected_term":null,"expected_mistake":null}"#,
+        )
+        .is_err());
+
+        let everywhere: RepairAction = serde_json::from_str(
+            r#"{"kind":"dictionary","operation":"add","dictionary_id":null,"term":"pull request","mistake":"pool request","scope":"everywhere","expected_term":null,"expected_mistake":null}"#,
+        )
+        .unwrap();
+        assert!(validate_action(&snapshot(), "I said pull request and it wrote pool request", everywhere).is_ok());
+    }
+
+    #[test]
+    fn valid_dictionary_add_requires_observed_evidence() {
+        let action: RepairAction = serde_json::from_str(
+            r#"{"kind":"dictionary","operation":"add","dictionary_id":null,"term":"pull request","mistake":"pool request","scope":"context","expected_term":null,"expected_mistake":null}"#,
+        )
+        .unwrap();
+        assert!(validate_action(&snapshot(), "I said pull request and it wrote pool request", action).is_ok());
+    }
+
+    #[test]
+    fn natural_phrasing_without_a_keyword_is_accepted() {
+        // Regression test: an earlier keyword allowlist ("said"/"wrote"/
+        // "transcribed"/...) rejected ordinary phrasing like "X became Y" —
+        // including the repair input's own placeholder example — even
+        // though both terms were genuinely present in what was transcribed.
+        let mut snap = snapshot();
+        snap.raw = "please open the pool request".into();
+        snap.cleaned = snap.raw.clone();
+        snap.delivered_private = snap.raw.clone();
+        let action: RepairAction = serde_json::from_str(
+            r#"{"kind":"dictionary","operation":"add","dictionary_id":null,"term":"pull request","mistake":"pool request","scope":"context","expected_term":null,"expected_mistake":null}"#,
+        )
+        .unwrap();
+        assert!(validate_action(&snap, "pool request should have been pull request", action).is_ok());
+    }
+
+    #[test]
+    fn no_op_dictionary_repairs_are_rejected() {
+        let action: RepairAction = serde_json::from_str(
+            r#"{"kind":"dictionary","operation":"update","dictionary_id":3,"term":"pull request","mistake":"pool request","scope":"context","expected_term":"pull request","expected_mistake":"pool request"}"#,
+        )
+        .unwrap();
+        assert!(validate_action(&snapshot(), "I said pull request and it wrote pool request", action).is_err());
+    }
+}

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -43,8 +43,14 @@ pub fn start_recording_session(
     ) {
         log::error!("start recording: {e}");
         hide_pill(app);
-        app.emit("verenu:error", format!("Failed to start recording: {e}"))
-            .ok();
+        app.emit(
+            "verenu:error",
+            format!(
+                "Failed to start recording: {}",
+                crate::api::user_facing_message(&e)
+            ),
+        )
+        .ok();
     }
 }
 
@@ -74,11 +80,12 @@ pub fn start_recording_session_ex(
     {
         // `AXIsProcessTrustedWithOptions` can return a stale cached `false` for the
         // life of the process. Check Accessibility strictly rather than using
-        // is_tap_active() as a proxy.
-        // The CGEventTap can be active on Input Monitoring alone — so a running tap
-        // does NOT prove Accessibility is granted. Without Accessibility, synthetic
-        // Cmd+V (posting events to the HID tap) silently fails. Using the real TCC
-        // check ensures we surface the error instead of recording and never pasting.
+        // hotkey liveness as a proxy.
+        // The global hotkey is Carbon `RegisterEventHotKey`, which needs no
+        // permission at all — so a working hotkey does NOT prove Accessibility
+        // is granted. Without Accessibility, synthetic Cmd+V (posting events to
+        // the HID tap) silently fails. Using the real TCC check ensures we
+        // surface the error instead of recording and never pasting.
         if !crate::system::mac_app::is_accessibility_verified()
             && !crate::commands::check_accessibility_permission(false)
         {
@@ -165,6 +172,15 @@ pub fn start_recording_session_ex(
                 manager.set_recording_active(true);
             }
             if options.show_recording_pill {
+                // Queued before show_pill (not after): show_pill's
+                // cross-monitor move animates and defers its own pill-state
+                // emission until the tween lands, well after this call
+                // returns — queuing here, before that reveal ever happens,
+                // is what makes the profile available in time regardless of
+                // which reveal path this particular call takes (see
+                // PENDING_PILL_PROFILE for the full ordering rationale).
+                let target_hwnd = lock_state(state).map(|st| st.target.id).unwrap_or(0);
+                emit_profile_for_window(app, target_hwnd);
                 show_pill(app, pill_state);
             }
             spawn_level_emitter(
@@ -240,6 +256,7 @@ pub async fn cancel_recording_with_resume(
     let gate_rms = effective_recording_rms(rms, raw_rms, active_gain);
 
     if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
+        log::info!("recording: cancelled — capture discarded (duration/quiet gate)");
         if start_stop_sounds_enabled(app) {
             crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
         }
@@ -251,7 +268,29 @@ pub async fn cancel_recording_with_resume(
         return;
     }
 
+    log::info!("recording: cancelled — capture stashed for resume");
     stash_cancelled_capture(app, state, captured_audio);
+}
+
+/// Stops and discards a recording that belongs to a transient flow such as
+/// repair feedback. Unlike normal dictation cancellation, this never stashes
+/// audio for resume and never shows the cancelled-dictation affordance.
+pub async fn discard_recording(
+    app: &AppHandle,
+    state: &SharedState,
+) {
+    let Some((session, exclusive_mic_session_id)) = state::take_recording_plain(state) else {
+        if state_is_idle(state) {
+            hide_pill(app);
+        }
+        return;
+    };
+    crate::media::sound::coordinated_unmute();
+    crate::system::media_control::end_dictation_media_pause();
+    let _ = stop_and_capture_audio(app, session, exclusive_mic_session_id).await;
+    if state_is_idle(state) {
+        hide_pill(app);
+    }
 }
 
 /// True when the recording lifecycle is currently `Idle`.

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -49,6 +49,15 @@ pub struct AppState {
     pub retry_capture: Option<RetryCapture>,
     pub cancelled_capture: Option<CancelledCapture>,
     pub paste_failure: Option<PasteFailure>,
+    pub repair: Option<super::repair::RepairSession>,
+    /// Set only by the hotkey path when a Press was routed into the repair
+    /// pill's complaint recording (see app_hotkey.rs) — checked and cleared
+    /// on the matching Release so that release routes to the same place the
+    /// press did, rather than re-deriving it from ambient repair-session
+    /// state, which stays around in the background long after the repair
+    /// pill has lost focus and would otherwise hijack an unrelated,
+    /// currently-focused-elsewhere dictation's Release too.
+    pub hotkey_recording_repair_complaint: bool,
 }
 
 /// Single source of truth for what the app is currently doing with the
@@ -103,6 +112,20 @@ impl DictationLifecycle {
     }
 }
 
+/// Compact, stable name for the lifecycle variant — used by transition logs
+/// so a session is reconstructable from the ring buffer alone.
+pub(super) fn describe_lifecycle(lifecycle: &DictationLifecycle) -> &'static str {
+    match lifecycle {
+        DictationLifecycle::Idle => "idle",
+        DictationLifecycle::Starting { .. } => "starting",
+        DictationLifecycle::Recording { handless, .. } if *handless => "recording_handsfree",
+        DictationLifecycle::Recording { .. } => "recording",
+        DictationLifecycle::Stopping { .. } => "stopping",
+        DictationLifecycle::Processing(_) => "processing",
+        DictationLifecycle::Finalizing { .. } => "finalizing",
+    }
+}
+
 pub struct ActivePipeline {
     pub generation: u64,
     pub cancel_tx: tokio::sync::watch::Sender<bool>,
@@ -122,6 +145,7 @@ pub struct RetryCapture {
     pub captured_at: std::time::Instant,
     pub target: WindowTarget,
     pub process_name: String,
+    pub context_id: i64,
     pub profile: String,
     pub app_context: Option<String>,
     pub caps_lock_on: bool,
@@ -171,6 +195,14 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
     if !st.lifecycle.is_idle() {
         return Err("Already recording".to_string());
     }
+    log::debug!(
+        "lifecycle: {} -> starting",
+        describe_lifecycle(&st.lifecycle)
+    );
+    // A new dictation owns the pill immediately. Drop any pending repair
+    // snapshot/proposal so a late provider response cannot repaint the new
+    // recording with stale repair UI.
+    st.repair = None;
     st.lifecycle = DictationLifecycle::Starting {
         prepend_audio: None,
     };
@@ -217,10 +249,15 @@ pub fn set_starting_prepend_audio(state: &SharedState, audio: CapturedAudio) {
 /// returns `None`.
 pub fn take_active_pipeline_for_interrupt(state: &SharedState) -> Option<ActivePipeline> {
     let mut st = lock_state(state).ok()?;
+    st.repair = None;
     match std::mem::replace(&mut st.lifecycle, DictationLifecycle::Idle) {
         DictationLifecycle::Processing(active) => {
             crate::core::hotkey::clear_processing_generation(active.generation);
             let prepend_audio = Some(active.captured_audio.clone());
+            log::debug!(
+                "lifecycle: processing -> starting gen={} (interrupt, audio prepended)",
+                active.generation
+            );
             st.lifecycle = DictationLifecycle::Starting { prepend_audio };
             Some(active)
         }
@@ -288,6 +325,10 @@ pub fn take_active_pipeline_for_escape(state: &SharedState) -> Option<ActivePipe
     match std::mem::replace(&mut st.lifecycle, DictationLifecycle::Idle) {
         DictationLifecycle::Processing(active) => {
             crate::core::hotkey::clear_processing_generation(active.generation);
+            log::debug!(
+                "lifecycle: processing -> idle gen={} (escape, audio discarded)",
+                active.generation
+            );
             Some(active)
         }
         other => {
@@ -303,12 +344,19 @@ pub fn take_active_pipeline_for_escape(state: &SharedState) -> Option<ActivePipe
 /// Escape while still actively recording (pre-`Release`).
 pub fn take_recording_plain(state: &SharedState) -> Option<(audio::RecordingSession, Option<u64>)> {
     let mut st = lock_state(state).ok()?;
+    // A discarded/cancelled recording never reaches app_hotkey's Release
+    // branch that would otherwise clear this — reset it here so a later,
+    // unrelated Release can't misroute into finish_complaint_recording.
+    st.hotkey_recording_repair_complaint = false;
     match std::mem::replace(&mut st.lifecycle, DictationLifecycle::Idle) {
         DictationLifecycle::Recording {
             session,
             exclusive_mic_session_id,
             ..
-        } => Some((session, exclusive_mic_session_id)),
+        } => {
+            log::info!("lifecycle: recording -> idle (plain cancel/discard)");
+            Some((session, exclusive_mic_session_id))
+        }
         DictationLifecycle::Starting { .. } => {
             // Cancelling a start must consume the reservation atomically. If
             // the microphone task has not installed Recording yet, it will
@@ -330,6 +378,7 @@ pub fn cancel_starting_reservation(state: &SharedState) -> bool {
         return false;
     };
     if matches!(st.lifecycle, DictationLifecycle::Starting { .. }) {
+        log::info!("lifecycle: starting -> idle (start reservation cancelled)");
         st.lifecycle = DictationLifecycle::Idle;
         true
     } else {
@@ -351,6 +400,7 @@ pub fn promote_recording_to_handless(state: &SharedState) -> bool {
     } = &mut st.lifecycle
     {
         if !*handless {
+            log::info!("lifecycle: recording -> recording_handsfree (Space conversion)");
             *handless = true;
             *handless_from_hold = true;
             return true;
@@ -427,6 +477,7 @@ pub(super) fn take_recording_for_stopping(state: &SharedState) -> Option<Stoppin
             ..
         } => {
             let generation = next_pipeline_generation();
+            log::info!("lifecycle: recording -> stopping gen={generation}");
             st.lifecycle = DictationLifecycle::Stopping {
                 generation,
                 prepend_audio: prepend_audio.clone(),
@@ -464,6 +515,7 @@ pub(super) fn leave_stopping_if_owned(state: &SharedState, generation: u64) -> b
         DictationLifecycle::Stopping { generation: g, .. } if *g == generation
     );
     if owns {
+        log::info!("lifecycle: stopping -> idle gen={generation} (rejected/discarded)");
         st.lifecycle = DictationLifecycle::Idle;
     }
     owns
@@ -484,6 +536,7 @@ pub(super) fn install_processing(
         DictationLifecycle::Stopping { generation: g, .. } if *g == generation
     );
     if owns {
+        log::info!("lifecycle: stopping -> processing gen={generation}");
         st.lifecycle = DictationLifecycle::Processing(active);
         crate::core::hotkey::set_processing_generation(generation);
     }
@@ -501,6 +554,7 @@ pub(super) fn enter_finalizing(state: &SharedState, generation: u64) -> bool {
     let owns =
         matches!(&st.lifecycle, DictationLifecycle::Processing(a) if a.generation == generation);
     if owns {
+        log::info!("lifecycle: processing -> finalizing gen={generation}");
         st.lifecycle = DictationLifecycle::Finalizing { generation };
         crate::core::hotkey::clear_processing_generation(generation);
     }
@@ -518,6 +572,7 @@ pub(super) fn leave_processing_if_owned(state: &SharedState, generation: u64) ->
     let owns =
         matches!(&st.lifecycle, DictationLifecycle::Processing(a) if a.generation == generation);
     if owns {
+        log::info!("lifecycle: processing -> idle gen={generation} (failed/cancelled)");
         st.lifecycle = DictationLifecycle::Idle;
         crate::core::hotkey::clear_processing_generation(generation);
     }
@@ -532,6 +587,7 @@ pub(super) fn leave_finalizing(state: &SharedState, generation: u64) {
     };
     if matches!(&st.lifecycle, DictationLifecycle::Finalizing { generation: g } if *g == generation)
     {
+        log::info!("lifecycle: finalizing -> idle gen={generation}");
         st.lifecycle = DictationLifecycle::Idle;
     }
 }
@@ -633,6 +689,8 @@ mod tests {
             retry_capture: None,
             cancelled_capture: None,
             paste_failure: None,
+            repair: None,
+            hotkey_recording_repair_complaint: false,
         }))
     }
 

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { getProfileLabel } from './lib/appMappings';
+  import { formatKeyLabel } from './lib/platform';
 
-  type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied';
+  type PillState = 'idle' | 'recording' | 'repair_recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied' | 'clipboard_warning' | 'feedback_prompt' | 'repair_input' | 'repair_processing' | 'repair_proposal' | 'repair_applying' | 'repair_done' | 'repair_error';
+  type RepairProposal = { id: number; summary: string; scope: string };
   let state: PillState = 'idle';
   let errorMsg = '';
   let errOpen = false;
@@ -28,6 +30,13 @@
   let prevState: PillState = 'idle';
   let dying = false;
   let dyingTimer: ReturnType<typeof setTimeout> | null = null;
+  let repairComplaint = '';
+  let repairError = '';
+  let repairProposal: RepairProposal | null = null;
+  let repairDoneTimer: ReturnType<typeof setTimeout> | null = null;
+  let repairFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
+  let repairIdleTimer: ReturnType<typeof setTimeout> | null = null;
+  let repairHotkeyLabel: string | null = null;
 
   // Resolved tone profile for the current dictation (label form, e.g. "Casual"),
   // emitted by the backend from the pipeline's own resolution.
@@ -468,6 +477,9 @@
       dyingTimer = null;
       prevState = state;
       state = 'idle';
+      repairComplaint = '';
+      repairError = '';
+      repairProposal = null;
       clearStage();
       profileLabel = null;
       smoothed = 0;
@@ -615,6 +627,22 @@
     // refreshDpr can re-arm it as the pill moves between displays).
     armDprWatch();
 
+    import('@tauri-apps/api/core').then(({ invoke }) =>
+      invoke<string[] | null>('get_setting', { key: 'repair_hotkey' })
+    ).then((hk) => {
+      if (!mounted) return;
+      // Nothing saved, or a malformed/stale value (e.g. a 2-slot array from
+      // before the hotkey required 2 modifiers + 1 trigger key) means the
+      // built-in Ctrl+Alt+Z default is active — only a genuine 3-slot save
+      // overrides it, and only an explicit ["","",""] within that shape
+      // means the user cleared it (disabled).
+      const keys = hk && hk.length === 3 ? hk : ['ControlLeft', 'AltLeft', 'KeyZ'];
+      // '' (distinct from the not-yet-loaded null default) means explicitly
+      // cleared/disabled — checked in the pill-state handler below to skip
+      // the feedback toast entirely rather than nagging about no keybind.
+      repairHotkeyLabel = keys[0] ? keys.filter(Boolean).map(formatKeyLabel).join(' + ') : '';
+    }).catch(() => {});
+
     // Track the rendered content size so the native window stays snug around
     // it. Fires on every width transition/animation frame of the pill, on
     // label/stage text appearing, and on the initial idle mount (which
@@ -636,11 +664,12 @@
         // they clear too (idle is handled by goIdle).
         if (
           incoming !== 'processing' &&
+          incoming !== 'repair_processing' &&
           incoming !== 'loading_local_model'
         ) {
           clearStage();
         }
-        if (incoming === 'recording') {
+        if (incoming === 'recording' || incoming === 'repair_recording') {
           profileLabel = null;
         } else if (
           incoming === 'error' ||
@@ -658,6 +687,44 @@
           return;
         }
 
+        // The repair-open hotkey being cleared means the user doesn't want
+        // this feature at all — behave as if it doesn't exist rather than
+        // nagging them to go bind one.
+        if (incoming === 'feedback_prompt' && repairHotkeyLabel === '') {
+          stopRaf();
+          goIdle();
+          return;
+        }
+
+        if (incoming === 'feedback_prompt') {
+          repairComplaint = '';
+          repairError = '';
+          repairProposal = null;
+          if (repairFeedbackTimer) clearTimeout(repairFeedbackTimer);
+          repairFeedbackTimer = setTimeout(() => {
+            repairFeedbackTimer = null;
+            if (state === 'feedback_prompt') goIdle();
+          }, 3000);
+        } else if (repairFeedbackTimer) {
+          clearTimeout(repairFeedbackTimer);
+          repairFeedbackTimer = null;
+        }
+
+        // Repair states that wait on the user (typing, dictating, or
+        // reviewing a proposal/error) with no timer of their own would
+        // otherwise sit open forever if the user walks away mid-flow.
+        if (repairIdleTimer) { clearTimeout(repairIdleTimer); repairIdleTimer = null; }
+        if (
+          incoming === 'repair_input' ||
+          incoming === 'repair_proposal' ||
+          incoming === 'repair_error'
+        ) {
+          repairIdleTimer = setTimeout(() => {
+            repairIdleTimer = null;
+            void cancelRepair();
+          }, 120_000);
+        }
+
         if (dyingTimer !== null) { clearTimeout(dyingTimer); dyingTimer = null; dying = false; }
 
         if (incoming === 'handsfree') {
@@ -666,13 +733,42 @@
         }
         prevState = state;
         state = incoming;
-        if (state === 'recording' || state === 'handsfree') {
+        if (state === 'repair_proposal' || state === 'repair_error') {
+          // The window now has real OS keyboard focus (see set_pill_focusable
+          // in pill.rs), but nothing has DOM focus yet — without this, Escape
+          // never reaches handleRepairKeydown because keydown fires on
+          // document.body, which isn't an ancestor of the dialog.
+          tick().then(() => {
+            if (state === 'repair_proposal' || state === 'repair_error') {
+              document.querySelector<HTMLElement>('.repair-proposal[role="dialog"]')?.focus();
+            }
+          });
+        }
+        if (state === 'repair_input') {
+          // Entering repair_input is now backend-driven only (the dedicated
+          // repair-open hotkey, see app_hotkey.rs) — there is no button click
+          // handler left to do this locally, so the generic state-change path
+          // owns focusing the textarea. Only clear stale fields on a genuinely
+          // fresh open (from the toast) — a retry or a just-finished dictation
+          // of the complaint both also land here with content that must survive.
+          if (prevState === 'feedback_prompt') {
+            repairComplaint = '';
+            repairError = '';
+            repairProposal = null;
+          }
+          tick().then(() => {
+            if (state === 'repair_input') {
+              document.querySelector<HTMLTextAreaElement>('.repair-input')?.focus();
+            }
+          });
+        }
+        if (state === 'recording' || state === 'repair_recording' || state === 'handsfree') {
           refreshDpr(); // align snapping to the current monitor before first paint
           startRaf();
         } else {
           stopRaf();
         }
-        if (state !== 'recording' && state !== 'handsfree') smoothed = 0;
+        if (state !== 'recording' && state !== 'repair_recording' && state !== 'handsfree') smoothed = 0;
         if (state === 'error') {
           openError();
           if (errorTimer) clearTimeout(errorTimer);
@@ -680,7 +776,7 @@
             errorTimer = null;
             if (state === 'error') goIdle();
           }, 10000);
-        } else if (state !== 'copied') {
+        } else if (state !== 'copied' && state !== 'clipboard_warning') {
           // Don't clear errorMsg on 'copied' — show_copied_pill carries its
           // confirmation text through the pill-error event, which fires just
           // before this pill-state one.
@@ -767,11 +863,11 @@
           showCopyBtn = false;
         }
 
-        if (state === 'copied') {
+        if (state === 'copied' || state === 'clipboard_warning') {
           if (copiedPillTimer) clearTimeout(copiedPillTimer);
           copiedPillTimer = setTimeout(() => {
             copiedPillTimer = null;
-            if (state === 'copied') goIdle();
+            if (state === 'copied' || state === 'clipboard_warning') goIdle();
           }, 5000);
         } else if (copiedPillTimer) {
           clearTimeout(copiedPillTimer);
@@ -817,6 +913,39 @@
       });
       if (!mounted) { l4(); return; }
       unlisteners.push(l4);
+
+      const l7 = await listen<RepairProposal>('repair-proposal', (ev) => {
+        repairProposal = ev.payload;
+        repairError = '';
+      });
+      if (!mounted) { l7(); return; }
+      unlisteners.push(l7);
+
+      const l8 = await listen<string>('repair-complaint-result', (ev) => {
+        // maxlength on the textarea only caps typing — a dictated complaint
+        // arrives here as a plain value assignment and bypassed it entirely.
+        repairComplaint = (ev.payload || '').slice(0, 200);
+        repairError = '';
+      });
+      if (!mounted) { l8(); return; }
+      unlisteners.push(l8);
+
+      const l9 = await listen<string>('repair-error', (ev) => {
+        repairError = ev.payload || 'Repair could not be prepared';
+        repairProposal = null;
+      });
+      if (!mounted) { l9(); return; }
+      unlisteners.push(l9);
+
+      const l10 = await listen<string>('repair-applied', () => {
+        if (repairDoneTimer) clearTimeout(repairDoneTimer);
+        repairDoneTimer = setTimeout(() => {
+          repairDoneTimer = null;
+          if (state === 'repair_done') goIdle();
+        }, 1200);
+      });
+      if (!mounted) { l10(); return; }
+      unlisteners.push(l10);
     })();
 
     return () => {
@@ -839,6 +968,9 @@
       if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
       if (copiedTimer) clearTimeout(copiedTimer);
       if (copiedPillTimer) clearTimeout(copiedPillTimer);
+      if (repairDoneTimer) clearTimeout(repairDoneTimer);
+      if (repairFeedbackTimer) clearTimeout(repairFeedbackTimer);
+      if (repairIdleTimer) clearTimeout(repairIdleTimer);
       unlisteners.forEach(u => u());
     };
   });
@@ -922,16 +1054,97 @@
     if (copiedPillTimer) { clearTimeout(copiedPillTimer); copiedPillTimer = null; }
     goIdle();
   }
+
+  async function repairPositive() {
+    // Same ordering fix as cancelRepair(): animate first, invoke after —
+    // repair_positive_feedback also hides the native window synchronously.
+    goIdle();
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('repair_positive_feedback').catch(() => {});
+  }
+
+  async function analyzeRepair() {
+    if (!repairComplaint.trim()) return;
+    const { invoke } = await import('@tauri-apps/api/core');
+    repairError = '';
+    state = 'repair_processing';
+    await invoke('repair_analyze', { complaint: repairComplaint }).catch(() => {});
+  }
+
+  async function stopRepairRecording() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('stop_repair_complaint_recording').catch((e) => { repairError = String(e); });
+  }
+
+  async function cancelRepair() {
+    // Animate out locally first — awaiting the backend invoke before calling
+    // goIdle() meant repair_cancel's synchronous native hide_pill() call (see
+    // pill.rs) hid the window before the dying/pillOut CSS animation ever had
+    // a frame to play, so every dismiss (X button, click-away, Escape) just
+    // snapped away instead of animating.
+    goIdle();
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('repair_cancel').catch(() => {});
+  }
+
+  async function retryRepair() {
+    repairError = '';
+    state = 'repair_input';
+    await tick();
+    document.querySelector<HTMLTextAreaElement>('.repair-input')?.focus();
+  }
+
+  function handleRepairKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      void cancelRepair();
+    } else if (
+      event.key === 'Enter' &&
+      !event.shiftKey &&
+      !event.isComposing &&
+      state === 'repair_input'
+    ) {
+      event.preventDefault();
+      void analyzeRepair();
+    }
+  }
+
+  function handleWrapClick(event: MouseEvent) {
+    // Only fires for a click that lands directly on the transparent margin
+    // around the card (not one that bubbled up from a real control inside
+    // it), and only for repair states the user can freely walk away from —
+    // recording/processing/applying should not be cancelable by a stray
+    // click outside the capsule.
+    if (event.target !== event.currentTarget) return;
+    if (
+      state === 'feedback_prompt' ||
+      state === 'repair_input' ||
+      state === 'repair_proposal' ||
+      state === 'repair_error'
+    ) {
+      void cancelRepair();
+    }
+  }
+
+  async function applyRepair() {
+    if (!repairProposal) return;
+    const { invoke } = await import('@tauri-apps/api/core');
+    state = 'repair_applying';
+    await invoke('repair_apply', { proposalId: repairProposal.id }).catch(() => {});
+  }
 </script>
 
 <!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
      has no bars of its own) inherits the DPI-snapped values for its width calc. -->
-<div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px; --stage-w:{stageW}px; --processing-steady-w:{processingSteadyW}px; --hf-expanded-w:{hfExpandedW}px">
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- Dismiss-on-click-outside backdrop: this is a floating overlay, not a page —
+     Escape/keyboard dismissal is already handled per-card (handleRepairKeydown). -->
+<div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px; --stage-w:{stageW}px; --processing-steady-w:{processingSteadyW}px; --hf-expanded-w:{hfExpandedW}px" onclick={handleWrapClick}>
   <div class="pill-cluster"
        class:steady-width={state === 'processing'}
        class:steady-width-hf={state === 'handsfree'}
        bind:this={clusterEl}>
-    {#if profileLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
+  {#if profileLabel && (state === 'recording' || state === 'repair_recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
       <span class="pill-profile">{profileLabel}</span>
     {/if}
 
@@ -940,6 +1153,115 @@
       {#each barHeights as h, i (i)}
         <div class="bar" style="height: {snap(h, dpr)}px"></div>
       {/each}
+    </div>
+
+  {:else if state === 'repair_recording'}
+    <!-- Recording the complaint stacks a small capsule above the still-visible
+         input card (instead of replacing it) so the user keeps context on
+         what they're re-dictating over, per the repair-flow redesign. -->
+    <div class="pill recording repair-recording" class:dying={dying}>
+      <button class="hf-btn cancel" onclick={cancelRepair} aria-label="Cancel complaint recording">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+          <path d="M6 6l12 12M6 18 18 6"/>
+        </svg>
+      </button>
+      <div class="bars-hf">
+        {#each barHeights as h, i (i)}
+          <div class="bar" style="height: {snap(h, dpr)}px"></div>
+        {/each}
+      </div>
+      <button class="hf-btn confirm" onclick={stopRepairRecording} aria-label="Use this complaint">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20 6L9 17l-5-5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="pill repair-card repair-form" class:dying={dying}>
+      <div class="repair-form-head">
+        <span class="repair-label">What went wrong?</span>
+      </div>
+      <textarea class="repair-input" rows="2" value={repairComplaint} disabled placeholder="e.g. “pull request” became “pool request”"></textarea>
+    </div>
+
+  {:else if state === 'feedback_prompt'}
+    <!-- Passive, buttonless toast — replaces the old Not-good/Good prompt.
+         Reporting an issue is now a dedicated hotkey (configured in Settings,
+         see app_hotkey.rs's RepairOpen handling) rather than a click target,
+         since the whole point is the AI does the classifying, not a canned
+         button flow. -->
+    <div class="pill repair-card feedback-card" class:dying={dying}>
+      {#if repairHotkeyLabel}
+        <span class="repair-question">Press {repairHotkeyLabel} to report an issue</span>
+      {:else}
+        <span class="repair-question">Set a hotkey in Settings to report dictation issues</span>
+      {/if}
+    </div>
+
+  {:else if state === 'repair_input' || state === 'repair_processing' || state === 'repair_applying'}
+    <div class="pill repair-card repair-form" class:dying={dying} role="dialog" tabindex="-1" onkeydown={handleRepairKeydown}>
+      <div class="repair-form-head">
+        <label for="repair-complaint" class="repair-label">What went wrong?</label>
+        {#if state !== 'repair_applying'}
+          <button class="hf-btn repair-close" onclick={cancelRepair} aria-label="Cancel">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+              <path d="M6 6l12 12M6 18 18 6"/>
+            </svg>
+          </button>
+        {/if}
+      </div>
+      <textarea id="repair-complaint" class="repair-input" rows="2" bind:value={repairComplaint} maxlength="200" disabled={state !== 'repair_input'} placeholder="e.g. “pull request” became “pool request”" spellcheck="false" autocomplete="off"></textarea>
+      {#if repairError}<span class="repair-inline-error">{repairError}</span>{/if}
+      <div class="repair-actions">
+        {#if state === 'repair_input'}
+          <button class="repair-primary" onclick={analyzeRepair} disabled={!repairComplaint.trim()}>Analyze</button>
+        {:else if state === 'repair_processing'}
+          <span class="repair-status"><span class="loading-spinner"></span>Diagnosing…</span>
+        {:else}
+          <span class="repair-status"><span class="loading-spinner"></span>Applying…</span>
+        {/if}
+      </div>
+    </div>
+
+  {:else if state === 'repair_proposal'}
+    <div class="pill repair-card repair-proposal" class:dying={dying} role="dialog" tabindex="-1" onkeydown={handleRepairKeydown}>
+      <div class="repair-form-head">
+        <span class="repair-label">Proposed repair</span>
+        <button class="hf-btn repair-close" onclick={cancelRepair} aria-label="Cancel">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <path d="M6 6l12 12M6 18 18 6"/>
+          </svg>
+        </button>
+      </div>
+      <strong>{repairProposal?.summary}</strong>
+      <span class="repair-scope">{repairProposal?.scope}</span>
+      {#if repairError}<span class="repair-inline-error">{repairError}</span>{/if}
+      <div class="repair-actions">
+        <button class="repair-primary" onclick={applyRepair}>Apply</button>
+      </div>
+    </div>
+
+  {:else if state === 'repair_error'}
+    <div class="pill repair-card repair-proposal" class:dying={dying} role="dialog" tabindex="-1" onkeydown={handleRepairKeydown}>
+      <div class="repair-form-head">
+        <span class="repair-label">Can't apply a fix</span>
+        <button class="hf-btn repair-close" onclick={cancelRepair} aria-label="Cancel">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <path d="M6 6l12 12M6 18 18 6"/>
+          </svg>
+        </button>
+      </div>
+      <span class="repair-error-text">{repairError || 'Repair could not be prepared'}</span>
+      <div class="repair-actions">
+        <button class="repair-primary" onclick={retryRepair} disabled={!repairComplaint.trim()}>Retry</button>
+      </div>
+    </div>
+
+  {:else if state === 'repair_done'}
+    <div class="pill copied" class:dying={dying}>
+      <svg class="copied-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="20 6 9 17 4 12"/>
+      </svg>
+      <span class="copied-text">Repair applied</span>
     </div>
 
   {:else if state === 'processing'}
@@ -1061,6 +1383,17 @@
       </button>
     </div>
 
+  {:else if state === 'clipboard_warning'}
+    <div class="pill copied clipboard-warning" class:dying={dying}>
+      <svg class="copied-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/>
+        <path d="M12 8v4"/>
+        <circle cx="12" cy="16" r="1" fill="currentColor" stroke="none"/>
+      </svg>
+      <span class="copied-text">{errorMsg || 'Clipboard phrase skipped'}</span>
+      <button class="hf-btn copied-dismiss" onclick={dismissCopied} aria-label="Dismiss"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M6 6l12 12M6 18 18 6"/></svg></button>
+    </div>
+
   {:else if state === 'handsfree'}
     <div class="pill handsfree" class:dying={dying} class:hf-expanded={showHfButtons && !dying} class:no-anim={prevState === 'recording'}>
       {#if showHfButtons}
@@ -1085,6 +1418,7 @@
     </div>
   {/if}
   </div>
+
 </div>
 
 <style>
@@ -1105,7 +1439,8 @@
 
   :global(html, body, #pill-root) {
     margin: 0; padding: 0;
-    background: transparent;
+    background: transparent !important;
+    background-color: rgba(0, 0, 0, 0) !important;
     overflow: hidden;
     width: 100vw; height: 100vh;
     font-family: var(--sans);
@@ -1211,6 +1546,80 @@
     animation: pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
 
+  /* Repair flow — built from the pill's own primitives (hf-btn icon
+     buttons, the copied/error capsule shells, loading-spinner) instead of
+     boxed generic-dialog buttons, so it reads as part of the same app
+     instead of a bolted-on modal. */
+  .repair-card {
+    width: 300px;
+    box-sizing: border-box;
+    height: auto;
+    min-height: 34px;
+    border-radius: 20px;
+    padding: 12px 14px;
+    gap: 8px;
+    background: var(--pill-bg);
+    color: var(--pill-fg);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08) inset, 0 10px 28px rgba(0,0,0,0.38);
+  }
+  .feedback-card {
+    width: auto;
+    max-width: 260px;
+    justify-content: center;
+    padding: 10px 16px;
+    border-radius: 999px;
+  }
+  .feedback-card .repair-question {
+    font-size: 11.5px;
+    font-weight: 500;
+    line-height: 15px;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .repair-form, .repair-proposal { flex-direction: column; align-items: stretch; border-radius: 18px; padding: 13px 14px 11px; gap: 9px; }
+  .repair-form-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .repair-label {
+    font-size: 10.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; color: var(--pill-muted);
+  }
+  .hf-btn.repair-close { color: var(--pill-muted); }
+  .hf-btn.repair-close:hover { color: var(--pill-muted-strong); background: rgba(255,255,255,0.1); }
+
+  .repair-input {
+    width: 100%; box-sizing: border-box; min-height: 46px; max-height: 112px; resize: none;
+    border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; background: rgba(255,255,255,0.04);
+    color: inherit; padding: 8px 10px; font: inherit; font-size: 12px; line-height: 1.4;
+    outline: none; user-select: text; -webkit-user-select: text;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .repair-input:focus { border-color: rgba(255,255,255,0.26); background: rgba(255,255,255,0.06); }
+  .repair-input:disabled { opacity: 0.55; }
+  .repair-input::placeholder { color: var(--pill-muted); opacity: 0.8; }
+
+  .repair-actions { display: flex; align-items: center; justify-content: center; gap: 8px; }
+  .repair-primary {
+    border: 0; border-radius: 999px; padding: 6px 14px; color: var(--pill-bg); background: var(--accent);
+    font: inherit; font-size: 11px; font-weight: 700; cursor: pointer; transition: opacity 0.15s ease;
+  }
+  .repair-primary:disabled { opacity: 0.4; cursor: default; }
+  .repair-primary:hover:not(:disabled) { opacity: 0.88; }
+
+  .repair-status { display: flex; align-items: center; gap: 7px; font-size: 11px; color: var(--pill-muted); }
+  .repair-scope, .repair-inline-error { font-size: 10.5px; color: var(--pill-muted); }
+  .repair-inline-error { color: var(--pill-error-fg); white-space: normal; }
+  .repair-proposal strong { font-size: 12.5px; font-weight: 600; line-height: 17px; white-space: normal; }
+  .repair-error-text { font-size: 11.5px; font-weight: 400; line-height: 16px; color: var(--pill-fg); opacity: 0.85; white-space: normal; }
+
+  .pill.recording.repair-recording {
+    width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 64px);
+    gap: 4px;
+    padding: 0 6px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .repair-input, .repair-primary { transition: none; }
+  }
+
   /* Translate distances stay inside the window's vertical padding (PILL_PAD_H
      / 2 per side). At the old 8px/6px against a 5px pad the pill's bottom edge
      was clipped by the window for the whole entrance and exit. */
@@ -1231,7 +1640,8 @@
   .pill.paste-failed.dying,
   .pill.copied.dying,
   .pill.processing.dying,
-  .pill.loading-local.dying {
+  .pill.loading-local.dying,
+  .repair-card.dying {
     animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
     pointer-events: none;
   }

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -51,6 +51,11 @@
   let recordingHotkey = $state(false);
   let capturedKeys = $state<string[]>([]);
   let hotkeyState = $state<'idle' | 'armed' | 'first' | 'saving' | 'success' | 'error'>('idle');
+  const defaultRepairHotkey = ['ControlLeft', 'AltLeft', 'KeyZ'];
+  let repairHotkey = $state<string[]>(defaultRepairHotkey);
+  let recordingRepairHotkey = $state(false);
+  let capturedRepairKeys = $state<string[]>([]);
+  let repairHotkeyState = $state<'idle' | 'armed' | 'first' | 'saving' | 'success' | 'error'>('idle');
   const HOTKEY_SUCCESS_MS = 700;
   const HOTKEY_ERROR_MS   = 900;
   const LANGUAGE_MENU_ID = 'spoken-language-menu';
@@ -97,10 +102,9 @@
     return formatKeyLabel(code);
   }
 
-  // A macOS hotkey can be a single key (e.g. F5) — its second slot is empty.
+  // A macOS hotkey can be a single key (e.g. F5) — later slots are empty.
   function formatHotkeyDisplay(hk: string[]): string {
-    const first = formatHotkeyBadgeLabel(hk[0] ?? '');
-    return hk[1] ? `${first} + ${formatHotkeyBadgeLabel(hk[1])}` : first;
+    return hk.filter(Boolean).map(formatHotkeyBadgeLabel).join(' + ');
   }
 
   let buttonText = $derived(
@@ -111,6 +115,22 @@
           ? isMac ? 'Press a key (e.g. F5)…' : 'Press Alt/Ctrl/Shift/Win...'
           : 'Press 2nd key...'
       : formatHotkeyDisplay(hotkey)
+  );
+
+  // Two modifiers plus one regular key (default Ctrl+Alt+Z), any press order
+  // — a modifier-only combo isn't allowed (see core::hotkey::win's
+  // REPAIR_MOD1 doc comment for the bug that came from allowing it), but
+  // there's no need to walk the user through which slot is which: almost
+  // nobody changes this from the default, so one plain "still recording"
+  // message beats a running commentary on each keypress.
+  let repairButtonText = $derived(
+    recordingRepairHotkey
+      ? capturedRepairKeys[0] === '__bad__'
+        ? 'Needs 2 modifiers + 1 key'
+        : 'Press your combo...'
+      : repairHotkey[0]
+        ? formatHotkeyDisplay(repairHotkey)
+        : 'Not set'
   );
 
   $effect.pre(() => {
@@ -147,6 +167,7 @@
     const results = await Promise.allSettled([
       invoke<boolean | null>('get_setting', { key: 'autostart_enabled' }),
       invoke<string[] | null>('get_setting', { key: 'hotkey' }),
+      invoke<string[] | null>('get_setting', { key: 'repair_hotkey' }),
       invoke<AppearanceMode | null>('get_setting', { key: 'appearance_mode' }),
       invoke<TranscriptionLanguageCode | null>('get_setting', { key: 'transcription_language' }),
       invoke<boolean | null>('get_setting', { key: 'cleanup_enabled' }),
@@ -162,28 +183,35 @@
       results[i].status === 'fulfilled' ? (results[i] as PromiseFulfilledResult<T>).value ?? fallback : fallback;
 
     autostart = val<boolean | null>(0, null) ?? false;
-    appStore.cleanupEnabled = val<boolean | null>(4, null) ?? true;
-    contextualCaps = val<boolean | null>(5, null) ?? true;
-    autoSpacing = val<boolean | null>(6, null) ?? true;
-    capsLockUppercase = val<boolean | null>(7, null) ?? false;
+    appStore.cleanupEnabled = val<boolean | null>(5, null) ?? true;
+    contextualCaps = val<boolean | null>(6, null) ?? true;
+    autoSpacing = val<boolean | null>(7, null) ?? true;
+    capsLockUppercase = val<boolean | null>(8, null) ?? false;
 
     const hk = val<string[] | null>(1, null);
     if (hk && hk.length === 2) hotkey = hk;
 
-    const appearance = val<AppearanceMode | null>(2, null);
+    // Absent from settings entirely (never touched) keeps the built-in
+    // Ctrl+Alt+Z default (repairHotkey's own initial state) since that's
+    // genuinely what's active. An explicit ["","",""] means the user cleared
+    // it, which really does disable the feature — show that as "Not set".
+    const repairHk = val<string[] | null>(2, null);
+    if (repairHk && repairHk.length === 3) repairHotkey = repairHk;
+
+    const appearance = val<AppearanceMode | null>(3, null);
     if (appearance === 'system' || appearance === 'light' || appearance === 'dark') {
       appStore.appearanceMode = appearance;
     }
 
-    const language = val<TranscriptionLanguageCode | null>(3, null);
+    const language = val<TranscriptionLanguageCode | null>(4, null);
     if (!languageTouched && language && transcriptionLanguages.some((option) => option.code === language)) {
       selectedLanguage = language;
     }
     initialLanguageLoaded = true;
 
-    microphones = val<string[]>(8, []);
-    selectedMic = val<string | null>(9, null) ?? '';
-    appStore.legacyFeaturesEnabled = val<boolean | null>(10, null) ?? false;
+    microphones = val<string[]>(9, []);
+    selectedMic = val<string | null>(10, null) ?? '';
+    appStore.legacyFeaturesEnabled = val<boolean | null>(11, null) ?? false;
 
     results.forEach((r, i) => {
       if (r.status === 'rejected') console.error(`GeneralSection: invoke[${i}] failed:`, r.reason);
@@ -465,9 +493,111 @@
     }
   }
 
+  function startRecordingRepairHotkey(e: MouseEvent | KeyboardEvent) {
+    e.stopPropagation();
+    if (recordingRepairHotkey) return;
+    recordingRepairHotkey = true;
+    repairHotkeyState = 'armed';
+    capturedRepairKeys = [];
+    window.addEventListener('keydown', handleRepairHotkeyKeydown, { capture: true });
+    window.addEventListener('keyup', handleRepairHotkeyKeyup, { capture: true });
+    window.addEventListener('mousedown', cancelRecordingRepairHotkey, { capture: true });
+  }
+
+  function removeRepairHotkeyCaptureListeners() {
+    window.removeEventListener('keydown', handleRepairHotkeyKeydown, { capture: true });
+    window.removeEventListener('keyup', handleRepairHotkeyKeyup, { capture: true });
+    window.removeEventListener('mousedown', cancelRecordingRepairHotkey, { capture: true });
+  }
+
+  function cancelRecordingRepairHotkey(e?: MouseEvent | KeyboardEvent) {
+    if (e && (e.target as HTMLElement).closest('.repair-keybind-btn')) return;
+    if (recordingRepairHotkey) {
+      removeRepairHotkeyCaptureListeners();
+      recordingRepairHotkey = false;
+      repairHotkeyState = 'idle';
+      capturedRepairKeys = [];
+    }
+  }
+
+  function handleRepairHotkeyKeydown(e: KeyboardEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.repeat) return;
+    if (e.code === 'Escape') { cancelRecordingRepairHotkey(); return; }
+    if (capturedRepairKeys.includes(e.code)) return;
+    if (capturedRepairKeys.length >= 3) return;
+
+    capturedRepairKeys = [...capturedRepairKeys, e.code];
+    if (capturedRepairKeys.length < 3) {
+      repairHotkeyState = 'first';
+      return;
+    }
+    // Any press order is fine — just needs to land on exactly 2 modifiers
+    // and 1 regular key once all 3 are in, then reorder into
+    // [modifier, modifier, trigger] for save_repair_hotkey.
+    const mods = capturedRepairKeys.filter((k) => MODIFIER_CODES.has(k));
+    const regular = capturedRepairKeys.filter((k) => !MODIFIER_CODES.has(k));
+    if (mods.length !== 2 || regular.length !== 1) {
+      capturedRepairKeys = ['__bad__'];
+      setTimeout(() => { capturedRepairKeys = []; }, 800);
+      return;
+    }
+    capturedRepairKeys = [...mods, ...regular];
+    repairHotkeyState = 'saving';
+    finishRecordingRepairHotkey();
+  }
+
+  function handleRepairHotkeyKeyup(e: KeyboardEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  async function finishRecordingRepairHotkey() {
+    removeRepairHotkeyCaptureListeners();
+    recordingRepairHotkey = false;
+    if (capturedRepairKeys.length === 3) {
+      try {
+        let available = true;
+        try {
+          available = await invoke<boolean>('check_repair_hotkey', { key1: capturedRepairKeys[0], key2: capturedRepairKeys[1], key3: capturedRepairKeys[2] });
+        } catch (e) {
+          console.warn('check_repair_hotkey failed (likely running in browser dev mode)', e);
+        }
+        if (!available) {
+          repairHotkeyState = 'error';
+          await emit('verenu:error', 'Hotkey may already be in use by another application');
+          setTimeout(() => { repairHotkeyState = 'idle'; }, HOTKEY_ERROR_MS);
+          return;
+        }
+        await invoke('save_repair_hotkey', { key1: capturedRepairKeys[0], key2: capturedRepairKeys[1], key3: capturedRepairKeys[2] });
+        repairHotkey = capturedRepairKeys;
+        repairHotkeyState = 'success';
+        setTimeout(() => { repairHotkeyState = 'idle'; }, HOTKEY_SUCCESS_MS);
+      } catch (e) {
+        console.error('Failed to save repair hotkey', e);
+        repairHotkeyState = 'error';
+        await emit('verenu:error', 'Failed to save hotkey - key may not be recognized');
+        setTimeout(() => { repairHotkeyState = 'idle'; }, HOTKEY_ERROR_MS);
+      }
+    }
+  }
+
+  async function clearRepairHotkey(e: MouseEvent) {
+    e.stopPropagation();
+    try {
+      await invoke('save_repair_hotkey', { key1: '', key2: '', key3: '' });
+      repairHotkey = ['', '', ''];
+    } catch (e) {
+      console.error('Failed to clear repair hotkey', e);
+    }
+  }
+
   onDestroy(() => {
     removeHotkeyCaptureListeners();
     recordingHotkey = false;
+    removeRepairHotkeyCaptureListeners();
+    recordingRepairHotkey = false;
   });
 
   loadSettings();
@@ -504,6 +634,24 @@
 <div class="setting-row">
   <div><div class="label">Copy last dictation</div><div class="desc">Always available — re-copies your last dictation to the clipboard, in case a paste didn't land</div></div>
   <span class="badge key-badge">{isMac ? '⌥⌘C' : 'Ctrl+Alt+C'}</span>
+</div>
+<div class="setting-row">
+  <div><div class="label">Report a dictation issue</div><div class="desc">Opens the complaint box right after a dictation, while the option is still showing</div></div>
+  <div style="display:flex; align-items:center; gap:8px;">
+    <button class="badge" onclick={clearRepairHotkey} type="button" style="cursor:pointer;">Clear</button>
+    <button
+      class="badge key-badge repair-keybind-btn"
+      onclick={startRecordingRepairHotkey}
+      class:recording={recordingRepairHotkey}
+      class:armed={repairHotkeyState === 'armed'}
+      class:first={repairHotkeyState === 'first'}
+      class:saving={repairHotkeyState === 'saving'}
+      class:success={repairHotkeyState === 'success'}
+      class:error={repairHotkeyState === 'error'}
+    >
+      {repairButtonText}
+    </button>
+  </div>
 </div>
 <div class="setting-row">
   <div class="lang-setting-text"><div class="label">Spoken Language</div><div class="desc">Tells transcription what language to expect{languageScopeNote}</div></div>


### PR DESCRIPTION
## What changed

Adds the post-dictation repair flow described in the accompanying changelog:

- Routes complaints through the configured cleanup model chain; no deterministic correction fast path.
- Validates model-proposed vocabulary and setting repairs against observed complaint/transcript evidence.
- Uses a closed semantic scope (context or everywhere) and resolves context IDs from the dictation snapshot.
- Adds the configurable three-key ?Report a dictation issue? hotkey with Ctrl+Alt+Z default.
- Hardens Windows/macOS hotkey handling, native pill focus/lifecycle, focus loss, profile ordering, and window rendering.
- Reworks repair cards, complaint recording, dismissal, focus, truncation, and disabled-hotkey behavior.
- Adds focused Rust coverage for parsing, evidence validation, scope, no-ops, and display limits.

## Verification

- npm run check ? passed.
- cargo test --manifest-path src-tauri/Cargo.toml repair ? 9 passed.
- Full Rust suite ? 577 passed, 2 failed in existing pipeline::tests::strip_trailing_hallucination_* cases unrelated to this change.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #224
- <kbd>&nbsp;1&nbsp;</kbd> #228 👈 
<!-- GitButler Footer Boundary Bottom -->