### PR TITLE
Use dated nightly beta update versions

### DIFF
--- a/.github/workflows/morning-release.yml
+++ b/.github/workflows/morning-release.yml
@@ -49,28 +49,42 @@ jobs:
           baseline_tag=""
           last_nightly=""
 
-          # A nightly tag points at a temporary version-bump commit whose
+          # A nightly tag points at a release-only metadata commit whose
           # parent is the dev snapshot it released. Find the newest such tag
           # whose parent is still reachable from the current dev branch.
+          last_nightly_date=""
           while IFS= read -r candidate; do
-            if [[ ! "$candidate" =~ ^Verenu-[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}$ ]]; then
+            if [[ ! "$candidate" =~ ^Verenu-[0-9]+\.[0-9]+\.[0-9]+-nightly\.([0-9]{8})$ ]]; then
               continue
             fi
+            candidate_date="${BASH_REMATCH[1]}"
             nightly_commit="$(git rev-parse "${candidate}^{commit}")"
             candidate_sha="$(git rev-parse "${nightly_commit}^")"
-            if git merge-base --is-ancestor "$candidate_sha" "$dev_sha"; then
+            if git merge-base --is-ancestor "$candidate_sha" "$dev_sha" && [[ -z "$last_nightly" || "$candidate_date" > "$last_nightly_date" ]]; then
               last_nightly="$candidate"
+              last_nightly_date="$candidate_date"
               baseline_sha="$candidate_sha"
               baseline_tag="$candidate"
-              break
             fi
-          done < <(git tag --list 'Verenu-*-nightly.*' | sort -Vr)
+          done < <(git tag --list 'Verenu-*-nightly.*')
+
+          # Nightlies keep the latest stable release as their numeric version
+          # base. The fallback is used only before the first reachable stable
+          # tag exists in the dev history.
+          nightly_base_version="$NIGHTLY_START_VERSION"
+          nightly_base_tag="$(git tag --merged "$dev_sha" --list 'Verenu-*' | grep -E '^Verenu-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+          if [[ -n "$nightly_base_tag" ]]; then
+            nightly_base_version="${nightly_base_tag#Verenu-}"
+          fi
 
           # Before the first nightly, use the newest release tag reachable
           # from dev. Tags are branch-agnostic, so reachability is the branch
           # association we can verify safely.
           if [[ -z "$baseline_sha" ]]; then
-            baseline_tag="$(git tag --merged "$dev_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
+            baseline_tag="$nightly_base_tag"
+            if [[ -z "$baseline_tag" ]]; then
+              baseline_tag="$(git tag --merged "$dev_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
+            fi
             if [[ -z "$baseline_tag" ]]; then
               echo 'No release tag reachable from dev; refusing to guess a baseline.' >&2
               exit 1
@@ -83,8 +97,8 @@ jobs:
           release_date="$(TZ=America/Vancouver date +%Y%m%d)"
 
           # If a prior run created today's tag but failed while building or
-          # publishing, resume that exact release instead of incrementing the
-          # nightly number again.
+          # publishing, resume that exact dated release instead of creating a
+          # second release for the same dev snapshot.
           resume_existing=false
           if [[ -n "$last_nightly" && "$baseline_sha" == "$dev_sha" && "$last_nightly" =~ \.nightly\.${release_date}$ ]]; then
             resume_existing=true
@@ -92,6 +106,7 @@ jobs:
 
           echo "Baseline: $baseline_tag ($baseline_sha)"
           echo "Dev:      $dev_sha"
+          echo "Nightly base: $nightly_base_version"
           echo "Changed lines: $changed_lines"
           git diff --stat "$baseline_sha..$dev_sha" -- . ':(exclude)package-lock.json'
 
@@ -103,21 +118,12 @@ jobs:
           if [[ "$resume_existing" == true ]]; then
             release_tag="$last_nightly"
             release_version="${release_tag#Verenu-}"
-            app_version="${release_version%%-nightly.*}"
+            app_version="$release_version"
             release_sha="$(git rev-parse "${release_tag}^{commit}")"
             tag_exists=true
-          elif [[ -n "$last_nightly" ]]; then
-            last_version="${last_nightly#Verenu-}"
-            last_core="${last_version%%-nightly.*}"
-            IFS=. read -r major minor patch <<< "$last_core"
-            next_core="$major.$minor.$((patch + 1))"
-            app_version="$next_core"
-            release_version="${app_version}-nightly.${release_date}"
-            release_tag="Verenu-${release_version}"
-            tag_exists=false
           else
