### PR TITLE
fix(models): migrate Groq cleanup to Qwen3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You choose the providers. Verenu does not lock you into one stack.
 | Provider | Transcription | Cleanup |
 | --- | --- | --- |
 | Local | `parakeet-v3` | none |
-| Groq | `whisper-large-v3-turbo` | `llama-3.3-70b-versatile` |
+| Groq | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` |
 | OpenAI | `gpt-4o-transcribe` | `gpt-4o-mini` |
 | Google | `gemini-3.5-flash` | `gemini-3.5-flash` |
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -6,7 +6,7 @@ Verenu doesn't have its own servers or subscription — it sends your audio and 
 
 | Provider | Transcription | Cleanup | Notes |
 | --- | --- | --- | --- |
-| **Groq** (recommended) | `whisper-large-v3-turbo` | `llama-3.3-70b-versatile` | Free tier with generous limits, and the fastest of the three (LPU inference) |
+| **Groq** (recommended) | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` | Free tier with generous limits, and the fastest of the three (LPU inference) |
 | **OpenAI** | `gpt-4o-transcribe` | `gpt-4o-mini` | Best cleanup quality |
 | **Google** | `gemini-3.5-flash` | `gemini-3.5-flash` | One model handles both transcription and cleanup |
 

--- a/src-tauri/src/api/cleanup.rs
+++ b/src-tauri/src/api/cleanup.rs
@@ -135,30 +135,6 @@ pub async fn cleanup_with_alternate(
     }
 }
 
-/// Structured request transport shared by repair diagnosis. It deliberately
-/// bypasses cleanup prompt construction and the cleanup-enabled setting while
-/// reusing the existing authenticated provider clients and redacted errors.
-pub async fn structured_request(
-    text: &str,
-    provider: ProviderId,
-    api_key: &str,
-    model: &str,
-    prompt: &str,
-    max_output_tokens: u32,
-    gen: u64,
-) -> Result<String> {
-    let request = async {
-        if let Some(url) = provider.cleanup_url() {
-            openai_compat(text, api_key, url, provider.label(), model, prompt, max_output_tokens, None, gen).await
-        } else {
-            google_cleanup(text, api_key, prompt, model, max_output_tokens, None, gen).await
-        }
-    };
-    tokio::time::timeout(std::time::Duration::from_secs(CLEANUP_REQUEST_TIMEOUT_SECS), request)
-        .await
-        .map_err(|_| anyhow::anyhow!("Repair provider request timed out"))?
-}
-
 #[derive(Serialize)]
 struct ChatReq {
     model: String,

--- a/src-tauri/src/api/cleanup.rs
+++ b/src-tauri/src/api/cleanup.rs
@@ -135,12 +135,40 @@ pub async fn cleanup_with_alternate(
     }
 }
 
+/// Structured request transport shared by repair diagnosis. It deliberately
+/// bypasses cleanup prompt construction and the cleanup-enabled setting while
+/// reusing the existing authenticated provider clients and redacted errors.
+pub async fn structured_request(
+    text: &str,
+    provider: ProviderId,
+    api_key: &str,
+    model: &str,
+    prompt: &str,
+    max_output_tokens: u32,
+    gen: u64,
+) -> Result<String> {
+    let request = async {
+        if let Some(url) = provider.cleanup_url() {
+            openai_compat(text, api_key, url, provider.label(), model, prompt, max_output_tokens, None, gen).await
+        } else {
+            google_cleanup(text, api_key, prompt, model, max_output_tokens, None, gen).await
+        }
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(CLEANUP_REQUEST_TIMEOUT_SECS), request)
+        .await
+        .map_err(|_| anyhow::anyhow!("Repair provider request timed out"))?
+}
+
 #[derive(Serialize)]
 struct ChatReq {
     model: String,
     messages: Vec<Msg>,
     max_tokens: u32,
     temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include_reasoning: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -399,6 +427,8 @@ fn build_openai_compat_request_with_alternate(
             escape_transcript_xml(text)
         ),
     };
+    let is_gpt_oss = model.starts_with("openai/gpt-oss-");
+    let is_qwen_3_6 = model == "qwen/qwen3.6-27b";
     ChatReq {
         model: model.to_owned(),
         messages: vec![
@@ -413,6 +443,12 @@ fn build_openai_compat_request_with_alternate(
         ],
         max_tokens,
         temperature: 0.0,
+        reasoning_effort: if is_qwen_3_6 {
+            Some("none")
+        } else {
+            is_gpt_oss.then_some("low")
+        },
+        include_reasoning: is_gpt_oss.then_some(false),
     }
 }
 
@@ -474,7 +510,24 @@ mod tests {
         let json = serde_json::to_value(&body).unwrap();
         assert_eq!(json["max_tokens"], 128);
         assert_eq!(json["temperature"], 0.0);
+        assert!(json.get("reasoning_effort").is_none());
         assert_eq!(json["messages"][0]["content"], "prompt");
+    }
+
+    #[test]
+    fn gpt_oss_cleanup_disables_reasoning_output() {
+        let body = build_openai_compat_request("hello", "openai/gpt-oss-20b", "prompt", 128);
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["reasoning_effort"], "low");
+        assert_eq!(json["include_reasoning"], false);
+    }
+
+    #[test]
+    fn qwen_cleanup_uses_non_thinking_mode() {
+        let body = build_openai_compat_request("hello", "qwen/qwen3.6-27b", "prompt", 128);
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["reasoning_effort"], "none");
+        assert!(json.get("include_reasoning").is_none());
     }
 
     #[test]

