### PR TITLE
Polish inline history search toolbar

### DIFF
--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -4,7 +4,10 @@
   import { expoOut } from 'svelte/easing';
   import { icons } from '../../icons';
   import { appStore } from '../../stores';
-  import { fmtDate, fmtTime, type Entry, type RenderItem } from './helpers';
+  import { motionMs } from '../../motion';
+  import { fmtDuration } from '../insights/helpers';
+  import HistoryToolbar from './HistoryToolbar.svelte';
+  import { fmtDate, fmtTime, formatAppLabel, type Entry, type RenderItem } from './helpers';
 
   export let recents: Entry[];
   export let failedEntry: { created_at: string } | null;
@@ -17,6 +20,12 @@
   export let copiedId: number | null;
   export let hk1: string;
   export let hk2: string;
+  export let search: string;
+  export let apps: string[];
+  export let appFilter: string | null;
+  export let onSearchChange: (value: string) => void;
+  export let onAppFilterChange: (app: string | null) => void;
+  export let onClearFilters: () => void;
   export let onRetry: () => void;
   export let onContinueCancelled: () => void;
   export let onDismissCancelled: () => void;
@@ -24,6 +33,21 @@
   export let onCopy: (entry: Entry) => void;
 
   $: hasBanner = !!failedEntry || !!cancelledEntry;
+  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+  $: firstLabel = recents.length > 0 ? fmtDate(recents[0].created_at) : '';
+
+  function rowMeta(entry: Entry): string {
+    const parts: string[] = [];
+    if (entry.app_name) parts.push(formatAppLabel(entry.app_name));
+    if (
+      typeof entry.duration_ms === 'number' &&
+      Number.isFinite(entry.duration_ms) &&
+      entry.duration_ms >= 0
+    ) {
+      parts.push(fmtDuration(entry.duration_ms));
+    }
+    return parts.join(' Â· ');
+  }
 
   let flatItems: RenderItem[] = [];
   $: {
@@ -38,7 +62,11 @@
       }
       if (!seenHeaders.has(dayKey)) {
         seenHeaders.add(dayKey);
-        if (!(hasBanner && label === 'Today')) {
+        // The very first header is rendered outside the virtualized list,
+        // paired with the search toolbar, so it isn't left to a
+        // ResizeObserver-measured item (that fought the expand animation).
+        const isFirstHeader = acc.length === 0;
+        if (!(hasBanner ? label === 'Today' : isFirstHeader)) {
           acc.push({ type: 'header', label, key: `header-${dayKey}` });
         }
       }
@@ -56,7 +84,7 @@
   }
 
   const DEFAULT_HEADER_HEIGHT = 38;
-  const DEFAULT_ROW_HEIGHT = 58;
+  const DEFAULT_ROW_HEIGHT = 74;
 
   let container: HTMLElement | null = null;
   let listContainer: HTMLElement | null = null;
@@ -168,7 +196,11 @@
     container;
     listContainer;
     appStore.updateInfo;
-    // Depend on the entries directly, not the derived `hasBanner` boolean —
+    // The toolbar's "Clear filters" button appears/disappears with filter
+    // state, which changes the list's vertical offset â€” recompute when it
+    // toggles, not just when history rows change.
+    filtersActive;
+    // Depend on the entries directly, not the derived `hasBanner` boolean â€”
     // swapping one banner for the other keeps the boolean true, so the block
     // would otherwise not re-run and `listOffset` would go stale.
     failedEntry;
