### PR TITLE
Add per-context custom instructions for cleanup LLM

### DIFF
--- a/src-tauri/src/commands/contexts.rs
+++ b/src-tauri/src/commands/contexts.rs
@@ -18,6 +18,7 @@ pub async fn create_context(
     icon: Option<String>,
     tone: Option<String>,
     cleanup_intensity: Option<String>,
+    custom_instructions: Option<String>,
 ) -> Result<db::Context, String> {
     let db = db_state(&app);
     run_blocking("create_context", move || {
@@ -27,6 +28,7 @@ pub async fn create_context(
             icon.as_deref(),
             tone.as_deref(),
             cleanup_intensity.as_deref(),
+            custom_instructions.as_deref(),
         )
         .map_err(|e| e.to_string())
     })
@@ -49,6 +51,7 @@ pub async fn update_context_settings(
     icon: Option<String>,
     tone: Option<String>,
     cleanup_intensity: Option<String>,
+    custom_instructions: Option<String>,
 ) -> Result<(), String> {
     let db = db_state(&app);
     run_blocking("update_context_settings", move || {
@@ -58,6 +61,7 @@ pub async fn update_context_settings(
             icon.as_deref(),
             tone.as_deref(),
             cleanup_intensity.as_deref(),
+            custom_instructions.as_deref(),
         )
         .map_err(|e| e.to_string())
     })

--- a/src-tauri/src/core/context.rs
+++ b/src-tauri/src/core/context.rs
@@ -15,7 +15,7 @@ mod tests {
     #[test]
     fn resolver_matches_executables_case_insensitively() {
         let db = db::open(":memory:").expect("db");
-        let context = db::insert_context_returning(&db, "Editor", None, None, None).expect("context");
+        let context = db::insert_context_returning(&db, "Editor", None, None, None, None).expect("context");
         db::assign_context_target(&db, context.id, "editor.exe").expect("target");
 
         assert_eq!(resolve_context(&db, "EDITOR.EXE", None).unwrap().id, context.id);

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -21,6 +21,7 @@ pub struct Context {
     pub tone: Option<String>,
     pub cleanup_intensity: Option<String>,
     pub color: Option<String>,
+    pub custom_instructions: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -50,8 +51,9 @@ fn context_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Context> {
         tone: row.get(4)?,
         cleanup_intensity: row.get(5)?,
         color: row.get(6)?,
-        created_at: row.get(7)?,
-        updated_at: row.get(8)?,
+        custom_instructions: row.get(7)?,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
     })
 }
 
@@ -59,6 +61,18 @@ fn normalize_context_name(name: &str) -> Result<String> {
     let normalized = require_nonempty_trimmed("Context name", name)?;
     validate_char_limit("Context name", &normalized, CONTEXT_NAME_CHAR_LIMIT)?;
     Ok(normalized)
+}
+
+fn normalize_custom_instructions(custom_instructions: Option<&str>) -> Result<Option<String>> {
+    let Some(normalized) = normalize_optional_trimmed(custom_instructions) else {
+        return Ok(None);
+    };
+    validate_char_limit(
+        "Custom instructions",
+        &normalized,
+        CONTEXT_CUSTOM_INSTRUCTIONS_CHAR_LIMIT,
+    )?;
+    Ok(Some(normalized))
 }
 
 fn normalize_executable(executable: &str) -> Result<String> {
@@ -105,7 +119,7 @@ pub fn everywhere_context_id(db: &Db) -> Result<i64> {
 pub fn query_contexts(db: &Db) -> Result<Vec<Context>> {
     let conn = lock_conn(db)?;
     let mut stmt = conn.prepare(
-        "SELECT id, name, is_everywhere, icon, tone, cleanup_intensity, color, created_at, updated_at
+        "SELECT id, name, is_everywhere, icon, tone, cleanup_intensity, color, custom_instructions, created_at, updated_at
          FROM contexts
          ORDER BY is_everywhere DESC, name COLLATE NOCASE ASC",
     )?;
@@ -115,7 +129,6 @@ pub fn query_contexts(db: &Db) -> Result<Vec<Context>> {
     Ok(rows)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn query_context(db: &Db, context_id: i64) -> Result<Context> {
     let conn = lock_conn(db)?;
     query_context_conn(&conn, context_id)
@@ -123,7 +136,7 @@ pub fn query_context(db: &Db, context_id: i64) -> Result<Context> {
 
 fn query_context_conn(conn: &rusqlite::Connection, context_id: i64) -> Result<Context> {
     conn.query_row(
-        "SELECT id, name, is_everywhere, icon, tone, cleanup_intensity, color, created_at, updated_at
+        "SELECT id, name, is_everywhere, icon, tone, cleanup_intensity, color, custom_instructions, created_at, updated_at
          FROM contexts WHERE id = ?1",
         params![context_id],
         context_from_row,
@@ -137,11 +150,13 @@ pub fn insert_context_returning(
     icon: Option<&str>,
     tone: Option<&str>,
     cleanup_intensity: Option<&str>,
+    custom_instructions: Option<&str>,
 ) -> Result<Context> {
     let normalized_name = normalize_context_name(name)?;
     if normalized_name.eq_ignore_ascii_case("Everywhere") {
         anyhow::bail!("The Everywhere context already exists");
     }
+    let normalized_custom_instructions = normalize_custom_instructions(custom_instructions)?;
 
     let conn = lock_conn(db)?;
     let count: i64 = conn.query_row(
@@ -153,12 +168,13 @@ pub fn insert_context_returning(
         anyhow::bail!("You've reached the limit of {MAX_USER_CONTEXTS} context groups");
     }
     conn.execute(
-        "INSERT INTO contexts (name, is_everywhere, icon, tone, cleanup_intensity) VALUES (?1, 0, ?2, ?3, ?4)",
+        "INSERT INTO contexts (name, is_everywhere, icon, tone, cleanup_intensity, custom_instructions) VALUES (?1, 0, ?2, ?3, ?4, ?5)",
         params![
             normalized_name,
             normalize_optional_trimmed(icon),
             normalize_optional_trimmed(tone),
-            normalize_optional_trimmed(cleanup_intensity)
+            normalize_optional_trimmed(cleanup_intensity),
+            normalized_custom_instructions,
         ],
     )?;
     let id = conn.last_insert_rowid();
@@ -188,19 +204,22 @@ pub fn update_context_settings(
     icon: Option<&str>,
     tone: Option<&str>,
     cleanup_intensity: Option<&str>,
+    custom_instructions: Option<&str>,
 ) -> Result<()> {
+    let normalized_custom_instructions = normalize_custom_instructions(custom_instructions)?;
     let conn = lock_conn(db)?;
     let context = query_context_conn(&conn, context_id)?;
     if context.is_everywhere {
         anyhow::bail!("The Everywhere context cannot have a tone override");
     }
     let changed = conn.execute(
-        "UPDATE contexts SET icon = ?2, tone = ?3, cleanup_intensity = ?4, updated_at = datetime('now') WHERE id = ?1",
+        "UPDATE contexts SET icon = ?2, tone = ?3, cleanup_intensity = ?4, custom_instructions = ?5, updated_at = datetime('now') WHERE id = ?1",
         params![
             context_id,
             normalize_optional_trimmed(icon),
             normalize_optional_trimmed(tone),
-            normalize_optional_trimmed(cleanup_intensity)
+            normalize_optional_trimmed(cleanup_intensity),
+            normalized_custom_instructions,
         ],
     )?;
     require_row_changed(changed, "Context", context_id)
@@ -583,9 +602,29 @@ mod tests {
     }
 
     #[test]
+    fn custom_instructions_round_trip_and_enforce_char_limit() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Support", None, None, None, Some("  Reply in a friendly tone.  "))
+            .expect("context");
+        assert_eq!(context.custom_instructions.as_deref(), Some("Reply in a friendly tone."));
+
+        update_context_settings(&db, context.id, None, None, None, Some("Keep it brief.")).expect("update");
+        assert_eq!(
+            query_context(&db, context.id).unwrap().custom_instructions.as_deref(),
+            Some("Keep it brief.")
+        );
+
+        update_context_settings(&db, context.id, None, None, None, None).expect("clear");
+        assert_eq!(query_context(&db, context.id).unwrap().custom_instructions, None);
+
+        let too_long = "x".repeat(CONTEXT_CUSTOM_INSTRUCTIONS_CHAR_LIMIT + 1);
+        assert!(update_context_settings(&db, context.id, None, None, None, Some(&too_long)).is_err());
+    }
+
+    #[test]
     fn content_assignment_is_scoped_and_reversible() {
         let db = open(":memory:").expect("db");
-        let context = insert_context_returning(&db, "Writing", None, None, None).expect("context");
+        let context = insert_context_returning(&db, "Writing", None, None, None, None).expect("context");
         insert_dictionary_entry(&db, "Verenu", Some("Varinu")).expect("dictionary");
         insert_snippet(&db, "sig", "signature", "").expect("snippet");
         let dictionary_id = query_dictionary(&db).unwrap()[0].id;
@@ -634,7 +673,7 @@ mod tests {
     #[test]
     fn target_resolution_returns_one_context_and_falls_back_to_everywhere() {
         let db = open(":memory:").expect("db");
-        let context = insert_context_returning(&db, "Writing", None, None, None).expect("context");
+        let context = insert_context_returning(&db, "Writing", None, None, None, None).expect("context");
         assign_context_target(&db, context.id, "Code.EXE").expect("target");
 
         assert_eq!(
@@ -654,8 +693,8 @@ mod tests {
     #[test]
     fn website_domain_match_takes_priority_over_executable_match() {
         let db = open(":memory:").expect("db");
-        let exe_context = insert_context_returning(&db, "Browsing", None, None, None).expect("exe context");
-        let site_context = insert_context_returning(&db, "Work Email", None, None, None).expect("site context");
+        let exe_context = insert_context_returning(&db, "Browsing", None, None, None, None).expect("exe context");
+        let site_context = insert_context_returning(&db, "Work Email", None, None, None, None).expect("site context");
         assign_context_target(&db, exe_context.id, "chrome.exe").expect("exe target");
         assign_context_website(&db, site_context.id, "mail.google.com").expect("website target");
 
@@ -682,7 +721,7 @@ mod tests {
     #[test]
     fn website_domain_normalizes_pasted_urls() {
         let db = open(":memory:").expect("db");
-        let context = insert_context_returning(&db, "Work Email", None, None, None).expect("context");
+        let context = insert_context_returning(&db, "Work Email", None, None, None, None).expect("context");
         let target = assign_context_website(&db, context.id, "https://Mail.Google.com/mail/u/0?tab=rm")
             .expect("assign");
         assert_eq!(target.domain, "mail.google.com");
@@ -691,8 +730,8 @@ mod tests {
     #[test]
     fn assigning_a_target_replaces_its_previous_context() {
         let db = open(":memory:").expect("db");
-        let first = insert_context_returning(&db, "First", None, None, None).expect("first");
-        let second = insert_context_returning(&db, "Second", None, None, None).expect("second");
+        let first = insert_context_returning(&db, "First", None, None, None, None).expect("first");
+        let second = insert_context_returning(&db, "Second", None, None, None, None).expect("second");
         assign_context_target(&db, first.id, "editor.exe").expect("first target");
         assign_context_target(&db, second.id, "EDITOR.EXE").expect("replacement target");
 
@@ -704,7 +743,7 @@ mod tests {
     #[test]
     fn deleting_a_context_returns_items_to_everywhere() {
         let db = open(":memory:").expect("db");
-        let context = insert_context_returning(&db, "Temporary", None, None, None).expect("context");
+        let context = insert_context_returning(&db, "Temporary", None, None, None, None).expect("context");
         insert_dictionary_entry(&db, "Tauri", Some("Tari")).expect("dictionary");
         insert_snippet(&db, "sig", "signature", "").expect("snippet");
         let dictionary_id = query_dictionary(&db).unwrap()[0].id;

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS contexts (
   tone              TEXT,
   cleanup_intensity TEXT,
   color             TEXT,
+  custom_instructions TEXT,
   created_at        DATETIME NOT NULL DEFAULT (datetime('now')),
   updated_at        DATETIME NOT NULL DEFAULT (datetime('now'))
 );
@@ -547,6 +548,23 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
         run_migration(&mut conn, |conn| {
             ensure_table_column(conn, "contexts", "color", "ALTER TABLE contexts ADD COLUMN color TEXT;")?;
             conn.execute_batch("PRAGMA user_version = 15;")?;
+            Ok(())
+        })?;
+    }
+    if user_version < 16 {
+        log::info!("db: migrating schema {user_version} -> 16");
+        // Per-context free-text instructions sent directly to the cleanup LLM
+        // alongside the tone/cleanup overrides. Column declared in SCHEMA for
+        // fresh databases; ensure_table_column is idempotent for databases
+        // that already have it.
+        run_migration(&mut conn, |conn| {
+            ensure_table_column(
+                conn,
+                "contexts",
+                "custom_instructions",
+                "ALTER TABLE contexts ADD COLUMN custom_instructions TEXT;",
+            )?;
+            conn.execute_batch("PRAGMA user_version = 16;")?;
             Ok(())
         })?;
     }

--- a/src-tauri/src/data/db/validation.rs
+++ b/src-tauri/src/data/db/validation.rs
@@ -9,6 +9,7 @@ pub const DICTIONARY_ENTRY_CHAR_LIMIT: usize = 120;
 pub const CONTEXT_NAME_CHAR_LIMIT: usize = 30;
 pub const CONTEXT_EXECUTABLE_CHAR_LIMIT: usize = 260;
 pub const CONTEXT_DOMAIN_CHAR_LIMIT: usize = 253; // max legal DNS name length
+pub const CONTEXT_CUSTOM_INSTRUCTIONS_CHAR_LIMIT: usize = 300;
 
 pub fn require_nonempty_trimmed(field: &str, value: &str) -> Result<String> {
     let normalized = value.trim();

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -280,6 +280,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
                 tone: None,
                 cleanup_intensity: None,
                 color: None,
+                custom_instructions: None,
                 created_at: String::new(),
                 updated_at: String::new(),
             }

--- a/src-tauri/src/pipeline/stages.rs
+++ b/src-tauri/src/pipeline/stages.rs
@@ -1305,7 +1305,15 @@ pub(super) async fn run_cleanup_and_snippets_for_db(
     );
 
     let dict_instructions = dictionary::build_relevant_dictionary_prompt_from(&dict_entries, raw);
-    let extra_rules = [snippet_instructions.as_str(), dict_instructions.as_str(), protected_instruction.unwrap_or("")]
+    let context_custom_instructions = db::query_context(db_handle, context_id)
+        .ok()
+        .and_then(|c| c.custom_instructions);
+    let extra_rules = [
+        snippet_instructions.as_str(),
+        dict_instructions.as_str(),
+        context_custom_instructions.as_deref().unwrap_or(""),
+        protected_instruction.unwrap_or(""),
+    ]
         .iter()
         .filter(|s| !s.is_empty())
         .copied()

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -36,6 +36,7 @@ export interface Context {
   tone: string | null;
   cleanup_intensity: string | null;
   color: string | null;
+  custom_instructions: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -39,6 +39,7 @@ type DevContext = {
   tone: string | null;
   cleanup_intensity: string | null;
   color: string | null;
+  custom_instructions: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -317,6 +318,7 @@ function readDevContexts(): DevContext[] {
     tone: null,
     cleanup_intensity: null,
     color: null,
+    custom_instructions: null,
     created_at: now,
     updated_at: now,
   };
@@ -1149,6 +1151,7 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
         tone: (args?.tone as string | null | undefined) ?? null,
         cleanup_intensity: (args?.cleanup_intensity as string | null | undefined) ?? null,
         color: null,
+        custom_instructions: ((args?.customInstructions ?? args?.custom_instructions) as string | null | undefined) ?? null,
         created_at: now,
         updated_at: now,
       };
@@ -1180,6 +1183,7 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
         icon: (args?.icon as string | null | undefined) ?? null,
         tone: (args?.tone as string | null | undefined) ?? null,
         cleanup_intensity: (args?.cleanupIntensity ?? args?.cleanup_intensity) as string | null | undefined ?? null,
+        custom_instructions: (args?.customInstructions ?? args?.custom_instructions) as string | null | undefined ?? null,
         updated_at: devNow(),
       };
       writeDevList(DEV_CONTEXTS_KEY, rows);

--- a/src/lib/views/Contexts.svelte
+++ b/src/lib/views/Contexts.svelte
@@ -36,6 +36,7 @@
 
   const EVERYWHERE_ID = 1;
   const CONTEXT_NAME_MAX_LENGTH = 30;
+  const CONTEXT_CUSTOM_INSTRUCTIONS_MAX_LENGTH = 300;
   const CONTEXT_TABS = [
     { id: 'vocabulary', label: 'Vocabulary' },
     { id: 'snippets', label: 'Snippets' },
@@ -112,6 +113,7 @@
   let modalColorPickerPos = $state<{ top: number; left: number } | null>(null);
   let modalTone = $state<string | null>(null);
   let modalCleanupIntensity = $state<string | null>(null);
+  let modalCustomInstructions = $state('');
   // Tone/cleanup dropdown menus render fixed-position at the top level (not
   // nested in the modal card) because the modal card and body both clip
   // overflow — an absolutely-positioned menu inside them gets cut off.
@@ -489,6 +491,7 @@
     closeModalColorPicker();
     modalTone = editing?.tone ?? null;
     modalCleanupIntensity = editing?.cleanup_intensity ?? null;
+    modalCustomInstructions = editing?.custom_instructions ?? '';
     modalApps = [];
     modalAppQuery = '';
     modalWebsites = [];
@@ -657,12 +660,13 @@
           icon: modalIcon,
           tone: modalTone,
           cleanupIntensity: modalCleanupIntensity,
+          customInstructions: modalCustomInstructions.trim() || null,
         });
         if (modalColor !== selectedContext.color) {
           await invoke('update_context_color', { contextId: selectedContext.id, color: modalColor });
         }
         contexts = contexts.map((context) => context.id === selectedContext.id
-          ? { ...context, name, icon: modalIcon, tone: modalTone, cleanup_intensity: modalCleanupIntensity, color: modalColor, updated_at: new Date().toISOString() }
+          ? { ...context, name, icon: modalIcon, tone: modalTone, cleanup_intensity: modalCleanupIntensity, custom_instructions: modalCustomInstructions.trim() || null, color: modalColor, updated_at: new Date().toISOString() }
           : context);
       } else {
         const created = await invoke<Context>('create_context', {
@@ -670,6 +674,7 @@
           icon: modalIcon,
           tone: modalTone,
           cleanupIntensity: modalCleanupIntensity,
+          customInstructions: modalCustomInstructions.trim() || null,
         });
         createdContextId = created.id;
         if (modalColor) {
@@ -1229,7 +1234,6 @@
               id="context-panel-{tab}"
               aria-labelledby="context-tab-{tab}"
               in:pageSwap={{ axis: 'x', distance: tabDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base) }}
-              out:pageSwap={{ axis: 'x', distance: -tabDir * motionPx(MOTION_PX.page), duration: motionMs(MOTION_MS.base) }}
             >
               {#if tab === 'vocabulary'}
                 {#if filteredDictionary.length === 0}
@@ -1583,6 +1587,21 @@
         </div>
       </div>
 
+      <div class="field-label-row">
+        <label class="field-label" for="context-custom-instructions">Custom instructions</label>
+        <span class="char-counter" class:is-limit={modalCustomInstructions.length >= CONTEXT_CUSTOM_INSTRUCTIONS_MAX_LENGTH}>{modalCustomInstructions.length}/{CONTEXT_CUSTOM_INSTRUCTIONS_MAX_LENGTH}</span>
+      </div>
+      <textarea
+        id="context-custom-instructions"
+        class="ui-input custom-instructions-input scrollbar-standard"
+        placeholder="e.g. Always write dates as DD/MM/YYYY."
+        bind:value={modalCustomInstructions}
+        maxlength={CONTEXT_CUSTOM_INSTRUCTIONS_MAX_LENGTH}
+        rows="3"
+        spellcheck="false"
+      ></textarea>
+      <p class="field-hint">Sent directly to the cleanup model whenever this context group is active.</p>
+
       {#if contextModalMode === 'create'}
         <label class="field-label" for="context-app">Attach apps (optional)</label>
         {#if modalApps.length > 0}
@@ -1934,6 +1953,7 @@
   .field-label-row .field-label { margin-top: 0; }
   .char-counter { font-size: 10.5px; color: var(--ink-faint); font-variant-numeric: tabular-nums; flex-shrink: 0; }
   .char-counter.is-limit { color: var(--danger); }
+  .custom-instructions-input { resize: vertical; font-size: 12.5px; max-height: 160px; }
   .field-hint { color: var(--ink-mute); font-size: 11px; margin: 3px 0 0; }
   .domain-preview { display: flex; align-items: center; gap: 5px; color: var(--ink-faint); font-size: 11px; margin: 5px 0 0; }
   .domain-preview.is-valid { color: var(--ink-mute); }


### PR DESCRIPTION
## Summary
- Context groups can now carry a free-text custom instruction (up to 300 characters) sent directly to the cleanup LLM's prompt whenever that context is active
- Editable in both the create and edit context group modals, with a live character counter and a scrollable, capped textarea
- New `custom_instructions` column added to `contexts` via schema migration 16, exposed through `create_context` / `update_context_settings`
- Fixed a layout jump in the Contexts view: switching between the Vocabulary/Snippets tabs when both are empty briefly double-mounted the empty-state box, making it appear to spawn mid-page and slide up

## Test plan
- [x] `cargo check` / `cargo test` (contexts module, including a new round-trip + char-limit test) pass
- [x] `npm run check` (Svelte/TS typecheck) passes
- [ ] Manual UI verification blocked by sandboxed shell network isolation in this session (dev server unreachable) — please spot check in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M28BkekEUMcfEXn8LS5VPM