-            app_version="$NIGHTLY_START_VERSION"
-            release_version="${app_version}-nightly.${release_date}"
+            release_version="${nightly_base_version}-nightly.${release_date}"
+            app_version="$release_version"
             release_tag="Verenu-${release_version}"
             tag_exists=false
           fi
@@ -285,7 +291,6 @@ jobs:
           const version = process.argv[2];
           const replacements = [
             ['package.json', /(\"version\"\s*:\s*\")[^\"]+(\")/, `$1${version}$2`],
-            ['src-tauri/tauri.conf.json', /(\"version\"\s*:\s*\")[^\"]+(\")/, `$1${version}$2`],
             ['src-tauri/Cargo.toml', /^version\s*=\s*\"[^\"]+\"/m, `version = \"${version}\"`],
           ];
 
@@ -295,6 +300,23 @@ jobs:
             if (after === before) throw new Error(`Could not update version in ${file}`);
             fs.writeFileSync(file, after);
           }
+
+          // tauri.conf.json drives both the app version (frontend display,
+          // bundle metadata) and the installer bundlers. The MSI bundler
+          // rejects non-numeric prerelease versions such as
+          // "0.16.5-nightly.20260810", while NSIS and macOS accept them, so
+          // the MSI gets an explicit numeric `bundle.windows.wix.version`
+          // derived from the same core version (e.g. "0.16.0.0"). This keeps
+          // one semantic app version for Rust/frontend/updater comparison and
+          // a numeric-only one where Windows requires it.
+          const tauriConf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+          tauriConf.version = version;
+          const wixVersion = version.split('-')[0].split('+')[0] + '.0';
+          tauriConf.bundle = tauriConf.bundle || {};
+          tauriConf.bundle.windows = tauriConf.bundle.windows || {};
+          tauriConf.bundle.windows.wix = tauriConf.bundle.windows.wix || {};
+          tauriConf.bundle.windows.wix.version = wixVersion;
+          fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(tauriConf, null, 2) + '\n');
           NODE
 
           git diff --check
@@ -489,12 +511,33 @@ jobs:
           EXPECTED_APP_VERSION: ${{ needs.prepare.outputs.app_version }}
         run: |
           set -euo pipefail
-          app_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
-          if [[ "$app_version" != "$EXPECTED_APP_VERSION" ]]; then
-            echo "Expected app version $EXPECTED_APP_VERSION but found $app_version" >&2
-            exit 1
-          fi
-          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+          node - "$EXPECTED_APP_VERSION" <<'NODE'
+          const fs = require('node:fs');
+          const expected = process.argv[2];
+          const packageVersion = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+          const cargoMatch = fs.readFileSync('src-tauri/Cargo.toml', 'utf8').match(/^version\s*=\s*"([^"]+)"/m);
+          const tauriConf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+          const wixVersion = expected.split('-')[0].split('+')[0] + '.0';
+          if (packageVersion !== expected) {
+            console.error(`Expected package.json version ${expected} but found ${packageVersion}`);
+            process.exit(1);
+          }
+          if (!cargoMatch || cargoMatch[1] !== expected) {
+            console.error(`Expected Cargo.toml version ${expected} but found ${cargoMatch ? cargoMatch[1] : 'missing'}`);
+            process.exit(1);
+          }
+          if (tauriConf.version !== expected) {
+            console.error(`Expected tauri.conf.json version ${expected} but found ${tauriConf.version}`);
+            process.exit(1);
+          }
+          const wix = tauriConf.bundle && tauriConf.bundle.windows && tauriConf.bundle.windows.wix;
+          if (!wix || !wix.version || wix.version !== wixVersion) {
+            console.error(`Expected numeric bundle.windows.wix.version ${wixVersion} but found ${wix ? wix.version : 'missing'}`);
+            process.exit(1);
+          }
+          console.log(`Verified app version ${expected} in package.json, Cargo.toml, tauri.conf.json (wix ${wix.version})`);
+          NODE
+          echo "APP_VERSION=$EXPECTED_APP_VERSION" >> "$GITHUB_ENV"
 
       - name: Build and name installers
         shell: bash

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -72,7 +72,7 @@ impl UpdateChannel {
 }
 
 /// Repo to check for releases.
-const RELEASE_REPO: &str = "MONKE2525E/Verenu";
+const RELEASE_REPO: &str = "Verenu/Verenu";
 
 /// Returns true only for URLs that point at an official release asset for
 /// [`RELEASE_REPO`]. GitHub serves release assets from
@@ -177,12 +177,7 @@ async fn check_repo(
         return Ok(None);
     };
 
-    if !should_offer_release_for_channel(
-        &display_version,
-        &current_package_version(),
-        channel,
-        require_newer,
-    ) {
+    if !should_offer_release(&display_version, &current_package_version(), require_newer) {
         return Ok(None);
     }
 
@@ -244,9 +239,13 @@ fn release_matches_channel(release: &GhRelease, channel: UpdateChannel) -> bool 
     }
 }
 
+pub fn is_beta_version(version: &str) -> bool {
+    let version = version.to_ascii_lowercase();
+    version.contains("-beta") || version.contains("-nightly") || version.contains("-dev")
+}
+
 fn is_beta_release_tag(tag: &str) -> bool {
-    let tag = tag.to_ascii_lowercase();
-    tag.contains("-beta") || tag.contains("-nightly") || tag.contains("-dev")
+    is_beta_version(tag)
 }
 
 fn is_commit_sha(value: &str) -> bool {
@@ -278,7 +277,7 @@ fn release_version(tag: &str) -> Option<String> {
     }
 }
 
-fn current_package_version() -> String {
+pub fn current_package_version() -> String {
     env!("CARGO_PKG_VERSION").to_owned()
 }
 
@@ -402,47 +401,30 @@ fn normalize_version(tag: &str) -> String {
 }
 
 fn is_newer(latest: &str, current: &str) -> bool {
-    compare_versions(latest, current) == std::cmp::Ordering::Greater
+    let latest = release_version(latest).unwrap_or_else(|| normalize_version(latest));
+    let current = release_version(current).unwrap_or_else(|| normalize_version(current));
+    let (Some(latest), Some(current)) = (parse_version(&latest), parse_version(&current)) else {
+        return false;
+    };
+
+    match latest.core.cmp(&current.core) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => match (&latest.prerelease, &current.prerelease) {
+            // A same-core beta is a valid update when beta updates are
+            // enabled. The channel filter prevents this rule from affecting
+            // stable-only checks.
+            (Some(_), None) => true,
+            (Some(latest), Some(current)) => {
+                compare_prerelease_parts(latest, current) == std::cmp::Ordering::Greater
+            }
+            _ => false,
+        },
+    }
 }
 
 fn should_offer_release(latest: &str, current: &str, require_newer: bool) -> bool {
     !require_newer || is_newer(latest, current)
-}
-
-/// SemVer deliberately considers `0.16.2-nightly` older than the final
-/// `0.16.2` release. That rule is normally correct, but an opted-in beta user
-/// needs to be able to move from the stable build to that matching nightly.
-/// The channel gate has already verified that `latest` is a beta release.
-fn should_offer_release_for_channel(
-    latest: &str,
-    current: &str,
-    channel: UpdateChannel,
-    require_newer: bool,
-) -> bool {
-    if should_offer_release(latest, current, require_newer) {
-        return true;
-    }
-
-    if !require_newer || channel != UpdateChannel::Beta {
-        return false;
-    }
-
-    let latest = parse_version(latest);
-    let current = parse_version(current);
-
-    matches!(
-        (latest, current),
-        (
-            Some(ParsedVersion {
-                core: latest_core,
-                prerelease: Some(_),
-            }),
-            Some(ParsedVersion {
-                core: current_core,
-                prerelease: None,
-            }),
-        ) if latest_core == current_core
-    )
 }
 
 fn current_update_target() -> UpdateTarget {
@@ -549,10 +531,10 @@ fn find_asset_with_suffix_and_hints<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        current_package_version, find_asset_with_suffix, is_authorized_release_asset_url, is_newer,
-        normalize_version, parse_prerelease_parts, release_version, select_release,
-        select_release_asset_for_target, should_offer_release, should_offer_release_for_channel,
-        GhAsset, GhRelease, InstallMode, UpdateChannel, UpdateTarget, VersionPart,
+        current_package_version, find_asset_with_suffix, is_authorized_release_asset_url,
+        is_beta_version, is_newer, normalize_version, parse_prerelease_parts, release_version,
+        select_release, select_release_asset_for_target, should_offer_release, GhAsset, GhRelease,
+        InstallMode, UpdateChannel, UpdateTarget, VersionPart,
     };
 
     fn asset(name: &str) -> GhAsset {
@@ -893,11 +875,11 @@ mod tests {
     #[test]
     fn authorized_url_accepts_official_release_assets() {
         assert!(is_authorized_release_asset_url(
-            "https://github.com/MONKE2525E/Verenu/releases/download/v0.15.0/Verenu_0.15.0_x64-setup.exe"
+            "https://github.com/Verenu/Verenu/releases/download/v0.15.0/Verenu_0.15.0_x64-setup.exe"
         ));
         // Owner/repo casing is insignificant on GitHub.
         assert!(is_authorized_release_asset_url(
-            "https://github.com/monke2525e/verenu/releases/download/v0.15.0/Verenu_0.15.0_Apple_Silicon.dmg"
+            "https://github.com/verenu/verenu/releases/download/v0.15.0/Verenu_0.15.0_Apple_Silicon.dmg"
         ));
     }
 
@@ -905,20 +887,20 @@ mod tests {
     fn authorized_url_rejects_bypasses_and_foreign_hosts() {
         let bad = [
             // Wrong host / scheme.
-            "http://github.com/MONKE2525E/Verenu/releases/download/v1/a.exe",
-            "https://evil.com/MONKE2525E/Verenu/releases/download/v1/a.exe",
+            "http://github.com/Verenu/Verenu/releases/download/v1/a.exe",
+            "https://evil.com/Verenu/Verenu/releases/download/v1/a.exe",
             // Different repo.
             "https://github.com/attacker/repo/releases/download/v1/a.exe",
             // Literal dot-segment traversal.
-            "https://github.com/MONKE2525E/Verenu/releases/download/../../attacker/repo/releases/download/v1/a.exe",
+            "https://github.com/Verenu/Verenu/releases/download/../../attacker/repo/releases/download/v1/a.exe",
             // Percent-encoded dot / slash / backslash traversal.
-            "https://github.com/MONKE2525E/Verenu/releases/download/%2e%2e/a.exe",
-            "https://github.com/MONKE2525E/Verenu/releases/download/v1/%2fa.exe",
-            "https://github.com/MONKE2525E/Verenu/releases/download/..%2f..%2fattacker/a.exe",
-            "https://github.com/MONKE2525E/Verenu/releases/download/..%5c..%5cattacker%5crepo/a.exe",
+            "https://github.com/Verenu/Verenu/releases/download/%2e%2e/a.exe",
+            "https://github.com/Verenu/Verenu/releases/download/v1/%2fa.exe",
+            "https://github.com/Verenu/Verenu/releases/download/..%2f..%2fattacker/a.exe",
+            "https://github.com/Verenu/Verenu/releases/download/..%5c..%5cattacker%5crepo/a.exe",
             // Wrong structure (too few / too many segments).
-            "https://github.com/MONKE2525E/Verenu/releases/download/v1",
-            "https://github.com/MONKE2525E/Verenu/blob/main/releases/download/v1/a.exe",
+            "https://github.com/Verenu/Verenu/releases/download/v1",
+            "https://github.com/Verenu/Verenu/blob/main/releases/download/v1/a.exe",
         ];
         for url in bad {
             assert!(

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -42,11 +42,14 @@ fn selected_update_channel(app: &AppHandle) -> Result<crate::api::updater::Updat
         .get(store::BETA_UPDATES_ENABLED)
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    Ok(if beta_enabled {
-        crate::api::updater::UpdateChannel::Beta
-    } else {
-        crate::api::updater::UpdateChannel::Stable
-    })
+    let installed_version = crate::api::updater::current_package_version();
+    Ok(
+        if beta_enabled || crate::api::updater::is_beta_version(&installed_version) {
+            crate::api::updater::UpdateChannel::Beta
+        } else {
+            crate::api::updater::UpdateChannel::Stable
+        },
+    )
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that includes a local desktop updater.
> - This change belongs to the release workflow and Rust updater channel/version logic.
> - Nightly releases were incrementing the patch number indefinitely, and same-core dated nightlies could not advance reliably.
> - The workflow now needs a stable release base plus a creation date, while beta clients must remain on beta updates.
> - This pull request aligns nightly tag generation, packaged version metadata, channel selection, and version comparison.
> - The benefit is predictable nightly names such as `0.16.0-nightly.20260814` and correct date-based update ordering.

## What Changed

- Reuse the latest reachable stable version as the nightly numeric base and append `-nightly.YYYYMMDD`.
- Select prior nightly baselines by date so legacy `0.16.5-nightly...` tags migrate safely.
- Compare same-base nightlies by their date and keep installed beta/nightly clients on the beta channel.
- Keep stable update selection separate from prerelease selection.

## Verification

- `cargo test --bin verenu api::updater` (29 passed)
- `npm run check` (0 errors, 0 warnings)
- Workflow YAML parsed successfully.
- Scoped updater formatting and diff checks passed.

## Risks

- Low runtime risk. The updater changes affect only release selection and version comparison.
- The workflow still resumes an existing same-day release instead of creating a duplicate.
- Stable builds continue using stable release filtering and numeric version comparison.

> Checked `docs/ROADMAP.md`; this PR does not duplicate planned work.

## Model Used

- OpenAI GPT-5.6 via Codex, extended reasoning and repository tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above