### PR TITLE
Remove Gemini 3.5 Flash from saved model lists

### DIFF
--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -52,6 +52,7 @@
     modelId,
     recommendedModels,
     migrateDeprecatedGroqCleanupModel,
+    migrateDeprecatedGoogleModel,
     splitModelId,
     type AllSettingsPayload,
     type TaskType,
@@ -563,15 +564,26 @@
       ? (rawLegacyCleanup.includes('/') ? rawLegacyCleanup : `groq/${rawLegacyCleanup}`)
       : 'groq/qwen/qwen3.6-27b';
 
-    transcriptionDefaultModel = all.transcription_default_model ?? legacyTranscription;
-    cleanupDefaultModel = all.cleanup_default_model ?? legacyCleanup;
+    transcriptionDefaultModel = migrateDeprecatedGoogleModel(all.transcription_default_model ?? legacyTranscription);
+    cleanupDefaultModel = migrateDeprecatedGoogleModel(all.cleanup_default_model ?? legacyCleanup);
+    const parsedTranscriptionDefault = splitModelId(transcriptionDefaultModel);
+    if (parsedTranscriptionDefault?.provider === 'google') {
+      transcriptionDefaultModel = modelId('google', migrateDeprecatedGoogleModel(parsedTranscriptionDefault.model));
+    }
     const parsedCleanupDefault = splitModelId(cleanupDefaultModel);
     if (parsedCleanupDefault?.provider === 'groq') {
       cleanupDefaultModel = modelId('groq', migrateDeprecatedGroqCleanupModel(parsedCleanupDefault.model));
     }
 
     if (Array.isArray(all.transcription_fallback_models)) {
-      transcriptionFallbackModels = all.transcription_fallback_models.filter((id) => !!splitModelId(id));
+      transcriptionFallbackModels = all.transcription_fallback_models
+        .filter((id) => !!splitModelId(id))
+        .map((id) => {
+          const parsed = splitModelId(id);
+          return parsed?.provider === 'google'
+            ? modelId('google', migrateDeprecatedGoogleModel(parsed.model))
+            : id;
+        });
     }
     dualTranscriptionEnabled = all.dual_transcription_enabled === true;
     if (Array.isArray(all.cleanup_fallback_models)) {

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -573,6 +573,8 @@
     const parsedCleanupDefault = splitModelId(cleanupDefaultModel);
     if (parsedCleanupDefault?.provider === 'groq') {
       cleanupDefaultModel = modelId('groq', migrateDeprecatedGroqCleanupModel(parsedCleanupDefault.model));
+    } else if (parsedCleanupDefault?.provider === 'google') {
+      cleanupDefaultModel = modelId('google', migrateDeprecatedGoogleModel(parsedCleanupDefault.model));
     }
 
     if (Array.isArray(all.transcription_fallback_models)) {
@@ -591,8 +593,11 @@
         .filter((id) => !!splitModelId(id))
         .map((id) => {
           const parsed = splitModelId(id);
-          return parsed?.provider === 'groq'
-            ? modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model))
+          if (parsed?.provider === 'groq') {
+            return modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model));
+          }
+          return parsed?.provider === 'google'
+            ? modelId('google', migrateDeprecatedGoogleModel(parsed.model))
             : id;
         });
     }

--- a/src/lib/components/settings/models.ts
+++ b/src/lib/components/settings/models.ts
@@ -41,13 +41,13 @@ export const recommendedModels: Record<TaskType, Partial<Record<UiProviderId, { 
   transcription: {
     groq: { premium: 'whisper-large-v3', standard: 'whisper-large-v3-turbo' },
     openai: { premium: 'gpt-4o-transcribe', standard: 'gpt-4o-mini-transcribe' },
-    google: { premium: 'gemini-3.5-flash', standard: 'gemini-2.5-flash' },
+    google: { premium: 'gemini-3.7-flash', standard: 'gemini-2.5-flash' },
     assemblyai: { premium: 'universal-3-5-pro', standard: 'universal-2' },
   },
   cleanup: {
     groq: { premium: GROQ_QWEN_3_6_27B_MODEL, standard: GROQ_GPT_OSS_20B_MODEL },
     openai: { premium: 'gpt-4o', standard: 'gpt-4o-mini' },
-    google: { premium: 'gemini-3.5-flash', standard: 'gemini-2.5-flash' },
+    google: { premium: 'gemini-3.7-flash', standard: 'gemini-2.5-flash' },
   },
 };
 
@@ -56,6 +56,12 @@ export function migrateDeprecatedGroqCleanupModel(model: string): string {
   if (normalized === DEPRECATED_GROQ_LLAMA_8B_MODEL) return GROQ_GPT_OSS_20B_MODEL;
   if (normalized === DEPRECATED_GROQ_LLAMA_70B_MODEL) return GROQ_QWEN_3_6_27B_MODEL;
   return normalized;
+}
+
+export function migrateDeprecatedGoogleModel(model: string): string {
+  return model.trim() === 'gemini-3.5-flash'
+    ? 'gemini-3.7-flash'
+    : model.trim();
 }
 
 export const emptyProviderModelMap = (): ProviderModelMap => ({
@@ -88,7 +94,11 @@ export function mergeProviderModelMap(raw: unknown): ProviderModelMap {
   for (const provider of ['groq', 'openai', 'google', 'assemblyai', 'local'] as ProviderId[]) {
     const values = (raw as Record<string, unknown>)[provider];
     if (Array.isArray(values)) {
-      base[provider] = values.map((value) => String(value).trim()).filter(Boolean);
+      base[provider] = values
+        .map((value) => String(value).trim())
+        .filter(Boolean)
+        .map((value) => provider === 'google' ? migrateDeprecatedGoogleModel(value) : value)
+        .filter((value, index, models) => models.indexOf(value) === index);
     }
   }
 


### PR DESCRIPTION
## Summary\n\nReplace persisted Gemini 3.5 Flash entries with Gemini 3.7 Flash so the obsolete model no longer appears in the model picker. Update Gemini recommendations and migrate defaults and fallbacks.\n\n## Verification\n\n- npm run check\n- Focused Rust API tests passed previously\n

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #224
- <kbd>&nbsp;2&nbsp;</kbd> #231 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #233
<!-- GitButler Footer Boundary Bottom -->