### PR TITLE
Suppress unwanted WebView context menus

### DIFF
--- a/src/lib/disable-context-menu.ts
+++ b/src/lib/disable-context-menu.ts
@@ -8,18 +8,11 @@
  * refusal. Contexts.svelte uses preventDefault() for its color picker, which
  * must remain available.
  */
-export function disableBrowserContextMenu(): () => void {
+export function disableBrowserContextMenu() {
   const handler = (event: MouseEvent) => {
     if (!event.defaultPrevented) {
       event.preventDefault();
     }
   };
   document.addEventListener('contextmenu', handler);
-
-  let removed = false;
-  return () => {
-    if (removed) return;
-    removed = true;
-    document.removeEventListener('contextmenu', handler);
-  };
 }

--- a/src/lib/disable-context-menu.ts
+++ b/src/lib/disable-context-menu.ts
@@ -1,0 +1,17 @@
+/**
+ * Tauri's WebView2 has a browser context menu by default. Verenu is a native
+ * app, so that menu is never useful; in particular, the idle pill webview is
+ * kept alive and can still receive a right-click during a click-through
+ * transition.
+ *
+ * Listen during bubbling so feature-specific contextmenu handlers get first
+ * refusal. Contexts.svelte uses preventDefault() for its color picker, which
+ * must remain available.
+ */
+export function disableBrowserContextMenu() {
+  document.addEventListener('contextmenu', (event) => {
+    if (!event.defaultPrevented) {
+      event.preventDefault();
+    }
+  });
+}

--- a/src/lib/disable-context-menu.ts
+++ b/src/lib/disable-context-menu.ts
@@ -8,10 +8,21 @@
  * refusal. Contexts.svelte uses preventDefault() for its color picker, which
  * must remain available.
  */
-export function disableBrowserContextMenu() {
-  document.addEventListener('contextmenu', (event) => {
+let contextMenuHandler: ((event: MouseEvent) => void) | null = null;
+
+export function disableBrowserContextMenu(): () => void {
+  if (contextMenuHandler) return () => {};
+
+  contextMenuHandler = (event) => {
     if (!event.defaultPrevented) {
       event.preventDefault();
     }
-  });
+  };
+  document.addEventListener('contextmenu', contextMenuHandler);
+
+  return () => {
+    if (!contextMenuHandler) return;
+    document.removeEventListener('contextmenu', contextMenuHandler);
+    contextMenuHandler = null;
+  };
 }

--- a/src/lib/disable-context-menu.ts
+++ b/src/lib/disable-context-menu.ts
@@ -8,21 +8,18 @@
  * refusal. Contexts.svelte uses preventDefault() for its color picker, which
  * must remain available.
  */
-let contextMenuHandler: ((event: MouseEvent) => void) | null = null;
-
 export function disableBrowserContextMenu(): () => void {
-  if (contextMenuHandler) return () => {};
-
-  contextMenuHandler = (event) => {
+  const handler = (event: MouseEvent) => {
     if (!event.defaultPrevented) {
       event.preventDefault();
     }
   };
-  document.addEventListener('contextmenu', contextMenuHandler);
+  document.addEventListener('contextmenu', handler);
 
+  let removed = false;
   return () => {
-    if (!contextMenuHandler) return;
-    document.removeEventListener('contextmenu', contextMenuHandler);
-    contextMenuHandler = null;
+    if (removed) return;
+    removed = true;
+    document.removeEventListener('contextmenu', handler);
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,11 @@
 import { mount } from 'svelte';
 import App from './App.svelte';
 import { invoke } from './lib/tauri';
+import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
 import './app.css';
+
+disableBrowserContextMenu();
 
 const app = mount(App, {
   target: document.getElementById('app') as HTMLElement,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
 import './app.css';
 
-void disableBrowserContextMenu();
+disableBrowserContextMenu(); // The app webview lives until the process exits.
 
 const app = mount(App, {
   target: document.getElementById('app') as HTMLElement,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
 import './app.css';
 
-disableBrowserContextMenu();
+void disableBrowserContextMenu();
 
 const app = mount(App, {
   target: document.getElementById('app') as HTMLElement,

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -4,7 +4,7 @@ import { invoke } from './lib/tauri';
 import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
 
-disableBrowserContextMenu();
+void disableBrowserContextMenu();
 
 type AppearanceMode = 'system' | 'light' | 'dark';
 type EffectiveTheme = 'light' | 'dark';

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -1,7 +1,10 @@
 import { mount } from 'svelte';
 import PillApp from './PillApp.svelte';
 import { invoke } from './lib/tauri';
+import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
+
+disableBrowserContextMenu();
 
 type AppearanceMode = 'system' | 'light' | 'dark';
 type EffectiveTheme = 'light' | 'dark';

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -4,7 +4,7 @@ import { invoke } from './lib/tauri';
 import { disableBrowserContextMenu } from './lib/disable-context-menu';
 import './theme.css';
 
-void disableBrowserContextMenu();
+disableBrowserContextMenu(); // The pill webview lives until the process exits.
 
 type AppearanceMode = 'system' | 'light' | 'dark';
 type EffectiveTheme = 'light' | 'dark';


### PR DESCRIPTION
## Problem

The idle pill webview stays alive for renderer reliability, but WebView2 can still show its browser context menu after a right-click.

## Fix

- Block the default browser context menu in the main and pill webviews.
- Preserve intentional context-specific handlers that call preventDefault(), including color pickers.

## Verification

- npm run check
- npm run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789543088&installation_model_id=432577&pr_number=254&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F254&signature=44849a11680bc9def9d03276faef15c840242595678845bf468655d92a7d1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->