@@ -254,18 +286,24 @@
 </script>
 
 {#if loading}
-  <div class="empty-state">Loading history…</div>
+  <div class="empty-state" role="status" aria-live="polite">
+    <p class="empty-h">Loading historyâ€¦</p>
+    <p class="empty-sub">Fetching your recent dictations.</p>
+  </div>
 {:else}
   {#if hasBanner}
-    <div class="day-head">Today</div>
+    <div class="day-head day-head-row">
+      <span>Today</span>
+      <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
+    </div>
     <div class="day-table">
       {#if cancelledEntry}
         <div
           class="day-row"
-          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
+          transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(cancelledEntry.created_at)}</div>
-          <div class="day-text error-msg">You cancelled a recording — pick it back up?</div>
+          <div class="day-text error-msg">You cancelled a recording â€” pick it back up?</div>
           <div class="row-actions">
             <button
               class="dismiss-btn"
@@ -283,7 +321,7 @@
               onclick={onContinueCancelled}
               disabled={resumingCancelled}
             >
-              {resumingCancelled ? '…' : 'Continue'}
+              {resumingCancelled ? 'â€¦' : 'Continue'}
             </button>
           </div>
         </div>
@@ -291,7 +329,7 @@
       {#if failedEntry}
         <div
           class="day-row"
-          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
+          transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(failedEntry.created_at)}</div>
           <div class="day-text error-msg">Looks like your last transcription failed.</div>
@@ -300,7 +338,7 @@
             onclick={onRetry}
             disabled={retrying}
           >
-            {retrying ? '…' : 'Retry'}
+            {retrying ? 'â€¦' : 'Retry'}
           </button>
         </div>
       {/if}
@@ -308,21 +346,45 @@
   {/if}
 
   {#if recents.length === 0 && !hasBanner}
-    <div class="empty-state">
-      No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
+    <div class="day-head day-head-row">
+      <span></span>
+      <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
     </div>
+    {#if filtersActive}
+      <div class="empty-state">
+        <p class="empty-h">No matches</p>
+        <p class="empty-sub">Nothing matches your current search and filters.</p>
+        <button class="btn-ghost" onclick={onClearFilters}>Clear filters</button>
+      </div>
+    {:else}
+      <div class="empty-state">
+        <p class="empty-h">No dictations yet</p>
+        <p class="empty-sub">Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to start your first dictation.</p>
+      </div>
+    {/if}
   {:else}
+    {#if !hasBanner}
+      <div class="day-head day-head-row">
+        <span>{firstLabel}</span>
+        <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
+      </div>
+    {/if}
     <div bind:this={listContainer}>
       <div style="height: {topSpacerHeight}px;"></div>
       {#each visibleItems as { item, index } (item.key)}
         {#if item.type === 'header'}
-          <div use:measureItem={item.key} class="day-head" class:muted={index > 0 || hasBanner}>
+          <div use:measureItem={item.key} class="day-head muted">
             {item.label}
           </div>
         {:else if item.type === 'row'}
           <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
             <div class="day-time">{fmtTime(item.entry.created_at)}</div>
-            <div class="day-text">{item.entry.clean_text}</div>
+            <div class="day-main">
+              <div class="day-text">{item.entry.clean_text}</div>
+              {#if rowMeta(item.entry)}
+                <div class="day-meta">{rowMeta(item.entry)}</div>
+              {/if}
+            </div>
             <button
               class="copy-btn"
               class:copied={copiedId === item.entry.id}
@@ -346,7 +408,7 @@
     {#if hasMoreHistory}
       <div class="load-older-wrap">
         <button class="btn-ghost load-older-btn" onclick={onLoadOlder} disabled={loadingMore}>
-          {loadingMore ? 'Loading…' : 'Load older'}
+          {loadingMore ? 'Loadingâ€¦' : 'Load older'}
         </button>
       </div>
     {/if}
@@ -368,6 +430,8 @@
     margin: 4px 4px 10px;
   }
   .day-head.muted { margin-top: 22px; color: var(--ink-mute); }
+  .day-head-row { display: flex; align-items: center; gap: 12px; }
+  .day-head-row > span { flex: 0 0 auto; }
 
   .day-table { border-top: 1px solid var(--line); }
 
@@ -380,7 +444,7 @@
     gap: 14px;
     cursor: default;
   }
-  .day-row:hover { background: var(--control-active); }
+  .day-row:hover { background: var(--control-hover); }
   .day-row:not(:hover) .copy-btn:not(:focus-visible) { opacity: 0.25; }
   .day-row:hover .copy-btn { opacity: 0.9; }
 
@@ -405,7 +469,7 @@
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
-  .copy-btn.copied { color: var(--jap-500, #d97757); opacity: 1; }
+  .copy-btn.copied { color: var(--accent); opacity: 1; }
   .copy-btn svg { width: 10px; height: 10px; }
 
   .day-time {
@@ -423,6 +487,36 @@
     color: var(--ink-strong);
     min-width: 0;
     overflow-wrap: anywhere;
+  }
+
+  .day-main {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .day-meta {
+    font-size: 10.5px;
+    color: var(--ink-faint);
+    letter-spacing: 0.01em;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0;
+    max-height: 0;
+    transform: translateY(-2px);
+    transition:
+      opacity var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-fast) var(--ui-ease-out),
+      max-height var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .day-row:hover .day-meta,
+  .day-row:focus-within .day-meta {
+    opacity: 1;
+    max-height: 16px;
+    transform: translateY(0);
   }
 
   .error-msg {
@@ -446,10 +540,14 @@
   }
   .retry-btn:hover:not(:disabled) {
     background: var(--accent);
-    color: var(--on-accent, #fff);
+    color: var(--on-accent);
+  }
+  .retry-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   .retry-btn:disabled {
-    opacity: 0.5;
+    opacity: var(--ui-disabled-opacity);
     cursor: not-allowed;
   }
 
@@ -473,24 +571,36 @@
     transition: color 0.12s, background 0.12s;
   }
   .dismiss-btn:hover { color: var(--ink-strong); background: var(--control-active); }
+  .dismiss-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
   .dismiss-btn svg { width: 11px; height: 11px; }
 
   .empty-state {
-    padding: 32px 4px;
-    font-size: 13px;
-    color: var(--ink-mute);
-    font-style: italic;
+    padding: 52px 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
   }
 
-  .empty-state :global(kbd) {
-    font-style: normal;
-    background: var(--paper-2);
-    border: 1px solid var(--line-strong);
-    border-radius: 4px;
-    font-family: var(--mono);
-    font-size: 11px;
-    padding: 1px 5px;
-    color: var(--ink);
+  .empty-h {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  .empty-sub {
+    font-size: 12.5px;
+    color: var(--ink-mute);
+    line-height: 1.5;
+    margin: 0;
+    max-width: 360px;
   }
 
   @media (max-width: 720px) {

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { scale, slide } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
+  import Dropdown from '../../components/Dropdown.svelte';
+  import { formatAppLabel } from './helpers';
+  import { motionMs, MOTION_MS } from '../../motion';
+
+  type Props = {
+    search: string;
+    apps?: string[];
+    appFilter: string | null;
+    onSearchChange: (value: string) => void;
+    onAppFilterChange: (app: string | null) => void;
+    onClearFilters: () => void;
+  };
+
+  let {
+    search,
+    apps = [],
+    appFilter,
+    onSearchChange,
+    onAppFilterChange,
+    onClearFilters,
+  }: Props = $props();
+
+  let appDropdownOpen = $state(false);
+  let uiExpanded = $state(false);
+  let preserveExpanded = $state(false);
+  let groupEl = $state<HTMLElement | null>(null);
+  let inputEl = $state<HTMLInputElement | null>(null);
+  let appTriggerEl = $state<HTMLButtonElement | null>(null);
+
+  let filtersActive = $derived((search ?? '').trim().length > 0 || appFilter !== null);
+  let expanded = $derived(uiExpanded || filtersActive);
+
+  async function expandSearch() {
+    // Replacing the focused icon button with the input emits focusout before
+    // the new input can receive focus. Keep the group open through that one
+    // DOM transition so keyboard and automation users can type immediately.
+    preserveExpanded = true;
+    uiExpanded = true;
+    await tick();
+    inputEl?.focus();
+    requestAnimationFrame(() => {
+      preserveExpanded = false;
+    });
+  }
+
+  async function selectAppFilter(app: string | null) {
+    preserveExpanded = true;
+    appDropdownOpen = false;
+    onAppFilterChange(app);
+    await tick();
+    appTriggerEl?.focus();
+    requestAnimationFrame(() => {
+      preserveExpanded = false;
+    });
+  }
+
+  function handleGroupFocusOut() {
+    requestAnimationFrame(() => {
+      if (preserveExpanded) {
+        // Some browsers finish the pointer transition after the replacement
+        // frame, briefly leaving body as the active element. Give the input a
+        // short settling window before deciding the group was really exited.
+        setTimeout(collapseIfFocusLeft, 300);
+        return;
+      }
+      collapseIfFocusLeft();
+    });
+  }
+
+  function collapseIfFocusLeft() {
+    if (filtersActive) return;
+    if (groupEl && document.activeElement && groupEl.contains(document.activeElement)) return;
+    uiExpanded = false;
+  }
+</script>
+
+<div class="history-toolbar">
+  <div class="history-search-group" class:expanded bind:this={groupEl} onfocusout={handleGroupFocusOut}>
+    {#if !expanded}
+      <button class="search-icon-btn ui-focus-ring" onclick={expandSearch} aria-label="Search history">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+      </button>
+    {:else}
+      <div class="history-search">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" /></svg>
+        <input
+          bind:this={inputEl}
+          class="ui-input ui-input--dense"
+          type="text"
+          placeholder="Search history or app..."
+          value={search}
+          oninput={(event) => onSearchChange(event.currentTarget.value)}
+          aria-label="Search history"
+        />
+        {#if search}
+          <button class="clear-btn ui-focus-ring" onmousedown={(event) => event.preventDefault()} onclick={() => onSearchChange('')} aria-label="Clear search">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12" /></svg>
+          </button>
+        {/if}
+      </div>
+
+      <div class="history-search-divider"></div>
+
+      <Dropdown bind:open={appDropdownOpen} closeSelector=".history-app-dropdown">
+        <div class="ui-dropdown history-app-dropdown">
+          <button
+            bind:this={appTriggerEl}
+            class="ui-dropdown-trigger ui-dropdown-trigger--compact history-app-trigger"
+            aria-haspopup="listbox"
+            aria-expanded={appDropdownOpen}
+            aria-controls="history-app-menu"
+            onclick={() => (appDropdownOpen = !appDropdownOpen)}
+          >
+            <span>{appFilter ? formatAppLabel(appFilter) : 'All apps'}</span>
+            <svg class="ui-chevron" class:open={appDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+          </button>
+          {#if appDropdownOpen}
+            <div id="history-app-menu" class="ui-dropdown-menu history-app-menu scroll-styled" role="listbox" aria-label="Filter history by app" transition:scale={{ duration: motionMs(MOTION_MS.fast), start: 0.96, opacity: 0 }}>
+              <button class="ui-dropdown-option" class:active={!appFilter} role="option" aria-selected={!appFilter} onclick={() => selectAppFilter(null)}>All apps</button>
+              {#each apps as app}
+                <button class="ui-dropdown-option" class:active={appFilter === app} role="option" aria-selected={appFilter === app} onclick={() => selectAppFilter(app)}>{formatAppLabel(app)}</button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </Dropdown>
+
+      {#if filtersActive}
+        <div class="clear-filters-wrap" transition:slide={{ axis: 'x', duration: motionMs(MOTION_MS.base), easing: cubicOut }}>
+          <div class="history-search-divider"></div>
+          <button class="btn-ghost clear-filters-btn ui-focus-ring" onclick={onClearFilters}>Clear filters</button>
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .history-toolbar { display: flex; align-items: center; justify-content: flex-end; flex: 1 1 auto; min-width: 0; }
+
+  .history-search-group {
+    flex: 0 0 32px;
+    min-width: 32px;
+    display: flex;
+    align-items: center;
+    height: 32px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--r-sm);
+    color: var(--ink-mute);
+    margin-left: auto;
+    overflow: hidden;
+    transition:
+      flex var(--ui-duration-base) var(--ui-ease-out),
+      border-color var(--ui-duration-fast) var(--ui-ease-out),
+      background-color var(--ui-duration-fast) var(--ui-ease-out);
+  }
+
+  .history-search-group.expanded {
+    flex: 1 1 260px;
+    min-width: 160px;
+    max-width: 460px;
+    background: var(--bg-elev);
+    border-color: var(--line);
+    overflow: visible;
+  }
+
+  .search-icon-btn {
+    all: unset;
+    box-sizing: border-box;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    color: var(--ink-mute);
+    border-radius: var(--r-sm);
+    transition: color var(--ui-duration-fast) var(--ui-ease-out);
+  }
+
+  .search-icon-btn:hover { color: var(--ink-strong); }
+
+  .history-search {
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    padding: 0 9px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+
+  .history-search .ui-input { flex: 1; min-width: 0; background: transparent; border: 1px solid transparent; }
+  .history-search .ui-input:focus-visible { outline: none; }
+
+  .history-search-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--line);
+    flex-shrink: 0;
+  }
+
+  .clear-btn {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--ink-mute);
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .clear-btn:hover { color: var(--ink-strong); }
+
+  .history-app-trigger { border-color: transparent; background: transparent; flex-shrink: 0; }
+  .history-app-trigger:hover,
+  .history-app-trigger[aria-expanded='true'] { background: var(--control-hover); border-color: transparent; }
+
+  .history-app-menu { width: max-content; min-width: 180px; max-width: 280px; }
+
+  .clear-filters-wrap { display: flex; align-items: center; height: 100%; flex-shrink: 0; }
+
+  .clear-filters-btn {
+    height: 100%;
+    padding: 0 12px;
+    border-color: transparent;
+    border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  }
+
+  .clear-filters-btn:hover { background: var(--control-hover); border-color: transparent; }
+
+  @media (max-width: 560px) {
+    .history-search-group.expanded { flex-basis: 100%; max-width: none; }
+  }
+</style>


### PR DESCRIPTION
## Summary

- Place the history search toolbar inline with the first date heading.
- Keep it outside the virtualized list measurement path.
- Restore a visible flex transition when expanding from the search icon.

## Verification

- npm run check passes.
- Full Rust tests: 580 passed, 1 ignored, 1 unrelated logger test failed.