### PR TITLE
Polish inline history search toolbar

### DIFF
--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -4,6 +4,7 @@
   import { expoOut } from 'svelte/easing';
   import { icons } from '../../icons';
   import { appStore } from '../../stores';
+  import { motionMs } from '../../motion';
   import { fmtDuration } from '../insights/helpers';
   import HistoryToolbar from './HistoryToolbar.svelte';
   import { fmtDate, fmtTime, formatAppLabel, type Entry, type RenderItem } from './helpers';
@@ -32,7 +33,8 @@
   export let onCopy: (entry: Entry) => void;
 
   $: hasBanner = !!failedEntry || !!cancelledEntry;
-  $: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
+  $: filtersActive = search.trim().length > 0 || appFilter !== null;
+  $: firstLabel = recents.length > 0 ? fmtDate(recents[0].created_at) : '';
 
   function rowMeta(entry: Entry): string {
     const parts: string[] = [];
@@ -44,7 +46,7 @@
     ) {
       parts.push(fmtDuration(entry.duration_ms));
     }
-    return parts.join(' · ');
+    return parts.join(' Â· ');
   }
 
   let flatItems: RenderItem[] = [];
@@ -60,7 +62,11 @@
       }
       if (!seenHeaders.has(dayKey)) {
         seenHeaders.add(dayKey);
-        if (!(hasBanner && label === 'Today')) {
+        // The very first header is rendered outside the virtualized list,
+        // paired with the search toolbar, so it isn't left to a
+        // ResizeObserver-measured item (that fought the expand animation).
+        const isFirstHeader = acc.length === 0;
+        if (!(hasBanner ? label === 'Today' : isFirstHeader)) {
           acc.push({ type: 'header', label, key: `header-${dayKey}` });
         }
       }
@@ -191,10 +197,10 @@
     listContainer;
     appStore.updateInfo;
     // The toolbar's "Clear filters" button appears/disappears with filter
-    // state, which changes the list's vertical offset — recompute when it
+    // state, which changes the list's vertical offset â€” recompute when it
     // toggles, not just when history rows change.
     filtersActive;
-    // Depend on the entries directly, not the derived `hasBanner` boolean —
+    // Depend on the entries directly, not the derived `hasBanner` boolean â€”
     // swapping one banner for the other keeps the boolean true, so the block
     // would otherwise not re-run and `listOffset` would go stale.
     failedEntry;
@@ -280,18 +286,24 @@
 </script>
 
 {#if loading}
-  <div class="empty-state">Loading history…</div>
+  <div class="empty-state" role="status" aria-live="polite">
+    <p class="empty-h">Loading historyâ€¦</p>
+    <p class="empty-sub">Fetching your recent dictations.</p>
+  </div>
 {:else}
   {#if hasBanner}
-    <div class="day-head">Today</div>
+    <div class="day-head day-head-row">
+      <span>Today</span>
+      <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
+    </div>
     <div class="day-table">
       {#if cancelledEntry}
         <div
           class="day-row"
-          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
+          transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(cancelledEntry.created_at)}</div>
-          <div class="day-text error-msg">You cancelled a recording — pick it back up?</div>
+          <div class="day-text error-msg">You cancelled a recording â€” pick it back up?</div>
           <div class="row-actions">
             <button
               class="dismiss-btn"
@@ -309,7 +321,7 @@
               onclick={onContinueCancelled}
               disabled={resumingCancelled}
             >
-              {resumingCancelled ? '…' : 'Continue'}
+              {resumingCancelled ? 'â€¦' : 'Continue'}
             </button>
           </div>
         </div>
@@ -317,7 +329,7 @@
       {#if failedEntry}
         <div
           class="day-row"
-          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
+          transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(failedEntry.created_at)}</div>
           <div class="day-text error-msg">Looks like your last transcription failed.</div>
@@ -326,39 +338,42 @@
             onclick={onRetry}
             disabled={retrying}
           >
-            {retrying ? '…' : 'Retry'}
+            {retrying ? 'â€¦' : 'Retry'}
           </button>
         </div>
       {/if}
     </div>
   {/if}
 
-  <HistoryToolbar
-    {search}
-    {apps}
-    {appFilter}
-    {onSearchChange}
-    {onAppFilterChange}
-    {onClearFilters}
-  />
-
   {#if recents.length === 0 && !hasBanner}
+    <div class="day-head day-head-row">
+      <span></span>
+      <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
+    </div>
     {#if filtersActive}
       <div class="empty-state">
         <p class="empty-h">No matches</p>
         <p class="empty-sub">Nothing matches your current search and filters.</p>
+        <button class="btn-ghost" onclick={onClearFilters}>Clear filters</button>
       </div>
     {:else}
       <div class="empty-state">
-        No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
+        <p class="empty-h">No dictations yet</p>
+        <p class="empty-sub">Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to start your first dictation.</p>
       </div>
     {/if}
   {:else}
+    {#if !hasBanner}
+      <div class="day-head day-head-row">
+        <span>{firstLabel}</span>
+        <HistoryToolbar {search} {apps} {appFilter} {onSearchChange} {onAppFilterChange} {onClearFilters} />
+      </div>
+    {/if}
     <div bind:this={listContainer}>
       <div style="height: {topSpacerHeight}px;"></div>
       {#each visibleItems as { item, index } (item.key)}
         {#if item.type === 'header'}
-          <div use:measureItem={item.key} class="day-head" class:muted={index > 0 || hasBanner}>
+          <div use:measureItem={item.key} class="day-head muted">
             {item.label}
           </div>
         {:else if item.type === 'row'}
@@ -393,7 +408,7 @@
     {#if hasMoreHistory}
       <div class="load-older-wrap">
         <button class="btn-ghost load-older-btn" onclick={onLoadOlder} disabled={loadingMore}>
-          {loadingMore ? 'Loading…' : 'Load older'}
+          {loadingMore ? 'Loadingâ€¦' : 'Load older'}
         </button>
       </div>
     {/if}
@@ -415,6 +430,8 @@
     margin: 4px 4px 10px;
   }
   .day-head.muted { margin-top: 22px; color: var(--ink-mute); }
+  .day-head-row { display: flex; align-items: center; gap: 12px; }
+  .day-head-row > span { flex: 0 0 auto; }
 
   .day-table { border-top: 1px solid var(--line); }
 
@@ -427,7 +444,7 @@
     gap: 14px;
     cursor: default;
   }
-  .day-row:hover { background: var(--control-active); }
+  .day-row:hover { background: var(--control-hover); }
   .day-row:not(:hover) .copy-btn:not(:focus-visible) { opacity: 0.25; }
   .day-row:hover .copy-btn { opacity: 0.9; }
 
@@ -452,7 +469,7 @@
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
-  .copy-btn.copied { color: var(--jap-500, #d97757); opacity: 1; }
+  .copy-btn.copied { color: var(--accent); opacity: 1; }
   .copy-btn svg { width: 10px; height: 10px; }
 
   .day-time {
@@ -487,6 +504,19 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    opacity: 0;
+    max-height: 0;
+    transform: translateY(-2px);
+    transition:
+      opacity var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-fast) var(--ui-ease-out),
+      max-height var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .day-row:hover .day-meta,
+  .day-row:focus-within .day-meta {
+    opacity: 1;
+    max-height: 16px;
+    transform: translateY(0);
   }
 
   .error-msg {
@@ -510,10 +540,14 @@
   }
   .retry-btn:hover:not(:disabled) {
     background: var(--accent);
-    color: var(--on-accent, #fff);
+    color: var(--on-accent);
+  }
+  .retry-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   .retry-btn:disabled {
-    opacity: 0.5;
+    opacity: var(--ui-disabled-opacity);
     cursor: not-allowed;
   }
 
@@ -537,18 +571,19 @@
     transition: color 0.12s, background 0.12s;
   }
   .dismiss-btn:hover { color: var(--ink-strong); background: var(--control-active); }
+  .dismiss-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
   .dismiss-btn svg { width: 11px; height: 11px; }
 
   .empty-state {
-    padding: 32px 4px;
-    font-size: 13px;
-    color: var(--ink-mute);
-    font-style: italic;
-  }
-
-  .empty-state .empty-h,
-  .empty-state .empty-sub {
-    font-style: normal;
+    padding: 52px 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
   }
 
   .empty-h {
@@ -564,19 +599,8 @@
     font-size: 12.5px;
     color: var(--ink-mute);
     line-height: 1.5;
-    margin: 0 0 10px;
+    margin: 0;
     max-width: 360px;
-  }
-
-  .empty-state :global(kbd) {
-    font-style: normal;
-    background: var(--paper-2);
-    border: 1px solid var(--line-strong);
-    border-radius: 4px;
-    font-family: var(--mono);
-    font-size: 11px;
-    padding: 1px 5px;
-    color: var(--ink);
   }
 
   @media (max-width: 720px) {

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -140,7 +140,7 @@
 </div>
 
 <style>
-  .history-toolbar { display: flex; align-items: center; margin-bottom: 12px; }
+  .history-toolbar { display: flex; align-items: center; justify-content: flex-end; flex: 1 1 auto; min-width: 0; }
 
   .history-search-group {
     flex: 0 0 32px;
@@ -155,7 +155,7 @@
     margin-left: auto;
     overflow: hidden;
     transition:
-      flex-basis var(--ui-duration-base) var(--ui-ease-out),
+      flex var(--ui-duration-base) var(--ui-ease-out),
       border-color var(--ui-duration-fast) var(--ui-ease-out),
       background-color var(--ui-duration-fast) var(--ui-ease-out);
   }


### PR DESCRIPTION
## Summary

- Place the history search toolbar inline with the first date heading.
- Keep it outside the virtualized list measurement path.
- Restore a visible flex transition when expanding from the search icon.

## Verification

- npm run check passes.
- Full Rust tests: 580 passed, 1 ignored, 1 unrelated logger test failed.