### PR TITLE
Polish inline history search toolbar

### DIFF
--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -33,6 +33,7 @@
 
   $: hasBanner = !!failedEntry || !!cancelledEntry;
   $: filtersActive = (search ?? '').trim().length > 0 || appFilter !== null;
+  $: firstLabel = recents.length > 0 ? fmtDate(recents[0].created_at) : '';
 
   function rowMeta(entry: Entry): string {
     const parts: string[] = [];
@@ -60,7 +61,8 @@
       }
       if (!seenHeaders.has(dayKey)) {
         seenHeaders.add(dayKey);
-        if (!(hasBanner && label === 'Today')) {
+        const isFirstHeader = acc.length === 0;
+        if (!(hasBanner ? label === 'Today' : isFirstHeader)) {
           acc.push({ type: 'header', label, key: `header-${dayKey}` });
         }
       }
@@ -333,14 +335,17 @@
     </div>
   {/if}
 
-  <HistoryToolbar
-    {search}
-    {apps}
-    {appFilter}
-    {onSearchChange}
-    {onAppFilterChange}
-    {onClearFilters}
-  />
+  <div class="day-head day-head-row">
+    <span>{hasBanner ? 'Today' : firstLabel}</span>
+    <HistoryToolbar
+      {search}
+      {apps}
+      {appFilter}
+      {onSearchChange}
+      {onAppFilterChange}
+      {onClearFilters}
+    />
+  </div>
 
   {#if recents.length === 0 && !hasBanner}
     {#if filtersActive}
@@ -415,6 +420,8 @@
     margin: 4px 4px 10px;
   }
   .day-head.muted { margin-top: 22px; color: var(--ink-mute); }
+  .day-head-row { display: flex; align-items: center; gap: 12px; }
+  .day-head-row > span { flex: 0 0 auto; }
 
   .day-table { border-top: 1px solid var(--line); }
 

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -140,7 +140,7 @@
 </div>
 
 <style>
-  .history-toolbar { display: flex; align-items: center; margin-bottom: 12px; }
+  .history-toolbar { display: flex; align-items: center; justify-content: flex-end; flex: 1 1 auto; min-width: 0; }
 
   .history-search-group {
     flex: 0 0 32px;
@@ -155,7 +155,7 @@
     margin-left: auto;
     overflow: hidden;
     transition:
-      flex-basis var(--ui-duration-base) var(--ui-ease-out),
+      flex var(--ui-duration-base) var(--ui-ease-out),
       border-color var(--ui-duration-fast) var(--ui-ease-out),
       background-color var(--ui-duration-fast) var(--ui-ease-out);
   }


### PR DESCRIPTION
## Summary

- Align the home history search control with the first date heading.
- Keep the toolbar out of the virtualized list measurement path.
- Animate the flex shorthand so icon-to-search expansion visibly transitions.

## Verification

- npm run check passes.
- Full Rust suite: 580 passed, 1 ignored, 1 unrelated logger test failed.