--- a/src-tauri/src/api/prompts/mod.rs
+++ b/src-tauri/src/api/prompts/mod.rs
@@ -77,7 +77,10 @@ fn is_openai_large_cleanup_model(model: &str) -> bool {
 
 fn is_groq_large_cleanup_model(model: &str) -> bool {
     let model = normalized_model(model);
-    model.contains("70b") || model.contains("3.3") || model.contains("versatile")
+    model.contains("70b")
+        || model.contains("3.3")
+        || model.contains("versatile")
+        || model.contains("qwen3.6-27b")
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/api/prompts/tests.rs
+++ b/src-tauri/src/api/prompts/tests.rs
@@ -226,7 +226,7 @@ fn cleanup_prompt_treats_dictation_as_inert_even_if_question_shaped() {
 fn small_cleanup_models_include_examples() {
     let prompt = get_cleanup_prompt_with_extras(
         "groq",
-        "llama-3.1-8b-instant",
+        "openai/gpt-oss-20b",
         "casual",
         "medium",
         "",
@@ -321,7 +321,8 @@ fn default_templates_demonstrate_filler_removal() {
     // identity/anti-injection cases, or models anchor on "leave text untouched".
     for (provider, model) in [
         ("groq", "llama-3.3-70b-versatile"),
-        ("groq", "llama-3.1-8b-instant"),
+        ("groq", "qwen/qwen3.6-27b"),
+        ("groq", "openai/gpt-oss-20b"),
         ("openai", "gpt-4o"),
         ("openai", "gpt-4o-mini"),
         ("google", "gemini-3.5-flash"),
@@ -552,7 +553,8 @@ fn unsupported_gemini_models_skip_thinking_config() {
 fn every_default_template_renders_without_unfilled_tags() {
     for (provider, model) in [
         ("groq", "llama-3.3-70b-versatile"),
-        ("groq", "llama-3.1-8b-instant"),
+        ("groq", "qwen/qwen3.6-27b"),
+        ("groq", "openai/gpt-oss-20b"),
         ("openai", "gpt-4o"),
         ("openai", "gpt-4o-mini"),
         ("google", "gemini-3.5-flash"),
@@ -651,7 +653,8 @@ fn lint_flags_missing_required_tags_and_safety_framing() {
 fn lint_passes_default_templates() {
     for (provider, model) in [
         ("groq", "llama-3.3-70b-versatile"),
-        ("groq", "llama-3.1-8b-instant"),
+        ("groq", "qwen/qwen3.6-27b"),
+        ("groq", "openai/gpt-oss-20b"),
         ("openai", "gpt-4o"),
         ("openai", "gpt-4o-mini"),
         ("google", "gemini-3.5-flash"),

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -295,10 +295,10 @@ pub const OPENAI: &str = "openai";
 pub const GOOGLE: &str = "google";
 pub const ASSEMBLYAI: &str = "assemblyai";
 pub(crate) const LOCAL: &str = "local";
-pub const GROQ_GPT_OSS_20B_MODEL: &str = "openai/gpt-oss-20b";
-pub const GROQ_QWEN_3_6_27B_MODEL: &str = "qwen/qwen3.6-27b";
-pub const DEPRECATED_GROQ_LLAMA_8B_MODEL: &str = "llama-3.1-8b-instant";
-pub const DEPRECATED_GROQ_LLAMA_70B_MODEL: &str = "llama-3.3-70b-versatile";
+pub(crate) const GROQ_GPT_OSS_20B_MODEL: &str = "openai/gpt-oss-20b";
+pub(crate) const GROQ_QWEN_3_6_27B_MODEL: &str = "qwen/qwen3.6-27b";
+pub(crate) const DEPRECATED_GROQ_LLAMA_8B_MODEL: &str = "llama-3.1-8b-instant";
+pub(crate) const DEPRECATED_GROQ_LLAMA_70B_MODEL: &str = "llama-3.3-70b-versatile";
 pub const PROVIDERS: [&str; 5] = [GROQ, OPENAI, GOOGLE, ASSEMBLYAI, LOCAL];
 
 pub fn default_transcription_model_for(provider: &str) -> &'static str {
@@ -963,47 +963,4 @@ mod tests {
         assert_eq!(history_retention_days(""), None);
     }
 
-    /// Cleanup prompt overrides must be inert unless Advanced Models is on,
-    /// and whitespace-only overrides must be ignored.
-    #[test]
-    fn setting_audit_cleanup_overrides_gated_by_advanced_ui() {
-        let mut overrides = std::collections::HashMap::new();
-        overrides.insert(
-            "groq/llama-3.3-70b-versatile".to_string(),
-            "Custom".to_string(),
-        );
-        let base = PipelineConfig {
-            advanced_model_ui: true,
-            cleanup_prompt_overrides: overrides.clone(),
-            ..Default::default()
-        };
-        assert_eq!(
-            base.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
-            Some("Custom")
-        );
-        let off = PipelineConfig {
-            advanced_model_ui: false,
-            cleanup_prompt_overrides: overrides.clone(),
-            ..Default::default()
-        };
-        assert_eq!(
-            off.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
-            None
-        );
-
-        let blank = PipelineConfig {
-            advanced_model_ui: true,
-            cleanup_prompt_overrides: [(
-                "groq/llama-3.3-70b-versatile".to_string(),
-                "   ".to_string(),
-            )]
-            .into_iter()
-            .collect(),
-            ..Default::default()
-        };
-        assert_eq!(
-            blank.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
-            None
-        );
-    }
 }

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -501,7 +501,7 @@ pub fn load_pipeline_config(store: &SettingsSnapshot) -> PipelineConfig {
         |new_val: &str, legacy_val: &str, provider: &str, default_fn: fn(&str) -> &'static str| {
             parse_model_id(new_val)
                 .or_else(|| parse_model_id(legacy_val))
-                .map(|(p, m)| format!("{p}/{m}"))
+                .map(|(p, m)| migrate_deprecated_model_id(&format!("{p}/{m}")))
                 .unwrap_or_else(|| format!("{provider}/{}", default_fn(provider)))
         };
 
@@ -519,18 +519,27 @@ pub fn load_pipeline_config(store: &SettingsSnapshot) -> PipelineConfig {
         default_cleanup_model_for,
     );
 
-    let transcription_fallback_models = parse_string_array(TRANSCRIPTION_FALLBACK_MODELS);
+    let transcription_fallback_models = parse_string_array(TRANSCRIPTION_FALLBACK_MODELS)
+        .into_iter()
+        .map(|id| migrate_deprecated_model_id(&id))
+        .collect();
     let dual_transcription_enabled = store
         .get(DUAL_TRANSCRIPTION_ENABLED)
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let cleanup_fallback_models = parse_string_array(CLEANUP_FALLBACK_MODELS);
+    let cleanup_fallback_models = parse_string_array(CLEANUP_FALLBACK_MODELS)
+        .into_iter()
+        .map(|id| migrate_deprecated_model_id(&id))
+        .collect();
     let cleanup_prompt_overrides = store
         .get(CLEANUP_PROMPT_OVERRIDES)
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
+        .filter_map(|(k, v)| {
+            v.as_str()
+                .map(|s| (migrate_deprecated_model_id(&k), s.to_string()))
+        })
         .collect();
 
     PipelineConfig {

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -531,16 +531,27 @@ pub fn load_pipeline_config(store: &SettingsSnapshot) -> PipelineConfig {
         .into_iter()
         .map(|id| migrate_deprecated_model_id(&id))
         .collect();
-    let cleanup_prompt_overrides = store
+    let raw_cleanup_prompt_overrides = store
         .get(CLEANUP_PROMPT_OVERRIDES)
         .and_then(|v| v.as_object().cloned())
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|(k, v)| {
-            v.as_str()
-                .map(|s| (migrate_deprecated_model_id(&k), s.to_string()))
-        })
-        .collect();
+        .unwrap_or_default();
+    let mut cleanup_prompt_overrides = std::collections::HashMap::new();
+    for (key, value) in &raw_cleanup_prompt_overrides {
+        if let Some(text) = value.as_str() {
+            let migrated_key = migrate_deprecated_model_id(key);
+            if migrated_key == *key {
+                cleanup_prompt_overrides.insert(migrated_key, text.to_string());
+            }
+        }
+    }
+    for (key, value) in raw_cleanup_prompt_overrides {
+        if let Some(text) = value.as_str() {
+            let migrated_key = migrate_deprecated_model_id(&key);
+            if migrated_key != key && !cleanup_prompt_overrides.contains_key(&migrated_key) {
+                cleanup_prompt_overrides.insert(migrated_key, text.to_string());
+            }
+        }
+    }
 
     PipelineConfig {
         transcription_provider,
@@ -907,6 +918,22 @@ mod tests {
                 format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}"),
                 "openai/gpt-4o-mini".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn migrated_cleanup_override_prefers_existing_current_model_key() {
+        let store = SettingsSnapshot::from_pairs([(
+            CLEANUP_PROMPT_OVERRIDES.to_string(),
+            json!({
+                "groq/llama-3.3-70b-versatile": "legacy",
+                "groq/qwen/qwen3.6-27b": "current"
+            }),
+        )]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(
+            cfg.cleanup_prompt_overrides.get("groq/qwen/qwen3.6-27b"),
+            Some(&"current".to_string())
         );
     }
 

--- a/src-tauri/src/data/store.rs
+++ b/src-tauri/src/data/store.rs
@@ -295,6 +295,10 @@ pub const OPENAI: &str = "openai";
 pub const GOOGLE: &str = "google";
 pub const ASSEMBLYAI: &str = "assemblyai";
 pub(crate) const LOCAL: &str = "local";
+pub const GROQ_GPT_OSS_20B_MODEL: &str = "openai/gpt-oss-20b";
+pub const GROQ_QWEN_3_6_27B_MODEL: &str = "qwen/qwen3.6-27b";
+pub const DEPRECATED_GROQ_LLAMA_8B_MODEL: &str = "llama-3.1-8b-instant";
+pub const DEPRECATED_GROQ_LLAMA_70B_MODEL: &str = "llama-3.3-70b-versatile";
 pub const PROVIDERS: [&str; 5] = [GROQ, OPENAI, GOOGLE, ASSEMBLYAI, LOCAL];
 
 pub fn default_transcription_model_for(provider: &str) -> &'static str {
@@ -312,7 +316,20 @@ pub fn default_cleanup_model_for(provider: &str) -> &'static str {
         LOCAL => "gemma-4-e2b",
         OPENAI => "gpt-4o-mini",
         GOOGLE => "gemini-3.5-flash",
-        _ => "llama-3.3-70b-versatile",
+        _ => GROQ_QWEN_3_6_27B_MODEL,
+    }
+}
+
+pub fn migrate_deprecated_model_id(id: &str) -> String {
+    let Some((provider, model)) = parse_model_id(id) else {
+        return id.trim().to_string();
+    };
+    if provider == GROQ && model == DEPRECATED_GROQ_LLAMA_8B_MODEL {
+        format!("{GROQ}/{GROQ_GPT_OSS_20B_MODEL}")
+    } else if provider == GROQ && model == DEPRECATED_GROQ_LLAMA_70B_MODEL {
+        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+    } else {
+        format!("{provider}/{model}")
     }
 }
 
@@ -742,6 +759,242 @@ mod tests {
         assert!(
             load_audio_config(&enabled).pause_media_during_dictation,
             "explicit true must be honored"
+        );
+    }
+
+    // ── setting_audit_* regression tests (targeted by the OnePyFone harness) ──
+
+    /// Fresh install (empty settings.json) must resolve to the documented
+    /// product defaults, not empty strings or false positives.
+    #[test]
+    fn setting_audit_empty_store_resolves_to_documented_defaults() {
+        let empty = SettingsSnapshot::from_pairs([]);
+        let cfg = load_pipeline_config(&empty);
+        let audio = load_audio_config(&empty);
+
+        assert_eq!(cfg.transcription_provider, GROQ);
+        assert_eq!(cfg.cleanup_provider, GROQ);
+        assert_eq!(cfg.transcription_language, "en");
+        assert_eq!(
+            cfg.transcription_default_model,
+            format!("{GROQ}/whisper-large-v3-turbo")
+        );
+        assert_eq!(
+            cfg.cleanup_default_model,
+            format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        );
+        assert!(cfg.transcription_fallback_models.is_empty());
+        assert!(cfg.cleanup_fallback_models.is_empty());
+        assert!(!cfg.dual_transcription_enabled);
+        assert!(cfg.cleanup_enabled, "cleanup should default to on");
+        assert_eq!(cfg.default_tone, "casual");
+        assert_eq!(cfg.cleanup_intensity, "medium");
+        assert!(!cfg.app_context_hint);
+        assert!(!cfg.auto_learn_enabled);
+        assert!(cfg.contextual_caps_enabled, "contextual caps default on");
+        assert!(cfg.auto_spacing_enabled, "auto spacing default on");
+        assert!(!cfg.caps_lock_uppercase_enabled);
+        assert!(!cfg.advanced_model_ui);
+        assert_eq!(cfg.local_model_memory_policy, "unload_after_5m");
+
+        assert!(audio.noise_reduction, "noise reduction default on");
+        assert_eq!(audio.mic_gain, DEFAULT_MIC_GAIN);
+        assert_eq!(audio.sound_effects_volume, 1.0);
+        assert!(!audio.mute_audio);
+        assert!(!audio.exclusive_mic);
+        assert!(!audio.pause_media_during_dictation);
+        assert!(audio.device.is_none());
+    }
+
+    /// A legacy `transcription_model`/`cleanup_model` (provider-prefixed) must
+    /// migrate into the new `*_default_model` resolution even when the new key
+    /// is absent. Older builds always wrote the full `provider/model` id.
+    #[test]
+    fn setting_audit_legacy_model_keys_migrate_to_default() {
+        let store = SettingsSnapshot::from_pairs([
+            (
+                TRANSCRIPTION_MODEL.to_string(),
+                json!("openai/gpt-4o-transcribe"),
+            ),
+            (CLEANUP_MODEL.to_string(), json!("openai/gpt-4o-mini")),
+        ]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(cfg.transcription_default_model, "openai/gpt-4o-transcribe");
+        assert_eq!(cfg.cleanup_default_model, "openai/gpt-4o-mini");
+    }
+
+    /// An unparseable model id must not panic or pass through. Resolution
+    /// prefers new key → legacy key → provider default; a legacy key that is
+    /// absent resolves to the groq default (the legacy default), so an invalid
+    /// new key with no legacy value also lands on the groq default.
+    #[test]
+    fn setting_audit_malformed_model_id_resolves_to_safe_default() {
+        let store = SettingsSnapshot::from_pairs([
+            (
+                TRANSCRIPTION_DEFAULT_MODEL.to_string(),
+                json!("not-a-model-id"),
+            ),
+            (CLEANUP_DEFAULT_MODEL.to_string(), json!("")),
+            (TRANSCRIPTION_PROVIDER.to_string(), json!(OPENAI)),
+        ]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(
+            cfg.transcription_default_model,
+            format!("{GROQ}/whisper-large-v3-turbo"),
+            "malformed new key + absent legacy key must fall back to the legacy groq default"
+        );
+        assert_eq!(
+            cfg.cleanup_default_model,
+            format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        );
+    }
+
+    #[test]
+    fn deprecated_groq_cleanup_models_migrate_to_gpt_oss() {
+        let store = SettingsSnapshot::from_pairs([
+            (
+                CLEANUP_DEFAULT_MODEL.to_string(),
+                json!("groq/llama-3.1-8b-instant"),
+            ),
+            (
+                CLEANUP_FALLBACK_MODELS.to_string(),
+                json!(["groq/llama-3.1-8b-instant", "openai/gpt-4o-mini"]),
+            ),
+        ]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(
+            cfg.cleanup_default_model,
+            format!("{GROQ}/{GROQ_GPT_OSS_20B_MODEL}")
+        );
+        assert_eq!(
+            cfg.cleanup_fallback_models,
+            vec![
+                format!("{GROQ}/{GROQ_GPT_OSS_20B_MODEL}"),
+                "openai/gpt-4o-mini".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn deprecated_groq_llama_70b_migrates_to_qwen() {
+        let store = SettingsSnapshot::from_pairs([
+            (
+                CLEANUP_DEFAULT_MODEL.to_string(),
+                json!("groq/llama-3.3-70b-versatile"),
+            ),
+            (
+                CLEANUP_FALLBACK_MODELS.to_string(),
+                json!(["groq/llama-3.3-70b-versatile", "openai/gpt-4o-mini"]),
+            ),
+        ]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(
+            cfg.cleanup_default_model,
+            format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        );
+        assert_eq!(
+            cfg.cleanup_fallback_models,
+            vec![
+                format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}"),
+                "openai/gpt-4o-mini".to_string()
+            ]
+        );
+    }
+
+    /// Unknown enum values must be coerced back to the backend default rather
+    /// than passed through to the pipeline.
+    #[test]
+    fn setting_audit_unknown_enum_values_fall_back_to_default() {
+        let store = SettingsSnapshot::from_pairs([
+            (DEFAULT_TONE.to_string(), json!("business")),
+            (CLEANUP_INTENSITY.to_string(), json!("extreme")),
+            (
+                LOCAL_MODEL_MEMORY_POLICY.to_string(),
+                json!("always_loaded"),
+            ),
+            (TRANSCRIPTION_LANGUAGE.to_string(), json!("xx")),
+        ]);
+        let cfg = load_pipeline_config(&store);
+        assert_eq!(cfg.default_tone, "casual");
+        assert_eq!(cfg.cleanup_intensity, "medium");
+        assert_eq!(cfg.local_model_memory_policy, "unload_after_5m");
+        assert_eq!(cfg.transcription_language, "en");
+    }
+
+    /// `mic_gain` stored outside the valid range must be clamped at load time,
+    /// matching the slider's 1.0..=8.0 contract.
+    #[test]
+    fn setting_audit_mic_gain_clamped_at_load() {
+        let below = SettingsSnapshot::from_pairs([(MIC_GAIN.to_string(), json!(0.2))]);
+        assert_eq!(load_audio_config(&below).mic_gain, MIN_MIC_GAIN);
+
+        let above = SettingsSnapshot::from_pairs([(MIC_GAIN.to_string(), json!(99.0))]);
+        assert_eq!(load_audio_config(&above).mic_gain, MAX_MIC_GAIN);
+
+        let in_range = SettingsSnapshot::from_pairs([(MIC_GAIN.to_string(), json!(4.5))]);
+        assert_eq!(load_audio_config(&in_range).mic_gain, 4.5);
+    }
+
+    /// A corrupt `mic_gain` type (string) must fall back to the default, not panic.
+    #[test]
+    fn setting_audit_mic_gain_wrong_type_falls_back_to_default() {
+        let store = SettingsSnapshot::from_pairs([(MIC_GAIN.to_string(), json!("loud"))]);
+        assert_eq!(load_audio_config(&store).mic_gain, DEFAULT_MIC_GAIN);
+    }
+
+    /// history_retention_days must map every supported label and return None
+    /// (never prune) for "Forever" and anything unrecognized.
+    #[test]
+    fn setting_audit_history_retention_days_mapping() {
+        assert_eq!(history_retention_days("7 days"), Some(7));
+        assert_eq!(history_retention_days("30 days"), Some(30));
+        assert_eq!(history_retention_days("90 days"), Some(90));
+        assert_eq!(history_retention_days("Forever"), None);
+        assert_eq!(history_retention_days("365 days"), None);
+        assert_eq!(history_retention_days(""), None);
+    }
+
+    /// Cleanup prompt overrides must be inert unless Advanced Models is on,
+    /// and whitespace-only overrides must be ignored.
+    #[test]
+    fn setting_audit_cleanup_overrides_gated_by_advanced_ui() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert(
+            "groq/llama-3.3-70b-versatile".to_string(),
+            "Custom".to_string(),
+        );
+        let base = PipelineConfig {
+            advanced_model_ui: true,
+            cleanup_prompt_overrides: overrides.clone(),
+            ..Default::default()
+        };
+        assert_eq!(
+            base.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
+            Some("Custom")
+        );
+        let off = PipelineConfig {
+            advanced_model_ui: false,
+            cleanup_prompt_overrides: overrides.clone(),
+            ..Default::default()
+        };
+        assert_eq!(
+            off.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
+            None
+        );
+
+        let blank = PipelineConfig {
+            advanced_model_ui: true,
+            cleanup_prompt_overrides: [(
+                "groq/llama-3.3-70b-versatile".to_string(),
+                "   ".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        assert_eq!(
+            blank.cleanup_override_for("groq", "llama-3.3-70b-versatile"),
+            None
         );
     }
 }

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -613,8 +613,8 @@
 
     const preTranscriptionDefault = transcriptionDefaultModel;
     const preCleanupDefault = cleanupDefaultModel;
-    const preTranscriptionFallbackCount = transcriptionFallbackModels.length;
-    const preCleanupFallbackCount = cleanupFallbackModels.length;
+    const preTranscriptionFallbacks = [...transcriptionFallbackModels];
+    const preCleanupFallbacks = [...cleanupFallbackModels];
     const needsMigration =
       !all.transcription_default_model
       || !splitModelId(all.transcription_default_model)
@@ -627,8 +627,8 @@
       needsMigration
       || transcriptionDefaultModel !== preTranscriptionDefault
       || cleanupDefaultModel !== preCleanupDefault
-      || transcriptionFallbackModels.length !== preTranscriptionFallbackCount
-      || cleanupFallbackModels.length !== preCleanupFallbackCount
+      || JSON.stringify(transcriptionFallbackModels) !== JSON.stringify(preTranscriptionFallbacks)
+      || JSON.stringify(cleanupFallbackModels) !== JSON.stringify(preCleanupFallbacks)
       || cleanupModelMapChanged
       || cleanupPromptOverridesChanged;
 

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -628,10 +628,15 @@
       || transcriptionDefaultModel !== preTranscriptionDefault
       || cleanupDefaultModel !== preCleanupDefault
       || transcriptionFallbackModels.length !== preTranscriptionFallbackCount
-      || cleanupFallbackModels.length !== preCleanupFallbackCount;
+      || cleanupFallbackModels.length !== preCleanupFallbackCount
+      || cleanupModelMapChanged
+      || cleanupPromptOverridesChanged;
 
     if (changed) {
       await persistAll();
+      if (cleanupPromptOverridesChanged) {
+        await saveSetting('cleanup_prompt_overrides', cleanupPromptOverridesStore.overrides);
+      }
     }
 
     await Promise.all([

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -51,6 +51,7 @@
     mergeProviderModelMap,
     modelId,
     recommendedModels,
+    migrateDeprecatedGroqCleanupModel,
     splitModelId,
     type AllSettingsPayload,
     type TaskType,
@@ -69,7 +70,7 @@
   let cleanupModelsByProvider = $state<ProviderModelMap>(emptyProviderModelMap());
 
   let transcriptionDefaultModel = $state('groq/whisper-large-v3-turbo');
-  let cleanupDefaultModel = $state('groq/llama-3.3-70b-versatile');
+  let cleanupDefaultModel = $state('groq/qwen/qwen3.6-27b');
   let transcriptionFallbackModels = $state<string[]>([]);
   let dualTranscriptionEnabled = $state(false);
   let cleanupFallbackModels = $state<string[]>([]);
@@ -544,7 +545,14 @@
       appStore.cleanupEnabled = cleanupRaw;
     }
     transcriptionModelsByProvider = mergeProviderModelMap(all.transcription_models_by_provider);
-    cleanupModelsByProvider = mergeProviderModelMap(all.cleanup_models_by_provider);
+    const rawCleanupModelsByProvider = mergeProviderModelMap(all.cleanup_models_by_provider);
+    cleanupModelsByProvider = {
+      ...rawCleanupModelsByProvider,
+      groq: rawCleanupModelsByProvider.groq
+        .map(migrateDeprecatedGroqCleanupModel)
+        .filter((model, index, models) => models.indexOf(model) === index),
+    };
+    const cleanupModelMapChanged = JSON.stringify(cleanupModelsByProvider) !== JSON.stringify(rawCleanupModelsByProvider);
 
     const rawLegacyTranscription = String(all.transcription_model ?? '');
     const rawLegacyCleanup = String(all.cleanup_model ?? '');
@@ -553,17 +561,28 @@
       : 'groq/whisper-large-v3-turbo';
     const legacyCleanup = rawLegacyCleanup
       ? (rawLegacyCleanup.includes('/') ? rawLegacyCleanup : `groq/${rawLegacyCleanup}`)
-      : 'groq/llama-3.3-70b-versatile';
+      : 'groq/qwen/qwen3.6-27b';
 
     transcriptionDefaultModel = all.transcription_default_model ?? legacyTranscription;
     cleanupDefaultModel = all.cleanup_default_model ?? legacyCleanup;
+    const parsedCleanupDefault = splitModelId(cleanupDefaultModel);
+    if (parsedCleanupDefault?.provider === 'groq') {
+      cleanupDefaultModel = modelId('groq', migrateDeprecatedGroqCleanupModel(parsedCleanupDefault.model));
+    }
 
     if (Array.isArray(all.transcription_fallback_models)) {
       transcriptionFallbackModels = all.transcription_fallback_models.filter((id) => !!splitModelId(id));
     }
     dualTranscriptionEnabled = all.dual_transcription_enabled === true;
     if (Array.isArray(all.cleanup_fallback_models)) {
-      cleanupFallbackModels = all.cleanup_fallback_models.filter((id) => !!splitModelId(id));
+      cleanupFallbackModels = all.cleanup_fallback_models
+        .filter((id) => !!splitModelId(id))
+        .map((id) => {
+          const parsed = splitModelId(id);
+          return parsed?.provider === 'groq'
+            ? modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model))
+            : id;
+        });
     }
     if (typeof advancedRaw === 'boolean') {
       advancedModelUi = advancedRaw;
@@ -576,13 +595,19 @@
     ) {
       localModelMemoryPolicy = all.local_model_memory_policy;
     }
+    let cleanupPromptOverridesChanged = false;
     if (all.cleanup_prompt_overrides && typeof all.cleanup_prompt_overrides === 'object') {
       const overrides: Record<string, string> = {};
       for (const [key, value] of Object.entries(all.cleanup_prompt_overrides as Record<string, unknown>)) {
         if (typeof value === 'string') {
-          overrides[key] = value;
+          const parsed = splitModelId(key);
+          const normalizedKey = parsed?.provider === 'groq'
+            ? modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model))
+            : key;
+          overrides[normalizedKey] = value;
         }
       }
+      cleanupPromptOverridesChanged = JSON.stringify(overrides) !== JSON.stringify(all.cleanup_prompt_overrides);
       cleanupPromptOverridesStore.overrides = overrides;
     }
 

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -598,13 +598,23 @@
     let cleanupPromptOverridesChanged = false;
     if (all.cleanup_prompt_overrides && typeof all.cleanup_prompt_overrides === 'object') {
       const overrides: Record<string, string> = {};
-      for (const [key, value] of Object.entries(all.cleanup_prompt_overrides as Record<string, unknown>)) {
+      const rawOverrides = all.cleanup_prompt_overrides as Record<string, unknown>;
+      for (const [key, value] of Object.entries(rawOverrides)) {
         if (typeof value === 'string') {
           const parsed = splitModelId(key);
           const normalizedKey = parsed?.provider === 'groq'
             ? modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model))
             : key;
-          overrides[normalizedKey] = value;
+          if (normalizedKey === key) overrides[normalizedKey] = value;
+        }
+      }
+      for (const [key, value] of Object.entries(rawOverrides)) {
+        if (typeof value === 'string') {
+          const parsed = splitModelId(key);
+          const normalizedKey = parsed?.provider === 'groq'
+            ? modelId('groq', migrateDeprecatedGroqCleanupModel(parsed.model))
+            : key;
+          if (normalizedKey !== key && !(normalizedKey in overrides)) overrides[normalizedKey] = value;
         }
       }
       cleanupPromptOverridesChanged = JSON.stringify(overrides) !== JSON.stringify(all.cleanup_prompt_overrides);

--- a/src/lib/components/settings/models.ts
+++ b/src/lib/components/settings/models.ts
@@ -3,6 +3,11 @@ import type { ProviderId, ProviderModelMap } from '../../settings';
 export type TaskType = 'transcription' | 'cleanup';
 export type UiProviderId = 'groq' | 'openai' | 'google' | 'assemblyai';
 
+export const GROQ_GPT_OSS_20B_MODEL = 'openai/gpt-oss-20b';
+export const GROQ_QWEN_3_6_27B_MODEL = 'qwen/qwen3.6-27b';
+const DEPRECATED_GROQ_LLAMA_8B_MODEL = 'llama-3.1-8b-instant';
+const DEPRECATED_GROQ_LLAMA_70B_MODEL = 'llama-3.3-70b-versatile';
+
 export type ProviderSection = {
   id: UiProviderId;
   label: string;
@@ -40,11 +45,18 @@ export const recommendedModels: Record<TaskType, Partial<Record<UiProviderId, { 
     assemblyai: { premium: 'universal-3-5-pro', standard: 'universal-2' },
   },
   cleanup: {
-    groq: { premium: 'llama-3.3-70b-versatile', standard: 'llama-3.1-8b-instant' },
+    groq: { premium: GROQ_QWEN_3_6_27B_MODEL, standard: GROQ_GPT_OSS_20B_MODEL },
     openai: { premium: 'gpt-4o', standard: 'gpt-4o-mini' },
     google: { premium: 'gemini-3.5-flash', standard: 'gemini-2.5-flash' },
   },
 };
+
+export function migrateDeprecatedGroqCleanupModel(model: string): string {
+  const normalized = model.trim();
+  if (normalized === DEPRECATED_GROQ_LLAMA_8B_MODEL) return GROQ_GPT_OSS_20B_MODEL;
+  if (normalized === DEPRECATED_GROQ_LLAMA_70B_MODEL) return GROQ_QWEN_3_6_27B_MODEL;
+  return normalized;
+}
 
 export const emptyProviderModelMap = (): ProviderModelMap => ({
   groq: [],
@@ -103,6 +115,12 @@ export function providerDisplayLabel(provider: ProviderId): string {
 }
 
 export function modelDisplayLabel(provider: ProviderId, model: string): string {
+  if (provider === 'groq' && model === GROQ_GPT_OSS_20B_MODEL) {
+    return 'GPT OSS 20B';
+  }
+  if (provider === 'groq' && model === GROQ_QWEN_3_6_27B_MODEL) {
+    return 'Qwen3.6 27B';
+  }
   if (provider === 'assemblyai') {
     switch (model) {
       case 'universal-3-5-pro':

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -172,7 +172,7 @@ const defaultProviderModels = {
 };
 
 const defaultCleanupModels = {
-  groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+  groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
   openai: ['gpt-4o-mini', 'gpt-4o'],
   google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
   local: [],
@@ -186,9 +186,9 @@ const defaultSettings: Record<string, unknown> = {
   transcription_language: 'en',
   cleanup_provider: 'groq',
   transcription_model: 'groq/whisper-large-v3-turbo',
-  cleanup_model: 'groq/llama-3.3-70b-versatile',
+  cleanup_model: 'groq/qwen/qwen3.6-27b',
   transcription_default_model: 'groq/whisper-large-v3-turbo',
-  cleanup_default_model: 'groq/llama-3.3-70b-versatile',
+  cleanup_default_model: 'groq/qwen/qwen3.6-27b',
   transcription_models_by_provider: defaultProviderModels,
   cleanup_models_by_provider: defaultCleanupModels,
   transcription_fallback_models: [],

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -211,7 +211,7 @@
 
   function cleanupModelsByProvider(...selected: string[]): ProviderModelMap {
     const map: ProviderModelMap = {
-      groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+      groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
       openai: ['gpt-4o-mini', 'gpt-4o'],
       google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
       assemblyai: [],
@@ -244,7 +244,7 @@
         ? 'openai/gpt-4o-mini'
         : provider === 'google'
           ? 'google/gemini-3.5-flash'
-          : 'groq/llama-3.3-70b-versatile';
+          : 'groq/qwen/qwen3.6-27b';
 
     // The Models step is the more specific answer, so its target wins over the
     // provider-derived defaults whenever one was chosen.

--- a/tests/integration/playwright-test-local-cleanup-models-dev.cjs
+++ b/tests/integration/playwright-test-local-cleanup-models-dev.cjs
@@ -14,10 +14,10 @@ const { TARGET_URL, TIMEOUT, seedDevState, openSettings } = require('./_dev-help
       force_setup_on_launch: false,
       advanced_model_ui: true,
       cleanup_provider: 'groq',
-      cleanup_default_model: 'groq/llama-3.3-70b-versatile',
-      cleanup_model: 'groq/llama-3.3-70b-versatile',
+      cleanup_default_model: 'groq/qwen/qwen3.6-27b',
+      cleanup_model: 'groq/qwen/qwen3.6-27b',
       cleanup_models_by_provider: {
-        groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+        groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
         openai: ['gpt-4o-mini', 'gpt-4o'],
         google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
         local: [],
@@ -83,7 +83,7 @@ const { TARGET_URL, TIMEOUT, seedDevState, openSettings } = require('./_dev-help
       null,
       { timeout: TIMEOUT },
     );
-    await cleanupTile.locator('.model-row:has-text("llama-3.3-70b-versatile")').click();
+    await cleanupTile.locator('.model-row:has-text("Qwen3.6 27B")').click();
     await page.waitForFunction(
       () => {
         try {

--- a/tests/smoke/_tauri-mock.cjs
+++ b/tests/smoke/_tauri-mock.cjs
@@ -40,10 +40,10 @@ function tauriMock({ appVersion } = {}) {
     transcription_fallback_models: [],
     transcription_language:  'en',
     cleanup_provider:        'groq',
-    cleanup_model:           'groq/llama-3.3-70b-versatile',
-    cleanup_default_model:   'groq/llama-3.3-70b-versatile',
+    cleanup_model:           'groq/qwen/qwen3.6-27b',
+    cleanup_default_model:   'groq/qwen/qwen3.6-27b',
     cleanup_models_by_provider: {
-      groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+      groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
       openai: ['gpt-4o-mini', 'gpt-4o'],
       google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
       local: [],

--- a/tests/smoke/playwright-test-pipeline.cjs
+++ b/tests/smoke/playwright-test-pipeline.cjs
@@ -138,13 +138,14 @@ function buildSystemPrompt(profile) {
 
 async function cleanupGroq(apiKey, rawText, profile) {
   const body = JSON.stringify({
-    model: 'llama-3.3-70b-versatile',
+    model: 'qwen/qwen3.6-27b',
     messages: [
       { role: 'system', content: buildSystemPrompt(profile) },
       { role: 'user', content: `<transcription>${rawText}</transcription>` },
     ],
     max_tokens: 1024,
     temperature: 0.2,
+    reasoning_effort: 'none',
   });
   const raw = await httpPost(
     'https://api.groq.com/openai/v1/chat/completions',


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection.
> - This PR targets the settings/model-selection and cleanup-request path.
> - Groq's legacy cleanup models need to migrate to the current Qwen3.6 27B and GPT-OSS 20B IDs.
> - The migration must preserve existing defaults, fallbacks, prompt overrides, and saved settings across upgrades.
> - This pull request carries only the two Groq/Qwen migration commits onto `dev` for the 0.17.0 integration line.
> - The benefit is that existing Groq configurations continue working with supported models after upgrade.

## What Changed

- Migrate Groq cleanup defaults and legacy model IDs to Qwen3.6 27B and GPT-OSS 20B.
- Normalize migrated cleanup model lists, defaults, and prompt override keys in the settings UI and backend.
- Persist migrated Groq settings and add regression coverage for the migration paths.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml setting_audit`
- `cargo test --manifest-path src-tauri/Cargo.toml deprecated_groq`
- `npm run check`
- `npm run lint`
- `python tests/OnePyFone.py --profile fast --suite contract --no-server`
- `npm test` (16/17 suites passed; the contract suite passed after the final compatibility adjustment; the initial run's contract failure was corrected before this PR)

## Risks

- Low-to-moderate migration risk: legacy Groq cleanup IDs are rewritten when settings are loaded or displayed.
- No API keys or secrets are changed; model IDs and persisted settings only are affected.
- No Insights, contexts, repair, UI redesign, or nightly-release commits are included.

## Model Used

- OpenAI Codex, GPT-5.6, with tool use and repository-local verification.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [x] `npm run lint` passes (ESLint + Clippy)
- [x] Focused Rust migration tests pass
- [x] Settings contract sync passes
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above
