### PR TITLE
Make AI review fallback recover from model failures

### DIFF
--- a/scripts/verenu-ai-review-logic.mjs
+++ b/scripts/verenu-ai-review-logic.mjs
@@ -45,7 +45,7 @@ export function selectReviewModels({
 }
 
 export function fallbackReason(result) {
-  if (!result || result.previewFailed || result.code === 0) return null;
+  if (!result || result.code === 0) return null;
 
   const output = `${result.stderr || ""}\n${result.stdout || ""}`;
   // CLIProxy and the upstream Gemini API use underscore-delimited error
@@ -53,9 +53,15 @@ export function fallbackReason(result) {
   // separators before matching so a quota response without an explicit 429
   // still reaches the next configured model.
   const normalizedOutput = output.replace(/[_-]+/g, " ");
+  if (/\b(?:401|403|unauthorized|forbidden|invalid api key|authentication failed)\b/i.test(normalizedOutput)) return null;
   if (/\b(?:quota|resource exhausted|insufficient quota|daily limit|usage limit|out of extra usage|model cooldown|cooling down|capacity on this model)\b/i.test(normalizedOutput)) return "quota";
   if (/\b(?:rate\s*limit|too many requests|429)\b/i.test(normalizedOutput)) return "rate_limit";
   if (FALLBACK_ERROR_PATTERNS.some((pattern) => pattern.test(normalizedOutput))) return "model_unavailable";
+  // OCR does not guarantee a stable provider error code. Once the preview
+  // passed, an opaque review failure is still a model/provider failure worth
+  // retrying with the next configured model. Keep infrastructure-only preview
+  // failures out of the fallback path unless their output matched above.
+  if (!result.previewFailed) return "review_failed";
   return null;
 }
 
@@ -65,8 +71,10 @@ export function shouldFallback(result, currentModel, fallbackModel) {
 
 export function failureCategory(result) {
   if (!result || result.code === 0) return null;
+  const reason = fallbackReason(result);
+  if (reason) return reason;
   if (result?.previewFailed) return "preview_failed";
-  return fallbackReason(result) || "review_failed";
+  return "review_failed";
 }
 
 export function reviewOutcome(findings) {
@@ -89,7 +97,7 @@ export function formatProgressSummary({ stage, model, fallbackModel, reason, mod
     case "reviewing":
       return `🔍 Reviewing ${shaText}${modelText}...`;
     case "switching":
-      return `🔁 ${model ? `\`${model}\`` : "Primary model"} ${reason === "model_unavailable" ? "unavailable" : reason === "rate_limit" ? "rate-limited" : "quota unavailable"}, switching to ${fallbackModel ? `\`${fallbackModel}\`` : "the fallback model"}...`;
+      return `🔁 ${model ? `\`${model}\`` : "Primary model"} ${reason === "model_unavailable" ? "unavailable" : reason === "rate_limit" ? "rate-limited" : reason === "review_failed" ? "failed" : "quota unavailable"}, switching to ${fallbackModel ? `\`${fallbackModel}\`` : "the fallback model"}...`;
     case "complete":
       {
         const findingCount = Number.isFinite(Number(findings)) ? Number(findings) : 0;

--- a/scripts/verenu-ai-review-logic.test.mjs
+++ b/scripts/verenu-ai-review-logic.test.mjs
@@ -82,12 +82,16 @@ test("quota, rate-limit, and model-unavailable failures are fallback eligible", 
   }
 });
 
-test("unrelated failures, preview failures, and successful reviews do not fallback", () => {
+test("opaque review failures fallback, while infrastructure preview failures do not", () => {
   assert.equal(fallbackReason({ code: 1, stderr: "401 unauthorized" }), null);
-  assert.equal(shouldFallback({ code: 1, stderr: "timeout" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), false);
-  assert.equal(shouldFallback({ code: 1, previewFailed: true, stderr: "429" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), false);
+  assert.equal(fallbackReason({ code: 1, stderr: "timeout" }), "review_failed");
+  assert.equal(shouldFallback({ code: 1, stderr: "timeout" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), true);
+  assert.equal(shouldFallback({ code: 1, previewFailed: true, stderr: "429" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), true);
+  assert.equal(shouldFallback({ code: 1, previewFailed: true, stderr: "model unavailable" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), true);
+  assert.equal(shouldFallback({ code: 1, previewFailed: true, stderr: "fatal: bad object" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), false);
   assert.equal(shouldFallback({ code: 0, stderr: "quota exceeded" }, DEFAULT_MODEL, DEFAULT_FALLBACK_MODEL), false);
   assert.equal(failureCategory({ code: 1, previewFailed: true }), "preview_failed");
+  assert.equal(failureCategory({ code: 1, previewFailed: true, stderr: "model unavailable" }), "model_unavailable");
   assert.equal(failureCategory({ code: 1, stderr: "401 unauthorized" }), "review_failed");
   assert.equal(failureCategory({ code: 0, stderr: "success" }), null);
 });

--- a/scripts/verenu-ai-review.mjs
+++ b/scripts/verenu-ai-review.mjs
@@ -278,9 +278,8 @@ async function previewOk(cwd, pr, providerEnvVars, ocrHome) {
   const result = await runOcrAt(cwd, ["review", "--from", pr.base.sha, "--to", pr.head.sha, "--preview"], providerEnvVars, ocrHome);
   if (result.code !== 0) {
     console.log(`ocr preview check failed at ${cwd}: exit ${result.code}: ${result.stderr.slice(0, 300)}`);
-    return false;
   }
-  return true;
+  return result;
 }
 
 function ocrReviewArgs({ baseSha, headSha, model, background }) {
@@ -336,11 +335,10 @@ async function reviewWithQuarantinedWorktree(pr, args, providerEnvVars, ocrHome)
       writeFileSync(dest, content);
     }
 
-    if (!(await previewOk(quarantineDir, pr, providerEnvVars, ocrHome))) {
+    const previewResult = await previewOk(quarantineDir, pr, providerEnvVars, ocrHome);
+    if (previewResult.code !== 0) {
       return {
-        code: 1,
-        stdout: "",
-        stderr: "ocr preview check failed in the quarantined worktree; aborting before the billed review",
+        ...previewResult,
         previewFailed: true,
       };
     }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a local-first review and automation toolchain.
> - The affected subsystem is the GitHub Actions Verenu AI review bot.
> - The bot only retried a narrow set of provider errors and discarded preview output before fallback classification.
> - An unavailable or opaque primary model could therefore fail the workflow without trying the configured fallback model.
> - This pull request preserves infrastructure preview failures while routing provider/model failures to the next model.
> - The benefit is that a broken primary model no longer prevents the automated review from completing with the fallback model.

## What Changed

- Preserve OCR preview results so provider errors remain visible to fallback classification.
- Retry opaque non-preview review failures with the next configured model while keeping authentication and infrastructure failures out of that path.
- Add regression coverage for opaque review failures and provider failures during preview.

## Verification

- `node --test scripts/verenu-ai-review-logic.test.mjs`
- `node --check scripts/verenu-ai-review.mjs`
- `git diff --check`

## Risks

- Low risk. The change is limited to the review bot's model-selection and failure handling. Authentication failures and infrastructure-only preview failures still fail without consuming a fallback attempt.

## Model Used

- OpenAI Codex (GPT-5.6), repository analysis and code edits.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [x] UI changes include before/after screenshots (not applicable)
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789544524&installation_model_id=432577&pr_number=255&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F255&signature=b1eb458c78b5b99d5dce818f1f82fd58b93e36761e8235a70c1ef973cb39173e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->