### PR TITLE
Add Insights analytics page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-See [CLAUDE.md](./CLAUDE.md) for all project context, conventions, and instructions.
+See [CLAUDE.md](./CLAUDE.md) for all project context, conventions, and instructions. Before adding or changing frontend controls, also read [DESIGN.md](./DESIGN.md): it defines the global button and dropdown primitives, animation rules, and control inventory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ Verenu is an open-source AI dictation desktop app for Windows and macOS — a fr
 
 ## Design System
 
-See [docs/colors.md](docs/colors.md) for the complete color palette, typography, and theming system.
+Read [DESIGN.md](DESIGN.md) before creating or restyling frontend controls. It is the source of truth for shared button variants, dropdown anatomy, UI motion, and the complete control inventory. See [docs/colors.md](docs/colors.md) for the complete color palette, typography, and theming system.
+
+Shared interactive styles live in `src/ui.css`; do not recreate `.btn-primary`, `.btn-ghost`, `.btn-danger`, or `.ui-dropdown-*` styles inside a Svelte component. Preserve feature-specific controls when they communicate a distinct state, such as navigation, recording, selection cards, or system permissions.
 
 ## Build & Dev Commands
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,127 @@
+# Verenu UI Design System
+
+This is the source of truth for shared frontend controls. Use it before adding or changing a button, dropdown, toggle, or control animation.
+
+## Source of truth
+
+| File | Owns |
+| --- | --- |
+| [`src/theme.css`](src/theme.css) | Themeable color, typography, radius, layout, and base elevation tokens. |
+| [`src/ui.css`](src/ui.css) | Shared button states, dropdown anatomy, focus feedback, and CSS motion tokens. |
+| [`src/lib/motion.ts`](src/lib/motion.ts) | Svelte transition timing, distance, reduced-motion behavior, and reusable transition helpers. |
+| [`src/lib/components/Dropdown.svelte`](src/lib/components/Dropdown.svelte) | Headless outside-click and Escape handling for composed dropdowns. |
+| [`src/lib/components/Toggle.svelte`](src/lib/components/Toggle.svelte) | The shared accessible switch control. The `toggle` class is a smoke-test contract. |
+| [`docs/colors.md`](docs/colors.md) | Palette and typography reference. |
+
+Do not define `.btn-primary`, `.btn-ghost`, `.btn-danger`, `.ui-dropdown-*`, or their basic interactive states inside a Svelte component. Add a semantic modifier only for layout or content that the primitive cannot know, such as a menu width or text truncation.
+
+## Standard controls
+
+### Buttons
+
+```svelte
+<!-- One obvious next action. -->
+<button class="btn-primary" onclick={save}>Save changes</button>
+
+<!-- A secondary, non-destructive action. -->
+<button class="btn-ghost" onclick={cancel}>Cancel</button>
+
+<!-- A destructive action. Use an explicit label. -->
+<button class="btn-danger" onclick={deleteItem}>Delete history</button>
+
+<!-- Use only when the surrounding control is intentionally compact. -->
+<button class="btn-primary btn-compact" onclick={add}>Add</button>
+```
+
+| Variant | Use for | Shared behavior |
+| --- | --- | --- |
+| `btn-primary` | The main action in a local context, such as Save, Add, or Confirm. | Ink surface, strong contrast, hover, disabled state, focus ring. |
+| `btn-ghost` | Secondary actions, utilities, external links, and dismiss actions. | Transparent surface, bordered hover state, disabled state, focus ring. |
+| `btn-danger` | Confirmed destructive actions only. | Warning surface, filled destructive hover, disabled state, focus ring. |
+| `btn-compact` | A space-constrained button that still has a complete label. | Reduces height, padding, and type size. It is a size modifier, not a visual variant. |
+
+Do not use a standard button for navigation rows, selection cards, tabs, microphone recording, or the dictation pill. Those controls communicate different states and are intentionally specialized.
+
+### Dropdowns
+
+Use the structural classes on a feature-local dropdown. This centralizes visual treatment while allowing each feature to retain typed values, option descriptions, width constraints, and keyboard behavior.
+
+```svelte
+<script lang="ts">
+  import Dropdown from '$lib/components/Dropdown.svelte';
+
+  let open = $state(false);
+</script>
+
+<Dropdown bind:open closeSelector=".example-dropdown">
+  <div class="ui-dropdown example-dropdown">
+    <button
+      class="btn-ghost ui-dropdown-trigger"
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      onclick={() => (open = !open)}
+    >
+      Current option
+      <svg aria-hidden="true">...</svg>
+    </button>
+
+    {#if open}
+      <div class="ui-dropdown-menu" role="listbox">
+        <button class="ui-dropdown-option active" role="option" aria-selected="true">Current option</button>
+      </div>
+    {/if}
+  </div>
+</Dropdown>
+```
+
+| Class | Responsibility |
+| --- | --- |
+| `ui-dropdown` | Anchors a menu to its trigger. |
+| `ui-dropdown-trigger` | Trigger shape, chevron motion, focus ring, and open treatment. Combine with `btn-ghost` when it is a secondary setting control. |
+| `ui-dropdown-menu` | Popover surface, stacking, border, shadow, and scroll behavior. |
+| `ui-dropdown-option` | Option row, selected state, hover, focus, and text overflow. |
+| `ui-dropdown-menu--padded` | Use for compact choice lists that need separated rounded options rather than row dividers. |
+
+`Dropdown.svelte` closes on outside click and Escape. Keep feature-local keyboard logic only when it has a real job, such as arrow-key listbox navigation or restoring focus to a particular trigger.
+
+## Interaction and motion
+
+| Token or helper | Value | Use |
+| --- | --- | --- |
+| `--ui-duration-fast` | `150ms` | Hover, focus, chevron rotation, button feedback. |
+| `--ui-duration-base` | `220ms` | A shared CSS duration reserved for more deliberate control transitions. |
+| `--ui-ease-out` | `cubic-bezier(0.22, 1, 0.36, 1)` | CSS control transitions. |
+| `MOTION_MS.fast` | `150` | Short Svelte transitions. |
+| `MOTION_MS.base` | `220` | Standard Svelte transitions. |
+| `MOTION_MS.panel` | `280` | Menu and panel entrance transitions. |
+
+Shared controls must use opacity, color, border, or transform for motion. Do not animate layout properties in CSS. `src/lib/motion.ts` scales transition duration and distance for users who prefer reduced motion; `src/ui.css` shortens its CSS durations to match.
+
+## Current inventory
+
+Audit performed 2026-08-05. The app contains 172 `<button>` elements, two visually-hidden native `<select>` elements that mirror custom listboxes, 98 static button class combinations, and 106 unique button class tokens. The list below assigns every current token to a design role so a new control can be matched to an existing role before another one is invented.
+
+| Category | Existing classes or roles | Standardization status |
+| --- | --- | --- |
+| Shared actions | `btn-primary`, `btn-ghost`, `btn-danger`, `btn-compact`, `add-btn`, `btn-clear`, `cal-btn`, `load-older-btn`, `notification-test-send-button`, `simulation-provider-button` | The first four are global in `src/ui.css`. The remaining tokens are layout or feature modifiers on an action. |
+| Dropdown anatomy | `ui-dropdown`, `ui-dropdown-trigger`, `ui-dropdown-menu`, `ui-dropdown-option`, `ui-dropdown-menu--padded`, `notification-test-item`, `simulation-provider-item` | Global in `src/ui.css`. Used by language, microphone, app mapping, transcription strategy, local-model memory policy, provider simulation, and notification-test menus. |
+| Switches and recording | `toggle`, `mic-btn`, `hf-btn`, `cancel`, `confirm`, `badge`, `key-badge`, `keybind-btn`, `local-meta-toggle` | Shared components or flow-specific controls. Do not flatten recording states into a normal button. |
+| Application navigation | `nav-item`, `settings-nav-item`, `settings-back`, `btn-back`, `tab`, `shot-nav`, `dot`, `dl-cancel` | Navigation-specific. Preserve smoke-test selectors. |
+| List selections | `dict-row`, `snip-row`, `lang-row`, `app-picker-item`, `language-item`, `mic-item`, `models-dropdown-item`, `profile-drop-item`, `cleanup-drop-item`, `row-drop-item`, `mapping-badge-btn` | Selection controls. Inherit dropdown option styles where they are menu options. |
+| Cards and accordions | `pick-card`, `env-card`, `provider-card`, `style-card`, `fork-card`, `tile-head`, `preset-select`, `state-pill`, `muted`, `card-btn`, `accent`, `ghost`, `flip-face`, `front`, `back` | Intentional feature-specific choices. They communicate a selected surface or disclosure state, not a generic action. |
+| Inspector actions | `btn-insp-edit`, `btn-insp-delete`, `mapping-delete-btn`, `remove-dot` | Destructive or contextual row actions. Keep feature-local confirmation state. |
+| Modal controls | `modal-backdrop`, `icon-btn`, `prompt-modal-close`, `prompt-btn`, `prompt-btn-ghost`, `snippet-nudge` | Modal mechanics and layout vary. Reuse standard action variants for modal footer actions. |
+| Form and settings utilities | `appearance-option`, `badge key-badge keybind-btn`, `cleanup-off-link`, `language-btn`, `mic-btn`, `models-dropdown-btn`, `notification-test-dropdown-button`, `simulation-provider-button`, `profile-drop-btn`, `cleanup-drop-btn` | Dropdown triggers use the global anatomy. Other controls remain semantic. |
+| Setup and calibration | `btn-skip`, `cal-cancel-btn`, `cal-cancel-icon-btn`, `cal-recalibrate-btn`, `btn-open`, `btn-got-key`, `show-btn`, `help-btn`, `tryit-reset`, `lang-clear` | Setup flow has deliberate pacing and spatial constraints. Do not swap in a primary button without checking the flow. |
+| Downloads and providers | `card-btn`, `accent`, `ghost`, `show-more-btn`, `custom-add-btn`, `custom-toggle-btn`, `simple-name`, `model-name`, `add-fallback-btn`, `preset-action-btn`, `prompt-edit-btn` | Feature-specific actions. Reassess only after three matching uses emerge. |
+| Permissions and system actions | `perm-action`, `permission-details-toggle`, `permission-refresh-btn`, `btn-repair`, `version-tap`, `desc` | System and permission states need their own semantics and feedback. |
+| History and feedback | `copy-btn`, `copy-logs-btn`, `retry-btn`, `load-warning-retry`, `load-older-btn`, `clear-btn`, `sort-pill`, `status-link`, `update-btn`, `update-dismiss`, `toast-close` | Feedback and one-off recovery actions. Prefer `btn-ghost` if a new use has no unique feedback state. |
+| Native select mirrors | `profile-select profile-select-hidden`, `cleanup-select cleanup-select-hidden` | Accessibility mirrors for app-mapping custom listboxes. Keep synchronized with their visible dropdown choices. |
+
+## Adoption rules
+
+1. Start with `btn-primary`, `btn-ghost`, or `btn-danger` for a new action. Add `btn-compact` only when density requires it.
+2. Start a new dropdown with the five `ui-dropdown` classes and the headless `Dropdown` controller. Give a feature its own behavior only when the selection logic needs it.
+3. Before extracting another control, confirm the same semantic intent appears at least three times. Similar pixels are not enough.
+4. Keep colors, radii, focus states, and core motion in `src/theme.css`, `src/ui.css`, or `src/lib/motion.ts`, never in a copied component rule.
+5. Preserve selectors named in `CLAUDE.md`'s smoke-test contract, even when their visual treatment moves into a shared primitive.

--- a/docs/insights-backend-brief.md
+++ b/docs/insights-backend-brief.md
@@ -1,0 +1,176 @@
+# Insights backend brief
+
+The Insights page (`src/lib/views/Insights.svelte`) is built and shipping against a
+mock. It calls exactly one Tauri command that does not exist yet. Your job is to
+implement that command so the page renders real data. **Do not change the frontend
+contract** — the page, its formatting, and its charts are already tuned to it.
+
+---
+
+## The command
+
+```rust
+#[tauri::command]
+fn get_insights(days: i64, /* state */) -> Result<Insights, String>
+```
+
+- Invoked from the frontend as `invoke('get_insights', { days })`.
+- `days` is one of `7 | 30 | 90 | 0`, where **`0` means all time**.
+- Register it in `src-tauri/src/commands/mod.rs` and in the `invoke_handler` list in
+  `src-tauri/src/main.rs`, alongside `get_stats` / `get_recent`.
+- Serde field names must match the TypeScript below **exactly** (snake_case as written).
+
+## The payload contract
+
+Source of truth: `src/lib/views/insights/types.ts`. Mirror it field for field.
+
+```ts
+export interface InsightsPayload {
+  range_days: number;                 // echo the requested window (7 | 30 | 90 | 0)
+  generated_at: string;               // "YYYY-MM-DD HH:MM:SS" UTC-naive, like created_at
+
+  totals: {
+    total_words: number;              // LIFETIME, from lifetime_stats — not the range
+    total_transcriptions: number;     // in range
+    total_speaking_ms: number;        // in range
+    avg_words_per_transcription: number;
+    avg_wpm: number;                  // spoken_words / duration
+    best_wpm: number;
+    words_in_range: number;
+    words_prev_range: number;         // same-length window immediately before the range
+  };
+
+  streak: {
+    current_days: number;
+    longest_days: number;
+    longest_started_on: string | null;   // "YYYY-MM-DD"
+    longest_ended_on: string | null;
+    longest_words: number;               // words dictated during the longest streak
+    active_days: number;                 // days with >=1 dictation, all time
+  };
+
+  daily: Array<{ day: string; words: number; transcriptions: number; speaking_ms: number }>;
+  hourly: number[];                   // exactly 24 entries, words per hour-of-day, local
+
+  providers: Array<{
+    model: string;                    // e.g. "whisper-large-v3-turbo"
+    provider: 'groq' | 'openai' | 'google' | 'local';
+    task: 'transcription' | 'cleanup';
+    calls: number;
+    audio_ms: number;                 // transcription models; 0 for cleanup
+    input_chars: number;              // cleanup models; 0 for transcription
+    output_chars: number;
+  }>;
+
+  cleanup: {
+    raw_words: number;                // pre-cleanup
+    clean_words: number;              // post-cleanup
+    edits_applied: number;            // dictionary substitutions + snippet expansions
+    dictionary_fixes: number;
+    auto_learned_terms: number;
+  };
+
+  words: {
+    top: Array<{ word: string; count: number }>;      // stopword-filtered, top 12
+    unique_words: number;
+    longest_word: string | null;
+    avg_word_length: number;
+  };
+}
+```
+
+## Rules that are easy to get wrong
+
+1. **Local-day bucketing.** `created_at` is stored UTC-naive. Every day and hour bucket
+   must go through `date(created_at, 'localtime')` / `strftime('%H', created_at,
+   'localtime')`. `query_stats()` in `src-tauri/src/data/db/transcriptions.rs` already
+   does this — follow its style for the whole module.
+2. **Zero-fill `daily` server-side.** The frontend chart assumes one row per calendar
+   day in the range, ascending, with `words: 0` for idle days. Do not send a sparse
+   series. For `days == 0`, span the first recorded transcription through today.
+3. **`hourly` is always length 24**, index 0 = midnight local, zeros included.
+4. **`totals.total_words` is lifetime**, read from the `lifetime_stats` table so it
+   never shrinks when retention pruning runs. Everything else is range-scoped from
+   `transcriptions` and legitimately does shrink — that asymmetry is intentional.
+5. **`words_prev_range`** is the immediately-preceding window of the same length. For
+   `days == 0` return `0`; the frontend then hides the delta pill.
+6. **Stopword-filter `words.top`.** Strip the obvious English filler ("the", "a",
+   "and", "to", "of", "it", "is", …) and anything under 3 characters, lowercase and
+   punctuation-strip before counting. The point is showing the user their distinctive
+   vocabulary, not "the ×4,102". Count from `clean_text`.
+7. **Unknown/empty is not an error.** A brand-new install with no transcriptions must
+   return a fully-populated zero payload, not an `Err`. The page has a dedicated empty
+   state keyed off `totals.total_transcriptions == 0`.
+8. **Privacy.** This runs entirely locally. Do not log dictated text, top words, or any
+   `clean_text` content — counts, ids, and model names only (see the logging rules in
+   `CLAUDE.md`).
+
+## Schema — what already exists
+
+`src-tauri/src/data/db/schema.rs`:
+
+```sql
+CREATE TABLE transcriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, raw_text TEXT, clean_text TEXT,
+  words INTEGER, spoken_words INTEGER, duration_ms INTEGER,
+  api_used TEXT, created_at DATETIME DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_transcriptions_created_at ON transcriptions(created_at);
+CREATE TABLE lifetime_stats (id PK CHECK(id=1), total_words INTEGER);
+```
+
+So `spoken_words`, `duration_ms`, `api_used`, `raw_text` and `clean_text` are already
+recorded and unused by the UI — most of the payload comes straight out of this table
+with no migration.
+
+**The one gap is cost.** `providers[]` needs per-call `audio_ms`, `input_chars`, and
+`output_chars` split by model *and* task. `api_used` today records a single string and
+doesn't separate the transcription model from the cleanup model, nor carry token/char
+counts. Pick one:
+
+- **Preferred:** add an `api_calls` table (`id, transcription_id, model, provider,
+  task, audio_ms, input_chars, output_chars, created_at`) written from
+  `src-tauri/src/pipeline/finalize.rs`, and aggregate it here. Historical rows simply
+  won't have cost data, which is fine — the card degrades to "No priced API usage in
+  this range."
+- **Cheaper:** derive approximate values from `duration_ms` (audio) and
+  `length(raw_text)` / `length(clean_text)` (chars), attributing them to the models
+  named in the current settings. Less accurate, no migration.
+
+Either way the *pricing* is the frontend's problem — `src/lib/views/insights/pricing.ts`
+holds the static rate table and does the arithmetic. Send raw usage, not dollars.
+
+## `cleanup` block sourcing
+
+- `raw_words` / `clean_words`: word counts of `raw_text` and `clean_text` in range.
+  `spoken_words` may already serve for `raw_words` — check before recomputing.
+- `dictionary_fixes`: `SUM(correction_count)` from the `dictionary` table.
+- `auto_learned_terms`: `COUNT(*) WHERE auto_learned = 1`.
+- `edits_applied`: dictionary substitutions + snippet expansions. If there's no counter
+  today, add one rather than guessing — `SUM(use_count)` on `snippets` plus
+  `dictionary_fixes` is an acceptable first cut.
+
+## Where the code goes
+
+- Queries: a new `src-tauri/src/data/db/insights.rs`, exported from `data/db/mod.rs`.
+- Command handler: `src-tauri/src/commands/mod.rs` (or a small `commands/insights.rs`).
+- Match the existing `anyhow::Result` + `.map_err(|e| e.to_string())` convention.
+
+## Tests
+
+Add Rust unit tests against an in-memory DB covering, at minimum:
+
+- Zero-fill: a range with a gap day yields a contiguous ascending `daily` with a zero.
+- Streak: a 3-day run followed by a gap gives `longest_days == 3` with the right
+  start/end dates, and `current_days == 0`.
+- Local-day boundary: a transcription written just before local midnight buckets to the
+  local day, not the UTC one.
+- Empty DB returns a zero payload, not an error.
+- `words.top` excludes stopwords and is sorted descending.
+
+## Definition of done
+
+`npm run test:rust` and `npm test` pass, and the Insights page shows real numbers in
+`npm run tauri dev`. Once real data flows, the dev mock in `devInvoke`
+(`src/lib/tauri.ts`, `case 'get_insights'` → `devInsights()`) **stays** — it's what
+keeps browser dev and the Playwright smoke tests working without a backend.

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -2,7 +2,8 @@ use std::sync::MutexGuard;
 
 use crate::core::window_geometry::WindowTarget;
 use crate::pipeline::{self, hide_pill, start_recording_session, AppState, SharedState};
-use tauri::Emitter;
+use crate::DbHandle;
+use tauri::{Emitter, Manager};
 
 fn lock_app_state(state: &SharedState) -> Option<MutexGuard<'_, AppState>> {
     match state.lock() {
@@ -24,6 +25,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         HandlessToggle,
         Cancel,
         EscapeCancel,
+        CopyLast,
     }
 
     let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::unbounded_channel::<HotkeyEvent>();
@@ -31,6 +33,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
     let tx_handless = hotkey_tx.clone();
     let tx_cancel = hotkey_tx.clone();
     let tx_escape = hotkey_tx.clone();
+    let tx_copy_last = hotkey_tx.clone();
     let tx_release = hotkey_tx;
 
     match crate::core::hotkey::start(
@@ -48,6 +51,9 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         },
         move || {
             let _ = tx_escape.send(HotkeyEvent::EscapeCancel);
+        },
+        move || {
+            let _ = tx_copy_last.send(HotkeyEvent::CopyLast);
         },
     ) {
         Ok(_handle) => { /* hook thread running */ }
@@ -206,19 +212,25 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         ));
                     } else {
                         // First click of a double-tap gesture outside handsfree:
-                        // discard the short recording that just started.
+                        // cancel the short recording that just started, but
+                        // stash its audio (if long/loud enough) so the pill's
+                        // Continue button can resume it instead of losing it.
                         let taken = pipeline::take_recording_plain(&state_hk);
                         if let Some((session, exclusive_mic_session_id)) = taken {
-                            tauri::async_runtime::spawn_blocking(move || {
-                                let _ = session.stop();
-                                if let Some(session_id) = exclusive_mic_session_id {
-                                    crate::system::volume::release_mic(session_id);
-                                }
-                                crate::media::sound::coordinated_unmute();
-                                crate::system::media_control::end_dictation_media_pause();
+                            let app_for_cancel = app_hk.clone();
+                            let state_for_cancel = state_hk.clone();
+                            tauri::async_runtime::spawn(async move {
+                                pipeline::cancel_recording_with_resume(
+                                    &app_for_cancel,
+                                    &state_for_cancel,
+                                    session,
+                                    exclusive_mic_session_id,
+                                )
+                                .await;
                             });
+                        } else {
+                            hide_pill(&app_hk);
                         }
-                        hide_pill(&app_hk);
                     }
                 }
 
@@ -230,28 +242,81 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                     // Cancel in-flight processing outright — no append, no
                     // insertion. Distinct from the pre-Release recording-cancel
                     // path below (a dictation can be in at most one of the two).
+                    // Its audio already cleared the pipeline's own quality gate
+                    // to get this far, so stash it unconditionally for Continue.
                     if let Some(active) = pipeline::take_active_pipeline_for_escape(&state_hk) {
                         let _ = active.cancel_tx.send(true);
-                        hide_pill(&app_hk);
+                        pipeline::stash_cancelled_capture(
+                            &app_hk,
+                            &state_hk,
+                            active.captured_audio,
+                        );
                         continue;
                     }
 
+                    // Cancel sound cue (if any) is now played inside
+                    // cancel_recording_with_resume/stash_cancelled_capture,
+                    // consistently across every cancel path.
                     let taken = pipeline::take_recording_plain(&state_hk);
-                    let had_recording = taken.is_some();
                     if let Some((session, exclusive_mic_session_id)) = taken {
-                        tauri::async_runtime::spawn_blocking(move || {
-                            let _ = session.stop();
-                            if let Some(session_id) = exclusive_mic_session_id {
-                                crate::system::volume::release_mic(session_id);
-                            }
-                            crate::media::sound::coordinated_unmute();
-                            crate::system::media_control::end_dictation_media_pause();
+                        let app_for_cancel = app_hk.clone();
+                        let state_for_cancel = state_hk.clone();
+                        tauri::async_runtime::spawn(async move {
+                            pipeline::cancel_recording_with_resume(
+                                &app_for_cancel,
+                                &state_for_cancel,
+                                session,
+                                exclusive_mic_session_id,
+                            )
+                            .await;
                         });
+                    } else {
+                        // Nothing was recording/processing — if the pill is
+                        // currently showing a pending "Cancelled -> Undo"
+                        // offer, Escape dismisses it (same as clicking the
+                        // pill's own dismiss button).
+                        if pipeline::take_cancelled_capture_if_fresh(&state_hk).is_some() {
+                            pipeline::emit_cancelled_capture_cleared(&app_hk);
+                        }
+                        hide_pill(&app_hk);
                     }
-                    if had_recording && pipeline::start_stop_sounds_enabled(&app_hk) {
-                        crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
-                    }
-                    hide_pill(&app_hk);
+                }
+
+                HotkeyEvent::CopyLast => {
+                    // Global fallback for a paste that failed silently (not
+                    // caught by the pipeline's own detection): re-copy the
+                    // most recent dictation to the clipboard on demand.
+                    let db_handle = app_hk.state::<DbHandle>().inner().clone();
+                    let app_for_copy = app_hk.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let recent = tokio::task::spawn_blocking(move || {
+                            crate::data::db::query_recent_page(&db_handle, 1, 0)
+                        })
+                        .await
+                        .ok()
+                        .and_then(|r| r.ok())
+                        .unwrap_or_default();
+                        match recent.into_iter().next() {
+                            Some(entry) if !entry.clean_text.trim().is_empty() => {
+                                if let Err(e) =
+                                    crate::core::injection::copy_to_clipboard(&entry.clean_text)
+                                        .await
+                                {
+                                    log::warn!(
+                                        "hotkey: copy-last-dictation clipboard write failed: {e}"
+                                    );
+                                    return;
+                                }
+                                pipeline::show_copied_pill(
+                                    &app_for_copy,
+                                    "Copied last dictation to clipboard",
+                                );
+                            }
+                            _ => {
+                                pipeline::show_copied_pill(&app_for_copy, "Nothing to copy yet");
+                            }
+                        }
+                    });
                 }
             }
         }

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -286,7 +286,14 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                     // Global fallback for a paste that failed silently (not
                     // caught by the pipeline's own detection): re-copy the
                     // most recent dictation to the clipboard on demand.
-                    let db_handle = app_hk.state::<DbHandle>().inner().clone();
+                    // try_state — a hotkey can fire during teardown when
+                    // managed state is already gone, and panicking in the
+                    // hook thread would take the app down.
+                    let Some(db_handle) = app_hk.try_state::<DbHandle>() else {
+                        log::warn!("CopyLast hotkey: DbHandle not managed, skipping");
+                        continue;
+                    };
+                    let db_handle = db_handle.inner().clone();
                     let app_for_copy = app_hk.clone();
                     tauri::async_runtime::spawn(async move {
                         let recent = tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -29,6 +29,17 @@ pub async fn get_stats(app: AppHandle) -> Result<db::Stats, String> {
     .await
 }
 
+/// Aggregated insights for the Insights page. `days` is 7 | 30 | 90 | 0,
+/// where 0 means all time.
+#[tauri::command]
+pub async fn get_insights(app: AppHandle, days: i64) -> Result<db::Insights, String> {
+    let db = db_state(&app);
+    run_blocking("get_insights", move || {
+        db::query_insights(&db, days).map_err(|e| e.to_string())
+    })
+    .await
+}
+
 #[tauri::command]
 pub async fn count_old_transcriptions(app: AppHandle, retention: String) -> Result<i64, String> {
     let Some(days) = store::history_retention_days(&retention) else {

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -288,7 +288,9 @@ pub async fn stop_calibration_monitoring(
                             speech.longest_segment_ms
                         );
                     }
-                    Err(e) => log::warn!("calibration: VAD unavailable, falling back to level check: {e}"),
+                    Err(e) => {
+                        log::warn!("calibration: VAD unavailable, falling back to level check: {e}")
+                    }
                 }
             }
             Ok(None) => log::warn!("calibration: capture returned no audio"),
@@ -396,7 +398,10 @@ pub async fn resume_cancelled_capture(
 /// for the full `CANCEL_RESUME_WINDOW` regardless of whether the toast is
 /// still on screen.
 #[tauri::command]
-pub async fn dismiss_cancelled_capture(app: AppHandle, state: tauri::State<'_, SharedState>) -> Result<(), String> {
+pub async fn dismiss_cancelled_capture(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
     if pipeline::take_cancelled_capture_if_fresh(state.inner()).is_some() {
         pipeline::emit_cancelled_capture_cleared(&app);
     }
@@ -411,10 +416,15 @@ pub async fn dismiss_cancelled_capture(app: AppHandle, state: tauri::State<'_, S
 pub async fn copy_paste_failure_to_clipboard(
     state: tauri::State<'_, SharedState>,
 ) -> Result<(), String> {
-    let Some(text) = pipeline::take_paste_failure_if_fresh(state.inner()) else {
+    // Peek rather than take: if the clipboard write fails (transient system
+    // clipboard lock/error), the text stays available so the user can retry.
+    // The slot is only cleared once the copy actually succeeds.
+    let Some(text) = pipeline::peek_paste_failure_if_fresh(state.inner()) else {
         return Err("Nothing to copy".to_string());
     };
     crate::core::injection::copy_to_clipboard(&text)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    pipeline::clear_paste_failure(state.inner());
+    Ok(())
 }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -378,8 +378,16 @@ pub async fn resume_cancelled_capture(
     app: AppHandle,
     state: tauri::State<'_, SharedState>,
 ) -> Result<(), String> {
-    let _audio = pipeline::reserve_starting_with_cancelled_capture(state.inner())?;
-    pipeline::emit_cancelled_capture_cleared(&app);
+    // Reserve first so a busy state fails before anything is consumed. The
+    // stashed capture is only cleared once the new session is actually
+    // underway — a mid-start failure (mic permissions, poisoned lock) must
+    // leave it resumable rather than destroying the audio.
+    pipeline::reserve_starting(state.inner())?;
+    let Some(audio) = pipeline::peek_cancelled_capture_if_fresh(state.inner()) else {
+        pipeline::cancel_starting_reservation(state.inner());
+        return Err("Nothing to resume".to_string());
+    };
+    pipeline::set_starting_prepend_audio(state.inner(), audio);
     let target = WindowTarget::capture_foreground();
     {
         let mut st = lock_state(&state)?;
@@ -388,6 +396,8 @@ pub async fn resume_cancelled_capture(
     }
     pipeline::start_recording_session(&app, state.inner(), "handsfree", true);
     crate::core::hotkey::set_handless_active(true);
+    pipeline::clear_cancelled_capture(state.inner());
+    pipeline::emit_cancelled_capture_cleared(&app);
     Ok(())
 }
 

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -368,11 +368,8 @@ pub async fn resume_cancelled_capture(
     app: AppHandle,
     state: tauri::State<'_, SharedState>,
 ) -> Result<(), String> {
-    let Some(audio) = pipeline::take_cancelled_capture_if_fresh(state.inner()) else {
-        return Err("Nothing to resume".to_string());
-    };
+    let _audio = pipeline::reserve_starting_with_cancelled_capture(state.inner())?;
     pipeline::emit_cancelled_capture_cleared(&app);
-    pipeline::reserve_starting_with_prepend(state.inner(), audio)?;
     let target = WindowTarget::capture_foreground();
     {
         let mut st = lock_state(&state)?;

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -319,23 +319,26 @@ pub async fn stop_recording(
 ) -> Result<(), String> {
     crate::core::hotkey::set_handless_active(false);
     let taken = pipeline::take_recording_plain(state.inner());
+    if let Some(manager) = app.try_state::<crate::local_stt::LocalTranscriptionManager>() {
+        manager.set_recording_active(false);
+    }
     if let Some((session, exclusive_mic_session_id)) = taken {
-        tauri::async_runtime::spawn_blocking(move || {
-            let _ = session.stop();
-            if let Some(session_id) = exclusive_mic_session_id {
-                crate::system::volume::release_mic(session_id);
-            }
-            crate::media::sound::coordinated_unmute();
-            crate::system::media_control::end_dictation_media_pause();
+        let app_for_cancel = app.clone();
+        let state_for_cancel = state.inner().clone();
+        tauri::async_runtime::spawn(async move {
+            pipeline::cancel_recording_with_resume(
+                &app_for_cancel,
+                &state_for_cancel,
+                session,
+                exclusive_mic_session_id,
+            )
+            .await;
         });
     } else {
         crate::media::sound::coordinated_unmute();
         crate::system::media_control::end_dictation_media_pause();
+        pipeline::hide_pill(&app);
     }
-    if let Some(manager) = app.try_state::<crate::local_stt::LocalTranscriptionManager>() {
-        manager.set_recording_active(false);
-    }
-    pipeline::hide_pill(&app);
     Ok(())
 }
 
@@ -354,4 +357,59 @@ pub async fn stop_handless_mode(
         crate::system::media_control::end_dictation_media_pause();
     }
     Ok(())
+}
+
+/// Resumes a cancelled recording's audio: starts a fresh hands-free
+/// recording that will be prepended with the previously-captured audio when
+/// it stops, so the finished dictation reads as one continuous take. Errs if
+/// the capture already expired or was already resumed/dismissed.
+#[tauri::command]
+pub async fn resume_cancelled_capture(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    let Some(audio) = pipeline::take_cancelled_capture_if_fresh(state.inner()) else {
+        return Err("Nothing to resume".to_string());
+    };
+    pipeline::emit_cancelled_capture_cleared(&app);
+    pipeline::reserve_starting_with_prepend(state.inner(), audio)?;
+    let target = WindowTarget::capture_foreground();
+    {
+        let mut st = lock_state(&state)?;
+        st.target = target;
+        st.pill_placement_stale = true;
+    }
+    pipeline::start_recording_session(&app, state.inner(), "handsfree", true);
+    crate::core::hotkey::set_handless_active(true);
+    Ok(())
+}
+
+/// Discards a cancelled recording's stashed audio without resuming it —
+/// called when the user explicitly dismisses the offer, either the pill's
+/// own dismiss (X) button or Home's dismiss button. The pill toast's plain
+/// 10s auto-hide does *not* call this: the capture stays resumable from Home
+/// for the full `CANCEL_RESUME_WINDOW` regardless of whether the toast is
+/// still on screen.
+#[tauri::command]
+pub async fn dismiss_cancelled_capture(app: AppHandle, state: tauri::State<'_, SharedState>) -> Result<(), String> {
+    if pipeline::take_cancelled_capture_if_fresh(state.inner()).is_some() {
+        pipeline::emit_cancelled_capture_cleared(&app);
+    }
+    Ok(())
+}
+
+/// Puts a failed dictation's text back on the clipboard so the user can
+/// paste it manually — called from the pill's "Paste failed" Copy button.
+/// The text itself never crosses to the frontend; only this command's
+/// success/failure result does.
+#[tauri::command]
+pub async fn copy_paste_failure_to_clipboard(
+    state: tauri::State<'_, SharedState>,
+) -> Result<(), String> {
+    let Some(text) = pipeline::take_paste_failure_if_fresh(state.inner()) else {
+        return Err("Nothing to copy".to_string());
+    };
+    crate::core::injection::copy_to_clipboard(&text)
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -325,7 +325,7 @@ pub async fn stop_recording(
     if let Some((session, exclusive_mic_session_id)) = taken {
         let app_for_cancel = app.clone();
         let state_for_cancel = state.inner().clone();
-        tauri::async_runtime::spawn(async move {
+        let handle = tauri::async_runtime::spawn(async move {
             pipeline::cancel_recording_with_resume(
                 &app_for_cancel,
                 &state_for_cancel,
@@ -333,6 +333,14 @@ pub async fn stop_recording(
                 exclusive_mic_session_id,
             )
             .await;
+        });
+        // The join handle is deliberately not awaited inline (stop_recording
+        // returns immediately), but a panicked/aborted task would otherwise
+        // be swallowed silently — log it so a broken cancel path is visible.
+        tauri::async_runtime::spawn(async move {
+            if handle.await.is_err() {
+                log::error!("cancel_recording_with_resume task panicked or was aborted");
+            }
         });
     } else {
         crate::media::sound::coordinated_unmute();

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -64,6 +64,7 @@ static RELEASE_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 static HANDLESS_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 static CANCEL_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 static ESCAPE_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
+static COPY_LAST_CB: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
 
 static CHORD_ACTIVE: AtomicBool = AtomicBool::new(false);
 static HANDLESS_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -100,6 +101,10 @@ static MANAGER: OnceLock<GlobalHotKeyManager> = OnceLock::new();
 static CURRENT_HOTKEY: Mutex<Option<HotKey>> = Mutex::new(None);
 static MAIN_HOTKEY_ID: AtomicU32 = AtomicU32::new(0);
 static ESCAPE_HOTKEY: OnceLock<HotKey> = OnceLock::new();
+// ⌥⌘C: always-registered fallback to re-copy the last dictation, in case
+// paste failed in a way the pipeline's own detection missed. Unlike Escape
+// this is registered permanently at startup, not just while recording.
+static COPY_LAST_HOTKEY: OnceLock<HotKey> = OnceLock::new();
 // `Mutex<bool>` (not an atomic) so the check and the register/unregister call are
 // one critical section — `set_escape_listening` is invoked from both the hotkey
 // event thread and Tauri command threads, and a lock-free swap could interleave
@@ -117,6 +122,14 @@ fn now_ms() -> u64 {
 /// from recording our own Cmd+V into the injection history. Without the tap this
 /// is a no-op (kept to satisfy the shared cross-platform contract).
 pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
+
+/// There's no Windows key on macOS — kept to satisfy the shared contract.
+pub fn is_win_key_down() -> bool {
+    false
+}
+
+/// No-op on macOS — see `is_win_key_down`.
+pub fn force_release_win_key() {}
 
 pub fn update_keys(k1: u32, k2: u32) {
     KEY1.store(k1, Ordering::SeqCst);
@@ -422,6 +435,17 @@ fn register_main_hotkey() {
     }
 }
 
+fn register_copy_last_hotkey() {
+    let Some(mgr) = MANAGER.get() else {
+        return;
+    };
+    let hk = *COPY_LAST_HOTKEY
+        .get_or_init(|| HotKey::new(Some(Modifiers::ALT | Modifiers::META), Code::KeyC));
+    if let Err(e) = mgr.register(hk) {
+        log::warn!("hotkey: failed to register copy-last-dictation hotkey: {e}");
+    }
+}
+
 /// Register/unregister a plain-Escape hotkey for the duration of an active
 /// recording so the user can cancel mid-dictation. We keep it transient because
 /// a registered hotkey is consumed system-wide — we don't want to swallow Escape
@@ -460,6 +484,14 @@ fn handle_hotkey_event(ev: GlobalHotKeyEvent) {
     if ESCAPE_HOTKEY.get().is_some_and(|h| h.id() == ev.id) {
         if matches!(ev.state, HotKeyState::Pressed) {
             on_escape_pressed();
+        }
+        return;
+    }
+    if COPY_LAST_HOTKEY.get().is_some_and(|h| h.id() == ev.id) {
+        if matches!(ev.state, HotKeyState::Pressed) {
+            if let Some(cb) = COPY_LAST_CB.get() {
+                cb();
+            }
         }
         return;
     }
@@ -532,12 +564,13 @@ fn on_escape_pressed() {
 
 // --- start -----------------------------------------------------------------
 
-pub fn start<P, R, H, C, E>(
+pub fn start<P, R, H, C, E, L>(
     on_press: P,
     on_release: R,
     on_handless: H,
     on_cancel: C,
     on_escape: E,
+    on_copy_last: L,
 ) -> Result<std::thread::JoinHandle<()>, String>
 where
     P: Fn() + Send + Sync + 'static,
@@ -545,6 +578,7 @@ where
     H: Fn() + Send + Sync + 'static,
     C: Fn() + Send + Sync + 'static,
     E: Fn() + Send + Sync + 'static,
+    L: Fn() + Send + Sync + 'static,
 {
     if MANAGER.get().is_some() {
         log::warn!("hotkey: global hotkey manager already initialized");
@@ -556,6 +590,7 @@ where
     let _ = HANDLESS_CB.set(Box::new(on_handless));
     let _ = CANCEL_CB.set(Box::new(on_cancel));
     let _ = ESCAPE_CB.set(Box::new(on_escape));
+    let _ = COPY_LAST_CB.set(Box::new(on_copy_last));
 
     // Created here (on the main thread, from Tauri `setup`) because the crate
     // installs its Carbon event handler on the application event target, which
@@ -567,6 +602,7 @@ where
         return Ok(std::thread::spawn(|| {}));
     }
     register_main_hotkey();
+    register_copy_last_hotkey();
 
     // Drain hotkey events on a background thread; the receiver is a process-wide
     // channel fed by the Carbon handler, so it is safe to poll off-thread.

--- a/src-tauri/src/core/hotkey/mac.rs
+++ b/src-tauri/src/core/hotkey/mac.rs
@@ -124,11 +124,13 @@ fn now_ms() -> u64 {
 pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
 
 /// There's no Windows key on macOS — kept to satisfy the shared contract.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn is_win_key_down() -> bool {
     false
 }
 
 /// No-op on macOS — see `is_win_key_down`.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn force_release_win_key() {}
 
 pub fn update_keys(k1: u32, k2: u32) {

--- a/src-tauri/src/core/hotkey/mod.rs
+++ b/src-tauri/src/core/hotkey/mod.rs
@@ -2,10 +2,11 @@
 //!
 //! Both platforms expose the same public contract consumed by `main.rs` and
 //! `commands`:
-//!   `start(on_press, on_release, on_handless, on_cancel, on_escape)`,
+//!   `start(on_press, on_release, on_handless, on_cancel, on_escape, on_copy_last)`,
 //!   `update_keys`, `map_code_to_vk`, `is_hotkey_available`,
 //!   `reset_chord_state`, `set_handless_active`,
-//!   `begin_synthetic_paste_suppression`.
+//!   `begin_synthetic_paste_suppression`, `is_win_key_down`,
+//!   `force_release_win_key`.
 //!
 //! Windows uses a `WH_KEYBOARD_LL` hook; macOS uses a `CGEventTap`. The numeric
 //! key ids produced by `map_code_to_vk` are platform-private — only the matching
@@ -35,18 +36,23 @@ mod noop {
     pub fn set_processing_generation(_generation: u64) {}
     pub fn clear_processing_generation(_expected_generation: u64) {}
     pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
+    pub fn is_win_key_down() -> bool {
+        false
+    }
+    pub fn force_release_win_key() {}
     pub fn caps_lock_is_on() -> bool {
         false
     }
     pub fn map_code_to_vk(_code: &str) -> u32 {
         0
     }
-    pub fn start<P, R, H, C, E>(
+    pub fn start<P, R, H, C, E, L>(
         _on_press: P,
         _on_release: R,
         _on_handless: H,
         _on_cancel: C,
         _on_escape: E,
+        _on_copy_last: L,
     ) -> Result<std::thread::JoinHandle<()>, String>
     where
         P: Fn() + Send + Sync + 'static,
@@ -54,6 +60,7 @@ mod noop {
         H: Fn() + Send + Sync + 'static,
         C: Fn() + Send + Sync + 'static,
         E: Fn() + Send + Sync + 'static,
+        L: Fn() + Send + Sync + 'static,
     {
         Ok(std::thread::spawn(|| {}))
     }

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -844,15 +844,20 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
 
         if vk == VK_C {
             if is_down && unsafe { modifier_held(VK_CTRL) && modifier_held(VK_ALT) } {
+                // Only intercept (swallow) the chord when there's a callback
+                // to act on it — otherwise the user's Ctrl+Alt+C would be
+                // lost entirely, so let it fall through to the target app.
                 // Windows auto-repeat sends repeated WM_KEYDOWN/WM_SYSKEYDOWN
-                // while Ctrl+Alt+C is held; fire the copy callback only on the
+                // while the chord is held; fire the callback only on the
                 // first physical keydown while still intercepting the repeats.
-                if !COPY_LAST_KEY_DOWN.swap(true, Ordering::SeqCst) {
-                    if let Some(cb) = COPY_LAST_CB.get() {
-                        cb();
+                if COPY_LAST_CB.get().is_some() {
+                    if !COPY_LAST_KEY_DOWN.swap(true, Ordering::SeqCst) {
+                        if let Some(cb) = COPY_LAST_CB.get() {
+                            cb();
+                        }
                     }
+                    return LRESULT(1);
                 }
-                return LRESULT(1);
             }
             if is_up && COPY_LAST_KEY_DOWN.swap(false, Ordering::SeqCst) {
                 return LRESULT(1);

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -7,6 +7,7 @@ const VK_SHIFT: u32 = 0x10; // VK_SHIFT
 const VK_CTRL: u32 = 0x11; // VK_CONTROL (generic, used with modifier_held)
 const VK_ALT: u32 = 0x12; // VK_MENU (generic, used with modifier_held)
 const VK_RETURN: u32 = 0x0D; // Enter
+const VK_C: u32 = 0x43; // 'C' — used by the Ctrl+Alt+C copy-last-dictation shortcut
 
 // Side-specific modifier VK codes that should never trigger a history update.
 // Generic codes (0x10/0x11/0x12) are omitted: the !is_injected guard already
@@ -479,6 +480,15 @@ thread_local! {
 // pipeline task, which cannot reach the hook thread's thread-local directly.
 static RESET_REQUESTED: AtomicBool = AtomicBool::new(false);
 
+// Cross-thread request to force both chord keys' down/ownership bookkeeping
+// to false, regardless of gesture state. Unlike RESET_REQUESTED (gesture
+// state only — see reset_gesture_state's own doc comment on why it never
+// touches physical-key state), this is a deliberately blunter reset: it's
+// only ever set by force_release_win_key(), after GetAsyncKeyState has
+// already confirmed the Win key reads stuck down at the OS level, so there's
+// no risk of prematurely forgetting a legitimately-still-suppressed key.
+static FORCE_KEY_RELEASE_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 pub fn update_keys(k1: u32, k2: u32) {
     if k1 != 0 {
         KEY1.store(k1, Ordering::SeqCst);
@@ -530,6 +540,47 @@ pub fn caps_lock_is_on() -> bool {
 
 #[allow(dead_code)]
 pub fn begin_synthetic_paste_suppression(_duration_ms: u64) {}
+
+/// Live OS-level check (not our own bookkeeping) — true if Windows currently
+/// thinks either Win key is held. Reuses the same `GetAsyncKeyState` primitive
+/// `modifier_held` already uses for Win (VK 91/92, no generic VK_WIN).
+pub fn is_win_key_down() -> bool {
+    unsafe { modifier_held(91) }
+}
+
+/// Recovery action for a stuck Win key (confirmed via `is_win_key_down()`
+/// first) — called right before a paste so a leftover "Win held" OS state
+/// can't turn the paste's Ctrl+V into a Win-shortcut. Synthesizes a real
+/// keyup for both Win keys (Windows should honor this as authoritative
+/// regardless of why its internal state was wrong) and asks the hook thread
+/// to forget its own chord-key ownership bookkeeping too, in case the hook
+/// itself still thinks it's holding/suppressing the key.
+pub fn force_release_win_key() {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, VK_LWIN, VK_RWIN,
+    };
+
+    // Win is an "extended key" per SendInput's own contract — omitting
+    // KEYEVENTF_EXTENDEDKEY can leave the OS's shell-hotkey state machine
+    // out of sync even when GetAsyncKeyState reports the key up.
+    let ki = |vk: windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY| INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: vk,
+                wScan: 0,
+                dwFlags: KEYBD_EVENT_FLAGS(KEYEVENTF_KEYUP.0 | KEYEVENTF_EXTENDEDKEY.0),
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    };
+    let release = [ki(VK_LWIN), ki(VK_RWIN)];
+    unsafe { SendInput(&release, std::mem::size_of::<INPUT>() as i32) };
+
+    FORCE_KEY_RELEASE_REQUESTED.store(true, Ordering::SeqCst);
+}
 
 pub fn map_code_to_vk(code: &str) -> u32 {
     match code {
@@ -617,6 +668,13 @@ static ESCAPE_CANCELLED: AtomicBool = AtomicBool::new(false);
 static ESCAPE_KEY_DOWN: AtomicBool = AtomicBool::new(false);
 static ESCAPE_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 
+// Ctrl+Alt+C: always-available fallback to re-copy the last dictation to the
+// clipboard, in case paste failed in a way the pipeline's own detection
+// missed. Not chord-based (no hold/release) — a plain keydown fires it,
+// mirroring how Escape is handled below.
+static COPY_LAST_KEY_DOWN: AtomicBool = AtomicBool::new(false);
+static COPY_LAST_CB: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
+
 unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     if code == HC_ACTION as i32 {
         let kb = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
@@ -639,6 +697,19 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             CHORD_MACHINE.with(|m| m.borrow_mut().reset_gesture_state());
             ESCAPE_CANCELLED.store(false, Ordering::SeqCst);
             ESCAPE_KEY_DOWN.store(false, Ordering::SeqCst);
+        }
+
+        if FORCE_KEY_RELEASE_REQUESTED.swap(false, Ordering::SeqCst) {
+            CHORD_MACHINE.with(|m| {
+                let mut machine = m.borrow_mut();
+                machine.key1_down = false;
+                machine.key2_down = false;
+                machine.key1_passed_through = false;
+                machine.key2_passed_through = false;
+                machine.key1_was_chord = false;
+                machine.key2_was_chord = false;
+                machine.chord_down = false;
+            });
         }
 
         if (is_key1 || is_key2) && (is_down || is_up) {
@@ -767,6 +838,19 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                 return LRESULT(1);
             }
             if is_up && ESCAPE_KEY_DOWN.swap(false, Ordering::SeqCst) {
+                return LRESULT(1);
+            }
+        }
+
+        if vk == VK_C {
+            if is_down && unsafe { modifier_held(VK_CTRL) && modifier_held(VK_ALT) } {
+                COPY_LAST_KEY_DOWN.store(true, Ordering::SeqCst);
+                if let Some(cb) = COPY_LAST_CB.get() {
+                    cb();
+                }
+                return LRESULT(1);
+            }
+            if is_up && COPY_LAST_KEY_DOWN.swap(false, Ordering::SeqCst) {
                 return LRESULT(1);
             }
         }
@@ -1049,12 +1133,13 @@ mod chord_tests {
     }
 }
 
-pub fn start<P, R, H, C, E>(
+pub fn start<P, R, H, C, E, L>(
     on_press: P,
     on_release: R,
     on_handless: H,
     on_cancel: C,
     on_escape: E,
+    on_copy_last: L,
 ) -> Result<std::thread::JoinHandle<()>, String>
 where
     P: Fn() + Send + Sync + 'static,
@@ -1062,12 +1147,14 @@ where
     H: Fn() + Send + Sync + 'static,
     C: Fn() + Send + Sync + 'static,
     E: Fn() + Send + Sync + 'static,
+    L: Fn() + Send + Sync + 'static,
 {
     let _ = PRESS_CB.set(Box::new(on_press));
     let _ = RELEASE_CB.set(Box::new(on_release));
     let _ = HANDLESS_CB.set(Box::new(on_handless));
     let _ = CANCEL_CB.set(Box::new(on_cancel));
     let _ = ESCAPE_CB.set(Box::new(on_escape));
+    let _ = COPY_LAST_CB.set(Box::new(on_copy_last));
 
     // Verify the hook can be installed before spawning the thread so the caller
     // gets a synchronous error instead of a silent panic on a background thread.

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -859,7 +859,15 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
                     return LRESULT(1);
                 }
             }
-            if is_up && COPY_LAST_KEY_DOWN.swap(false, Ordering::SeqCst) {
+            // Swallow the C keyup only while the chord modifiers are still
+            // held (the normal release order: C first, then Ctrl/Alt). If the
+            // user released Ctrl/Alt first, letting the C keyup pass keeps
+            // the target app's modifier/keyup bookkeeping consistent — the
+            // down was already suppressed, so it's just an orphaned keyup.
+            if is_up
+                && COPY_LAST_KEY_DOWN.swap(false, Ordering::SeqCst)
+                && unsafe { modifier_held(VK_CTRL) && modifier_held(VK_ALT) }
+            {
                 return LRESULT(1);
             }
         }

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -844,9 +844,13 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
 
         if vk == VK_C {
             if is_down && unsafe { modifier_held(VK_CTRL) && modifier_held(VK_ALT) } {
-                COPY_LAST_KEY_DOWN.store(true, Ordering::SeqCst);
-                if let Some(cb) = COPY_LAST_CB.get() {
-                    cb();
+                // Windows auto-repeat sends repeated WM_KEYDOWN/WM_SYSKEYDOWN
+                // while Ctrl+Alt+C is held; fire the copy callback only on the
+                // first physical keydown while still intercepting the repeats.
+                if !COPY_LAST_KEY_DOWN.swap(true, Ordering::SeqCst) {
+                    if let Some(cb) = COPY_LAST_CB.get() {
+                        cb();
+                    }
                 }
                 return LRESULT(1);
             }

--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -100,6 +100,68 @@ enum CursorContextState {
     },
 }
 
+// Post-paste verification text helpers. Pure functions (no UIA/OS access) so
+// they're unit-testable on every platform; the Windows injection path drives
+// the actual reads and owns the retry timing. They exist because Chromium/
+// ProseMirror-style editors (ChatGPT, Claude, Slack, ...) commit a paste to
+// their own state before the accessibility tree catches up — a caret-local
+// read taken too early still sees the pre-paste text, which used to flag a
+// *successful* paste as failed (the false positives reported in Chrome).
+
+// Capped suffix for the cheap tail check — enough to catch "nothing landed" or
+// "wrong window" without being thrown off by trailing whitespace/newline
+// normalization differences between what we sent and what UIA reports back.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_SUFFIX_CHARS: usize = 20;
+
+// A `contains` cross-check on the control's full text only counts when the
+// fragment is long enough to be distinctive; short dictations rely on the
+// precise ends-with check instead.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_CONTAINS_MIN_CHARS: usize = 12;
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn injected_suffix(injected: &str) -> String {
+    let mut chars: Vec<char> = injected
+        .trim_end()
+        .chars()
+        .rev()
+        .take(PASTE_VERIFY_SUFFIX_CHARS)
+        .collect();
+    chars.reverse();
+    chars.into_iter().collect()
+}
+
+// Cheap, lenient tail check for post-paste verification: true if the
+// control's freshly-read caret-local tail ends with (roughly) the end of what
+// we just injected.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn paste_tail_matches(injected: &str, probe_tail: &str) -> bool {
+    if injected.trim_end().is_empty() {
+        return true;
+    }
+    probe_tail.trim_end().ends_with(&injected_suffix(injected))
+}
+
+// Full-text cross-check for the caret-range-lag case: the caret-range read
+// can stay stale/anchored (or scoped to a stale block) even after the
+// accessibility tree reflects the paste in the document/value text. Verifies
+// the injected text actually reached the field by looking at the whole thing.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn full_text_confirms_paste(injected: &str, full_text: &str) -> bool {
+    let injected_trim = injected.trim_end();
+    if injected_trim.is_empty() {
+        return true;
+    }
+    let suffix = injected_suffix(injected);
+    if full_text.trim_end().ends_with(&suffix) {
+        return true;
+    }
+    // A paste into the middle of existing text leaves our tail mid-field, not
+    // at the very end — only trust that when the fragment is distinctive.
+    suffix.chars().count() >= PASTE_VERIFY_CONTAINS_MIN_CHARS && full_text.contains(&suffix)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +333,46 @@ mod tests {
         backspace_injection_history(22);
         let state = last_injection().lock().expect("lock");
         assert!(matches!(&*state, CursorContextState::Unknown { .. }));
+    }
+
+    #[test]
+    fn paste_tail_matches_matches_our_suffix() {
+        assert!(paste_tail_matches("hello world", "some prefix hello world"));
+        assert!(paste_tail_matches("hello world", "hello world"));
+        // trailing whitespace / newline normalization is tolerated
+        assert!(paste_tail_matches("hello world ", "prefix hello world\n"));
+        // long injected text only needs its final fragment to match
+        let long = "the quick brown fox jumps over the lazy dog near the river";
+        assert!(paste_tail_matches(
+            long,
+            "stale pre-paste text the quick brown fox jumps over the lazy dog near the river"
+        ));
+        // empty injected text trivially passes
+        assert!(paste_tail_matches("", "anything at all"));
+        // a genuinely different tail fails
+        assert!(!paste_tail_matches("hello world", "some other text"));
+    }
+
+    #[test]
+    fn full_text_confirms_paste_checks_whole_document() {
+        // appended at the end of the field
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "existing prompt dictated text here"
+        ));
+        // pasted mid-document: our suffix sits mid-field, not at the end
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "start dictated text here rest of document"
+        ));
+        // short dictation still verified by the precise ends-with check
+        assert!(full_text_confirms_paste("short", "abc short"));
+        // ...but a short fragment is never trusted as a mid-field contains
+        assert!(!full_text_confirms_paste("short", "abc shortx"));
+        // empty injected text trivially passes
+        assert!(full_text_confirms_paste("", "anything at all"));
+        // unrelated text fails
+        assert!(!full_text_confirms_paste("didn't paste", "totally unrelated text"));
     }
 }
 #[derive(Clone, Copy, Debug)]

--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -59,6 +59,24 @@ const CLIPBOARD_WRITE_RETRY_MS: u64 = 50;
 #[cfg(target_os = "windows")]
 const MODIFIER_GAP_MS: u64 = 30;
 
+// Grace window for a Win key that still reads down right before a paste —
+// releasing Ctrl to stop dictation and releasing Win a beat later is normal
+// human timing, not the stuck-key OS bug this guards against. Polled at
+// WIN_KEY_GRACE_POLL_MS intervals up to WIN_KEY_GRACE_POLL_ATTEMPTS times
+// (150ms total) before escalating to forced recovery.
+#[cfg(target_os = "windows")]
+const WIN_KEY_GRACE_POLL_MS: u64 = 30;
+#[cfg(target_os = "windows")]
+const WIN_KEY_GRACE_POLL_ATTEMPTS: u32 = 5;
+
+// Settle time after releasing Win specifically, before the first
+// is_win_key_down() check. Win participates in OS-wide/shell hotkey
+// dispatch (unlike a plain app-level Ctrl/Alt release), which can need more
+// time to settle than MODIFIER_GAP_MS's 30ms — that constant was tuned for
+// beating an app's own message pump, not a system-wide hotkey matcher.
+#[cfg(target_os = "windows")]
+const WIN_KEY_RELEASE_SETTLE_MS: u64 = 80;
+
 // Settle time after the paste (Ctrl+V) before restoring saved clipboard
 // formats - gives the target app time to read the clipboard before we
 // overwrite it with the original contents. `SendInput` only queues the
@@ -98,6 +116,68 @@ enum CursorContextState {
         tail: String,
         instant: Instant,
     },
+}
+
+// Post-paste verification text helpers. Pure functions (no UIA/OS access) so
+// they're unit-testable on every platform; the Windows injection path drives
+// the actual reads and owns the retry timing. They exist because Chromium/
+// ProseMirror-style editors (ChatGPT, Claude, Slack, ...) commit a paste to
+// their own state before the accessibility tree catches up — a caret-local
+// read taken too early still sees the pre-paste text, which used to flag a
+// *successful* paste as failed (the false positives reported in Chrome).
+
+// Capped suffix for the cheap tail check — enough to catch "nothing landed" or
+// "wrong window" without being thrown off by trailing whitespace/newline
+// normalization differences between what we sent and what UIA reports back.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_SUFFIX_CHARS: usize = 20;
+
+// A `contains` cross-check on the control's full text only counts when the
+// fragment is long enough to be distinctive; short dictations rely on the
+// precise ends-with check instead.
+#[cfg_attr(not(windows), allow(dead_code))]
+const PASTE_VERIFY_CONTAINS_MIN_CHARS: usize = 12;
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn injected_suffix(injected: &str) -> String {
+    let mut chars: Vec<char> = injected
+        .trim_end()
+        .chars()
+        .rev()
+        .take(PASTE_VERIFY_SUFFIX_CHARS)
+        .collect();
+    chars.reverse();
+    chars.into_iter().collect()
+}
+
+// Cheap, lenient tail check for post-paste verification: true if the
+// control's freshly-read caret-local tail ends with (roughly) the end of what
+// we just injected.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn paste_tail_matches(injected: &str, probe_tail: &str) -> bool {
+    if injected.trim_end().is_empty() {
+        return true;
+    }
+    probe_tail.trim_end().ends_with(&injected_suffix(injected))
+}
+
+// Full-text cross-check for the caret-range-lag case: the caret-range read
+// can stay stale/anchored (or scoped to a stale block) even after the
+// accessibility tree reflects the paste in the document/value text. Verifies
+// the injected text actually reached the field by looking at the whole thing.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn full_text_confirms_paste(injected: &str, full_text: &str) -> bool {
+    let injected_trim = injected.trim_end();
+    if injected_trim.is_empty() {
+        return true;
+    }
+    let suffix = injected_suffix(injected);
+    if full_text.trim_end().ends_with(&suffix) {
+        return true;
+    }
+    // A paste into the middle of existing text leaves our tail mid-field, not
+    // at the very end — only trust that when the fragment is distinctive.
+    suffix.chars().count() >= PASTE_VERIFY_CONTAINS_MIN_CHARS && full_text.contains(&suffix)
 }
 
 #[cfg(test)]
@@ -271,6 +351,46 @@ mod tests {
         backspace_injection_history(22);
         let state = last_injection().lock().expect("lock");
         assert!(matches!(&*state, CursorContextState::Unknown { .. }));
+    }
+
+    #[test]
+    fn paste_tail_matches_matches_our_suffix() {
+        assert!(paste_tail_matches("hello world", "some prefix hello world"));
+        assert!(paste_tail_matches("hello world", "hello world"));
+        // trailing whitespace / newline normalization is tolerated
+        assert!(paste_tail_matches("hello world ", "prefix hello world\n"));
+        // long injected text only needs its final fragment to match
+        let long = "the quick brown fox jumps over the lazy dog near the river";
+        assert!(paste_tail_matches(
+            long,
+            "stale pre-paste text the quick brown fox jumps over the lazy dog near the river"
+        ));
+        // empty injected text trivially passes
+        assert!(paste_tail_matches("", "anything at all"));
+        // a genuinely different tail fails
+        assert!(!paste_tail_matches("hello world", "some other text"));
+    }
+
+    #[test]
+    fn full_text_confirms_paste_checks_whole_document() {
+        // appended at the end of the field
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "existing prompt dictated text here"
+        ));
+        // pasted mid-document: our suffix sits mid-field, not at the end
+        assert!(full_text_confirms_paste(
+            "dictated text here",
+            "start dictated text here rest of document"
+        ));
+        // short dictation still verified by the precise ends-with check
+        assert!(full_text_confirms_paste("short", "abc short"));
+        // ...but a short fragment is never trusted as a mid-field contains
+        assert!(!full_text_confirms_paste("short", "abc shortx"));
+        // empty injected text trivially passes
+        assert!(full_text_confirms_paste("", "anything at all"));
+        // unrelated text fails
+        assert!(!full_text_confirms_paste("didn't paste", "totally unrelated text"));
     }
 }
 #[derive(Clone, Copy, Debug)]
@@ -700,6 +820,7 @@ fn context_tail_signal(tail: &str) -> &'static str {
         Some(_) => "other",
     }
 }
+
 #[cfg_attr(not(any(test, target_os = "windows")), allow(dead_code))]
 pub fn reset_injection_history() {
     if let Ok(mut guard) = last_injection().lock() {

--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -653,6 +653,7 @@ fn lowercase_first_word_if_safe(text: &str) -> (String, bool) {
     out.push_str(&text[start + first_len..]);
     (out, true)
 }
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn unavailable_injection_probe() -> InjectionContextProbe {
     InjectionContextProbe::unavailable(ContextProbeSource::Unavailable, "unavailable")
 }

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -363,6 +363,21 @@ async fn windows_clipboard_sniff_context(target_hwnd: usize) -> Option<Injection
     }
 }
 
+// Post-paste verification loop timing (the matching logic itself lives in
+// `super::paste_tail_matches` / `super::full_text_confirms_paste`). Heavier
+// editors (ProseMirror-style rich text, React-rendered chat inputs) commit a
+// paste to their own state before the accessibility tree catches up — a UIA
+// read taken immediately after PASTE_SETTLE_MS can still see the pre-paste
+// text and read as a false mismatch. Chromium's a11y lag is variable and can
+// exceed a second while the editor is still settling, so retry with growing
+// gaps, then cross-check the control's full text, before ever reporting
+// failure (see the verify loop below).
+const PASTE_VERIFY_ATTEMPTS: u32 = 6;
+const PASTE_VERIFY_RETRY_MS: u64 = 100;
+const PASTE_VERIFY_RETRY_GROWTH_MS: u64 = 40;
+const PASTE_VERIFY_MAX_RETRY_MS: u64 = 260;
+const PASTE_VERIFY_FULLTEXT_ATTEMPTS: u32 = 2;
+
 #[allow(unused_variables)]
 pub(super) async fn inject_text(
     text: &str,
@@ -374,10 +389,67 @@ pub(super) async fn inject_text(
 ) -> anyhow::Result<InjectionOutcome> {
     use ::windows::Win32::Foundation::HWND;
     use ::windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-        VK_CONTROL, VK_LMENU, VK_V,
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, VK_CONTROL, VK_LMENU, VK_LWIN, VK_RWIN, VK_V,
     };
-    use ::windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
+    use ::windows::Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetGUIThreadInfo, GetShellWindow, GetWindowThreadProcessId,
+        SetForegroundWindow, GUITHREADINFO,
+    };
+
+    // No window was focused when recording started (Ctrl+V would land
+    // wherever the OS currently thinks focus is, with no way to tell if
+    // that's meaningful) — or the focused window IS the desktop/shell
+    // itself (GetShellWindow — clicking empty desktop, nothing selected).
+    // Either way there's nowhere for the paste to land; fail loudly instead
+    // of silently sending Ctrl+V into nothing.
+    let shell_hwnd = unsafe { GetShellWindow() }.0 as usize;
+    let current_foreground_hwnd = unsafe { GetForegroundWindow() }.0 as usize;
+    let is_desktop_shell = target_hwnd != 0 && shell_hwnd == target_hwnd;
+    log::debug!(
+        "inject: target_hwnd={} shell_hwnd={} current_foreground_hwnd={} is_desktop_shell={}",
+        target_hwnd,
+        shell_hwnd,
+        current_foreground_hwnd,
+        is_desktop_shell
+    );
+    if target_hwnd == 0 || is_desktop_shell {
+        log::warn!("inject: aborting — no meaningful paste target (hwnd=0 or desktop/shell)");
+        anyhow::bail!("Nothing was focused to paste into");
+    }
+
+    // Read-only check: does any control in the target thread actually own
+    // keyboard focus? Covers a real window with zero editable controls
+    // selected (e.g. a fresh Chrome tab with nothing clicked) — Ctrl+V
+    // would silently go nowhere. This replaced a post-paste clipboard-sniff
+    // fallback (select-back-one-char + Ctrl+C) that tried to infer the same
+    // thing after already sending Ctrl+V; that approach both false-flagged
+    // working pastes into controls UIA can't read (ProseMirror/Chromium
+    // editors) and could edit/delete live document content by racing the
+    // editor's own async paste-settling. GetGUIThreadInfo answers the
+    // question directly with no synthetic input.
+    let target_thread_id =
+        unsafe { GetWindowThreadProcessId(HWND(target_hwnd as *mut core::ffi::c_void), None) };
+    // Scoped so `GUITHREADINFO` (holds raw HWND pointers, not Send) is
+    // dropped before any `.await` below — otherwise it'd make this whole
+    // async fn's future non-Send.
+    let has_focus = {
+        let mut gti = GUITHREADINFO {
+            cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
+            ..Default::default()
+        };
+        unsafe { GetGUIThreadInfo(target_thread_id, &mut gti) }.is_ok()
+            && gti.hwndFocus.0 as usize != 0
+    };
+    log::debug!(
+        "inject: target_thread_id={} has_focus={}",
+        target_thread_id,
+        has_focus
+    );
+    if !has_focus {
+        log::warn!("inject: aborting — no control has keyboard focus in target thread");
+        anyhow::bail!("Nothing was focused to paste into");
+    }
 
     // Declared before the restore guard so it releases *after* the clipboard
     // has been restored (Rust drops in reverse declaration order).
@@ -409,6 +481,30 @@ pub(super) async fn inject_text(
     } else {
         unavailable_injection_probe()
     };
+
+    // GetGUIThreadInfo (checked above) can't tell "a real textbox is
+    // focused inside this page" apart from "nothing is" — Chromium/Electron
+    // expose exactly one native HWND for the whole content area, which
+    // keeps OS keyboard focus regardless of what's focused (or isn't)
+    // inside the DOM. When nothing inside the page claims focus, UIA's
+    // focused-element walk instead resolves to that container itself,
+    // reported here as control_type "pane"/"window" with no value/text
+    // pattern support (source falls through to UnsupportedControl). A real
+    // focused control — even one UIA can't read the *text* of — reports a
+    // more specific control type. This is a read-only signal (reuses the
+    // probe already fetched above), so it's safe where the old post-paste
+    // clipboard-sniff wasn't.
+    if injection_probe.source == ContextProbeSource::UnsupportedControl
+        && matches!(injection_probe.control_type.as_str(), "pane" | "window")
+    {
+        log::warn!(
+            "inject: aborting — focused element is the container ({}), not a text control",
+            injection_probe.control_type
+        );
+        restore_guard.restore_now();
+        anyhow::bail!("Nothing was focused to paste into");
+    }
+
     if (contextual_caps || auto_spacing) && injection_probe.source.allows_history_fallback() {
         if let Some(history_probe) = fallback_probe_from_history(target_hwnd) {
             injection_probe = history_probe;
@@ -469,15 +565,80 @@ pub(super) async fn inject_text(
     ))
     .await;
 
+    // Always release Win alongside Ctrl/Alt before every paste — cheap
+    // no-op if it's already up, and the one guaranteed defense against a
+    // leftover "Win held" OS state turning this Ctrl+V into a Win-shortcut
+    // instead of a paste. Win is an "extended key" per SendInput's own
+    // contract (same category as arrow keys, Ins/Del, right Ctrl/Alt) —
+    // omitting KEYEVENTF_EXTENDEDKEY can leave the OS's shell-hotkey state
+    // machine out of sync even when GetAsyncKeyState reports the key up.
     let clear = [
         ki(VK_CONTROL, 0),
         ki(VK_LMENU, KEYEVENTF_KEYUP.0),
         ki(VK_CONTROL, KEYEVENTF_KEYUP.0),
+        ki(VK_LWIN, KEYEVENTF_KEYUP.0 | KEYEVENTF_EXTENDEDKEY.0),
+        ki(VK_RWIN, KEYEVENTF_KEYUP.0 | KEYEVENTF_EXTENDEDKEY.0),
     ];
     unsafe { SendInput(&clear, std::mem::size_of::<INPUT>() as i32) };
 
     tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+    // Win specifically gets extra settle time beyond the Ctrl/Alt gap above
+    // — see WIN_KEY_RELEASE_SETTLE_MS.
+    tokio::time::sleep(tokio::time::Duration::from_millis(WIN_KEY_RELEASE_SETTLE_MS)).await;
 
+    // Belt-and-suspenders: if the OS still reports Win held after the
+    // release above, ask the hook to force its own bookkeeping clear too and
+    // try once more. A Win-modified V can open a shortcut instead of
+    // pasting, so if it's still stuck after that, abort rather than risk it.
+    let win_down_after_clear = crate::core::hotkey::is_win_key_down();
+    log::debug!("inject: win_key_down_after_clear={win_down_after_clear}");
+    if win_down_after_clear {
+        // Give the user's own release timing a moment first — releasing
+        // Ctrl to stop dictation and releasing Win a beat later is normal
+        // human timing, not a stuck key. Poll briefly before escalating to
+        // the forced-recovery path; a genuinely stuck key (the OS bug this
+        // guards against) stays down far longer than this grace window.
+        let mut still_down = true;
+        let mut poll_attempts_used = 0u32;
+        for _ in 0..WIN_KEY_GRACE_POLL_ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_millis(WIN_KEY_GRACE_POLL_MS)).await;
+            poll_attempts_used += 1;
+            if !crate::core::hotkey::is_win_key_down() {
+                still_down = false;
+                break;
+            }
+        }
+        log::debug!(
+            "inject: win_key grace poll attempts_used={poll_attempts_used} still_down={still_down}"
+        );
+        if still_down {
+            log::warn!("inject: Win key reads stuck down before paste, attempting recovery");
+            crate::core::hotkey::force_release_win_key();
+            tokio::time::sleep(tokio::time::Duration::from_millis(MODIFIER_GAP_MS)).await;
+            let still_stuck = crate::core::hotkey::is_win_key_down();
+            log::debug!("inject: win_key_down_after_force_release={still_stuck}");
+            if still_stuck {
+                restore_guard.restore_now();
+                log::warn!("inject: aborting paste — Win key still stuck after forced recovery");
+                return Err(anyhow::anyhow!(
+                    "Windows key appears stuck down — release it and try again"
+                ));
+            }
+        }
+    }
+
+    // Final check immediately adjacent to the send — no further gap where a
+    // fresh Win-down edge could slip in between "confirmed clear" and
+    // actually sending Ctrl+V.
+    if crate::core::hotkey::is_win_key_down() {
+        restore_guard.restore_now();
+        log::warn!("inject: aborting — Win key down at the last check before Ctrl+V");
+        return Err(anyhow::anyhow!(
+            "Windows key appears stuck down — release it and try again"
+        ));
+    }
+
+    log::debug!("inject: sending Ctrl+V");
     let paste = [
         ki(VK_CONTROL, 0),
         ki(VK_V, 0),
@@ -488,6 +649,116 @@ pub(super) async fn inject_text(
     tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_SETTLE_MS)).await;
 
     restore_guard.restore_now();
+
+    // Best-effort post-paste verification: reuse the same UIA read already
+    // used pre-injection for caret reads, not new plumbing. Only act on a
+    // real CaretLocal readback — any other source (unavailable, permission
+    // missing, unsupported control, etc.) means UIA can't reliably tell
+    // either way (many working Chromium/Electron widgets fall in this
+    // bucket), so it's left lenient here. The "was anything focused at all"
+    // question is answered up front, before Ctrl+V is ever sent — see the
+    // GetGUIThreadInfo check near the top of this function — rather than
+    // inferred here after the fact.
+    //
+    // Chromium/ProseMirror-style editors commit a paste to their own state
+    // before the accessibility tree catches up, and that lag is variable —
+    // often well over the retry window — so a read taken too early reads the
+    // pre-paste text and flags a *successful* paste as failed (the false
+    // positives reported in Chrome). The loop retries with growing gaps and,
+    // before giving up, cross-checks the control's full text (the
+    // ValuePattern/document read reflects the DOM even when the caret-range
+    // read stays stale). A hard failure is only declared when the tree
+    // *freshly* read the caret as not containing our text. A read that stays
+    // frozen on the pre-injection tail means UIA never observed the change at
+    // all — an unverifiable paste, not a failed one — which we log and treat
+    // as best-effort success, since the pre-injection guards already
+    // confirmed a focused, writable text control and a false "paste failed"
+    // is worse than an unverified-but-likely-fine paste.
+    if !adjusted.trim_end().is_empty() {
+        let pre_injection_tail = injection_probe.context_tail.as_str();
+        let mut verified = false;
+        // A caret-local read that differs from the pre-injection tail but
+        // still doesn't match our text is real evidence the paste didn't land
+        // where expected. Frozen reads (identical to before the paste) are no
+        // signal either way.
+        let mut saw_fresh_mismatch = false;
+        let mut saw_frozen = false;
+
+        for attempt in 0..PASTE_VERIFY_ATTEMPTS {
+            let post_probe = crate::core::context_probe::read_injection_context_probe().await;
+
+            if post_probe.source != ContextProbeSource::CaretLocal {
+                // This source can't tell us anything reliable — no point
+                // retrying either way.
+                verified = true;
+            } else {
+                let tail_frozen = !pre_injection_tail.is_empty()
+                    && post_probe.context_tail == pre_injection_tail;
+                saw_frozen |= tail_frozen;
+                if paste_tail_matches(&adjusted, &post_probe.context_tail) {
+                    verified = true;
+                } else if !tail_frozen {
+                    saw_fresh_mismatch = true;
+                }
+            }
+
+            log::debug!(
+                "inject: post-paste verify attempt={} probe_source={} probe_tail_len={} injected_len={} verified={}",
+                attempt + 1,
+                post_probe.source.as_str(),
+                post_probe.context_tail.chars().count(),
+                adjusted.chars().count(),
+                verified
+            );
+
+            if verified {
+                break;
+            }
+            if attempt + 1 < PASTE_VERIFY_ATTEMPTS {
+                let grow =
+                    PASTE_VERIFY_RETRY_MS + (attempt as u64) * PASTE_VERIFY_RETRY_GROWTH_MS;
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    grow.min(PASTE_VERIFY_MAX_RETRY_MS),
+                ))
+                .await;
+            }
+        }
+
+        // Cross-check the full field text before concluding anything — the
+        // caret-range read can stay stale/anchored even after the document
+        // text reflects the paste (Chromium re-anchors lazily).
+        if !verified {
+            for _ in 0..PASTE_VERIFY_FULLTEXT_ATTEMPTS {
+                if let Some(full_text) = crate::api::auto_learn::read_focused_text() {
+                    if full_text_confirms_paste(&adjusted, &full_text) {
+                        verified = true;
+                        log::debug!("inject: post-paste verified via full-text match");
+                        break;
+                    }
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_VERIFY_RETRY_MS))
+                    .await;
+            }
+        }
+
+        if !verified {
+            if saw_fresh_mismatch {
+                // The tree updated and the text before the caret genuinely
+                // doesn't contain our paste — a real failure.
+                log::warn!("inject: aborting — post-paste verification tail mismatch");
+                return Err(anyhow::anyhow!(
+                    "Paste could not be verified — target text does not match"
+                ));
+            }
+            // Frozen reads only: UIA never caught up with the paste. The
+            // target was already confirmed as a focused, writable text
+            // control, so treat this as unverifiable rather than failed.
+            log::warn!(
+                "inject: paste unverified after {} attempts (saw_frozen={saw_frozen}) — treating as best-effort success",
+                PASTE_VERIFY_ATTEMPTS,
+            );
+        }
+    }
 
     if target_hwnd != 0 && !adjusted.is_empty() {
         if let Ok(mut guard) = last_injection().lock() {

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -363,6 +363,21 @@ async fn windows_clipboard_sniff_context(target_hwnd: usize) -> Option<Injection
     }
 }
 
+// Post-paste verification loop timing (the matching logic itself lives in
+// `super::paste_tail_matches` / `super::full_text_confirms_paste`). Heavier
+// editors (ProseMirror-style rich text, React-rendered chat inputs) commit a
+// paste to their own state before the accessibility tree catches up — a UIA
+// read taken immediately after PASTE_SETTLE_MS can still see the pre-paste
+// text and read as a false mismatch. Chromium's a11y lag is variable and can
+// exceed a second while the editor is still settling, so retry with growing
+// gaps, then cross-check the control's full text, before ever reporting
+// failure (see the verify loop below).
+const PASTE_VERIFY_ATTEMPTS: u32 = 6;
+const PASTE_VERIFY_RETRY_MS: u64 = 100;
+const PASTE_VERIFY_RETRY_GROWTH_MS: u64 = 40;
+const PASTE_VERIFY_MAX_RETRY_MS: u64 = 260;
+const PASTE_VERIFY_FULLTEXT_ATTEMPTS: u32 = 2;
+
 #[allow(unused_variables)]
 pub(super) async fn inject_text(
     text: &str,
@@ -488,6 +503,117 @@ pub(super) async fn inject_text(
     tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_SETTLE_MS)).await;
 
     restore_guard.restore_now();
+
+    // Best-effort post-paste verification: reuse the same UIA read already
+    // used pre-injection for caret reads, not new plumbing. Only act on a
+    // real CaretLocal readback — any other source (unavailable, permission
+    // missing, unsupported control, etc.) means UIA can't reliably tell
+    // either way (many working Chromium/Electron widgets fall in this
+    // bucket), so it's left lenient here.
+    //
+    // Chromium/ProseMirror-style editors commit a paste to their own state
+    // before the accessibility tree catches up, and that lag is variable —
+    // often well over the retry window — so a read taken too early reads the
+    // pre-paste text and flags a *successful* paste as failed (the false
+    // positives reported in Chrome). The loop retries with growing gaps and,
+    // before giving up, cross-checks the control's full text (the
+    // ValuePattern/document read reflects the DOM even when the caret-range
+    // read stays stale). A hard failure is only declared when the tree
+    // *freshly* read the caret as not containing our text. A read that stays
+    // frozen on the pre-injection tail means UIA never observed the change at
+    // all — an unverifiable paste, not a failed one — which we log and treat
+    // as best-effort success, since a false "paste failed" report is worse
+    // than an unverified-but-likely-fine paste.
+    if !adjusted.trim_end().is_empty() {
+        let pre_injection_tail = injection_probe.context_tail.as_str();
+        let mut verified = false;
+        // A caret-local read that differs from the pre-injection tail but
+        // still doesn't match our text is real evidence the paste didn't land
+        // where expected. Frozen reads (identical to before the paste) are no
+        // signal either way.
+        let mut saw_fresh_mismatch = false;
+        let mut saw_frozen = false;
+
+        for attempt in 0..PASTE_VERIFY_ATTEMPTS {
+            let post_probe = crate::core::context_probe::read_injection_context_probe().await;
+
+            if post_probe.source != ContextProbeSource::CaretLocal {
+                // This source can't tell us anything reliable — no point
+                // retrying either way.
+                verified = true;
+            } else {
+                // A read byte-identical to the pre-injection tail carries no
+                // new information — either the accessibility tree hasn't
+                // caught up with the paste yet, or the field truly didn't
+                // change. That is ambiguous, not proof the paste failed. A
+                // read that CHANGED and still doesn't contain our text is a
+                // real signal the paste went wrong, even in a field that was
+                // empty before.
+                let read_is_ambiguous = post_probe.context_tail == pre_injection_tail;
+                saw_frozen |= read_is_ambiguous;
+                if paste_tail_matches(&adjusted, &post_probe.context_tail) {
+                    verified = true;
+                } else if !read_is_ambiguous {
+                    saw_fresh_mismatch = true;
+                }
+            }
+
+            log::debug!(
+                "inject: post-paste verify attempt={} probe_source={} probe_tail_len={} injected_len={} verified={}",
+                attempt + 1,
+                post_probe.source.as_str(),
+                post_probe.context_tail.chars().count(),
+                adjusted.chars().count(),
+                verified
+            );
+
+            if verified {
+                break;
+            }
+            if attempt + 1 < PASTE_VERIFY_ATTEMPTS {
+                let grow =
+                    PASTE_VERIFY_RETRY_MS + (attempt as u64) * PASTE_VERIFY_RETRY_GROWTH_MS;
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    grow.min(PASTE_VERIFY_MAX_RETRY_MS),
+                ))
+                .await;
+            }
+        }
+
+        // Cross-check the full field text before concluding anything — the
+        // caret-range read can stay stale/anchored even after the document
+        // text reflects the paste (Chromium re-anchors lazily).
+        if !verified {
+            for _ in 0..PASTE_VERIFY_FULLTEXT_ATTEMPTS {
+                if let Some(full_text) = crate::api::auto_learn::read_focused_text() {
+                    if full_text_confirms_paste(&adjusted, &full_text) {
+                        verified = true;
+                        log::debug!("inject: post-paste verified via full-text match");
+                        break;
+                    }
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(PASTE_VERIFY_RETRY_MS))
+                    .await;
+            }
+        }
+
+        if !verified {
+            if saw_fresh_mismatch {
+                // The tree updated and the text before the caret genuinely
+                // doesn't contain our paste — a real failure.
+                log::warn!("inject: aborting — post-paste verification tail mismatch");
+                return Err(anyhow::anyhow!(
+                    "Paste could not be verified — target text does not match"
+                ));
+            }
+            // Frozen reads only: UIA never caught up with the paste. Treat
+            // this as unverifiable rather than failed.
+            log::warn!(
+                "inject: paste unverified after {} attempts (saw_frozen={saw_frozen}) — treating as best-effort success",
+                PASTE_VERIFY_ATTEMPTS,
+            );
+        }
+    }
 
     if target_hwnd != 0 && !adjusted.is_empty() {
         if let Ok(mut guard) = last_injection().lock() {

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -478,11 +478,7 @@ pub(super) async fn inject_text(
         },
     };
 
-    let mut injection_probe = if contextual_caps || auto_spacing {
-        crate::core::context_probe::read_injection_context_probe().await
-    } else {
-        unavailable_injection_probe()
-    };
+    let mut injection_probe = crate::core::context_probe::read_injection_context_probe().await;
 
     // GetGUIThreadInfo (checked above) can't tell "a real textbox is
     // focused inside this page" apart from "nothing is" — Chromium/Electron

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -432,8 +432,10 @@ pub(super) async fn inject_text(
         unsafe { GetWindowThreadProcessId(HWND(target_hwnd as *mut core::ffi::c_void), None) };
     // Scoped so `GUITHREADINFO` (holds raw HWND pointers, not Send) is
     // dropped before any `.await` below — otherwise it'd make this whole
-    // async fn's future non-Send.
-    let has_focus = {
+    // async fn's future non-Send. A zero thread id means the target window
+    // was invalid/closed — `GetGUIThreadInfo(0)` would otherwise treat 0 as
+    // a request to inspect the OS foreground thread and wrongly report focus.
+    let has_focus = target_thread_id != 0 && {
         let mut gti = GUITHREADINFO {
             cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
             ..Default::default()

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -692,8 +692,12 @@ pub(super) async fn inject_text(
                 // retrying either way.
                 verified = true;
             } else {
-                let tail_frozen = !pre_injection_tail.is_empty()
-                    && post_probe.context_tail == pre_injection_tail;
+                // Frozen reads (identical to before the paste) are no signal
+                // either way — including when both tails are empty (pasting
+                // into an empty field, or contextual_caps/auto_spacing off),
+                // which a laggy UIA read returning "" would otherwise
+                // misclassify as a real mismatch.
+                let tail_frozen = post_probe.context_tail == pre_injection_tail;
                 saw_frozen |= tail_frozen;
                 if paste_tail_matches(&adjusted, &post_probe.context_tail) {
                     verified = true;

--- a/src-tauri/src/core/injection/windows.rs
+++ b/src-tauri/src/core/injection/windows.rs
@@ -485,23 +485,18 @@ pub(super) async fn inject_text(
     // expose exactly one native HWND for the whole content area, which
     // keeps OS keyboard focus regardless of what's focused (or isn't)
     // inside the DOM. When nothing inside the page claims focus, UIA's
-    // focused-element walk instead resolves to that container itself,
-    // reported here as control_type "pane"/"window" with no value/text
-    // pattern support (source falls through to UnsupportedControl). A real
-    // focused control — even one UIA can't read the *text* of — reports a
-    // more specific control type. This is a read-only signal (reuses the
-    // probe already fetched above), so it's safe where the old post-paste
-    // clipboard-sniff wasn't.
-    if injection_probe.source == ContextProbeSource::UnsupportedControl
-        && matches!(injection_probe.control_type.as_str(), "pane" | "window")
-    {
-        log::warn!(
-            "inject: aborting — focused element is the container ({}), not a text control",
-            injection_probe.control_type
-        );
-        restore_guard.restore_now();
-        anyhow::bail!("Nothing was focused to paste into");
-    }
+    // focused-element walk resolves to that container itself, reported as
+    // control_type "pane"/"window" with no text pattern support
+    // (UnsupportedControl).
+    //
+    // This probe is deliberately NOT used to abort the paste, though: many
+    // perfectly pasteable apps (Qt, Java Swing, Flutter, terminal emulators,
+    // custom Win32 controls, webviews without UIA initialized) also expose
+    // only a generic pane/window to UIA with UnsupportedControl — so
+    // rejecting that state would break dictation into all of them. The
+    // GetGUIThreadInfo has_focus guard above already answers "was anything
+    // focused at all"; this probe only feeds contextual formatting and
+    // post-paste verification, never a hard reject.
 
     if (contextual_caps || auto_spacing) && injection_probe.source.allows_history_fallback() {
         if let Some(history_probe) = fallback_probe_from_history(target_hwnd) {

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -628,9 +628,18 @@ fn compute_streak(daily: &[InsightsDay]) -> InsightsStreak {
     let active_days = daily.iter().filter(|d| d.words > 0).count() as i64;
 
     let mut current_days = 0i64;
-    for day in daily.iter().rev() {
+    // The series is zero-filled and ends on today. A quiet today (the day
+    // isn't over yet) must not zero a streak that's still alive through
+    // yesterday — GitHub-style, the streak holds until the day ends.
+    let mut iter = daily.iter().rev();
+    let mut pending_today = true;
+    for day in &mut iter {
         if day.words > 0 {
             current_days += 1;
+        } else if pending_today {
+            // Skip the empty trailing day (today) once; a second empty day
+            // is a real break.
+            pending_today = false;
         } else {
             break;
         }
@@ -820,6 +829,28 @@ mod tests {
         assert_eq!(insights.streak.longest_words, 8);
         assert_eq!(insights.streak.current_days, 0, "gap at the range end breaks the current streak");
         assert_eq!(insights.streak.active_days, 3);
+    }
+
+    #[test]
+    fn streak_survives_a_quiet_today() {
+        let db = test_db();
+        // Yesterday and the day before were active; today is silent (the day
+        // isn't over yet) — the streak must still read as alive.
+        insert_on_day(&db, 1, "yesterday", 2, 1000);
+        insert_on_day(&db, 2, "two days ago", 2, 1000);
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.streak.current_days, 2);
+    }
+
+    #[test]
+    fn streak_breaks_after_two_quiet_days() {
+        let db = test_db();
+        // Today and yesterday silent; the last activity is two days back.
+        insert_on_day(&db, 2, "two days ago", 2, 1000);
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.streak.current_days, 0);
     }
 
     #[test]

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -25,6 +25,10 @@ pub struct Insights {
     pub totals: InsightsTotals,
     pub streak: InsightsStreak,
     pub daily: Vec<InsightsDay>,
+    /// One compact rolling year. The frontend shows as many fixed-width weeks
+    /// as fit without scrolling.
+    pub streak_daily: Vec<InsightsDay>,
+    pub history_started_on: Option<String>,
     pub hourly: Vec<i64>,
     pub providers: Vec<InsightsProviderUsage>,
     pub cleanup: InsightsCleanup,
@@ -138,11 +142,18 @@ pub fn query_insights(db: &Db, days: i64) -> Result<Insights> {
 
     let totals = query_totals(&conn, &range_start, &range_end, days)?;
     let daily = query_daily(&conn, &range_start, &range_end)?;
+    let (streak_start, streak_end) = rolling_year_bounds(&conn)?;
+    let streak_daily = query_daily(&conn, &streak_start, &streak_end)?;
+    let history_started_on = conn.query_row(
+        "SELECT date(MIN(created_at), 'localtime') FROM transcriptions",
+        [],
+        |r| r.get(0),
+    )?;
     let hourly = query_hourly(&conn, &range_start, &range_end)?;
     let providers = query_providers(&conn, &range_start, &range_end)?;
     let cleanup = query_cleanup(&conn, &range_start, &range_end)?;
     let words = query_words(&conn, &range_start, &range_end)?;
-    let streak = compute_streak(&daily);
+    let streak = compute_streak(&streak_daily);
 
     Ok(Insights {
         range_days: days,
@@ -150,6 +161,8 @@ pub fn query_insights(db: &Db, days: i64) -> Result<Insights> {
         totals,
         streak,
         daily,
+        streak_daily,
+        history_started_on,
         hourly,
         providers,
         cleanup,
@@ -312,6 +325,18 @@ fn range_bounds(conn: &Connection, days: i64) -> Result<(String, String)> {
         )?
     };
     Ok((start, today))
+}
+
+/// One compact rolling year ending today. The frontend clips this to however
+/// many fixed-width weeks fit in the current window.
+fn rolling_year_bounds(conn: &Connection) -> Result<(String, String)> {
+    let end: String = conn.query_row("SELECT date('now', 'localtime')", [], |r| r.get(0))?;
+    let start: String = conn.query_row(
+        "SELECT date('now', 'localtime', '-364 days')",
+        [],
+        |r| r.get(0),
+    )?;
+    Ok((start, end))
 }
 
 fn query_totals(
@@ -812,6 +837,21 @@ mod tests {
     }
 
     #[test]
+    fn streak_calendar_retains_one_compact_year() {
+        let db = test_db();
+        insert_on_day(&db, 2, "recent activity", 3, 1_500);
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.daily.len(), 7, "page data respects the selected range");
+        assert_eq!(insights.streak_daily.len(), 365, "one compact year is retained");
+        assert_eq!(
+            insights.streak_daily.last().map(|d| d.day.as_str()),
+            Some(local_day_string(0).as_str()),
+            "calendar ends today"
+        );
+    }
+
+    #[test]
     fn streak_counts_a_three_day_run_followed_by_a_gap() {
         let db = test_db();
         insert_on_day(&db, 6, "run one", 2, 1000);
@@ -1009,6 +1049,8 @@ mod tests {
             "totals",
             "streak",
             "daily",
+            "streak_daily",
+            "history_started_on",
             "hourly",
             "providers",
             "cleanup",

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -569,11 +569,14 @@ fn query_words(
             // count a human word length should measure (non-ASCII words like
             // accented or non-Latin text would otherwise be over-counted).
             let char_len = normalized.chars().count();
-            if char_len > longest.as_ref().map_or(0, |w| w.chars().count()) {
-                longest = Some(normalized.clone());
-            }
+            // Stopwords are excluded from the vocabulary insights — check
+            // before tracking `longest` so a long filler word like
+            // "because"/"themselves" never shows up as the longest word.
             if char_len < MIN_WORD_CHARS || STOPWORDS.contains(&normalized.as_str()) {
                 continue;
+            }
+            if char_len > longest.as_ref().map_or(0, |w| w.chars().count()) {
+                longest = Some(normalized.clone());
             }
             *counts.entry(normalized.clone()).or_insert(0) += 1;
             length_sum += char_len as u64;

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -630,16 +630,18 @@ fn compute_streak(daily: &[InsightsDay]) -> InsightsStreak {
     let mut current_days = 0i64;
     // The series is zero-filled and ends on today. A quiet today (the day
     // isn't over yet) must not zero a streak that's still alive through
-    // yesterday — GitHub-style, the streak holds until the day ends.
+    // yesterday — GitHub-style, the streak holds until the day ends. The
+    // grace applies only to the trailing day (today) itself: if today is
+    // empty it's skipped, and counting continues strictly from yesterday.
     let mut iter = daily.iter().rev();
-    let mut pending_today = true;
-    for day in &mut iter {
+    if let Some(today) = iter.next() {
+        if today.words > 0 {
+            current_days += 1;
+        }
+    }
+    for day in iter {
         if day.words > 0 {
             current_days += 1;
-        } else if pending_today {
-            // Skip the empty trailing day (today) once; a second empty day
-            // is a real break.
-            pending_today = false;
         } else {
             break;
         }
@@ -851,6 +853,18 @@ mod tests {
 
         let insights = query_insights(&db, 7).expect("insights");
         assert_eq!(insights.streak.current_days, 0);
+    }
+
+    #[test]
+    fn streak_stops_at_a_real_gap_even_when_today_is_active() {
+        let db = test_db();
+        // Today is active, but yesterday was a gap — the grace for a quiet
+        // today must not swallow real historical gaps. Streak is just today.
+        insert_on_day(&db, 0, "today", 2, 1000);
+        insert_on_day(&db, 2, "two days ago", 2, 1000);
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.streak.current_days, 1);
     }
 
     #[test]

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -1,0 +1,1098 @@
+//! Insights aggregation for the Insights page.
+//!
+//! Mirrors `src/lib/views/insights/types.ts` field for field — serde field
+//! names are the frontend contract and must not drift. Day/hour bucketing
+//! always goes through `date(created_at, 'localtime')` / `strftime('%H',
+//! created_at, 'localtime')` because `created_at` is stored UTC-naive (see
+//! `query_stats` in transcriptions.rs).
+//!
+//! Privacy: this module only ever emits counts, model ids, and normalized
+//! word stats. It never logs dictated text, clean_text, or top words.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::{NaiveDate, Utc};
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Insights {
+    pub range_days: i64,
+    pub generated_at: String,
+    pub totals: InsightsTotals,
+    pub streak: InsightsStreak,
+    pub daily: Vec<InsightsDay>,
+    pub hourly: Vec<i64>,
+    pub providers: Vec<InsightsProviderUsage>,
+    pub cleanup: InsightsCleanup,
+    pub words: InsightsWords,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsTotals {
+    pub total_words: i64,
+    pub total_transcriptions: i64,
+    pub total_speaking_ms: i64,
+    pub avg_words_per_transcription: i64,
+    pub avg_wpm: f64,
+    pub best_wpm: i64,
+    pub words_in_range: i64,
+    pub words_prev_range: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsStreak {
+    pub current_days: i64,
+    pub longest_days: i64,
+    pub longest_started_on: Option<String>,
+    pub longest_ended_on: Option<String>,
+    pub longest_words: i64,
+    pub active_days: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsDay {
+    pub day: String,
+    pub words: i64,
+    pub transcriptions: i64,
+    pub speaking_ms: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsProviderUsage {
+    pub model: String,
+    pub provider: String,
+    pub task: String,
+    pub calls: i64,
+    pub audio_ms: i64,
+    pub input_chars: i64,
+    pub output_chars: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsCleanup {
+    pub raw_words: i64,
+    pub clean_words: i64,
+    pub edits_applied: i64,
+    pub dictionary_fixes: i64,
+    pub auto_learned_terms: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsWords {
+    pub top: Vec<InsightsWordCount>,
+    pub unique_words: i64,
+    pub longest_word: Option<String>,
+    pub avg_word_length: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightsWordCount {
+    pub word: String,
+    pub count: i64,
+}
+
+/// One provider call recorded at pipeline finalize time, aggregated into
+/// `Insights.providers`. `audio_ms` is set for transcription tasks only;
+/// `input_chars`/`output_chars` for cleanup tasks only.
+#[derive(Debug, Clone)]
+pub struct ApiCall {
+    pub transcription_id: i64,
+    pub model: String,
+    pub provider: String,
+    pub task: String,
+    pub audio_ms: i64,
+    pub input_chars: i64,
+    pub output_chars: i64,
+    pub created_at: String,
+}
+
+const TOP_WORDS_LIMIT: usize = 12;
+const MIN_WORD_CHARS: usize = 3;
+
+// Filler/function words users don't need to see in their distinctive
+// vocabulary. Lowercase; `top`/`unique_words`/`avg_word_length` filter on it.
+const STOPWORDS: &[&str] = &[
+    "a", "about", "after", "all", "also", "am", "an", "and", "any", "are", "as", "at", "be",
+    "because", "been", "before", "being", "but", "by", "could", "did", "do", "does", "for",
+    "from", "had", "has", "have", "he", "her", "hers", "him", "his", "how", "i", "if", "in",
+    "into", "is", "it", "its", "me", "more", "most", "my", "no", "not", "of", "off", "on",
+    "or", "our", "ours", "out", "over", "own", "said", "she", "so", "some", "than", "that",
+    "the", "their", "them", "then", "there", "these", "they", "this", "those", "through",
+    "to", "too", "under", "up", "us", "was", "we", "were", "what", "when", "where", "which",
+    "while", "who", "whom", "why", "will", "with", "would", "you", "your", "yours",
+];
+
+/// Aggregated insights for `days` (`0` = all time). A brand-new install with
+/// no transcriptions returns a fully-populated zero payload, never an error.
+pub fn query_insights(db: &Db, days: i64) -> Result<Insights> {
+    let conn = lock_conn(db)?;
+    let (range_start, range_end) = range_bounds(&conn, days)?;
+
+    let totals = query_totals(&conn, &range_start, &range_end, days)?;
+    let daily = query_daily(&conn, &range_start, &range_end)?;
+    let hourly = query_hourly(&conn, &range_start, &range_end)?;
+    let providers = query_providers(&conn, &range_start, &range_end)?;
+    let cleanup = query_cleanup(&conn, &range_start, &range_end)?;
+    let words = query_words(&conn, &range_start, &range_end)?;
+    let streak = compute_streak(&daily);
+
+    Ok(Insights {
+        range_days: days,
+        generated_at: Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        totals,
+        streak,
+        daily,
+        hourly,
+        providers,
+        cleanup,
+        words,
+    })
+}
+
+/// Inserts the per-call API usage rows for one transcription.
+pub fn insert_api_calls(db: &Db, calls: &[ApiCall]) -> Result<()> {
+    if calls.is_empty() {
+        return Ok(());
+    }
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO api_calls \
+             (transcription_id, model, provider, task, audio_ms, input_chars, output_chars, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )?;
+        for call in calls {
+            stmt.execute(params![
+                call.transcription_id,
+                call.model,
+                call.provider,
+                call.task,
+                call.audio_ms,
+                call.input_chars,
+                call.output_chars,
+                call.created_at,
+            ])?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Builds `ApiCall` rows for one finalized transcription by parsing the
+/// `api_used` string the pipeline assembled (formats: `provider/model`,
+/// `provider/model/transcription`, `primary=..;secondary=..`, with an
+/// optional `;cleanup=..` suffix). Unparseable strings yield no rows, never
+/// an error — cost accounting is best-effort and must not fail a dictation.
+///
+/// `audio_ms` is attributed to every transcription model (each one processed
+/// the same clip); cleanup rows carry `input_chars`/`output_chars` derived
+/// from the raw and cleaned text.
+pub(crate) fn build_api_calls(
+    transcription_id: i64,
+    created_at: &str,
+    api_used: &str,
+    duration_ms: i64,
+    raw: &str,
+    clean: &str,
+) -> Vec<ApiCall> {
+    let parts = parse_api_usage(api_used);
+    let mut calls = Vec::with_capacity(
+        parts.transcription_models.len() + parts.cleanup_models.len(),
+    );
+    for (provider, model) in parts.transcription_models {
+        calls.push(ApiCall {
+            transcription_id,
+            model,
+            provider,
+            task: "transcription".to_string(),
+            audio_ms: duration_ms,
+            input_chars: 0,
+            output_chars: 0,
+            created_at: created_at.to_string(),
+        });
+    }
+    if !parts.cleanup_models.is_empty() {
+        let input_chars = raw.chars().count() as i64;
+        let output_chars = clean.chars().count() as i64;
+        for (provider, model) in parts.cleanup_models {
+            calls.push(ApiCall {
+                transcription_id,
+                model,
+                provider,
+                task: "cleanup".to_string(),
+                audio_ms: 0,
+                input_chars,
+                output_chars,
+                created_at: created_at.to_string(),
+            });
+        }
+    }
+    calls
+}
+
+/// Models parsed out of an `api_used` string, split by task. Each entry is
+/// `(provider, model)`.
+struct ApiUsageParts {
+    transcription_models: Vec<(String, String)>,
+    cleanup_models: Vec<(String, String)>,
+}
+
+/// Splits an `api_used` string into transcription and cleanup model pairs.
+fn parse_api_usage(api_used: &str) -> ApiUsageParts {
+    let (transcription_part, cleanup_part) = match api_used.split_once(";cleanup=") {
+        Some((before, after)) => (before, Some(after)),
+        None => (api_used, None),
+    };
+
+    let mut transcription = Vec::new();
+    if let Some(primary) = transcription_part.strip_prefix("primary=") {
+        for segment in primary.split(';') {
+            let segment = segment.strip_prefix("secondary=").unwrap_or(segment);
+            if let Some((provider, model)) = segment.split_once('/') {
+                if !provider.is_empty() && !model.is_empty() {
+                    transcription.push((provider.to_string(), model.to_string()));
+                }
+            }
+        }
+    } else if let Some((provider, rest)) = transcription_part.split_once('/') {
+        let model = rest.strip_suffix("/transcription").unwrap_or(rest);
+        if !provider.is_empty() && !model.is_empty() {
+            transcription.push((provider.to_string(), model.to_string()));
+        }
+    }
+
+    let mut cleanup = Vec::new();
+    if let Some(segment) = cleanup_part {
+        if let Some((provider, model)) = segment.split_once('/') {
+            if !provider.is_empty() && !model.is_empty() {
+                cleanup.push((provider.to_string(), model.to_string()));
+            }
+        }
+    }
+
+    ApiUsageParts {
+        transcription_models: transcription,
+        cleanup_models: cleanup,
+    }
+}
+
+/// Local calendar-day bounds of the requested range, as `"YYYY-MM-DD"`.
+/// `days > 0` spans the last `days` calendar days ending today; `days == 0`
+/// spans the first recorded transcription through today.
+fn range_bounds(conn: &Connection, days: i64) -> Result<(String, String)> {
+    let today: String = conn.query_row("SELECT date('now', 'localtime')", [], |r| r.get(0))?;
+    let start = if days > 0 {
+        let n = (days - 1).max(0);
+        conn.query_row(
+            "SELECT date('now', 'localtime', ?1)",
+            params![format!("-{n} days")],
+            |r| r.get(0),
+        )?
+    } else {
+        conn.query_row(
+            "SELECT COALESCE(
+               date((SELECT MIN(created_at) FROM transcriptions), 'localtime'),
+               date('now', 'localtime')
+             )",
+            [],
+            |r| r.get(0),
+        )?
+    };
+    Ok((start, today))
+}
+
+fn query_totals(
+    conn: &Connection,
+    range_start: &str,
+    range_end: &str,
+    days: i64,
+) -> Result<InsightsTotals> {
+    let (total_transcriptions, words_in_range, total_speaking_ms): (i64, i64, i64) = conn
+        .query_row(
+            "SELECT COUNT(*), COALESCE(SUM(words), 0), COALESCE(SUM(duration_ms), 0)
+             FROM transcriptions
+             WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2",
+            params![range_start, range_end],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )?;
+
+    // Identical definition to query_stats (average of each clip's own wpm)
+    // so the Insights "All time" number matches the Home page exactly;
+    // scoped to the range here. Not total_words/total_duration — that
+    // aggregates differently and makes the two pages disagree.
+    let avg_wpm: f64 = conn.query_row(
+        "SELECT COALESCE(AVG(CAST(spoken_words AS REAL) * 60000.0 / duration_ms), 0.0)
+         FROM transcriptions
+         WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
+           AND duration_ms > 0 AND spoken_words > 0",
+        params![range_start, range_end],
+        |r| r.get(0),
+    )?;
+
+    let best_wpm: i64 = conn.query_row(
+        "SELECT COALESCE(CAST(MAX(CAST(spoken_words AS REAL) * 60000.0 / duration_ms) AS INTEGER), 0)
+         FROM transcriptions
+         WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
+           AND duration_ms > 0 AND spoken_words > 0",
+        params![range_start, range_end],
+        |r| r.get(0),
+    )?;
+
+    let total_words: i64 = conn.query_row(
+        "SELECT COALESCE((SELECT total_words FROM lifetime_stats WHERE id = 1), 0)",
+        [],
+        |r| r.get(0),
+    )?;
+
+    let words_prev_range: i64 = if days > 0 {
+        let prev_start = format!("-{} days", (2 * days - 1).max(1));
+        let prev_end = format!("-{} days", days);
+        conn.query_row(
+            "SELECT COALESCE(SUM(words), 0)
+             FROM transcriptions
+             WHERE date(created_at, 'localtime') BETWEEN date('now', 'localtime', ?1)
+                                                   AND date('now', 'localtime', ?2)",
+            params![prev_start, prev_end],
+            |r| r.get(0),
+        )?
+    } else {
+        0
+    };
+
+    let avg_words_per_transcription = if total_transcriptions > 0 {
+        (words_in_range as f64 / total_transcriptions as f64).round() as i64
+    } else {
+        0
+    };
+
+    Ok(InsightsTotals {
+        total_words,
+        total_transcriptions,
+        total_speaking_ms,
+        avg_words_per_transcription,
+        avg_wpm,
+        best_wpm,
+        words_in_range,
+        words_prev_range,
+    })
+}
+
+/// One row per calendar day in the range, ascending, zero-filled for idle days.
+fn query_daily(
+    conn: &Connection,
+    range_start: &str,
+    range_end: &str,
+) -> Result<Vec<InsightsDay>> {
+    let mut per_day: HashMap<String, (i64, i64, i64)> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT date(created_at, 'localtime'), SUM(words), COUNT(*), SUM(duration_ms)
+             FROM transcriptions
+             WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
+             GROUP BY 1",
+        )?;
+        let rows = stmt.query_map(params![range_start, range_end], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                (r.get::<_, i64>(1)?, r.get::<_, i64>(2)?, r.get::<_, i64>(3)?),
+            ))
+        })?;
+        for row in rows {
+            let (day, sums) = row?;
+            per_day.insert(day, sums);
+        }
+    }
+
+    let start = NaiveDate::parse_from_str(range_start, "%Y-%m-%d")?;
+    let end = NaiveDate::parse_from_str(range_end, "%Y-%m-%d")?;
+    let span_days = (end - start).num_days();
+    let mut daily = Vec::with_capacity(span_days.max(1) as usize);
+    let mut current = start;
+    loop {
+        let day = current.format("%Y-%m-%d").to_string();
+        let (words, transcriptions, speaking_ms) =
+            per_day.get(&day).copied().unwrap_or((0, 0, 0));
+        daily.push(InsightsDay {
+            day,
+            words,
+            transcriptions,
+            speaking_ms,
+        });
+        if current == end {
+            break;
+        }
+        current = current.succ_opt().ok_or_else(|| {
+            anyhow::anyhow!("insights: date overflow while zero-filling daily series")
+        })?;
+    }
+    debug_assert_eq!(daily.len() as i64, span_days + 1);
+    Ok(daily)
+}
+
+/// Words per hour-of-day, local time; exactly 24 entries, zeros included.
+fn query_hourly(conn: &Connection, range_start: &str, range_end: &str) -> Result<Vec<i64>> {
+    let mut hourly = vec![0i64; 24];
+    let mut stmt = conn.prepare(
+        "SELECT CAST(strftime('%H', created_at, 'localtime') AS INTEGER), SUM(words)
+         FROM transcriptions
+         WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
+         GROUP BY 1",
+    )?;
+    let rows = stmt.query_map(params![range_start, range_end], |r| {
+        Ok((r.get::<_, usize>(0)?, r.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (hour, words) = row?;
+        if let Some(slot) = hourly.get_mut(hour) {
+            *slot = words;
+        }
+    }
+    Ok(hourly)
+}
+
+/// Per-model/per-task usage from the `api_calls` table, in range. Rows
+/// predating the table simply contribute nothing.
+fn query_providers(
+    conn: &Connection,
+    range_start: &str,
+    range_end: &str,
+) -> Result<Vec<InsightsProviderUsage>> {
+    let mut stmt = conn.prepare(
+        "SELECT model, provider, task, COUNT(*),
+                COALESCE(SUM(audio_ms), 0),
+                COALESCE(SUM(input_chars), 0),
+                COALESCE(SUM(output_chars), 0)
+         FROM api_calls
+         WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2
+         GROUP BY model, provider, task
+         ORDER BY COUNT(*) DESC, model ASC",
+    )?;
+    let rows = stmt.query_map(params![range_start, range_end], |r| {
+        Ok(InsightsProviderUsage {
+            model: r.get(0)?,
+            provider: r.get(1)?,
+            task: r.get(2)?,
+            calls: r.get(3)?,
+            audio_ms: r.get(4)?,
+            input_chars: r.get(5)?,
+            output_chars: r.get(6)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn query_cleanup(
+    conn: &Connection,
+    range_start: &str,
+    range_end: &str,
+) -> Result<InsightsCleanup> {
+    // raw/clean word counts are range-scoped from the transcriptions rows we
+    // already load for the vocabulary stats.
+    let (raw_words, clean_words) = {
+        let mut stmt = conn.prepare(
+            "SELECT clean_text, COALESCE(spoken_words, words)
+             FROM transcriptions
+             WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2",
+        )?;
+        let rows = stmt.query_map(params![range_start, range_end], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })?;
+        let mut raw = 0i64;
+        let mut clean = 0i64;
+        for row in rows {
+            let (clean_text, spoken) = row?;
+            raw += spoken;
+            clean += clean_text.split_whitespace().count() as i64;
+        }
+        (raw, clean)
+    };
+
+    let dictionary_fixes: i64 = conn.query_row(
+        "SELECT COALESCE((SELECT dictionary_fixes FROM lifetime_stats WHERE id = 1), 0)",
+        [],
+        |r| r.get(0),
+    )?;
+    let auto_learned_terms: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM dictionary WHERE auto_learned = 1",
+        [],
+        |r| r.get(0),
+    )?;
+    let snippet_expansions: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(use_count), 0) FROM snippets",
+        [],
+        |r| r.get(0),
+    )?;
+
+    Ok(InsightsCleanup {
+        raw_words,
+        clean_words,
+        edits_applied: dictionary_fixes + snippet_expansions,
+        dictionary_fixes,
+        auto_learned_terms,
+    })
+}
+
+fn query_words(
+    conn: &Connection,
+    range_start: &str,
+    range_end: &str,
+) -> Result<InsightsWords> {
+    let mut stmt = conn.prepare(
+        "SELECT clean_text FROM transcriptions
+         WHERE date(created_at, 'localtime') BETWEEN ?1 AND ?2",
+    )?;
+    let rows = stmt.query_map(params![range_start, range_end], |r| r.get::<_, String>(0))?;
+
+    let mut counts: HashMap<String, i64> = HashMap::new();
+    let mut longest: Option<String> = None;
+    let mut length_sum = 0u64;
+    let mut length_count = 0u64;
+
+    for row in rows {
+        let clean_text = row?;
+        for token in clean_text.split_whitespace() {
+            let normalized = normalize_word(token);
+            if normalized.is_empty() {
+                continue;
+            }
+            if normalized.len() > longest.as_ref().map_or(0, String::len) {
+                longest = Some(normalized.clone());
+            }
+            if normalized.len() < MIN_WORD_CHARS || STOPWORDS.contains(&normalized.as_str()) {
+                continue;
+            }
+            *counts.entry(normalized.clone()).or_insert(0) += 1;
+            length_sum += normalized.len() as u64;
+            length_count += 1;
+        }
+    }
+
+    let mut top: Vec<InsightsWordCount> = counts
+        .iter()
+        .map(|(word, count)| InsightsWordCount {
+            word: word.clone(),
+            count: *count,
+        })
+        .collect();
+    top.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.word.cmp(&b.word)));
+    top.truncate(TOP_WORDS_LIMIT);
+
+    Ok(InsightsWords {
+        top,
+        unique_words: counts.len() as i64,
+        longest_word: longest,
+        avg_word_length: if length_count > 0 {
+            length_sum as f64 / length_count as f64
+        } else {
+            0.0
+        },
+    })
+}
+
+/// Lowercases and strips punctuation, keeping only alphanumeric characters.
+fn normalize_word(word: &str) -> String {
+    word.chars()
+        .filter(|c| c.is_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
+/// Computes current/longest streak over the (already zero-filled, ascending)
+/// daily series. A day with `words > 0` counts as active.
+fn compute_streak(daily: &[InsightsDay]) -> InsightsStreak {
+    let active_days = daily.iter().filter(|d| d.words > 0).count() as i64;
+
+    let mut current_days = 0i64;
+    for day in daily.iter().rev() {
+        if day.words > 0 {
+            current_days += 1;
+        } else {
+            break;
+        }
+    }
+
+    let mut longest_days = 0i64;
+    let mut longest_words = 0i64;
+    let mut longest_started_on = None;
+    let mut longest_ended_on = None;
+    let mut run = 0i64;
+    let mut run_words = 0i64;
+    let mut run_start: Option<&str> = None;
+    for day in daily {
+        if day.words > 0 {
+            if run == 0 {
+                run_start = Some(day.day.as_str());
+            }
+            run += 1;
+            run_words += day.words;
+        } else {
+            run = 0;
+            run_words = 0;
+            run_start = None;
+        }
+        if run > longest_days {
+            longest_days = run;
+            longest_words = run_words;
+            longest_started_on = run_start.map(str::to_string);
+            longest_ended_on = Some(day.day.clone());
+        }
+    }
+
+    InsightsStreak {
+        current_days,
+        longest_days,
+        longest_started_on,
+        longest_ended_on,
+        longest_words,
+        active_days,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Local, TimeZone};
+
+    fn test_db() -> Db {
+        open(":memory:").expect("test db")
+    }
+
+    /// UTC-naive timestamp whose local representation lands on `days_ago`
+    /// local calendar days at the given local wall-clock time.
+    fn utc_for_local_day(days_ago: i64, hour: u32, minute: u32) -> String {
+        let local_date = Local::now().date_naive() - Duration::days(days_ago);
+        let wall = local_date
+            .and_hms_opt(hour, minute, 0)
+            .expect("valid wall time");
+        let utc = Local
+            .from_local_datetime(&wall)
+            .single()
+            .expect("local to utc")
+            .naive_utc();
+        utc.format("%Y-%m-%d %H:%M:%S").to_string()
+    }
+
+    fn local_day_string(days_ago: i64) -> String {
+        (Local::now().date_naive() - Duration::days(days_ago))
+            .format("%Y-%m-%d")
+            .to_string()
+    }
+
+    fn insert_on_day(db: &Db, days_ago: i64, text: &str, words: i64, duration_ms: i64) -> i64 {
+        let entry = insert_transcription_returning(db, text, text, words, duration_ms, "groq/whisper-large-v3-turbo")
+            .expect("insert transcription");
+        {
+            let conn = lock_conn(db).expect("lock");
+            conn.execute(
+                "UPDATE transcriptions SET created_at = ?1 WHERE id = ?2",
+                params![utc_for_local_day(days_ago, 10, 0), entry.id],
+            )
+            .expect("backdate transcription");
+        }
+        entry.id
+    }
+
+    fn days_in(insights: &Insights) -> Vec<String> {
+        insights.daily.iter().map(|d| d.day.clone()).collect()
+    }
+
+    #[test]
+    fn empty_db_returns_zero_payload_not_an_error() {
+        let db = test_db();
+        let insights = query_insights(&db, 30).expect("insights on empty db");
+
+        assert_eq!(insights.range_days, 30);
+        assert_eq!(insights.totals.total_words, 0);
+        assert_eq!(insights.totals.total_transcriptions, 0);
+        assert_eq!(insights.totals.total_speaking_ms, 0);
+        assert_eq!(insights.totals.avg_words_per_transcription, 0);
+        assert_eq!(insights.totals.avg_wpm, 0.0);
+        assert_eq!(insights.totals.best_wpm, 0);
+        assert_eq!(insights.totals.words_in_range, 0);
+        assert_eq!(insights.totals.words_prev_range, 0);
+        assert_eq!(insights.streak.current_days, 0);
+        assert_eq!(insights.streak.longest_days, 0);
+        assert_eq!(insights.streak.longest_started_on, None);
+        assert_eq!(insights.streak.longest_ended_on, None);
+        assert_eq!(insights.streak.longest_words, 0);
+        assert_eq!(insights.streak.active_days, 0);
+        assert_eq!(insights.daily.len(), 30);
+        assert!(insights.daily.iter().all(|d| d.words == 0));
+        assert_eq!(insights.hourly.len(), 24);
+        assert!(insights.hourly.iter().all(|h| *h == 0));
+        assert!(insights.providers.is_empty());
+        assert_eq!(insights.cleanup.raw_words, 0);
+        assert_eq!(insights.cleanup.clean_words, 0);
+        assert_eq!(insights.cleanup.edits_applied, 0);
+        assert_eq!(insights.cleanup.dictionary_fixes, 0);
+        assert_eq!(insights.cleanup.auto_learned_terms, 0);
+        assert!(insights.words.top.is_empty());
+        assert_eq!(insights.words.unique_words, 0);
+        assert_eq!(insights.words.longest_word, None);
+        assert_eq!(insights.words.avg_word_length, 0.0);
+    }
+
+    #[test]
+    fn all_time_range_spans_first_transcription_through_today() {
+        let db = test_db();
+        insert_on_day(&db, 5, "hello world", 2, 1000);
+        insert_on_day(&db, 2, "more dictation", 2, 1000);
+
+        let insights = query_insights(&db, 0).expect("insights all time");
+        let expected = (0..=5).rev().map(local_day_string).collect::<Vec<_>>();
+        assert_eq!(days_in(&insights), expected);
+        assert_eq!(insights.range_days, 0);
+        assert_eq!(insights.totals.words_in_range, 4);
+        assert_eq!(insights.totals.words_prev_range, 0);
+    }
+
+    #[test]
+    fn daily_zero_fills_a_gap_day_and_stays_ascending() {
+        let db = test_db();
+        insert_on_day(&db, 3, "day one", 2, 1000);
+        insert_on_day(&db, 1, "day three", 3, 1500);
+
+        let insights = query_insights(&db, 7).expect("insights");
+        let expected = (0..7).rev().map(local_day_string).collect::<Vec<_>>();
+        assert_eq!(days_in(&insights), expected);
+
+        let gap = insights
+            .daily
+            .iter()
+            .find(|d| d.day == local_day_string(2))
+            .expect("gap day present");
+        assert_eq!(gap.words, 0);
+        assert_eq!(gap.transcriptions, 0);
+        assert_eq!(gap.speaking_ms, 0);
+
+        let active: Vec<_> = insights.daily.iter().filter(|d| d.words > 0).collect();
+        assert_eq!(active.len(), 2);
+        assert_eq!(active[0].day, local_day_string(3));
+        assert_eq!(active[0].words, 2);
+        assert_eq!(active[1].day, local_day_string(1));
+        assert_eq!(active[1].words, 3);
+        assert_eq!(active[1].speaking_ms, 1500);
+    }
+
+    #[test]
+    fn streak_counts_a_three_day_run_followed_by_a_gap() {
+        let db = test_db();
+        insert_on_day(&db, 6, "run one", 2, 1000);
+        insert_on_day(&db, 5, "run two", 2, 1000);
+        insert_on_day(&db, 4, "run three", 4, 2000);
+
+        let insights = query_insights(&db, 7).expect("insights");
+
+        assert_eq!(insights.streak.longest_days, 3);
+        assert_eq!(
+            insights.streak.longest_started_on.as_deref(),
+            Some(local_day_string(6).as_str())
+        );
+        assert_eq!(
+            insights.streak.longest_ended_on.as_deref(),
+            Some(local_day_string(4).as_str())
+        );
+        assert_eq!(insights.streak.longest_words, 8);
+        assert_eq!(insights.streak.current_days, 0, "gap at the range end breaks the current streak");
+        assert_eq!(insights.streak.active_days, 3);
+    }
+
+    #[test]
+    fn transcription_just_before_local_midnight_buckets_to_the_local_day() {
+        let db = test_db();
+        // 23:50 local two days ago — within an hour of the local-day boundary.
+        let entry = insert_transcription_returning(
+            &db,
+            "late night words",
+            "late night words",
+            3,
+            1000,
+            "groq/whisper-large-v3-turbo",
+        )
+        .expect("insert transcription");
+        let created_at = utc_for_local_day(2, 23, 50);
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "UPDATE transcriptions SET created_at = ?1 WHERE id = ?2",
+                params![created_at, entry.id],
+            )
+            .expect("set boundary timestamp");
+        }
+
+        let insights = query_insights(&db, 0).expect("insights");
+
+        let expected_local_day = local_day_string(2);
+        let bucket = insights
+            .daily
+            .iter()
+            .find(|d| d.words > 0)
+            .expect("transcription bucketed somewhere");
+        assert_eq!(bucket.day, expected_local_day);
+
+        // When the machine's local offset is non-zero, the UTC calendar day
+        // of the stored timestamp must NOT be the bucket (proving the
+        // 'localtime' conversion happened).
+        let utc_day = created_at[..10].to_string();
+        if utc_day != expected_local_day {
+            assert!(
+                !insights.daily.iter().any(|d| d.day == utc_day && d.words > 0),
+                "must bucket to the local day, not the UTC one"
+            );
+        }
+    }
+
+    #[test]
+    fn top_words_exclude_stopwords_and_sort_descending() {
+        let db = test_db();
+        let text = "the the the and and and apple banana banana cherry the";
+        insert_transcription_returning(&db, text, text, 11, 1000, "groq/whisper-large-v3-turbo")
+            .expect("insert transcription");
+
+        let insights = query_insights(&db, 7).expect("insights");
+
+        let top = &insights.words.top;
+        assert_eq!(top.len(), 3);
+        assert_eq!(top[0].word, "banana");
+        assert_eq!(top[0].count, 2);
+        assert_eq!(top[1].word, "apple");
+        assert_eq!(top[1].count, 1);
+        assert_eq!(top[2].word, "cherry");
+        assert_eq!(top[2].count, 1);
+        assert!(
+            !top.iter().any(|w| w.word == "the" || w.word == "and"),
+            "stopwords must not appear in top words"
+        );
+        assert_eq!(insights.words.unique_words, 3);
+        assert_eq!(insights.words.longest_word.as_deref(), Some("banana"));
+        assert!(insights.words.avg_word_length > 5.0 && insights.words.avg_word_length < 7.0);
+    }
+
+    #[test]
+    fn top_words_strip_punctuation_and_drop_short_tokens() {
+        let db = test_db();
+        let text = "React, Vue! React? Vue. Svelte. i a um go";
+        insert_transcription_returning(&db, text, text, 10, 1000, "groq/whisper-large-v3-turbo")
+            .expect("insert transcription");
+
+        let insights = query_insights(&db, 7).expect("insights");
+
+        let top = &insights.words.top;
+        assert!(top.iter().any(|w| w.word == "react" && w.count == 2));
+        assert!(top.iter().any(|w| w.word == "vue" && w.count == 2));
+        assert!(top.iter().any(|w| w.word == "svelte" && w.count == 1));
+        assert!(
+            !top.iter().any(|w| w.word == "i" || w.word == "a" || w.word == "um"),
+            "sub-3-char and stopword tokens must be excluded"
+        );
+    }
+
+    #[test]
+    fn api_calls_round_trip_and_aggregate_per_model_and_task() {
+        let db = test_db();
+        let id = insert_on_day(&db, 1, "cost test", 2, 1000);
+        let created_at = utc_for_local_day(1, 10, 0);
+
+        let calls = build_api_calls(id, &created_at, "groq/whisper-large-v3-turbo;cleanup=groq/llama-3.3-70b-versatile", 1234, "raw words", "clean words");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].task, "transcription");
+        assert_eq!(calls[0].audio_ms, 1234);
+        assert_eq!(calls[1].task, "cleanup");
+        assert_eq!(calls[1].input_chars, 9);
+        assert_eq!(calls[1].output_chars, 11);
+
+        insert_api_calls(&db, &calls).expect("insert api calls");
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.providers.len(), 2);
+        let tx = insights
+            .providers
+            .iter()
+            .find(|p| p.task == "transcription")
+            .expect("transcription row");
+        assert_eq!(tx.model, "whisper-large-v3-turbo");
+        assert_eq!(tx.provider, "groq");
+        assert_eq!(tx.calls, 1);
+        assert_eq!(tx.audio_ms, 1234);
+        let cleanup = insights
+            .providers
+            .iter()
+            .find(|p| p.task == "cleanup")
+            .expect("cleanup row");
+        assert_eq!(cleanup.model, "llama-3.3-70b-versatile");
+        assert_eq!(cleanup.calls, 1);
+        assert_eq!(cleanup.input_chars, 9);
+        assert_eq!(cleanup.output_chars, 11);
+    }
+
+    #[test]
+    fn serde_field_names_match_the_frontend_contract_exactly() {
+        let db = test_db();
+        let insights = query_insights(&db, 30).expect("insights");
+        let json = serde_json::to_value(&insights).expect("serialize insights");
+        let object = json.as_object().expect("object");
+
+        for key in [
+            "range_days",
+            "generated_at",
+            "totals",
+            "streak",
+            "daily",
+            "hourly",
+            "providers",
+            "cleanup",
+            "words",
+        ] {
+            assert!(object.contains_key(key), "missing top-level key: {key}");
+        }
+        for key in [
+            "total_words",
+            "total_transcriptions",
+            "total_speaking_ms",
+            "avg_words_per_transcription",
+            "avg_wpm",
+            "best_wpm",
+            "words_in_range",
+            "words_prev_range",
+        ] {
+            assert!(
+                object["totals"].as_object().expect("totals").contains_key(key),
+                "missing totals key: {key}"
+            );
+        }
+        for key in [
+            "current_days",
+            "longest_days",
+            "longest_started_on",
+            "longest_ended_on",
+            "longest_words",
+            "active_days",
+        ] {
+            assert!(
+                object["streak"].as_object().expect("streak").contains_key(key),
+                "missing streak key: {key}"
+            );
+        }
+        for key in ["day", "words", "transcriptions", "speaking_ms"] {
+            assert!(
+                object["daily"]
+                    .as_array()
+                    .expect("daily")
+                    .first()
+                    .and_then(|d| d.as_object())
+                    .expect("day object")
+                    .contains_key(key),
+                "missing daily key: {key}"
+            );
+        }
+        assert_eq!(
+            object["hourly"].as_array().expect("hourly").len(),
+            24,
+            "hourly must have exactly 24 entries"
+        );
+        for key in ["model", "provider", "task", "calls", "audio_ms", "input_chars", "output_chars"]
+        {
+            assert!(
+                object["providers"]
+                    .as_array()
+                    .expect("providers")
+                    .first()
+                    .and_then(|p| p.as_object())
+                    .map(|o| o.contains_key(key))
+                    .unwrap_or(true),
+                "missing providers key: {key}"
+            );
+        }
+        for key in ["raw_words", "clean_words", "edits_applied", "dictionary_fixes", "auto_learned_terms"] {
+            assert!(
+                object["cleanup"].as_object().expect("cleanup").contains_key(key),
+                "missing cleanup key: {key}"
+            );
+        }
+        for key in ["top", "unique_words", "longest_word", "avg_word_length"] {
+            assert!(
+                object["words"].as_object().expect("words").contains_key(key),
+                "missing words key: {key}"
+            );
+        }
+        assert!(
+            object["words"]["top"].as_array().expect("top").is_empty(),
+            "top is an array"
+        );
+    }
+
+    #[test]
+    fn all_time_avg_wpm_matches_query_stats_on_the_same_data() {
+        let db = test_db();
+        insert_on_day(&db, 1, "two words", 2, 1000);
+        insert_on_day(&db, 2, "also two", 2, 2000);
+
+        let stats = query_stats(&db).expect("stats");
+        let insights = query_insights(&db, 0).expect("insights");
+
+        assert!(stats.avg_wpm > 0.0);
+        assert!(
+            (insights.totals.avg_wpm - stats.avg_wpm).abs() < 1e-9,
+            "all-time insights avg_wpm ({}) must equal query_stats avg_wpm ({})",
+            insights.totals.avg_wpm,
+            stats.avg_wpm
+        );
+    }
+
+    #[test]
+    fn cleanup_fixes_count_applied_substitutions_and_snippet_expansions() {
+        let db = test_db();
+        insert_snippet(&db, "sig", "signature", "").expect("snippet");
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute("UPDATE snippets SET use_count = 7", [])
+                .expect("set use count");
+        }
+        increment_lifetime_dictionary_fixes(&db, 3).expect("increment");
+
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.cleanup.dictionary_fixes, 3);
+        assert_eq!(insights.cleanup.edits_applied, 10);
+
+        increment_lifetime_dictionary_fixes(&db, 2).expect("increment again");
+        let insights = query_insights(&db, 7).expect("insights");
+        assert_eq!(insights.cleanup.dictionary_fixes, 5);
+        assert_eq!(insights.cleanup.edits_applied, 12);
+    }
+
+    #[test]
+    fn parse_api_usage_handles_all_pipeline_formats() {
+        let parts = parse_api_usage("groq/whisper-large-v3-turbo/transcription");
+        assert_eq!(
+            parts.transcription_models,
+            vec![("groq".to_string(), "whisper-large-v3-turbo".to_string())]
+        );
+        assert!(parts.cleanup_models.is_empty());
+
+        let parts = parse_api_usage(
+            "primary=groq/whisper-large-v3-turbo;secondary=openai/gpt-4o-transcribe;cleanup=groq/llama-3.3-70b-versatile",
+        );
+        assert_eq!(parts.transcription_models.len(), 2);
+        assert_eq!(
+            parts.transcription_models[0],
+            ("groq".to_string(), "whisper-large-v3-turbo".to_string())
+        );
+        assert_eq!(
+            parts.transcription_models[1],
+            ("openai".to_string(), "gpt-4o-transcribe".to_string())
+        );
+        assert_eq!(
+            parts.cleanup_models,
+            vec![("groq".to_string(), "llama-3.3-70b-versatile".to_string())]
+        );
+
+        let parts = parse_api_usage("garbage");
+        assert!(parts.transcription_models.is_empty());
+        assert!(parts.cleanup_models.is_empty());
+    }
+}

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -410,8 +410,13 @@ fn query_daily(
 
     let start = NaiveDate::parse_from_str(range_start, "%Y-%m-%d")?;
     let end = NaiveDate::parse_from_str(range_end, "%Y-%m-%d")?;
+    if start > end {
+        // A future-dated transcription (clock drift) can make the range
+        // bounds inverted; never spin the zero-fill loop to NaiveDate::MAX.
+        return Ok(Vec::new());
+    }
     let span_days = (end - start).num_days();
-    let mut daily = Vec::with_capacity(span_days.max(1) as usize);
+    let mut daily = Vec::with_capacity(span_days as usize + 1);
     let mut current = start;
     loop {
         let day = current.format("%Y-%m-%d").to_string();
@@ -560,14 +565,18 @@ fn query_words(
             if normalized.is_empty() {
                 continue;
             }
-            if normalized.len() > longest.as_ref().map_or(0, String::len) {
+            // `.len()` is byte length; `chars().count()` is the character
+            // count a human word length should measure (non-ASCII words like
+            // accented or non-Latin text would otherwise be over-counted).
+            let char_len = normalized.chars().count();
+            if char_len > longest.as_ref().map_or(0, |w| w.chars().count()) {
                 longest = Some(normalized.clone());
             }
-            if normalized.len() < MIN_WORD_CHARS || STOPWORDS.contains(&normalized.as_str()) {
+            if char_len < MIN_WORD_CHARS || STOPWORDS.contains(&normalized.as_str()) {
                 continue;
             }
             *counts.entry(normalized.clone()).or_insert(0) += 1;
-            length_sum += normalized.len() as u64;
+            length_sum += char_len as u64;
             length_count += 1;
         }
     }

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -126,6 +126,10 @@ const STOPWORDS: &[&str] = &[
     "while", "who", "whom", "why", "will", "with", "would", "you", "your", "yours",
 ];
 
+fn is_stopword(word: &str) -> bool {
+    STOPWORDS.binary_search(&word).is_ok()
+}
+
 /// Aggregated insights for `days` (`0` = all time). A brand-new install with
 /// no transcriptions returns a fully-populated zero payload, never an error.
 pub fn query_insights(db: &Db, days: i64) -> Result<Insights> {
@@ -254,6 +258,10 @@ fn parse_api_usage(api_used: &str) -> ApiUsageParts {
         for segment in primary.split(';') {
             let segment = segment.strip_prefix("secondary=").unwrap_or(segment);
             if let Some((provider, model)) = segment.split_once('/') {
+                // Uniform with the single-provider fallback below: drop a
+                // trailing /transcription so the model key is identical
+                // regardless of which format produced the row.
+                let model = model.strip_suffix("/transcription").unwrap_or(model);
                 if !provider.is_empty() && !model.is_empty() {
                     transcription.push((provider.to_string(), model.to_string()));
                 }
@@ -572,7 +580,7 @@ fn query_words(
             // Stopwords are excluded from the vocabulary insights — check
             // before tracking `longest` so a long filler word like
             // "because"/"themselves" never shows up as the longest word.
-            if char_len < MIN_WORD_CHARS || STOPWORDS.contains(&normalized.as_str()) {
+            if char_len < MIN_WORD_CHARS || is_stopword(&normalized) {
                 continue;
             }
             if char_len > longest.as_ref().map_or(0, |w| w.chars().count()) {
@@ -1078,6 +1086,18 @@ mod tests {
     }
 
     #[test]
+    fn stopwords_stay_sorted_for_binary_search() {
+        // `is_stopword` relies on binary_search over a sorted slice — a
+        // mis-sorted STOPWORDS would silently fail lookups.
+        assert!(STOPWORDS.windows(2).all(|w| w[0] < w[1]));
+        // Spot-check membership works for both ends and a middle entry.
+        assert!(is_stopword("a"));
+        assert!(is_stopword("because"));
+        assert!(is_stopword("yours"));
+        assert!(!is_stopword("verenu"));
+    }
+
+    #[test]
     fn parse_api_usage_handles_all_pipeline_formats() {
         let parts = parse_api_usage("groq/whisper-large-v3-turbo/transcription");
         assert_eq!(
@@ -1106,5 +1126,17 @@ mod tests {
         let parts = parse_api_usage("garbage");
         assert!(parts.transcription_models.is_empty());
         assert!(parts.cleanup_models.is_empty());
+    }
+
+    #[test]
+    fn parse_api_usage_strips_transcription_suffix_in_primary_branch() {
+        // The primary= branch must normalize model names exactly like the
+        // single-provider fallback — a trailing /transcription must not leak
+        // into the stored model key.
+        let parts = parse_api_usage("primary=groq/whisper-large-v3-turbo/transcription");
+        assert_eq!(
+            parts.transcription_models,
+            vec![("groq".to_string(), "whisper-large-v3-turbo".to_string())]
+        );
     }
 }

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -586,7 +586,8 @@ fn query_words(
             if char_len > longest.as_ref().map_or(0, |w| w.chars().count()) {
                 longest = Some(normalized.clone());
             }
-            *counts.entry(normalized.clone()).or_insert(0) += 1;
+            // Move `normalized` here — it's not referenced again this iteration.
+            *counts.entry(normalized).or_insert(0) += 1;
             length_sum += char_len as u64;
             length_count += 1;
         }

--- a/src-tauri/src/data/db/mod.rs
+++ b/src-tauri/src/data/db/mod.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 mod cleanup_cache;
 mod dictionary;
+mod insights;
 mod schema;
 mod snippets;
 mod transcriptions;
@@ -21,6 +22,7 @@ mod validation;
 
 pub use cleanup_cache::*;
 pub use dictionary::*;
+pub use insights::*;
 pub use schema::*;
 pub use snippets::*;
 pub use transcriptions::*;

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -20,8 +20,9 @@ CREATE TABLE IF NOT EXISTS transcriptions (
 CREATE INDEX IF NOT EXISTS idx_transcriptions_created_at
   ON transcriptions(created_at);
 CREATE TABLE IF NOT EXISTS lifetime_stats (
-  id          INTEGER PRIMARY KEY CHECK (id = 1),
-  total_words INTEGER NOT NULL DEFAULT 0
+  id               INTEGER PRIMARY KEY CHECK (id = 1),
+  total_words      INTEGER NOT NULL DEFAULT 0,
+  dictionary_fixes INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS dictionary (
   id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -94,6 +95,19 @@ CREATE INDEX IF NOT EXISTS idx_cleanup_cache_last_hit_at
 CREATE TABLE IF NOT EXISTS seeded_defaults (
   key TEXT PRIMARY KEY
 );
+CREATE TABLE IF NOT EXISTS api_calls (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  transcription_id  INTEGER NOT NULL,
+  model             TEXT    NOT NULL,
+  provider          TEXT    NOT NULL,
+  task              TEXT    NOT NULL,
+  audio_ms          INTEGER NOT NULL DEFAULT 0,
+  input_chars       INTEGER NOT NULL DEFAULT 0,
+  output_chars      INTEGER NOT NULL DEFAULT 0,
+  created_at        DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_api_calls_created_at
+  ON api_calls(created_at);
 ";
 
 pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
@@ -290,6 +304,53 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
             let _ = conn.execute_batch("ROLLBACK;");
             return Err(err.into());
         }
+    }
+    if user_version < 10 {
+        // Per-call API usage records for the Insights cost card. Written
+        // from the pipeline at finalize time; historical transcriptions
+        // predating this table simply have no cost data. Also declared in
+        // SCHEMA above so an interrupted migration can't leave a database
+        // without the table (the CREATE TABLE IF NOT EXISTS self-heals).
+        let res = conn.execute_batch(
+            "BEGIN;
+             CREATE TABLE IF NOT EXISTS api_calls (
+               id                INTEGER PRIMARY KEY AUTOINCREMENT,
+               transcription_id  INTEGER NOT NULL,
+               model             TEXT    NOT NULL,
+               provider          TEXT    NOT NULL,
+               task              TEXT    NOT NULL,
+               audio_ms          INTEGER NOT NULL DEFAULT 0,
+               input_chars       INTEGER NOT NULL DEFAULT 0,
+               output_chars      INTEGER NOT NULL DEFAULT 0,
+               created_at        DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE INDEX IF NOT EXISTS idx_api_calls_created_at
+               ON api_calls(created_at);
+             PRAGMA user_version = 10;
+             COMMIT;",
+        );
+        if let Err(err) = res {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(err.into());
+        }
+    }
+    if user_version < 11 {
+        // Real lifetime counter for dictionary substitutions actually
+        // applied to dictations (incremented from the pipeline with the
+        // `applied_dict_ids` count). Mirrors `total_words`: never recomputed
+        // from history, so retention pruning can't shrink it. The column is
+        // declared in SCHEMA for fresh databases; ensure_table_column is
+        // idempotent for databases that already have it.
+        run_migration(&mut conn, |conn| {
+            ensure_table_column(
+                conn,
+                "lifetime_stats",
+                "dictionary_fixes",
+                "ALTER TABLE lifetime_stats ADD COLUMN dictionary_fixes INTEGER NOT NULL DEFAULT 0;",
+            )?;
+            conn.execute_batch("PRAGMA user_version = 11;")?;
+            Ok(())
+        })?;
     }
     ensure_cleanup_cache_schema(&conn)?;
 

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -58,6 +58,22 @@ pub fn insert_transcription_returning(
     Ok(entry)
 }
 
+/// Lifetime counter for dictionary substitutions actually applied to
+/// dictations. Like `total_words`, it is only ever incremented — never
+/// recomputed from history — so retention pruning can't shrink it. `count`
+/// is the number of dictionary substitution events from one dictation.
+pub fn increment_lifetime_dictionary_fixes(db: &Db, count: i64) -> Result<()> {
+    if count <= 0 {
+        return Ok(());
+    }
+    let conn = lock_conn(db)?;
+    conn.execute(
+        "UPDATE lifetime_stats SET dictionary_fixes = dictionary_fixes + ?1 WHERE id = 1",
+        params![count],
+    )?;
+    Ok(())
+}
+
 pub fn query_recent(db: &Db) -> Result<Vec<RecentEntry>> {
     let conn = lock_conn(db)?;
     // We order by id DESC instead of created_at DESC because id is the autoincrementing

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -49,9 +49,11 @@ pub fn insert_transcription_returning(
     // Lifetime counter is intentionally separate from the transcriptions
     // table so history retention pruning never shrinks it. Committed in the
     // same transaction as the insert so a crash between the two can't leave
-    // total_words permanently undercounted.
+    // total_words permanently undercounted. Upsert because a fresh database
+    // (no transcriptions at migration time) may have no id=1 row yet.
     tx.execute(
-        "UPDATE lifetime_stats SET total_words = total_words + ?1 WHERE id = 1",
+        "INSERT INTO lifetime_stats (id, total_words) VALUES (1, ?1)
+         ON CONFLICT(id) DO UPDATE SET total_words = total_words + ?1",
         params![words],
     )?;
     tx.commit()?;
@@ -68,7 +70,8 @@ pub fn increment_lifetime_dictionary_fixes(db: &Db, count: i64) -> Result<()> {
     }
     let conn = lock_conn(db)?;
     conn.execute(
-        "UPDATE lifetime_stats SET dictionary_fixes = dictionary_fixes + ?1 WHERE id = 1",
+        "INSERT INTO lifetime_stats (id, dictionary_fixes) VALUES (1, ?1)
+         ON CONFLICT(id) DO UPDATE SET dictionary_fixes = dictionary_fixes + ?1",
         params![count],
     )?;
     Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -261,6 +261,8 @@ fn main() {
         pill_placement: None,
         pill_placement_stale: false,
         retry_capture: None,
+        cancelled_capture: None,
+        paste_failure: None,
     }));
 
     std::fs::create_dir_all(app_data_dir()).ok();
@@ -513,6 +515,7 @@ fn main() {
             commands::hide_main,
             commands::get_recent,
             commands::get_stats,
+            commands::get_insights,
             commands::count_old_transcriptions,
             commands::get_cleanup_cache_status,
             commands::clear_cleanup_cache,
@@ -531,6 +534,9 @@ fn main() {
             commands::stop_setup_try_recording,
             commands::stop_recording,
             commands::stop_handless_mode,
+            commands::resume_cancelled_capture,
+            commands::dismiss_cancelled_capture,
+            commands::copy_paste_failure_to_clipboard,
             commands::get_installed_apps,
             commands::get_app_mappings,
             commands::save_app_mappings,

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -73,15 +73,28 @@ pub(super) async fn finalize_pipeline_completion(
     let clean_for_insert = final_text_substituted.clone();
     let api_used_for_insert = ctx.api_used.to_string();
     let duration_for_insert = ctx.duration_ms as i64;
-    let entry = match tokio::task::spawn_blocking(move || {
-        db::insert_transcription_returning(
+    let dictionary_fixes_applied = applied_dict_ids.len() as i64;
+    let entry = match tokio::task::spawn_blocking(move || -> anyhow::Result<db::RecentEntry> {
+        let entry = db::insert_transcription_returning(
             &db_for_insert,
             &raw_for_insert,
             &clean_for_insert,
             words,
             duration_for_insert,
             &api_used_for_insert,
-        )
+        )?;
+        if dictionary_fixes_applied > 0 {
+            // Lifetime counter for the Insights "fixes made by Verenu" card;
+            // same never-recomputed pattern as total_words. Best-effort —
+            // a failed counter must not fail the dictation itself.
+            if let Err(e) = db::increment_lifetime_dictionary_fixes(
+                &db_for_insert,
+                dictionary_fixes_applied,
+            ) {
+                log::warn!("pipeline: failed to record dictionary fixes: {e}");
+            }
+        }
+        Ok(entry)
     })
     .await
     {
@@ -100,6 +113,29 @@ pub(super) async fn finalize_pipeline_completion(
         }
     };
 
+    // Per-call API usage records for the Insights cost card. Best-effort:
+    // a failed audit row must never fail the dictation that already
+    // inserted fine above. Only counts and model ids are ever logged.
+    let calls = db::build_api_calls(
+        entry.id,
+        &entry.created_at,
+        ctx.api_used,
+        ctx.duration_ms as i64,
+        ctx.raw,
+        ctx.final_text_before_dict,
+    );
+    if !calls.is_empty() {
+        let db_for_calls = db_handle.inner().clone();
+        match tokio::task::spawn_blocking(move || db::insert_api_calls(&db_for_calls, &calls)).await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                log::warn!("pipeline: failed to record api usage rows: {}", trim_err(&e.to_string()))
+            }
+            Err(e) => log::warn!("pipeline: api usage recording task panicked: {e}"),
+        }
+    }
+
     if let Ok(mut st) = lock_state(state) {
         if st.retry_capture.as_ref().map(|v| v.captured_at) == Some(ctx.captured_at) {
             st.retry_capture = None;
@@ -112,6 +148,12 @@ pub(super) async fn finalize_pipeline_completion(
     // land in our own WebView with no active text field and silently disappear.
     // Detect this by PID and fall back to clipboard-only so the user can paste manually.
     let self_inject = foreground_is_own_process() || hwnd_is_own_process(ctx.target_hwnd);
+    log::debug!(
+        "pipeline: injection decision target_hwnd={} event_only={} self_inject={}",
+        ctx.target_hwnd,
+        ctx.event_only,
+        self_inject
+    );
 
     let injected = if ctx.event_only {
         injection::InjectionOutcome {
@@ -152,7 +194,13 @@ pub(super) async fn finalize_pipeline_completion(
             Ok(outcome) => outcome,
             Err(e) => {
                 log::error!("inject: {e}");
-                show_error_pill(app, "Failed to paste - text saved to history").await;
+                if let Ok(mut st) = lock_state(state) {
+                    st.paste_failure = Some(PasteFailure {
+                        text: final_text_substituted.clone(),
+                        captured_at: std::time::Instant::now(),
+                    });
+                }
+                show_paste_failed_pill(app);
                 injection::InjectionOutcome {
                     text: final_text_substituted.clone(),
                     context_state: "unknown",
@@ -182,7 +230,15 @@ pub(super) async fn finalize_pipeline_completion(
         return Ok(entry);
     }
 
-    hide_pill(app);
+    // Don't stomp the "Paste failed" pill (with its Copy button) that
+    // show_paste_failed_pill just showed a few lines up — hide_pill would
+    // instantly revert it to idle before the button even has a chance to
+    // fade in, let alone be clicked.
+    if injected.case_decision != "inject_failed" {
+        hide_pill(app);
+    } else {
+        log::debug!("pipeline: skipping hide_pill — paste_failed pill stays up");
+    }
 
     if !ctx.cleanup_cache_key.is_empty() {
         auto_learn::start_cache_rejection_monitor(

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -38,8 +38,8 @@ use gates::{
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
     silence_floor_gate_rms, strip_hallucinated_suffix, MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
-pub(crate) use pill::{hide_pill, show_pill, update_pill_state};
-use pill::{reject_with_pill, show_error_pill};
+pub(crate) use pill::{hide_pill, show_copied_pill, show_pill, update_pill_state};
+use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub use session::*;
 use stages::*;
 pub use state::*;

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -224,8 +224,10 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     PILL_VISUALLY_ACTIVE.store(true, Ordering::SeqCst);
 
     // Click-through for passive states so nothing behind the pill is blocked.
-    // Handsfree needs real cursor events for its cancel/confirm buttons.
-    pill.set_ignore_cursor_events(state != "handsfree").ok();
+    // Handsfree, error (Retry), and cancelled (Undo/Dismiss) all have real
+    // buttons that need real cursor events.
+    let has_clickable_buttons = matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed");
+    pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
 
     // Show the window before emitting state so WebView2 is active when it
     // receives the event. WebView2 suspends event processing while hidden;
@@ -333,6 +335,38 @@ pub(crate) fn hide_pill(app: &AppHandle) {
         // The pill window is transparent + click-through in idle state, so
         // leaving it visible has no user-visible effect.
     }
+}
+
+/// Shows the pill's "Cancelled" state — a cancelled recording whose audio was
+/// good enough to stash for the pill's Continue button (see
+/// `pipeline::cancel_recording_with_resume`). Auto-dismiss is handled by the
+/// frontend (`PillApp.svelte`), same as `show_error_pill`.
+pub(super) fn show_cancelled_pill(app: &AppHandle) {
+    show_pill_msg(app, "cancelled", None);
+}
+
+/// Shows the pill's "Paste failed" state — injection didn't land (or
+/// couldn't be verified), but the finished text is safely stashed as
+/// `paste_failure` for the pill's Copy button (see
+/// `commands::recording::copy_paste_failure_to_clipboard`). Auto-dismiss is
+/// handled by the frontend, same as `show_error_pill`.
+pub(super) fn show_paste_failed_pill(app: &AppHandle) {
+    if super::start_stop_sounds_enabled(app) {
+        crate::media::sound::play(crate::media::sound::SoundCue::Error);
+    }
+    show_pill_msg(app, "paste_failed", None);
+}
+
+/// Shows the pill's "Copied" confirmation for the global copy-last-dictation
+/// shortcut (Ctrl+Alt+C / ⌥⌘C) — a lightweight, button-less toast so the
+/// user gets clear feedback the shortcut actually did something, even when
+/// nothing is focused to receive it. Auto-dismiss (5s) is handled by the
+/// frontend, same as the other transient pill states.
+pub(crate) fn show_copied_pill(app: &AppHandle, msg: &str) {
+    if super::start_stop_sounds_enabled(app) {
+        crate::media::sound::play(crate::media::sound::SoundCue::Stop);
+    }
+    show_pill_msg(app, "copied", Some(msg));
 }
 
 pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -243,11 +243,20 @@ pub async fn cancel_recording_with_resume(
         if start_stop_sounds_enabled(app) {
             crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
         }
-        hide_pill(app);
+        // A new dictation may have started while we were awaiting
+        // stop_and_capture_audio — don't hide that session's pill.
+        if state_is_idle(state) {
+            hide_pill(app);
+        }
         return;
     }
 
     stash_cancelled_capture(app, state, captured_audio);
+}
+
+/// True when the recording lifecycle is currently `Idle`.
+fn state_is_idle(state: &SharedState) -> bool {
+    lock_state(state).is_ok_and(|st| st.lifecycle.is_idle())
 }
 
 /// Stores `audio` as the resumable `cancelled_capture`, plays the cancel

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -257,32 +257,45 @@ pub async fn cancel_recording_with_resume(
 /// gates before calling this; a cancel mid-processing has already cleared
 /// the pipeline's own gate by the time it gets here).
 pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: CapturedAudio) {
-    let stashed = lock_state(state)
-        .and_then(|mut st| {
+    enum StashOutcome {
+        Stashed,
+        LockPoisoned,
+        SessionActive,
+    }
+    let outcome = match lock_state(state) {
+        Ok(mut st) => {
             // Only stash while the system is genuinely idle. Between
             // `stop_and_capture_audio` (which released the Recording
             // lifecycle) and this call the user may have already started a
             // new dictation — overwriting the capture or forcing the pill
             // into "Cancelled" would clobber that fresh session.
             if !st.lifecycle.is_idle() {
-                return Err(anyhow::anyhow!(
-                    "state advanced past idle while stashing cancelled capture"
-                ));
+                StashOutcome::SessionActive
+            } else {
+                st.cancelled_capture = Some(CancelledCapture {
+                    audio,
+                    captured_at: std::time::Instant::now(),
+                });
+                StashOutcome::Stashed
             }
-            st.cancelled_capture = Some(CancelledCapture {
-                audio,
-                captured_at: std::time::Instant::now(),
-            });
-            Ok(())
-        })
-        .is_ok();
-    if !stashed {
-        // Lock poisoned, or a new session started while we were stopping —
-        // either way the pill's Continue button would offer a resume that
-        // can't work (or would fight the live session). Hide the pill.
-        log::warn!("skipping cancelled-capture pill: state not idle when stashing");
-        hide_pill(app);
-        return;
+        }
+        Err(_) => StashOutcome::LockPoisoned,
+    };
+    match outcome {
+        StashOutcome::Stashed => {}
+        StashOutcome::SessionActive => {
+            // A newer dictation owns the pill now — don't touch it, and
+            // don't offer a resume that would fight the live session.
+            log::debug!("skipping cancelled-capture pill: a new session is active");
+            return;
+        }
+        StashOutcome::LockPoisoned => {
+            // Poisoned lock: the pill's Continue button would offer a resume
+            // that can't work since nothing was stashed. Hide the pill.
+            log::warn!("failed to stash cancelled capture (state lock poisoned)");
+            hide_pill(app);
+            return;
+        }
     }
     if start_stop_sounds_enabled(app) {
         crate::media::sound::play(crate::media::sound::SoundCue::Cancel);

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -207,6 +207,69 @@ pub fn start_recording_session_ex(
     }
 }
 
+/// Stops a just-cancelled recording session, and — if the captured audio is
+/// long/loud enough to clear the normal recording quality gates — stashes it
+/// as a `CancelledCapture` and shows the pill's "Cancelled" state (Continue
+/// button resumes hands-free with this audio prepended, see
+/// `state::reserve_starting_with_prepend`). Otherwise behaves like a plain
+/// discard: unmute, end any media pause, hide the pill.
+///
+/// Mirrors `stages::stop_and_capture_audio`'s gating (same constants
+/// `run_pipeline`/`transcribe_input_only` use), applied here instead of to a
+/// pipeline that's actually about to transcribe.
+pub async fn cancel_recording_with_resume(
+    app: &AppHandle,
+    state: &SharedState,
+    session: audio::RecordingSession,
+    exclusive_mic_session_id: Option<u64>,
+) {
+    crate::media::sound::coordinated_unmute();
+    crate::system::media_control::end_dictation_media_pause();
+
+    let Some((captured_audio, rms, raw_rms)) =
+        stop_and_capture_audio(app, session, exclusive_mic_session_id).await
+    else {
+        // stop_and_capture_audio already hid the pill on failure.
+        return;
+    };
+
+    let active_gain = store::settings_snapshot(app)
+        .map(|s| store::load_audio_config(&s).mic_gain)
+        .unwrap_or(store::DEFAULT_MIC_GAIN);
+    let min_rms = recording_gate_rms(active_gain);
+    let gate_rms = effective_recording_rms(rms, raw_rms, active_gain);
+
+    if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
+        if start_stop_sounds_enabled(app) {
+            crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
+        }
+        hide_pill(app);
+        return;
+    }
+
+    stash_cancelled_capture(app, state, captured_audio);
+}
+
+/// Stores `audio` as the resumable `cancelled_capture`, plays the cancel
+/// cue, and shows the pill's "Cancelled" state. Callers are responsible for
+/// having already decided the audio is worth keeping
+/// (`cancel_recording_with_resume` applies the normal recording quality
+/// gates before calling this; a cancel mid-processing has already cleared
+/// the pipeline's own gate by the time it gets here).
+pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: CapturedAudio) {
+    if let Ok(mut st) = lock_state(state) {
+        st.cancelled_capture = Some(CancelledCapture {
+            audio,
+            captured_at: std::time::Instant::now(),
+        });
+    }
+    if start_stop_sounds_enabled(app) {
+        crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
+    }
+    emit_cancelled_capture(app);
+    show_cancelled_pill(app);
+}
+
 /// Releases a `Starting` reservation back to `Idle` when the mic failed to
 /// open — the carried prepend audio (if any) is simply dropped, not
 /// retained anywhere a later, unrelated dictation could inherit it.

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -258,17 +258,29 @@ pub async fn cancel_recording_with_resume(
 /// the pipeline's own gate by the time it gets here).
 pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: CapturedAudio) {
     let stashed = lock_state(state)
-        .map(|mut st| {
+        .and_then(|mut st| {
+            // Only stash while the system is genuinely idle. Between
+            // `stop_and_capture_audio` (which released the Recording
+            // lifecycle) and this call the user may have already started a
+            // new dictation — overwriting the capture or forcing the pill
+            // into "Cancelled" would clobber that fresh session.
+            if !st.lifecycle.is_idle() {
+                return Err(anyhow::anyhow!(
+                    "state advanced past idle while stashing cancelled capture"
+                ));
+            }
             st.cancelled_capture = Some(CancelledCapture {
                 audio,
                 captured_at: std::time::Instant::now(),
             });
+            Ok(())
         })
         .is_ok();
     if !stashed {
-        // Lock poisoned — the pill's Continue button would offer a resume
-        // that can't work since nothing was stashed. Hide the pill instead.
-        log::warn!("failed to stash cancelled capture (state lock poisoned)");
+        // Lock poisoned, or a new session started while we were stopping —
+        // either way the pill's Continue button would offer a resume that
+        // can't work (or would fight the live session). Hide the pill.
+        log::warn!("skipping cancelled-capture pill: state not idle when stashing");
         hide_pill(app);
         return;
     }

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -211,8 +211,8 @@ pub fn start_recording_session_ex(
 /// long/loud enough to clear the normal recording quality gates — stashes it
 /// as a `CancelledCapture` and shows the pill's "Cancelled" state (Continue
 /// button resumes hands-free with this audio prepended, see
-/// `state::reserve_starting_with_cancelled_capture`). Otherwise behaves like
-/// a plain discard: unmute, end any media pause, hide the pill.
+/// `state::peek_cancelled_capture_if_fresh`). Otherwise behaves like a plain
+/// discard: unmute, end any media pause, hide the pill.
 ///
 /// Mirrors `stages::stop_and_capture_audio`'s gating (same constants
 /// `run_pipeline`/`transcribe_input_only` use), applied here instead of to a

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -211,8 +211,8 @@ pub fn start_recording_session_ex(
 /// long/loud enough to clear the normal recording quality gates — stashes it
 /// as a `CancelledCapture` and shows the pill's "Cancelled" state (Continue
 /// button resumes hands-free with this audio prepended, see
-/// `state::reserve_starting_with_prepend`). Otherwise behaves like a plain
-/// discard: unmute, end any media pause, hide the pill.
+/// `state::reserve_starting_with_cancelled_capture`). Otherwise behaves like
+/// a plain discard: unmute, end any media pause, hide the pill.
 ///
 /// Mirrors `stages::stop_and_capture_audio`'s gating (same constants
 /// `run_pipeline`/`transcribe_input_only` use), applied here instead of to a
@@ -257,11 +257,20 @@ pub async fn cancel_recording_with_resume(
 /// gates before calling this; a cancel mid-processing has already cleared
 /// the pipeline's own gate by the time it gets here).
 pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: CapturedAudio) {
-    if let Ok(mut st) = lock_state(state) {
-        st.cancelled_capture = Some(CancelledCapture {
-            audio,
-            captured_at: std::time::Instant::now(),
-        });
+    let stashed = lock_state(state)
+        .map(|mut st| {
+            st.cancelled_capture = Some(CancelledCapture {
+                audio,
+                captured_at: std::time::Instant::now(),
+            });
+        })
+        .is_ok();
+    if !stashed {
+        // Lock poisoned — the pill's Continue button would offer a resume
+        // that can't work since nothing was stashed. Hide the pill instead.
+        log::warn!("failed to stash cancelled capture (state lock poisoned)");
+        hide_pill(app);
+        return;
     }
     if start_stop_sounds_enabled(app) {
         crate::media::sound::play(crate::media::sound::SoundCue::Cancel);

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -4,6 +4,15 @@ use crate::pipeline::pill_position::PillPlacement;
 use std::sync::atomic::AtomicU64;
 
 pub(super) const RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// How long a cancelled recording's audio stays resumable — matches
+/// `RETRY_WINDOW` so a missed pill notification (which auto-hides after 10s)
+/// still leaves plenty of time to continue it from the Home history list.
+pub(super) const CANCEL_RESUME_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// How long a failed paste's text stays available for the pill's Copy
+/// button to pull back onto the clipboard.
+pub(super) const PASTE_FAILURE_WINDOW: std::time::Duration = std::time::Duration::from_secs(300);
 // ---------- shared state ----------
 
 pub struct AppState {
@@ -12,6 +21,8 @@ pub struct AppState {
     pub pill_placement: Option<PillPlacement>,
     pub pill_placement_stale: bool,
     pub retry_capture: Option<RetryCapture>,
+    pub cancelled_capture: Option<CancelledCapture>,
+    pub paste_failure: Option<PasteFailure>,
 }
 
 /// Single source of truth for what the app is currently doing with the
@@ -90,6 +101,26 @@ pub struct RetryCapture {
     pub caps_lock_on: bool,
 }
 
+/// Audio from a recording the user cancelled, kept around briefly so the
+/// pill's "Cancelled" state can offer a Continue button that resumes
+/// recording (hands-free) with this audio prepended — see
+/// `reserve_starting_with_prepend` and `commands::recording::resume_cancelled_capture`.
+#[derive(Clone)]
+pub struct CancelledCapture {
+    pub audio: CapturedAudio,
+    pub captured_at: std::time::Instant,
+}
+
+/// Final injected text from a dictation whose paste couldn't be confirmed
+/// (or definitely failed), kept around briefly so the pill's "Paste failed"
+/// state can offer a Copy button — see
+/// `commands::recording::copy_paste_failure_to_clipboard`.
+#[derive(Clone)]
+pub struct PasteFailure {
+    pub text: String,
+    pub captured_at: std::time::Instant,
+}
+
 pub(super) fn lock_state(state: &SharedState) -> anyhow::Result<MutexGuard<'_, AppState>> {
     state
         .lock()
@@ -119,6 +150,23 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
     Ok(())
 }
 
+/// Same as `reserve_starting`, but seeds the reservation with audio to
+/// prepend once the new recording is stopped — used to resume a cancelled
+/// recording without re-recording what was already said.
+pub fn reserve_starting_with_prepend(
+    state: &SharedState,
+    audio: CapturedAudio,
+) -> Result<(), String> {
+    let mut st = lock_state(state).map_err(|e| e.to_string())?;
+    if !st.lifecycle.is_idle() {
+        return Err("Already recording".to_string());
+    }
+    st.lifecycle = DictationLifecycle::Starting {
+        prepend_audio: Some(audio),
+    };
+    Ok(())
+}
+
 /// `Processing(active) -> Starting { prepend_audio: Some(active.captured_audio) }`
 /// in one step, so the old task loses ownership of its `ActivePipeline`
 /// atomically with the replacement recording being reserved. Returns the
@@ -139,6 +187,33 @@ pub fn take_active_pipeline_for_interrupt(state: &SharedState) -> Option<ActiveP
             None
         }
     }
+}
+
+/// Takes `cancelled_capture`'s audio if present and still within
+/// `CANCEL_RESUME_WINDOW`. Always clears the slot (a stale or already-taken
+/// capture must not be resumable twice).
+pub fn take_cancelled_capture_if_fresh(state: &SharedState) -> Option<CapturedAudio> {
+    let mut st = lock_state(state).ok()?;
+    st.cancelled_capture.take().and_then(|c| {
+        if c.captured_at.elapsed() < CANCEL_RESUME_WINDOW {
+            Some(c.audio)
+        } else {
+            None
+        }
+    })
+}
+
+/// Takes `paste_failure`'s text if present and still within
+/// `PASTE_FAILURE_WINDOW`. Always clears the slot.
+pub fn take_paste_failure_if_fresh(state: &SharedState) -> Option<String> {
+    let mut st = lock_state(state).ok()?;
+    st.paste_failure.take().and_then(|f| {
+        if f.captured_at.elapsed() < PASTE_FAILURE_WINDOW {
+            Some(f.text)
+        } else {
+            None
+        }
+    })
 }
 
 /// `Processing(active) -> Idle`, discarding the audio entirely (Escape
@@ -405,6 +480,24 @@ pub(super) fn emit_pipeline_failed(app: &AppHandle) {
     .ok();
 }
 
+/// Tells any open window (Home's history list in particular) that a
+/// recording was just cancelled and its audio is resumable for
+/// `CANCEL_RESUME_WINDOW`. Mirrors `emit_pipeline_failed`'s payload shape.
+pub(super) fn emit_cancelled_capture(app: &AppHandle) {
+    app.emit(
+        "verenu:cancelled-capture",
+        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+    )
+    .ok();
+}
+
+/// Tells any open window that the current cancelled capture is gone —
+/// resumed, explicitly dismissed, or expired — so a stale offer (pill toast
+/// or Home banner) doesn't linger past its usefulness.
+pub fn emit_cancelled_capture_cleared(app: &AppHandle) {
+    app.emit("verenu:cancelled-capture-cleared", ()).ok();
+}
+
 /// Tells the frontend to re-poll provider status immediately rather than
 /// waiting for its next 5-minute interval, because a pipeline call just
 /// failed in a way that looks provider-side (quota or a retryable
@@ -472,6 +565,8 @@ mod tests {
             pill_placement: None,
             pill_placement_stale: false,
             retry_capture: None,
+            cancelled_capture: None,
+            paste_failure: None,
         }))
     }
 
@@ -500,6 +595,50 @@ mod tests {
         assert!(reserve_starting(&state).is_ok());
         // Already Starting now — a second reservation must fail.
         assert!(reserve_starting(&state).is_err());
+    }
+
+    #[test]
+    fn reserve_starting_with_prepend_fails_unless_idle() {
+        let state = fresh_state();
+        assert!(reserve_starting_with_prepend(&state, fake_audio(1000)).is_ok());
+        match &lock_state(&state).unwrap().lifecycle {
+            DictationLifecycle::Starting { prepend_audio } => assert!(prepend_audio.is_some()),
+            _ => panic!("expected Starting with prepend_audio"),
+        }
+        // Already Starting now — a second reservation must fail.
+        assert!(reserve_starting_with_prepend(&state, fake_audio(1000)).is_err());
+    }
+
+    #[test]
+    fn take_paste_failure_if_fresh_returns_text_once() {
+        let state = fresh_state();
+        {
+            let mut st = lock_state(&state).unwrap();
+            st.paste_failure = Some(PasteFailure {
+                text: "hello world".to_string(),
+                captured_at: std::time::Instant::now(),
+            });
+        }
+        assert_eq!(
+            take_paste_failure_if_fresh(&state),
+            Some("hello world".to_string())
+        );
+        // Already taken — a second call must return None.
+        assert_eq!(take_paste_failure_if_fresh(&state), None);
+    }
+
+    #[test]
+    fn take_paste_failure_if_fresh_expires_after_window() {
+        let state = fresh_state();
+        {
+            let mut st = lock_state(&state).unwrap();
+            st.paste_failure = Some(PasteFailure {
+                text: "stale".to_string(),
+                captured_at: std::time::Instant::now() - PASTE_FAILURE_WINDOW
+                    - std::time::Duration::from_secs(1),
+            });
+        }
+        assert_eq!(take_paste_failure_if_fresh(&state), None);
     }
 
     #[test]

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -157,7 +157,9 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
 /// the naive take-then-reserve order in
 /// `commands::recording::resume_cancelled_capture` lost it permanently when
 /// the reservation errored after the take.
-pub fn reserve_starting_with_cancelled_capture(state: &SharedState) -> Result<CapturedAudio, String> {
+pub fn reserve_starting_with_cancelled_capture(
+    state: &SharedState,
+) -> Result<CapturedAudio, String> {
     let mut st = lock_state(state).map_err(|e| e.to_string())?;
     if !st.lifecycle.is_idle() {
         return Err("Already recording".to_string());
@@ -215,6 +217,7 @@ pub fn take_cancelled_capture_if_fresh(state: &SharedState) -> Option<CapturedAu
 
 /// Takes `paste_failure`'s text if present and still within
 /// `PASTE_FAILURE_WINDOW`. Always clears the slot.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn take_paste_failure_if_fresh(state: &SharedState) -> Option<String> {
     let mut st = lock_state(state).ok()?;
     st.paste_failure.take().and_then(|f| {
@@ -224,6 +227,27 @@ pub fn take_paste_failure_if_fresh(state: &SharedState) -> Option<String> {
             None
         }
     })
+}
+
+/// Reads `paste_failure`'s text if present and still within
+/// `PASTE_FAILURE_WINDOW`, without clearing the slot — so a transient
+/// clipboard failure can be retried instead of permanently losing the text.
+pub fn peek_paste_failure_if_fresh(state: &SharedState) -> Option<String> {
+    let st = lock_state(state).ok()?;
+    st.paste_failure.as_ref().and_then(|f| {
+        if f.captured_at.elapsed() < PASTE_FAILURE_WINDOW {
+            Some(f.text.clone())
+        } else {
+            None
+        }
+    })
+}
+
+/// Clears the `paste_failure` slot after it has been successfully handled.
+pub fn clear_paste_failure(state: &SharedState) {
+    if let Ok(mut st) = lock_state(state) {
+        st.paste_failure = None;
+    }
 }
 
 /// `Processing(active) -> Idle`, discarding the audio entirely (Escape
@@ -679,7 +703,8 @@ mod tests {
             let mut st = lock_state(&state).unwrap();
             st.paste_failure = Some(PasteFailure {
                 text: "stale".to_string(),
-                captured_at: std::time::Instant::now() - PASTE_FAILURE_WINDOW
+                captured_at: std::time::Instant::now()
+                    - PASTE_FAILURE_WINDOW
                     - std::time::Duration::from_secs(1),
             });
         }

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -104,7 +104,7 @@ pub struct RetryCapture {
 /// Audio from a recording the user cancelled, kept around briefly so the
 /// pill's "Cancelled" state can offer a Continue button that resumes
 /// recording (hands-free) with this audio prepended — see
-/// `reserve_starting_with_cancelled_capture` and
+/// `peek_cancelled_capture_if_fresh`/`clear_cancelled_capture` and
 /// `commands::recording::resume_cancelled_capture`.
 #[derive(Clone)]
 pub struct CancelledCapture {
@@ -151,32 +151,36 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
     Ok(())
 }
 
-/// Atomically reserves `Starting` seeded with the stashed cancelled capture,
-/// but only if the state is idle. The capture is left in place when the
-/// reservation fails, so a busy state can never destroy resumable audio —
-/// the naive take-then-reserve order in
-/// `commands::recording::resume_cancelled_capture` lost it permanently when
-/// the reservation errored after the take.
-pub fn reserve_starting_with_cancelled_capture(
-    state: &SharedState,
-) -> Result<CapturedAudio, String> {
-    let mut st = lock_state(state).map_err(|e| e.to_string())?;
-    if !st.lifecycle.is_idle() {
-        return Err("Already recording".to_string());
-    }
-    let Some(audio) = st.cancelled_capture.take().and_then(|c| {
+/// Reads the stashed cancelled capture (cloned) if present and fresh, without
+/// consuming it — so a resume attempt that fails partway doesn't destroy the
+/// resumable audio.
+pub fn peek_cancelled_capture_if_fresh(state: &SharedState) -> Option<CapturedAudio> {
+    let st = lock_state(state).ok()?;
+    st.cancelled_capture.as_ref().and_then(|c| {
         if c.captured_at.elapsed() < CANCEL_RESUME_WINDOW {
-            Some(c.audio)
+            Some(c.audio.clone())
         } else {
             None
         }
-    }) else {
-        return Err("Nothing to resume".to_string());
-    };
-    st.lifecycle = DictationLifecycle::Starting {
-        prepend_audio: Some(audio.clone()),
-    };
-    Ok(audio)
+    })
+}
+
+/// Clears the stashed cancelled capture after it has been successfully
+/// consumed by a resume.
+pub fn clear_cancelled_capture(state: &SharedState) {
+    if let Ok(mut st) = lock_state(state) {
+        st.cancelled_capture = None;
+    }
+}
+
+/// Attaches `audio` as the prepend audio of an already-reserved `Starting`
+/// lifecycle (see `commands::recording::resume_cancelled_capture`).
+pub fn set_starting_prepend_audio(state: &SharedState, audio: CapturedAudio) {
+    if let Ok(mut st) = lock_state(state) {
+        if let DictationLifecycle::Starting { prepend_audio } = &mut st.lifecycle {
+            *prepend_audio = Some(audio);
+        }
+    }
 }
 
 /// `Processing(active) -> Starting { prepend_audio: Some(active.captured_audio) }`
@@ -632,7 +636,7 @@ mod tests {
     }
 
     #[test]
-    fn reserve_starting_with_cancelled_capture_preserves_capture_on_busy() {
+    fn peek_cancelled_capture_does_not_consume() {
         let state = fresh_state();
         {
             let mut st = lock_state(&state).unwrap();
@@ -641,15 +645,16 @@ mod tests {
                 captured_at: std::time::Instant::now(),
             });
         }
-        // Occupy the state so the reservation must fail.
-        reserve_starting(&state).unwrap();
-        assert!(reserve_starting_with_cancelled_capture(&state).is_err());
-        // The capture must survive the failed reservation.
+        // Peeking clones — the slot must survive for the later clear.
+        assert_eq!(
+            peek_cancelled_capture_if_fresh(&state).unwrap().duration_ms,
+            500
+        );
         assert!(lock_state(&state).unwrap().cancelled_capture.is_some());
     }
 
     #[test]
-    fn reserve_starting_with_cancelled_capture_reserves_with_audio() {
+    fn clear_cancelled_capture_removes_the_slot() {
         let state = fresh_state();
         {
             let mut st = lock_state(&state).unwrap();
@@ -658,24 +663,21 @@ mod tests {
                 captured_at: std::time::Instant::now(),
             });
         }
-        let taken = reserve_starting_with_cancelled_capture(&state).unwrap();
-        assert_eq!(taken.duration_ms, 500);
-        let lifecycle = lock_state(&state).unwrap();
-        match &lifecycle.lifecycle {
+        clear_cancelled_capture(&state);
+        assert!(lock_state(&state).unwrap().cancelled_capture.is_none());
+    }
+
+    #[test]
+    fn set_starting_prepend_audio_attaches_to_reserved_start() {
+        let state = fresh_state();
+        reserve_starting(&state).unwrap();
+        set_starting_prepend_audio(&state, fake_audio(500));
+        match &lock_state(&state).unwrap().lifecycle {
             DictationLifecycle::Starting { prepend_audio } => {
                 assert_eq!(prepend_audio.as_ref().unwrap().duration_ms, 500)
             }
             _ => panic!("expected Starting with prepend_audio"),
-        }
-    }
-
-    #[test]
-    fn reserve_starting_with_cancelled_capture_rejects_when_nothing_stashed() {
-        let state = fresh_state();
-        assert!(matches!(
-            reserve_starting_with_cancelled_capture(&state),
-            Err(ref e) if e == "Nothing to resume"
-        ));
+        };
     }
 
     #[test]

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -104,7 +104,8 @@ pub struct RetryCapture {
 /// Audio from a recording the user cancelled, kept around briefly so the
 /// pill's "Cancelled" state can offer a Continue button that resumes
 /// recording (hands-free) with this audio prepended — see
-/// `reserve_starting_with_prepend` and `commands::recording::resume_cancelled_capture`.
+/// `reserve_starting_with_cancelled_capture` and
+/// `commands::recording::resume_cancelled_capture`.
 #[derive(Clone)]
 pub struct CancelledCapture {
     pub audio: CapturedAudio,
@@ -150,21 +151,30 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
     Ok(())
 }
 
-/// Same as `reserve_starting`, but seeds the reservation with audio to
-/// prepend once the new recording is stopped — used to resume a cancelled
-/// recording without re-recording what was already said.
-pub fn reserve_starting_with_prepend(
-    state: &SharedState,
-    audio: CapturedAudio,
-) -> Result<(), String> {
+/// Atomically reserves `Starting` seeded with the stashed cancelled capture,
+/// but only if the state is idle. The capture is left in place when the
+/// reservation fails, so a busy state can never destroy resumable audio —
+/// the naive take-then-reserve order in
+/// `commands::recording::resume_cancelled_capture` lost it permanently when
+/// the reservation errored after the take.
+pub fn reserve_starting_with_cancelled_capture(state: &SharedState) -> Result<CapturedAudio, String> {
     let mut st = lock_state(state).map_err(|e| e.to_string())?;
     if !st.lifecycle.is_idle() {
         return Err("Already recording".to_string());
     }
-    st.lifecycle = DictationLifecycle::Starting {
-        prepend_audio: Some(audio),
+    let Some(audio) = st.cancelled_capture.take().and_then(|c| {
+        if c.captured_at.elapsed() < CANCEL_RESUME_WINDOW {
+            Some(c.audio)
+        } else {
+            None
+        }
+    }) else {
+        return Err("Nothing to resume".to_string());
     };
-    Ok(())
+    st.lifecycle = DictationLifecycle::Starting {
+        prepend_audio: Some(audio.clone()),
+    };
+    Ok(audio)
 }
 
 /// `Processing(active) -> Starting { prepend_audio: Some(active.captured_audio) }`
@@ -598,15 +608,50 @@ mod tests {
     }
 
     #[test]
-    fn reserve_starting_with_prepend_fails_unless_idle() {
+    fn reserve_starting_with_cancelled_capture_preserves_capture_on_busy() {
         let state = fresh_state();
-        assert!(reserve_starting_with_prepend(&state, fake_audio(1000)).is_ok());
-        match &lock_state(&state).unwrap().lifecycle {
-            DictationLifecycle::Starting { prepend_audio } => assert!(prepend_audio.is_some()),
+        {
+            let mut st = lock_state(&state).unwrap();
+            st.cancelled_capture = Some(CancelledCapture {
+                audio: fake_audio(500),
+                captured_at: std::time::Instant::now(),
+            });
+        }
+        // Occupy the state so the reservation must fail.
+        reserve_starting(&state).unwrap();
+        assert!(reserve_starting_with_cancelled_capture(&state).is_err());
+        // The capture must survive the failed reservation.
+        assert!(lock_state(&state).unwrap().cancelled_capture.is_some());
+    }
+
+    #[test]
+    fn reserve_starting_with_cancelled_capture_reserves_with_audio() {
+        let state = fresh_state();
+        {
+            let mut st = lock_state(&state).unwrap();
+            st.cancelled_capture = Some(CancelledCapture {
+                audio: fake_audio(500),
+                captured_at: std::time::Instant::now(),
+            });
+        }
+        let taken = reserve_starting_with_cancelled_capture(&state).unwrap();
+        assert_eq!(taken.duration_ms, 500);
+        let lifecycle = lock_state(&state).unwrap();
+        match &lifecycle.lifecycle {
+            DictationLifecycle::Starting { prepend_audio } => {
+                assert_eq!(prepend_audio.as_ref().unwrap().duration_ms, 500)
+            }
             _ => panic!("expected Starting with prepend_audio"),
         }
-        // Already Starting now — a second reservation must fail.
-        assert!(reserve_starting_with_prepend(&state, fake_audio(1000)).is_err());
+    }
+
+    #[test]
+    fn reserve_starting_with_cancelled_capture_rejects_when_nothing_stashed() {
+        let state = fresh_state();
+        assert!(matches!(
+            reserve_starting_with_cancelled_capture(&state),
+            Err(ref e) if e == "Nothing to resume"
+        ));
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
   import { cleanupPromptEditor } from './lib/stores.svelte';
   import Sidebar from './lib/components/layout/Sidebar.svelte';
   import Home from './lib/views/Home.svelte';
+  import Insights from './lib/views/Insights.svelte';
   import Dictionary from './lib/views/Dictionary.svelte';
   import Snippets from './lib/views/Snippets.svelte';
   import Style from './lib/views/Style.svelte';
@@ -224,6 +225,8 @@
         >
           {#if appStore.currentPage === 'home'}
             <Home />
+          {:else if appStore.currentPage === 'insights'}
+            <Insights />
           {:else if appStore.currentPage === 'dictionary'}
             <Dictionary />
           {:else if appStore.currentPage === 'snippets'}

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -350,6 +350,12 @@
         if (state === 'paste_failed') {
           showCopyBtn = false;
           copied = false;
+          // A stale copiedTimer from a previous copy click could fire goIdle()
+          // on the fresh paste_failed state — clear it alongside the others.
+          if (copiedTimer) {
+            clearTimeout(copiedTimer);
+            copiedTimer = null;
+          }
           if (copyBtnTimer) clearTimeout(copyBtnTimer);
           copyBtnTimer = setTimeout(() => {
             copyBtnTimer = null;
@@ -368,6 +374,10 @@
           if (pasteFailedDismissTimer) {
             clearTimeout(pasteFailedDismissTimer);
             pasteFailedDismissTimer = null;
+          }
+          if (copiedTimer) {
+            clearTimeout(copiedTimer);
+            copiedTimer = null;
           }
           showCopyBtn = false;
         }
@@ -446,9 +456,12 @@
     if (errorTimer) { clearTimeout(errorTimer); errorTimer = null; }
     const { invoke } = await import('@tauri-apps/api/core');
     // Don't go idle before the call — Rust emits 'processing' on success so
-    // the pill morphs from error to processing. Only fall back to idle if the
-    // retry itself fails, so a rejected retry still shows the error state.
-    await invoke('retry_transcription').catch(() => { goIdle(); });
+    // the pill morphs from error to processing. If the retry fails, only
+    // fall back to idle while still in the error state — the pill may have
+    // moved on to an active state (recording/handsfree) during the invoke.
+    await invoke('retry_transcription').catch(() => {
+      if (state === 'error') goIdle();
+    });
   }
 
   async function continueCancelled() {

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -302,7 +302,10 @@
             errorTimer = null;
             if (state === 'error') goIdle();
           }, 10000);
-        } else {
+        } else if (state !== 'copied') {
+          // Don't clear errorMsg on 'copied' — show_copied_pill carries its
+          // confirmation text through the pill-error event, which fires just
+          // before this pill-state one.
           if (errorTimer) {
             clearTimeout(errorTimer);
             errorTimer = null;

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -444,9 +444,11 @@
 
   async function retryFailed() {
     if (errorTimer) { clearTimeout(errorTimer); errorTimer = null; }
-    goIdle();
     const { invoke } = await import('@tauri-apps/api/core');
-    await invoke('retry_transcription').catch(() => {});
+    // Don't go idle before the call — Rust emits 'processing' on success so
+    // the pill morphs from error to processing. Only fall back to idle if the
+    // retry itself fails, so a rejected retry still shows the error state.
+    await invoke('retry_transcription').catch(() => { goIdle(); });
   }
 
   async function continueCancelled() {

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -421,6 +421,7 @@
       if (copyBtnTimer) clearTimeout(copyBtnTimer);
       if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
       if (copiedTimer) clearTimeout(copiedTimer);
+      if (copiedPillTimer) clearTimeout(copiedPillTimer);
       unlisteners.forEach(u => u());
     };
   });

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
 
-  type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error';
+  type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied';
   let state: PillState = 'idle';
   let errorMsg = '';
   let errOpen = false;
@@ -10,6 +10,16 @@
   let errorTimer: ReturnType<typeof setTimeout> | null = null;
   let showHfButtons = false;
   let hfTimer: ReturnType<typeof setTimeout> | null = null;
+  let cancelOpen = false;
+  let showCancelBtn = false;
+  let cancelBtnTimer: ReturnType<typeof setTimeout> | null = null;
+  let cancelDismissTimer: ReturnType<typeof setTimeout> | null = null;
+  let showCopyBtn = false;
+  let copyBtnTimer: ReturnType<typeof setTimeout> | null = null;
+  let pasteFailedDismissTimer: ReturnType<typeof setTimeout> | null = null;
+  let copiedPillTimer: ReturnType<typeof setTimeout> | null = null;
+  let copied = false;
+  let copiedTimer: ReturnType<typeof setTimeout> | null = null;
   let prevState: PillState = 'idle';
   let dying = false;
   let dyingTimer: ReturnType<typeof setTimeout> | null = null;
@@ -172,6 +182,34 @@
         clearTimeout(errorTimer);
         errorTimer = null;
       }
+      cancelOpen = false;
+      showCancelBtn = false;
+      if (cancelBtnTimer) {
+        clearTimeout(cancelBtnTimer);
+        cancelBtnTimer = null;
+      }
+      if (cancelDismissTimer) {
+        clearTimeout(cancelDismissTimer);
+        cancelDismissTimer = null;
+      }
+      showCopyBtn = false;
+      copied = false;
+      if (copyBtnTimer) {
+        clearTimeout(copyBtnTimer);
+        copyBtnTimer = null;
+      }
+      if (pasteFailedDismissTimer) {
+        clearTimeout(pasteFailedDismissTimer);
+        pasteFailedDismissTimer = null;
+      }
+      if (copiedTimer) {
+        clearTimeout(copiedTimer);
+        copiedTimer = null;
+      }
+      if (copiedPillTimer) {
+        clearTimeout(copiedPillTimer);
+        copiedPillTimer = null;
+      }
     }, 200);
   }
 
@@ -179,6 +217,9 @@
   const ERROR_COLLAPSED_WIDTH = 42;
   const ERROR_GAP = 8;
   const ERROR_MAX_WIDTH = 356;
+  // Retry button (18px) + the flex gap in front of it — reserved
+  // unconditionally since the button always shows once the pill is open.
+  const ERROR_RETRY_BTN_WIDTH = 26;
 
   // Opens the error pill: render collapsed (icon-only), measure the message
   // text, then grow to its natural width so the CSS width transition has a
@@ -202,7 +243,7 @@
     const applyWidth = () => {
       const textW = errTextEl?.scrollWidth ?? 0;
       const errWidthNatural = textW > 0
-        ? Math.min(ERROR_COLLAPSED_WIDTH + ERROR_GAP + textW, ERROR_MAX_WIDTH)
+        ? Math.min(ERROR_COLLAPSED_WIDTH + ERROR_GAP + textW + ERROR_RETRY_BTN_WIDTH, ERROR_MAX_WIDTH)
         : ERROR_COLLAPSED_WIDTH;
       errWidth = errWidthNatural;
       errOpen = true;
@@ -260,7 +301,7 @@
           errorTimer = setTimeout(() => {
             errorTimer = null;
             if (state === 'error') goIdle();
-          }, 2000);
+          }, 10000);
         } else {
           if (errorTimer) {
             clearTimeout(errorTimer);
@@ -269,6 +310,74 @@
           errorMsg = '';
           errOpen = false;
           errWidth = 0;
+        }
+
+        if (state === 'cancelled') {
+          cancelOpen = false;
+          showCancelBtn = false;
+          requestAnimationFrame(() => {
+            if (state === 'cancelled') cancelOpen = true;
+          });
+          if (cancelBtnTimer) clearTimeout(cancelBtnTimer);
+          cancelBtnTimer = setTimeout(() => {
+            cancelBtnTimer = null;
+            if (state === 'cancelled') showCancelBtn = true;
+          }, 200);
+          if (cancelDismissTimer) clearTimeout(cancelDismissTimer);
+          cancelDismissTimer = setTimeout(() => {
+            cancelDismissTimer = null;
+            // Just hide the toast — the capture itself stays resumable from
+            // Home for the full backend window. Only the explicit dismiss
+            // button actually discards it (see dismissCancelled()).
+            if (state === 'cancelled') goIdle();
+          }, 10000);
+        } else {
+          if (cancelBtnTimer) {
+            clearTimeout(cancelBtnTimer);
+            cancelBtnTimer = null;
+          }
+          if (cancelDismissTimer) {
+            clearTimeout(cancelDismissTimer);
+            cancelDismissTimer = null;
+          }
+          cancelOpen = false;
+          showCancelBtn = false;
+        }
+
+        if (state === 'paste_failed') {
+          showCopyBtn = false;
+          copied = false;
+          if (copyBtnTimer) clearTimeout(copyBtnTimer);
+          copyBtnTimer = setTimeout(() => {
+            copyBtnTimer = null;
+            if (state === 'paste_failed') showCopyBtn = true;
+          }, 1200);
+          if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
+          pasteFailedDismissTimer = setTimeout(() => {
+            pasteFailedDismissTimer = null;
+            if (state === 'paste_failed') goIdle();
+          }, 10000);
+        } else {
+          if (copyBtnTimer) {
+            clearTimeout(copyBtnTimer);
+            copyBtnTimer = null;
+          }
+          if (pasteFailedDismissTimer) {
+            clearTimeout(pasteFailedDismissTimer);
+            pasteFailedDismissTimer = null;
+          }
+          showCopyBtn = false;
+        }
+
+        if (state === 'copied') {
+          if (copiedPillTimer) clearTimeout(copiedPillTimer);
+          copiedPillTimer = setTimeout(() => {
+            copiedPillTimer = null;
+            if (state === 'copied') goIdle();
+          }, 5000);
+        } else if (copiedPillTimer) {
+          clearTimeout(copiedPillTimer);
+          copiedPillTimer = null;
         }
       });
       if (!mounted) { l1(); return; }
@@ -289,6 +398,15 @@
       });
       if (!mounted) { l3(); return; }
       unlisteners.push(l3);
+
+      // Fired when the cancelled capture is resumed or dismissed from
+      // *another* window (Home's banner) — if this toast is still showing,
+      // it's now stale, so drop it without re-invoking dismiss.
+      const l4 = await listen('verenu:cancelled-capture-cleared', () => {
+        if (state === 'cancelled') goIdle();
+      });
+      if (!mounted) { l4(); return; }
+      unlisteners.push(l4);
     })();
 
     return () => {
@@ -298,6 +416,11 @@
       if (errorTimer) clearTimeout(errorTimer);
       if (dyingTimer) clearTimeout(dyingTimer);
       if (hfTimer) clearTimeout(hfTimer);
+      if (cancelBtnTimer) clearTimeout(cancelBtnTimer);
+      if (cancelDismissTimer) clearTimeout(cancelDismissTimer);
+      if (copyBtnTimer) clearTimeout(copyBtnTimer);
+      if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
+      if (copiedTimer) clearTimeout(copiedTimer);
       unlisteners.forEach(u => u());
     };
   });
@@ -313,6 +436,45 @@
     const { invoke } = await import('@tauri-apps/api/core');
     goIdle();
     await invoke('stop_recording').catch(() => {});
+  }
+
+  async function retryFailed() {
+    if (errorTimer) { clearTimeout(errorTimer); errorTimer = null; }
+    goIdle();
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('retry_transcription').catch(() => {});
+  }
+
+  async function continueCancelled() {
+    if (cancelDismissTimer) { clearTimeout(cancelDismissTimer); cancelDismissTimer = null; }
+    const { invoke } = await import('@tauri-apps/api/core');
+    // Don't force idle on success — Rust emits 'handsfree' next so the pill
+    // morphs directly from cancelled to handsfree, mirroring confirmHandless.
+    await invoke('resume_cancelled_capture').catch(() => { goIdle(); });
+  }
+
+  async function dismissCancelled() {
+    if (cancelDismissTimer) { clearTimeout(cancelDismissTimer); cancelDismissTimer = null; }
+    goIdle();
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('dismiss_cancelled_capture').catch(() => {});
+  }
+
+  async function copyPasteFailure() {
+    const { invoke } = await import('@tauri-apps/api/core');
+    try {
+      await invoke('copy_paste_failure_to_clipboard');
+      copied = true;
+      if (pasteFailedDismissTimer) { clearTimeout(pasteFailedDismissTimer); pasteFailedDismissTimer = null; }
+      if (copiedTimer) clearTimeout(copiedTimer);
+      copiedTimer = setTimeout(() => {
+        copiedTimer = null;
+        if (state === 'paste_failed') goIdle();
+      }, 1500);
+    } catch {
+      // Nothing left to copy (expired/already copied) — just let the toast
+      // run out its normal auto-dismiss timer.
+    }
   }
 </script>
 
@@ -348,6 +510,57 @@
         <circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/>
       </svg>
       <span class="err-text" bind:this={errTextEl}>{errorMsg || 'Something went wrong'}</span>
+      {#if errOpen}
+        <button class="hf-btn err-retry" onclick={retryFailed} aria-label="Retry">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 4v5h-5"/>
+          </svg>
+        </button>
+      {/if}
+    </div>
+
+  {:else if state === 'cancelled'}
+    <div class="pill cancelled" class:cancel-open={cancelOpen} class:dying={dying}>
+      <button class="hf-btn cancel" onclick={dismissCancelled} aria-label="Dismiss">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+          <path d="M6 6l12 12M6 18 18 6"/>
+        </svg>
+      </button>
+      <span class="cancel-text">Cancelled</span>
+      {#if showCancelBtn}
+        <button class="hf-btn confirm" onclick={continueCancelled} aria-label="Undo — keep recording">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5v0a5.5 5.5 0 0 1-5.5 5.5H11"/>
+          </svg>
+        </button>
+      {/if}
+    </div>
+
+  {:else if state === 'paste_failed'}
+    <div class="pill paste-failed" class:copy-open={showCopyBtn} class:dying={dying}>
+      <svg class="err-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/>
+      </svg>
+      <span class="paste-failed-text">Not pasted</span>
+      {#if showCopyBtn}
+        <button class="hf-btn copy-btn" onclick={copyPasteFailure} aria-label="Copy to clipboard">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            {#if copied}
+              <polyline points="20 6 9 17 4 12"/>
+            {:else}
+              <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+            {/if}
+          </svg>
+        </button>
+      {/if}
+    </div>
+
+  {:else if state === 'copied'}
+    <div class="pill copied" class:dying={dying}>
+      <svg class="copied-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="20 6 9 17 4 12"/>
+      </svg>
+      <span class="copied-text">{errorMsg || 'Copied last dictation to clipboard'}</span>
     </div>
 
   {:else if state === 'handsfree'}
@@ -417,6 +630,9 @@
   .pill.recording.dying,
   .pill.handsfree.dying,
   .pill.error.dying,
+  .pill.cancelled.dying,
+  .pill.paste-failed.dying,
+  .pill.copied.dying,
   .pill.processing.dying,
   .pill.loading-local.dying {
     animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
@@ -577,14 +793,14 @@
     to   { opacity: 1; }
   }
 
-  /* Error: rounded rectangle, dark red-tinted, expands horizontally to reveal the message */
+  /* Error: dark red-tinted stadium pill, expands horizontally to reveal the message */
   .pill.error {
     width: 42px;
     gap: 8px;
     padding: 0 14px;
     background: var(--pill-error-bg);
     color: var(--pill-error-fg);
-    border-radius: 14px;
+    border-radius: 999px;
     box-shadow: 0 0 0 1px var(--pill-error-border),
                 0 6px 18px rgba(0,0,0,0.28);
     max-width: 356px;
@@ -603,6 +819,87 @@
     transition: opacity 0.18s ease 0.08s;
   }
   .pill.error.err-open .err-text { opacity: 1; }
+
+  .hf-btn.err-retry {
+    color: var(--pill-error-fg);
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s both;
+  }
+  .hf-btn.err-retry:hover { background: rgba(255,255,255,0.14); }
+
+  /* Cancelled: neutral stadium pill (not the red error palette) — starts as
+     a dismiss (X) button only, expands to reveal the "Cancelled" label and
+     an Undo button that resumes recording hands-free with the cancelled
+     audio prepended. Both buttons are real, clickable controls (not status
+     icons) — dismiss discards the capture for good, Undo keeps it going. */
+  .pill.cancelled {
+    width: 42px;
+    gap: 8px;
+    padding: 0 12px;
+    border-radius: 999px;
+    overflow: hidden;
+    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+                padding 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  .pill.cancelled.cancel-open {
+    width: 158px;
+    padding: 0 8px;
+  }
+  .cancel-text {
+    font-size: 11.5px; font-weight: 500;
+    white-space: nowrap; overflow: hidden;
+    opacity: 0;
+    flex: 1;
+    text-align: center;
+    transition: opacity 0.18s ease 0.08s;
+  }
+  .pill.cancelled.cancel-open .cancel-text { opacity: 1; }
+
+  /* Paste failed: same red-tinted stadium pill as .pill.error, message-first
+     (no collapsed-icon entry — the message is a fixed short string, not a
+     dynamic one to measure), then widens to reveal a Copy button after a
+     beat so "paste failed" registers before the fallback action appears. */
+  .pill.paste-failed {
+    gap: 8px;
+    padding: 0 14px;
+    background: var(--pill-error-bg);
+    color: var(--pill-error-fg);
+    border-radius: 999px;
+    box-shadow: 0 0 0 1px var(--pill-error-border),
+                0 6px 18px rgba(0,0,0,0.28);
+    width: 128px;
+    overflow: hidden;
+    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+                padding 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  .pill.paste-failed.copy-open {
+    width: 158px;
+    padding: 0 8px 0 14px;
+  }
+  .paste-failed-text {
+    font-size: 11.5px; font-weight: 500;
+    color: var(--pill-error-fg);
+    white-space: nowrap; overflow: hidden;
+    flex: 1;
+    text-align: center;
+  }
+  .hf-btn.copy-btn {
+    color: var(--pill-error-fg);
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+  .hf-btn.copy-btn:hover { background: rgba(255,255,255,0.14); }
+
+  /* Copied confirmation: neutral (not error-red) stadium pill for the global
+     Ctrl+Alt+C / ⌥⌘C shortcut — fixed short message, auto-sized, no buttons. */
+  .pill.copied {
+    gap: 8px;
+    padding: 0 14px;
+    white-space: nowrap;
+  }
+  .copied-icon { color: var(--accent); flex-shrink: 0; }
+  .copied-text {
+    font-size: 11.5px; font-weight: 500;
+    white-space: nowrap;
+  }
 
   /* Handsfree: starts compact (mirrors recording — same DPI-snapped width so the
      recording→handsfree continuation doesn't jump), expands to 112px after 450ms */

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -24,8 +24,13 @@
   });
 
   function handleOutsideClick(e: MouseEvent) {
-    // e.target can be document/text nodes — closest() only exists on Element.
-    if (closeSelector && e.target instanceof Element && (e.target as HTMLElement).closest(closeSelector)) return;
+    // closest() only exists on Element; a click target can be a Text node or
+    // document, so resolve to the nearest element first before testing the
+    // close selector (e.g. clicking the label text inside the trigger).
+    const target = e.target instanceof Element
+      ? e.target
+      : (e.target as Node)?.parentElement;
+    if (closeSelector && target?.closest(closeSelector)) return;
     open = false;
   }
 

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -24,7 +24,8 @@
   });
 
   function handleOutsideClick(e: MouseEvent) {
-    if (closeSelector && (e.target as HTMLElement).closest(closeSelector)) return;
+    // e.target can be document/text nodes — closest() only exists on Element.
+    if (closeSelector && e.target instanceof Element && (e.target as HTMLElement).closest(closeSelector)) return;
     open = false;
   }
 

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -8,16 +8,28 @@
   }: { open: boolean; closeSelector?: string; children?: import('svelte').Snippet } = $props();
 
   $effect(() => {
-    if (open) {
-      tick().then(() =>
-        window.addEventListener('click', handleOutsideClick, { once: true })
-      );
-    }
+    if (!open) return;
+
+    let disposed = false;
+    tick().then(() => {
+      if (!disposed) window.addEventListener('click', handleOutsideClick);
+    });
+    window.addEventListener('keydown', handleWindowKeydown);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('click', handleOutsideClick);
+      window.removeEventListener('keydown', handleWindowKeydown);
+    };
   });
 
   function handleOutsideClick(e: MouseEvent) {
     if (closeSelector && (e.target as HTMLElement).closest(closeSelector)) return;
     open = false;
+  }
+
+  function handleWindowKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') open = false;
   }
 </script>
 

--- a/src/lib/components/appMappings/AppMappingsAddForm.svelte
+++ b/src/lib/components/appMappings/AppMappingsAddForm.svelte
@@ -268,7 +268,7 @@
       {/if}
     </div>
 
-    <div class="profile-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
+    <div class="ui-dropdown profile-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
       <select class="profile-select profile-select-hidden" bind:value={addProfile} tabindex="-1" aria-hidden="true">
         {#each profileOptions as profile}
           <option value={profile.id}>{profile.label}</option>
@@ -277,7 +277,7 @@
       <button
         bind:this={profileDropdownButton}
         type="button"
-        class="profile-drop-btn"
+        class="ui-dropdown-trigger profile-drop-btn"
         use:animateWidth={{ text: getProfileLabel(addProfile) }}
         onclick={() => (profileDropdownOpen ? profileDropdownOpen = false : openProfileDropdown())}
         onkeydown={handleProfileButtonKeydown}
@@ -293,7 +293,7 @@
       {#if profileDropdownOpen}
         <div
           id={ADD_PROFILE_MENU_ID}
-          class="profile-drop-menu scroll-styled"
+          class="ui-dropdown-menu profile-drop-menu scroll-styled"
           role="listbox"
           tabindex="-1"
           aria-label="Tone options"
@@ -304,7 +304,7 @@
           {#each profileOptions as profile}
             <button
               type="button"
-              class="profile-drop-item"
+              class="ui-dropdown-option profile-drop-item"
               class:active={addProfile === profile.id}
               onclick={() => {
                 addProfile = profile.id;
@@ -327,7 +327,7 @@
       {/if}
     </div>
 
-    <div class="cleanup-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
+    <div class="ui-dropdown cleanup-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
       <select class="cleanup-select cleanup-select-hidden" bind:value={addCleanupIntensity} tabindex="-1" aria-hidden="true">
         {#each cleanupIntensityChoices as choice}
           <option value={choice.id}>{choice.label}</option>
@@ -336,7 +336,7 @@
       <button
         bind:this={cleanupDropdownButton}
         type="button"
-        class="cleanup-drop-btn"
+        class="ui-dropdown-trigger cleanup-drop-btn"
         use:animateWidth={{ text: getCleanupIntensityLabel(addCleanupIntensity) }}
         onclick={() => (cleanupDropdownOpen ? cleanupDropdownOpen = false : openCleanupDropdown())}
         onkeydown={handleCleanupButtonKeydown}
@@ -352,7 +352,7 @@
       {#if cleanupDropdownOpen}
         <div
           id={ADD_CLEANUP_MENU_ID}
-          class="cleanup-drop-menu scroll-styled"
+          class="ui-dropdown-menu cleanup-drop-menu scroll-styled"
           role="listbox"
           tabindex="-1"
           aria-label="Cleanup intensity options"
@@ -363,7 +363,7 @@
           {#each cleanupIntensityChoices as choice}
             <button
               type="button"
-              class="cleanup-drop-item"
+              class="ui-dropdown-option cleanup-drop-item"
               class:active={addCleanupIntensity === choice.id}
               onclick={() => {
                 addCleanupIntensity = choice.id;
@@ -386,7 +386,7 @@
       {/if}
     </div>
 
-    <button type="button" class="btn-primary add-btn" onclick={submit} disabled={!addExe && !appSearch.trim()}>Add</button>
+    <button type="button" class="btn-primary btn-compact add-btn" onclick={submit} disabled={!addExe && !appSearch.trim()}>Add</button>
   </div>
 
   {#if pendingExe}
@@ -508,8 +508,7 @@
 
   .profile-drop-wrap,
   .cleanup-drop-wrap {
-    position: relative;
-    flex-shrink: 0;
+    --ui-dropdown-trigger-height: 28px;
   }
 
   .profile-select-hidden,
@@ -529,34 +528,10 @@
 
   .profile-drop-btn,
   .cleanup-drop-btn {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    background: transparent;
-    border: 1px solid var(--line-strong);
+    --ui-dropdown-trigger-bg: transparent;
+    border-color: var(--line-strong);
     border-radius: 6px;
-    padding: 6px 12px;
     font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    font-weight: 500;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .profile-drop-btn:hover,
-  .cleanup-drop-btn:hover {
-    background: var(--control-hover);
-  }
-
-  .profile-drop-btn svg,
-  .cleanup-drop-btn svg {
-    transition: transform 150ms;
-  }
-
-  .profile-drop-btn svg.open,
-  .cleanup-drop-btn svg.open {
-    transform: rotate(180deg);
   }
 
   .profile-drop-btn span,
@@ -569,16 +544,7 @@
 
   .profile-drop-menu,
   .cleanup-drop-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    box-shadow: var(--shadow-popover);
     max-height: 200px;
-    overflow-y: auto;
-    z-index: 20;
   }
 
   .profile-drop-menu {
@@ -588,58 +554,6 @@
   .cleanup-drop-menu {
     min-width: 120px;
   }
-
-  .profile-drop-item,
-  .cleanup-drop-item {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 8px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--line);
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .profile-drop-item:last-child,
-  .cleanup-drop-item:last-child {
-    border-bottom: none;
-  }
-
-  .profile-drop-item:hover,
-  .cleanup-drop-item:hover {
-    background: var(--control-hover);
-  }
-
-  .profile-drop-item.active,
-  .cleanup-drop-item.active {
-    background: var(--accent-soft);
-    color: var(--ink);
-    font-weight: 500;
-  }
-
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 1px solid transparent;
-    border-radius: 6px;
-    padding: 6px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    font-weight: 500;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
 
   .add-btn {
     flex-shrink: 0;

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -40,6 +40,7 @@
 
   const navItems = [
     { id: 'home',       label: 'Home',       icon: 'home',     locked: false },
+    { id: 'insights',   label: 'Insights',   icon: 'chart',    locked: false },
     { id: 'dictionary', label: 'Dictionary', icon: 'book',     locked: false },
     { id: 'snippets',   label: 'Snippets',   icon: 'scissors', locked: false },
     { id: 'style',      label: 'Style',      icon: 'type',     locked: false },

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -330,27 +330,6 @@
   }
   .modal-footer { padding: 0 20px 20px; }
   .footer-actions { display: flex; justify-content: flex-end; gap: 8px; }
-  .btn-ghost, .btn-primary {
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    color: var(--ink-soft);
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-  }
-  .btn-primary:hover { background: var(--ink-strong); }
-  .btn-primary:disabled { opacity: 0.5; cursor: default; }
 
   @keyframes update-drop {
     from {

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -354,9 +354,9 @@
   </div>
   <div class="simulation-actions">
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="simulation-provider-dropdown" onclick={(event) => event.stopPropagation()} onkeydown={(event) => { if (event.key === 'Escape') providerDropdownOpen = false; }}>
+    <div class="ui-dropdown simulation-provider-dropdown" onclick={(event) => event.stopPropagation()} onkeydown={(event) => { if (event.key === 'Escape') providerDropdownOpen = false; }}>
       <button
-        class="btn-ghost simulation-provider-button"
+        class="btn-ghost ui-dropdown-trigger simulation-provider-button"
         onclick={() => (providerDropdownOpen = !providerDropdownOpen)}
         aria-haspopup="true"
         aria-expanded={providerDropdownOpen}
@@ -372,7 +372,7 @@
         <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
         <div
           id="provider-status-preview-menu"
-          class="simulation-provider-menu"
+          class="ui-dropdown-menu ui-dropdown-menu--padded simulation-provider-menu"
           aria-label="Provider status preview options"
           onclick={(event) => event.stopPropagation()}
           in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
@@ -380,7 +380,7 @@
         >
           {#each simulatedProviders as provider}
             <button
-              class="simulation-provider-item"
+              class="ui-dropdown-option simulation-provider-item"
               class:active={simulatedProvider === provider.id}
               onclick={() => { simulatedProvider = provider.id; providerDropdownOpen = false; }}
             >{provider.label}</button>
@@ -406,7 +406,7 @@
     <Dropdown bind:open={notificationDropdownOpen} closeSelector=".notification-test-dropdown">
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        class="notification-test-dropdown"
+        class="ui-dropdown notification-test-dropdown"
         onclick={(event) => event.stopPropagation()}
         onkeydown={(event) => {
           if (event.key === 'Escape' && notificationDropdownOpen) {
@@ -416,7 +416,7 @@
         }}
       >
         <button
-          class="btn-ghost notification-test-dropdown-button"
+          class="btn-ghost ui-dropdown-trigger notification-test-dropdown-button"
           type="button"
           use:animateWidth={{ text: notificationTypeLabel(), max: 180 }}
           onclick={() => (notificationDropdownOpen = !notificationDropdownOpen)}
@@ -434,7 +434,7 @@
           <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
           <div
             id="notification-test-menu"
-            class="notification-test-menu"
+            class="ui-dropdown-menu ui-dropdown-menu--padded notification-test-menu"
             role="listbox"
             tabindex="0"
             aria-label="Notification type options"
@@ -444,7 +444,7 @@
           >
             {#each notificationTestTypes as option}
               <button
-                class="notification-test-item"
+                class="ui-dropdown-option notification-test-item"
                 class:active={notificationTestType === option.value}
                 type="button"
                 role="option"
@@ -578,60 +578,17 @@
     flex-wrap: wrap;
     gap: 8px;
   }
-  .notification-test-dropdown {
-    position: relative;
-    flex-shrink: 0;
-  }
   .notification-test-dropdown-button {
-    display: inline-flex;
-    align-items: center;
     justify-content: space-between;
-    gap: 8px;
-    height: 32px;
-    padding: 0 12px;
-    border-radius: var(--r-md);
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 500;
   }
-  .notification-test-dropdown-button svg { transition: transform 150ms; }
-  .notification-test-dropdown-button svg.open { transform: rotate(180deg); }
   .notification-test-send-button {
     display: inline-flex;
     align-items: center;
     height: 32px;
   }
   .notification-test-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
     min-width: 170px;
-    padding: 4px;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    box-shadow: var(--shadow-popover);
-    z-index: 10;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
   }
-  .notification-test-item {
-    width: 100%;
-    padding: 6px 10px;
-    border: none;
-    border-radius: var(--r-sm);
-    background: transparent;
-    color: var(--ink-soft);
-    font: inherit;
-    font-size: 12.5px;
-    text-align: left;
-    cursor: pointer;
-  }
-  .notification-test-item:hover { background: var(--paper-2); color: var(--ink); }
-  .notification-test-item.active { background: var(--accent-soft); color: var(--accent-ink); font-weight: 500; }
   .actions {
     display: flex;
     gap: 8px;
@@ -642,54 +599,12 @@
     justify-content: flex-end;
     gap: 8px;
   }
-  .simulation-provider-dropdown {
-    position: relative;
-    flex-shrink: 0;
-  }
   .simulation-provider-button {
-    display: inline-flex;
-    align-items: center;
     gap: 6px;
-    height: 32px;
-    padding: 0 12px;
-    border-radius: var(--r-md);
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 500;
   }
-  .simulation-provider-button svg { transition: transform 150ms; }
-  .simulation-provider-button svg.open { transform: rotate(180deg); }
   .simulation-provider-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
     min-width: 160px;
-    padding: 4px;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    box-shadow: var(--shadow-popover);
-    z-index: 10;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
   }
-  .simulation-provider-item {
-    width: 100%;
-    padding: 6px 10px;
-    border: none;
-    border-radius: var(--r-sm);
-    background: transparent;
-    color: var(--ink-soft);
-    font: inherit;
-    font-size: 12.5px;
-    text-align: left;
-    cursor: pointer;
-  }
-  .simulation-provider-item:hover { background: var(--paper-2); color: var(--ink); }
-  .simulation-provider-item.active { background: var(--accent-soft); color: var(--accent-ink); font-weight: 500; }
   .privacy-warn {
     margin: 10px 0 4px;
     padding: 10px 12px;

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -467,11 +467,15 @@
   </p>
 {/if}
 <div class="setting-row">
+  <div><div class="label">Copy last dictation</div><div class="desc">Always available — re-copies your last dictation to the clipboard, in case a paste didn't land</div></div>
+  <span class="badge key-badge">{isMac ? '⌥⌘C' : 'Ctrl+Alt+C'}</span>
+</div>
+<div class="setting-row">
   <div class="lang-setting-text"><div class="label">Spoken Language</div><div class="desc">Tells transcription what language to expect{languageScopeNote}</div></div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="language-dropdown" onkeydown={(e) => { if (e.key === 'Escape' && languageDropdownOpen) { languageDropdownOpen = false; e.stopPropagation(); } }}>
+  <div class="ui-dropdown language-dropdown" onkeydown={(e) => { if (e.key === 'Escape' && languageDropdownOpen) { languageDropdownOpen = false; e.stopPropagation(); } }}>
     <button
-      class="btn-ghost language-btn"
+      class="btn-ghost ui-dropdown-trigger language-btn"
       use:animateWidth={{ text: getTranscriptionLanguageLabel(selectedLanguage) }}
       onclick={() => (languageDropdownOpen = !languageDropdownOpen)}
       aria-haspopup="true"
@@ -489,7 +493,7 @@
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
       <div
         id={LANGUAGE_MENU_ID}
-        class="language-menu scroll-styled scroll-thumb-elev"
+        class="ui-dropdown-menu language-menu scroll-styled scroll-thumb-elev"
         aria-label="Spoken language options"
         onclick={(e) => e.stopPropagation()}
         in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
@@ -497,7 +501,7 @@
       >
         {#each visibleLanguages as language}
           <button
-            class="language-item"
+            class="ui-dropdown-option language-item"
             class:active={selectedLanguage === language.code}
             onclick={() => saveLanguage(language.code)}
           >
@@ -515,9 +519,9 @@
     <div class="desc">{microphoneCopy.inputDeviceDescription}</div>
   </div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="mic-dropdown" onkeydown={(e) => { if (e.key === 'Escape' && micDropdownOpen) { micDropdownOpen = false; e.stopPropagation(); } }}>
+  <div class="ui-dropdown mic-dropdown" onkeydown={(e) => { if (e.key === 'Escape' && micDropdownOpen) { micDropdownOpen = false; e.stopPropagation(); } }}>
     <button
-      class="btn-ghost mic-btn"
+      class="btn-ghost ui-dropdown-trigger mic-btn"
       use:animateWidth={{ text: selectedMic || microphoneCopy.defaultDevice, max: 180 }}
       onclick={() => (micDropdownOpen = !micDropdownOpen)}
       aria-haspopup="true"
@@ -534,15 +538,15 @@
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
       <div
         id={MIC_MENU_ID}
-        class="mic-menu scroll-styled scroll-thumb-elev"
+        class="ui-dropdown-menu ui-dropdown-menu--padded mic-menu scroll-styled scroll-thumb-elev"
         aria-label="Microphone device options"
         onclick={(e) => e.stopPropagation()}
         in:fly={{ y: -motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.panel), easing: expoOut }}
         out:fade={{ duration: motionMs(MOTION_MS.fast) }}
       >
-        <button class="mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{microphoneCopy.defaultDevice}</button>
+        <button class="ui-dropdown-option mic-item" class:active={!selectedMic} onclick={() => saveMic('')}>{microphoneCopy.defaultDevice}</button>
         {#each microphones as m}
-          <button class="mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>{m}</button>
+          <button class="ui-dropdown-option mic-item" class:active={selectedMic === m} onclick={() => saveMic(m)}>{m}</button>
         {/each}
         {#if microphones.length === 0}
           <div class="mic-empty">{microphoneCopy.noDevicesFound}</div>
@@ -659,25 +663,9 @@
   .keybind-btn.success { background: color-mix(in srgb, var(--accent) 82%, white 18%); color: var(--on-accent); transform: scale(1.03); }
   .keybind-btn.error { background: var(--danger-bg); color: var(--danger); border-color: var(--danger-line); animation: none; }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.7; } }
-  .mic-dropdown { position: relative; flex-shrink: 0; }
   .mic-btn {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    height: 32px;
-    padding: 0 12px;
-    border-radius: var(--r-md);
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 500;
     max-width: 180px;
   }
-  .mic-btn svg { transition: transform 0.2s; }
-  .mic-btn svg.open { transform: rotate(180deg); }
-  .language-btn svg { transition: transform 150ms; }
-  .language-btn svg.open { transform: rotate(180deg); }
   .mic-btn-label {
     min-width: 0;
     overflow: hidden;
@@ -687,44 +675,13 @@
     text-align: left;
   }
   .mic-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
     width: 220px;
-    max-height: 240px;
-    overflow-y: auto;
-    background: var(--bg-elev);
-    border: 1px solid var(--line-strong);
-    border-radius: var(--r-md);
-    box-shadow: 0 4px 16px var(--shadow-md);
-    z-index: 10;
-    padding: 4px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
   }
-  .mic-item {
-    width: 100%;
-    text-align: left;
-    padding: 6px 10px;
-    border-radius: var(--r-sm);
-    font-size: 12.5px;
-    color: var(--ink-soft);
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .mic-item:hover { background: var(--paper-2); color: var(--ink); }
-  .mic-item.active { background: var(--accent-soft); color: var(--accent-ink); font-weight: 500; }
   .mic-empty { padding: 8px 10px; font-size: 12px; color: var(--ink-mute); text-align: center; }
   /* Let the label+desc column take remaining width and wrap within itself,
      so the (sometimes long) language-scope note never runs under the
      fixed-width dropdown button to its right. */
   .lang-setting-text { min-width: 0; flex: 1; padding-right: 14px; }
-  .language-dropdown { position: relative; flex-shrink: 0; }
   .language-btn { max-width: 210px; }
   .language-btn span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
   .language-code {
@@ -734,36 +691,14 @@
     text-transform: uppercase;
   }
   .language-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    box-shadow: var(--shadow-popover);
     min-width: 220px;
     max-width: 280px;
     max-height: 260px;
-    overflow-y: auto;
-    z-index: 10;
   }
   .language-item {
     display: flex;
-    justify-content: space-between;
     gap: 12px;
-    width: 100%;
-    text-align: left;
-    padding: 8px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--line);
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    justify-content: space-between;
   }
   .language-item span:last-child {
     color: var(--ink-faint);
@@ -771,9 +706,6 @@
     font-size: 10.5px;
     text-transform: uppercase;
   }
-  .language-item:last-child { border-bottom: none; }
-  .language-item:hover { background: var(--paper); }
-  .language-item.active { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
   .appearance-segment {
     position: relative;
     display: inline-flex;
@@ -862,30 +794,4 @@
     justify-content: flex-end;
     gap: 8px;
   }
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:hover { opacity: 0.82; }
 </style>

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -936,7 +936,7 @@
   </div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="models-dropdown"
+    class="ui-dropdown models-dropdown"
     onkeydown={(event) => {
       if (event.key === 'Escape' && transcriptionModeDropdownOpen) {
         transcriptionModeDropdownOpen = false;
@@ -945,7 +945,7 @@
     }}
   >
     <button
-      class="btn-ghost models-dropdown-btn"
+      class="btn-ghost ui-dropdown-trigger models-dropdown-btn"
       type="button"
       onclick={() => (transcriptionModeDropdownOpen = !transcriptionModeDropdownOpen)}
       aria-haspopup="listbox"
@@ -961,7 +961,7 @@
     {#if transcriptionModeDropdownOpen}
       <div
         id="transcription-mode-menu"
-        class="models-dropdown-menu scroll-styled scroll-thumb-elev"
+        class="ui-dropdown-menu models-dropdown-menu scroll-styled scroll-thumb-elev"
         role="listbox"
         tabindex="-1"
         aria-label="Transcription strategy"
@@ -969,7 +969,7 @@
         out:fade={{ duration: motionMs(MOTION_MS.fast) }}
       >
         <button
-          class="models-dropdown-item"
+          class="ui-dropdown-option models-dropdown-item"
           class:is-active={!dualTranscriptionEnabled}
           type="button"
           onclick={() => handleDualTranscription(false)}
@@ -980,7 +980,7 @@
           <small>Fastest, uses the primary model and fallbacks only on failure.</small>
         </button>
         <button
-          class="models-dropdown-item"
+          class="ui-dropdown-option models-dropdown-item"
           class:is-active={dualTranscriptionEnabled}
           type="button"
           onclick={() => handleDualTranscription(true)}
@@ -1004,7 +1004,7 @@
   </div>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="models-dropdown"
+    class="ui-dropdown models-dropdown"
     onkeydown={(event) => {
       if (event.key === 'Escape' && localModelMemoryDropdownOpen) {
         localModelMemoryDropdownOpen = false;
@@ -1013,7 +1013,7 @@
     }}
   >
     <button
-      class="btn-ghost models-dropdown-btn"
+      class="btn-ghost ui-dropdown-trigger models-dropdown-btn"
       type="button"
       use:animateWidth={{ text: localMemoryPolicyLabel(localModelMemoryPolicy), max: 220 }}
       onclick={() => (localModelMemoryDropdownOpen = !localModelMemoryDropdownOpen)}
@@ -1031,7 +1031,7 @@
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <div
         id={LOCAL_MEMORY_POLICY_MENU_ID}
-        class="models-dropdown-menu scroll-styled scroll-thumb-elev"
+        class="ui-dropdown-menu models-dropdown-menu scroll-styled scroll-thumb-elev"
         role="listbox"
         tabindex="-1"
         aria-label="Local model memory policy options"
@@ -1041,7 +1041,7 @@
       >
         {#each localMemoryPolicyOptions as option}
           <button
-            class="models-dropdown-item"
+            class="ui-dropdown-option models-dropdown-item"
             class:is-active={localModelMemoryPolicy === option.value}
             type="button"
             onclick={() => updateLocalMemoryPolicy(option.value)}
@@ -1135,23 +1135,7 @@
     color: var(--ink-mute);
   }
 
-  .models-dropdown {
-    position: relative;
-    flex-shrink: 0;
-  }
-
   .models-dropdown-btn {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    height: 32px;
-    padding: 0 12px;
-    border-radius: var(--r-md);
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 500;
     max-width: 220px;
   }
 
@@ -1161,56 +1145,9 @@
     white-space: nowrap;
   }
 
-  .models-dropdown-btn svg { transition: transform 150ms; }
-  .models-dropdown-btn svg.open { transform: rotate(180deg); }
-
   .models-dropdown-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
     min-width: 220px;
     max-height: 220px;
-    overflow-y: auto;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-sm);
-    box-shadow: var(--shadow-popover);
-    z-index: 10;
-  }
-
-  .models-dropdown-item {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 8px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    color: var(--ink-strong);
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid var(--line);
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .models-dropdown-item:last-child {
-    border-bottom: none;
-  }
-
-  .models-dropdown-item:hover {
-    background: var(--paper);
-  }
-
-  .models-dropdown-item:focus-visible,
-  .models-dropdown-btn:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  .models-dropdown-item.is-active {
-    background: var(--accent-soft);
-    color: var(--ink);
-    font-weight: 500;
   }
 
   /* Keyed to the settings content column, not the window — this stacks when the

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -440,7 +440,7 @@
     <div class="modal-footer">
       <div class="footer-actions">
         <button bind:this={retentionCancelButton} class="btn-ghost" onclick={() => (confirmRetention = null)}>Cancel</button>
-        <button class="btn-danger" onclick={confirmHistoryRetention}>Delete history</button>
+        <button class="btn-danger btn-compact" onclick={confirmHistoryRetention}>Delete history</button>
       </div>
     </div>
   </div>
@@ -569,22 +569,5 @@
     display: flex;
     justify-content: flex-end;
     gap: 8px;
-  }
-  .btn-danger {
-    background: var(--danger-bg);
-    color: var(--danger);
-    border: 1px solid var(--danger-line);
-    border-radius: 6px;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-family: var(--sans);
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s, border-color 0.12s;
-  }
-  .btn-danger:hover {
-    background: var(--danger);
-    color: var(--on-accent);
-    border-color: var(--danger);
   }
 </style>

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -10,6 +10,7 @@ export const icons = {
   min:      `<path d="M5 12h14"/>`,
   close:    `<path d="M6 6l12 12M6 18 18 6"/>`,
   key:      `<circle cx="7.5" cy="15.5" r="3.5"/><path d="m21 2-9.6 9.6M15 6l3 3"/>`,
+  chart:    `<path d="M4 20V4"/><path d="M4 20h16"/><path d="M8 20v-6M13 20V8M18 20v-9"/>`,
   sliders:  `<path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"/>`,
   command:  `<path d="M18 3a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3H6a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/>`,
   lock:     `<rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>`,

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -16,7 +16,7 @@ export const MOTION_PX = {
   page: 18,
 } as const;
 
-export const NAV_ORDER = ['home', 'dictionary', 'snippets', 'style'] as const;
+export const NAV_ORDER = ['home', 'insights', 'dictionary', 'snippets', 'style'] as const;
 export const STYLE_TAB_ORDER = ['cleanup', 'personal', 'apps'] as const;
 
 export function directionFromOrder(current: string, next: string, order: readonly string[]): 1 | -1 {

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -2,7 +2,7 @@ import { invoke } from './tauri';
 import type { ProviderId } from './settings';
 import type { SettingsSectionId } from './settingsSections';
 
-export type PageId = 'home' | 'dictionary' | 'snippets' | 'style';
+export type PageId = 'home' | 'insights' | 'dictionary' | 'snippets' | 'style';
 export type AppearanceMode = 'system' | 'light' | 'dark';
 export type PillState = 'idle' | 'recording' | 'processing' | 'handsfree';
 export type FetchStatus = 'idle' | 'loading' | 'loaded' | 'error';

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -878,9 +878,22 @@ function devInsights(days: number): unknown {
   for (let i = daily.length - 1; i >= 0 && daily[i].words > 0; i--) current++;
   let longest = 0;
   let run = 0;
+  let runStart: string | null = null;
+  let longestStartedOn: string | null = null;
+  let longestEndedOn: string | null = null;
   for (const d of daily) {
-    run = d.words > 0 ? run + 1 : 0;
-    longest = Math.max(longest, run);
+    if (d.words > 0) {
+      if (run === 0) runStart = d.day;
+      run += 1;
+      if (run > longest) {
+        longest = run;
+        longestStartedOn = runStart;
+        longestEndedOn = d.day;
+      }
+    } else {
+      run = 0;
+      runStart = null;
+    }
   }
 
   const hourly = Array.from({ length: 24 }, (_, h) => {
@@ -904,8 +917,8 @@ function devInsights(days: number): unknown {
     streak: {
       current_days: current,
       longest_days: longest,
-      longest_started_on: daily[Math.max(0, daily.length - longest - 4)]?.day ?? null,
-      longest_ended_on: daily[Math.max(0, daily.length - 5)]?.day ?? null,
+      longest_started_on: longestStartedOn,
+      longest_ended_on: longestEndedOn,
       longest_words: Math.round(wordsInRange * 0.62),
       active_days: daily.filter((d) => d.words > 0).length + 96,
     },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -869,19 +869,39 @@ function devInsights(days: number): unknown {
       speaking_ms: Math.round((words / 145) * 60_000),
     };
   });
+  const streakStart = new Date(today);
+  streakStart.setDate(today.getDate() - 364);
+  const streakSpan = 365;
+  const streakDaily = Array.from({ length: streakSpan }, (_, i) => {
+    const date = new Date(today);
+    date.setTime(streakStart.getTime());
+    date.setDate(streakStart.getDate() + i);
+    const weekend = date.getDay() === 0 || date.getDay() === 6;
+    const r = noise(i + 101);
+    const idle = r < (weekend ? 0.45 : 0.12);
+    const words = idle ? 0 : Math.round(400 + r * (weekend ? 1400 : 4200));
+    const transcriptions = words === 0 ? 0 : Math.max(1, Math.round(words / 95));
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return {
+      day: `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+      words,
+      transcriptions,
+      speaking_ms: Math.round((words / 145) * 60_000),
+    };
+  });
 
   const wordsInRange = daily.reduce((sum, d) => sum + d.words, 0);
   const transcriptions = daily.reduce((sum, d) => sum + d.transcriptions, 0);
   const speakingMs = daily.reduce((sum, d) => sum + d.speaking_ms, 0);
 
   let current = 0;
-  for (let i = daily.length - 1; i >= 0 && daily[i].words > 0; i--) current++;
+  for (let i = streakDaily.length - 1; i >= 0 && streakDaily[i].words > 0; i--) current++;
   let longest = 0;
   let run = 0;
   let runStart: string | null = null;
   let longestStartedOn: string | null = null;
   let longestEndedOn: string | null = null;
-  for (const d of daily) {
+  for (const d of streakDaily) {
     if (d.words > 0) {
       if (run === 0) runStart = d.day;
       run += 1;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -843,6 +843,132 @@ function devPermissionSnapshot(provider?: unknown) {
   };
 }
 
+/*
+ * Browser-dev stand-in for `get_insights`. Deterministic (seeded off the day
+ * index, no Math.random) so the page doesn't flicker between renders and the
+ * smoke tests see stable numbers.
+ */
+function devInsights(days: number): unknown {
+  const span = days > 0 ? days : 120;
+  const noise = (n: number) => ((Math.sin(n * 12.9898) * 43758.5453) % 1 + 1) % 1;
+
+  const today = new Date();
+  const daily = Array.from({ length: span }, (_, i) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() - (span - 1 - i));
+    const weekend = date.getDay() === 0 || date.getDay() === 6;
+    const r = noise(i + 1);
+    const idle = r < (weekend ? 0.45 : 0.12);
+    const words = idle ? 0 : Math.round(400 + r * (weekend ? 1400 : 4200));
+    const transcriptions = words === 0 ? 0 : Math.max(1, Math.round(words / 95));
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return {
+      day: `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+      words,
+      transcriptions,
+      speaking_ms: Math.round((words / 145) * 60_000),
+    };
+  });
+
+  const wordsInRange = daily.reduce((sum, d) => sum + d.words, 0);
+  const transcriptions = daily.reduce((sum, d) => sum + d.transcriptions, 0);
+  const speakingMs = daily.reduce((sum, d) => sum + d.speaking_ms, 0);
+
+  let current = 0;
+  for (let i = daily.length - 1; i >= 0 && daily[i].words > 0; i--) current++;
+  let longest = 0;
+  let run = 0;
+  for (const d of daily) {
+    run = d.words > 0 ? run + 1 : 0;
+    longest = Math.max(longest, run);
+  }
+
+  const hourly = Array.from({ length: 24 }, (_, h) => {
+    const bell = Math.exp(-((h - 14) ** 2) / 24) + 0.35 * Math.exp(-((h - 9) ** 2) / 8);
+    return Math.round(bell * wordsInRange * 0.11);
+  });
+
+  return {
+    range_days: days,
+    generated_at: new Date().toISOString().slice(0, 19).replace('T', ' '),
+    totals: {
+      total_words: wordsInRange + 218_400,
+      total_transcriptions: transcriptions,
+      total_speaking_ms: speakingMs,
+      avg_words_per_transcription: transcriptions ? Math.round(wordsInRange / transcriptions) : 0,
+      avg_wpm: 148,
+      best_wpm: 197,
+      words_in_range: wordsInRange,
+      words_prev_range: Math.round(wordsInRange * 0.91),
+    },
+    streak: {
+      current_days: current,
+      longest_days: longest,
+      longest_started_on: daily[Math.max(0, daily.length - longest - 4)]?.day ?? null,
+      longest_ended_on: daily[Math.max(0, daily.length - 5)]?.day ?? null,
+      longest_words: Math.round(wordsInRange * 0.62),
+      active_days: daily.filter((d) => d.words > 0).length + 96,
+    },
+    daily,
+    hourly,
+    providers: [
+      {
+        model: 'whisper-large-v3-turbo',
+        provider: 'groq',
+        task: 'transcription',
+        calls: transcriptions,
+        audio_ms: speakingMs,
+        input_chars: 0,
+        output_chars: 0,
+      },
+      {
+        model: 'llama-3.3-70b-versatile',
+        provider: 'groq',
+        task: 'cleanup',
+        calls: Math.round(transcriptions * 0.86),
+        audio_ms: 0,
+        input_chars: wordsInRange * 6,
+        output_chars: wordsInRange * 5,
+      },
+      {
+        model: 'gemini-3.5-flash',
+        provider: 'google',
+        task: 'cleanup',
+        calls: Math.round(transcriptions * 0.14),
+        audio_ms: 0,
+        input_chars: Math.round(wordsInRange * 0.9),
+        output_chars: Math.round(wordsInRange * 0.8),
+      },
+    ],
+    cleanup: {
+      raw_words: Math.round(wordsInRange * 1.08),
+      clean_words: wordsInRange,
+      edits_applied: Math.round(wordsInRange * 0.031),
+      dictionary_fixes: Math.round(wordsInRange * 0.009),
+      auto_learned_terms: 24,
+    },
+    words: {
+      top: [
+        { word: 'transcription', count: 412 },
+        { word: 'component', count: 388 },
+        { word: 'settings', count: 341 },
+        { word: 'basically', count: 297 },
+        { word: 'pipeline', count: 264 },
+        { word: 'window', count: 231 },
+        { word: 'actually', count: 210 },
+        { word: 'clipboard', count: 188 },
+        { word: 'dictation', count: 165 },
+        { word: 'backend', count: 142 },
+        { word: 'shortcut', count: 121 },
+        { word: 'accent', count: 104 },
+      ],
+      unique_words: 7_412,
+      longest_word: 'internationalisation',
+      avg_word_length: 4.7,
+    },
+  };
+}
+
 function assertDevText(value: unknown, field: string): string {
   if (typeof value !== 'string') {
     throw new Error(`${field} must be text.`);
@@ -878,6 +1004,8 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return [] as T;
     case 'get_stats':
       return { total_words: 0, avg_wpm: 0, day_streak: 0 } as T;
+    case 'get_insights':
+      return devInsights(Number(args?.days ?? 30)) as T;
     case 'get_memory_mb':
       return 0 as T;
     case 'local_models_supported_on_this_platform':
@@ -1327,6 +1455,9 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'start_setup_try_recording':
     case 'stop_setup_try_recording':
     case 'retry_transcription':
+    case 'resume_cancelled_capture':
+    case 'dismiss_cancelled_capture':
+    case 'copy_paste_failure_to_clipboard':
     case 'install_update':
     case 'start_calibration_monitoring':
     case 'stop_calibration_monitoring':

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -287,38 +287,6 @@
     max-width: 360px;
   }
 
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
-
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-
   @media (max-width: 1060px) {
     .dict-layout { grid-template-columns: 1fr; }
   }

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -22,6 +22,9 @@
   let failedEntry: { created_at: string } | null = null;
   let retrying = false;
   let failedTimer: ReturnType<typeof setTimeout> | null = null;
+  let cancelledEntry: { created_at: string } | null = null;
+  let resumingCancelled = false;
+  let cancelledTimer: ReturnType<typeof setTimeout> | null = null;
 
   const greeting = getGreeting();
 
@@ -43,6 +46,37 @@
     } finally {
       retrying = false;
     }
+  }
+
+  function clearCancelledEntry() {
+    cancelledEntry = null;
+    if (cancelledTimer) {
+      clearTimeout(cancelledTimer);
+      cancelledTimer = null;
+    }
+  }
+
+  async function continueCancelled() {
+    if (resumingCancelled) return;
+    resumingCancelled = true;
+    try {
+      await invoke('resume_cancelled_capture');
+      // Rust also emits verenu:cancelled-capture-cleared, but clear locally
+      // too so the banner drops immediately rather than waiting on the event.
+      clearCancelledEntry();
+    } catch (err) {
+      console.error('Resume cancelled capture failed:', err);
+      // keep cancelledEntry so the user can try again
+    } finally {
+      resumingCancelled = false;
+    }
+  }
+
+  async function dismissCancelled() {
+    clearCancelledEntry();
+    try {
+      await invoke('dismiss_cancelled_capture');
+    } catch { /* dev mode */ }
   }
 
   async function copyText(entry: Entry) {
@@ -150,6 +184,21 @@
       }, 10 * 60 * 1000);
     }));
 
+    trackListener(listen<string>('verenu:cancelled-capture', (ev) => {
+      cancelledEntry = { created_at: ev.payload };
+      if (cancelledTimer) clearTimeout(cancelledTimer);
+      cancelledTimer = setTimeout(() => {
+        cancelledEntry = null;
+        cancelledTimer = null;
+      }, 10 * 60 * 1000);
+    }));
+
+    // Fired when the capture is resumed or dismissed from elsewhere (the
+    // pill's own buttons) — drop the banner if it's still showing.
+    trackListener(listen('verenu:cancelled-capture-cleared', () => {
+      clearCancelledEntry();
+    }));
+
     return () => {
       mounted = false;
       while (unlisteners.length > 0) {
@@ -158,6 +207,10 @@
       if (failedTimer) {
         clearTimeout(failedTimer);
         failedTimer = null;
+      }
+      if (cancelledTimer) {
+        clearTimeout(cancelledTimer);
+        cancelledTimer = null;
       }
     };
   });
@@ -191,14 +244,18 @@
       <HistoryList
         {recents}
         {failedEntry}
+        {cancelledEntry}
         {loading}
         {hasMoreHistory}
         {loadingMore}
         {retrying}
+        {resumingCancelled}
         {copiedId}
         {hk1}
         {hk2}
         onRetry={retryTranscription}
+        onContinueCancelled={continueCancelled}
+        onDismissCancelled={dismissCancelled}
         onLoadOlder={loadOlder}
         onCopy={copyText}
       />

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -39,8 +39,9 @@
       status = 'loaded';
       error = '';
       // Keep the previous range visible while its replacement loads, then
-      // give the refreshed figures one deliberate, reduced-motion-aware entry.
-      displayVersion += 1;
+      // give explicit range/manual refreshes one deliberate entry. Silent
+      // polling must update values in place so chart hover/focus state survives.
+      if (!opts?.silent) displayVersion += 1;
     } catch (err) {
       if (!mounted || token !== fetchToken) return;
       console.error('IPC get_insights failed:', err);

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fade } from 'svelte/transition';
+  import { invoke, listen } from '../tauri';
+  import { formatIpcError } from '../stores';
+  import Dropdown from '../components/Dropdown.svelte';
+  import HeroStats from './insights/HeroStats.svelte';
+  import DailyChart from './insights/DailyChart.svelte';
+  import StreakHeatmap from './insights/StreakHeatmap.svelte';
+  import CostBreakdown from './insights/CostBreakdown.svelte';
+  import HourStrip from './insights/HourStrip.svelte';
+  import WordStats from './insights/WordStats.svelte';
+  import { EMPTY_INSIGHTS, RANGE_OPTIONS, type InsightsPayload, type InsightsRange } from './insights/types';
+
+  let range = $state<InsightsRange>(30);
+  let data = $state<InsightsPayload | null>(null);
+  let status = $state<'loading' | 'loaded' | 'error'>('loading');
+  let error = $state('');
+  let rangeOpen = $state(false);
+
+  let fetchToken = 0;
+
+  const rangeLabel = $derived(RANGE_OPTIONS.find((o) => o.value === range)?.label ?? 'Last 30 days');
+  const isEmpty = $derived(!data || data.totals.total_transcriptions === 0);
+
+  async function load(opts?: { silent?: boolean }) {
+    const token = ++fetchToken;
+    if (!opts?.silent) {
+      status = 'loading';
+      error = '';
+    }
+    try {
+      const payload = await invoke<InsightsPayload>('get_insights', { days: range });
+      if (token !== fetchToken) return;
+      data = payload ?? EMPTY_INSIGHTS;
+      status = 'loaded';
+      error = '';
+    } catch (err) {
+      if (token !== fetchToken) return;
+      console.error('IPC get_insights failed:', err);
+      // A background refresh failure must not replace good data with an
+      // error banner — the last known numbers stay up, next tick retries.
+      if (!opts?.silent) {
+        error = formatIpcError(err);
+        status = 'error';
+      }
+    }
+  }
+
+  function pickRange(next: InsightsRange) {
+    rangeOpen = false;
+    if (next === range) return;
+    range = next;
+    load();
+  }
+
+  onMount(() => {
+    load();
+    let unlisten: (() => void) | undefined;
+    // Refresh live as new dictations land, so the page never shows stale
+    // numbers while it's open.
+    listen('verenu:transcribed', () => load())
+      .then((cleanup) => { unlisten = cleanup; })
+      .catch(() => {});
+    // Belt and suspenders: poll on a fixed cadence too, so the page catches
+    // up even when a transcription event was missed (e.g. it landed before
+    // the page opened). Silent ticks never flash the loading state.
+    const timer = setInterval(() => load({ silent: true }), 10_000);
+    return () => {
+      unlisten?.();
+      clearInterval(timer);
+    };
+  });
+</script>
+
+<div class="content-inner">
+  <div class="head">
+    <div>
+      <h1 class="page-h">Insights</h1>
+      <p class="page-sub">How much you dictate, how fast, and what it costs. Everything here is computed locally from your own history — nothing leaves your machine.</p>
+    </div>
+
+    <div class="ui-dropdown range-picker">
+      <button
+        type="button"
+        class="ui-dropdown-trigger"
+        aria-expanded={rangeOpen}
+        aria-haspopup="listbox"
+        onclick={() => (rangeOpen = !rangeOpen)}
+      >
+        {rangeLabel}
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+      </button>
+      {#if rangeOpen}
+        <Dropdown bind:open={rangeOpen} closeSelector=".range-picker">
+          <div class="ui-dropdown-menu ui-dropdown-menu--padded" role="listbox" aria-label="Date range">
+            {#each RANGE_OPTIONS as option}
+              <button
+                type="button"
+                class="ui-dropdown-option"
+                class:active={option.value === range}
+                role="option"
+                aria-selected={option.value === range}
+                onclick={() => pickRange(option.value)}
+              >{option.label}</button>
+            {/each}
+          </div>
+        </Dropdown>
+      {/if}
+    </div>
+  </div>
+
+  {#if status === 'error' && !data}
+    <div class="empty-state empty-state-error" role="alert" in:fade={{ duration: 220 }}>
+      <p class="empty-h">Could not load insights</p>
+      <p class="empty-sub">The backend is unavailable right now. {error}</p>
+      <button type="button" class="btn-ghost" onclick={() => load()}>Try again</button>
+    </div>
+  {:else if status === 'loading' && !data}
+    <div class="grid" aria-busy="true" aria-label="Loading insights">
+      <div class="skeleton span-4"></div>
+      <div class="skeleton span-4"></div>
+      <div class="skeleton span-4"></div>
+      <div class="skeleton span-8 tall"></div>
+      <div class="skeleton span-4 tall"></div>
+      <div class="skeleton span-12 tall"></div>
+    </div>
+  {:else if data && isEmpty}
+    <div class="empty-state" in:fade={{ duration: 220 }}>
+      <p class="empty-h">No dictations yet</p>
+      <p class="empty-sub">Hold your hotkey and say something. Once you've dictated a few times, your streaks, speed, and cost estimates will show up here.</p>
+    </div>
+  {:else if data}
+    {#if status === 'error'}
+      <p class="fetch-status fetch-status-error" role="alert">Refresh failed: {error}</p>
+    {:else if status === 'loading'}
+      <p class="fetch-status" role="status" aria-live="polite">Refreshing insights…</p>
+    {/if}
+
+    <HeroStats {data} {rangeLabel} />
+
+    <div class="grid">
+      <div class="span-8"><DailyChart daily={data.daily} {rangeLabel} /></div>
+      <div class="span-4"><StreakHeatmap daily={data.daily} streak={data.streak} /></div>
+      <div class="span-6"><CostBreakdown providers={data.providers} {rangeLabel} /></div>
+      <div class="span-6"><HourStrip hourly={data.hourly} /></div>
+      <div class="span-12">
+        <WordStats words={data.words} cleanup={data.cleanup} totals={data.totals} />
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .content-inner {
+    width: min(100%, var(--page-max));
+    margin-inline: auto;
+    padding: var(--page-pad-y) var(--page-pad-x) 36px;
+    min-width: 0;
+  }
+
+  .head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .page-h {
+    font-family: var(--serif);
+    font-size: 26px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    margin: 0 0 4px;
+    line-height: 1.1;
+    color: var(--ink);
+  }
+
+  .page-sub { color: var(--ink-mute); font-size: 12.5px; margin: 0 0 22px; max-width: 560px; line-height: 1.5; }
+
+  /* Match the app-mappings / tone dropdowns rather than the default pill radius. */
+  .range-picker {
+    margin-top: 2px;
+    --ui-dropdown-trigger-height: 28px;
+  }
+
+  .range-picker .ui-dropdown-trigger {
+    --ui-dropdown-trigger-bg: transparent;
+    border-color: var(--line-strong);
+    border-radius: 6px;
+    font-size: 12px;
+  }
+
+  .fetch-status { margin: 0 0 10px; font-size: 12px; color: var(--ink-mute); }
+  .fetch-status-error { color: var(--danger); }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  /* display:flex + a flex:1 child makes each card fill the tallest sibling in
+     its row (e.g. cost breakdown's table vs. the shorter hour strip), instead
+     of every card sizing to its own content. */
+  .span-4,
+  .span-6,
+  .span-8,
+  .span-12 {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .span-4  { grid-column: span 4; }
+  .span-6  { grid-column: span 6; }
+  .span-8  { grid-column: span 8; }
+  .span-12 { grid-column: span 12; }
+
+  .span-4 :global(.card),
+  .span-6 :global(.card),
+  .span-8 :global(.card),
+  .span-12 :global(.card) {
+    flex: 1;
+  }
+
+  .skeleton {
+    height: 118px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--line);
+    background: linear-gradient(
+      100deg,
+      var(--bg-elev) 30%,
+      var(--control-hover) 50%,
+      var(--bg-elev) 70%
+    );
+    background-size: 300% 100%;
+    animation: shimmer 1.4s linear infinite;
+  }
+  .skeleton.tall { height: 232px; }
+
+  @keyframes shimmer {
+    from { background-position: 150% 0; }
+    to   { background-position: -150% 0; }
+  }
+
+  .empty-state {
+    padding: 52px 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+  }
+
+  .empty-h {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  .empty-sub {
+    font-size: 12.5px;
+    color: var(--ink-mute);
+    line-height: 1.5;
+    margin: 0 0 10px;
+    max-width: 380px;
+  }
+
+  @media (max-width: 900px) {
+    .grid { grid-template-columns: 1fr; }
+    .span-4, .span-6, .span-8, .span-12 { grid-column: span 1; }
+    .head { flex-direction: column; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton { animation-duration: 2.6s; }
+  }
+</style>

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -57,16 +57,27 @@
   onMount(() => {
     load();
     let unlisten: (() => void) | undefined;
+    let mounted = true;
     // Refresh live as new dictations land, so the page never shows stale
     // numbers while it's open.
     listen('verenu:transcribed', () => load())
-      .then((cleanup) => { unlisten = cleanup; })
+      .then((cleanup) => {
+        // If the component already unmounted while `listen` was still
+        // resolving, tear the listener down immediately rather than leaking
+        // it onto a dead component.
+        if (!mounted) {
+          cleanup();
+        } else {
+          unlisten = cleanup;
+        }
+      })
       .catch(() => {});
     // Belt and suspenders: poll on a fixed cadence too, so the page catches
     // up even when a transcription event was missed (e.g. it landed before
     // the page opened). Silent ticks never flash the loading state.
     const timer = setInterval(() => load({ silent: true }), 10_000);
     return () => {
+      mounted = false;
       unlisten?.();
       clearInterval(timer);
     };

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -39,13 +39,20 @@
     } catch (err) {
       if (!mounted || token !== fetchToken) return;
       console.error('IPC get_insights failed:', err);
-      // A background refresh failure must not replace good data with an
-      // error banner — the last known numbers stay up, next tick retries.
-      // But if there's no data yet (initial load still in flight or failed),
-      // swallowing the error would leave the skeleton loading forever.
-      if (!opts?.silent || !data) {
+      if (!opts?.silent) {
         error = formatIpcError(err);
         status = 'error';
+      } else if (!data) {
+        // No data to fall back on — surface the error so the skeleton can't
+        // spin forever (e.g. initial load failed, or a silent refresh landed
+        // while the first load was still in flight).
+        error = formatIpcError(err);
+        status = 'error';
+      } else {
+        // Silent refresh failed but we have good data: keep it up. Also clear
+        // any 'loading' a superseded non-silent load may have left behind, or
+        // the skeleton would stick even though data is present.
+        status = 'loaded';
       }
     }
   }

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -41,7 +41,9 @@
       console.error('IPC get_insights failed:', err);
       // A background refresh failure must not replace good data with an
       // error banner — the last known numbers stay up, next tick retries.
-      if (!opts?.silent) {
+      // But if there's no data yet (initial load still in flight or failed),
+      // swallowing the error would leave the skeleton loading forever.
+      if (!opts?.silent || !data) {
         error = formatIpcError(err);
         status = 'error';
       }

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -93,7 +93,17 @@
       <p class="page-sub">How much you dictate, how fast, and what it costs. Everything here is computed locally from your own history — nothing leaves your machine.</p>
     </div>
 
-    <div class="ui-dropdown range-picker">
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="ui-dropdown range-picker"
+      onclick={(event) => event.stopPropagation()}
+      onkeydown={(event) => {
+        if (event.key === 'Escape' && rangeOpen) {
+          rangeOpen = false;
+          event.stopPropagation();
+        }
+      }}
+    >
       <button
         type="button"
         class="ui-dropdown-trigger"

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -19,6 +19,7 @@
   let rangeOpen = $state(false);
 
   let fetchToken = 0;
+  let mounted = false;
 
   const rangeLabel = $derived(RANGE_OPTIONS.find((o) => o.value === range)?.label ?? 'Last 30 days');
   const isEmpty = $derived(!data || data.totals.total_transcriptions === 0);
@@ -31,12 +32,12 @@
     }
     try {
       const payload = await invoke<InsightsPayload>('get_insights', { days: range });
-      if (token !== fetchToken) return;
+      if (!mounted || token !== fetchToken) return;
       data = payload ?? EMPTY_INSIGHTS;
       status = 'loaded';
       error = '';
     } catch (err) {
-      if (token !== fetchToken) return;
+      if (!mounted || token !== fetchToken) return;
       console.error('IPC get_insights failed:', err);
       // A background refresh failure must not replace good data with an
       // error banner — the last known numbers stay up, next tick retries.
@@ -55,12 +56,13 @@
   }
 
   onMount(() => {
+    mounted = true;
     load();
     let unlisten: (() => void) | undefined;
-    let mounted = true;
     // Refresh live as new dictations land, so the page never shows stale
-    // numbers while it's open.
-    listen('verenu:transcribed', () => load())
+    // numbers while it's open. Silent so a background refresh never flashes
+    // the loading state.
+    listen('verenu:transcribed', () => load({ silent: true }))
       .then((cleanup) => {
         // If the component already unmounted while `listen` was still
         // resolving, tear the listener down immediately rather than leaking

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -3,6 +3,7 @@
   import { fade } from 'svelte/transition';
   import { invoke, listen } from '../tauri';
   import { formatIpcError } from '../stores';
+  import { MOTION_MS, motionMs } from '../motion';
   import Dropdown from '../components/Dropdown.svelte';
   import HeroStats from './insights/HeroStats.svelte';
   import DailyChart from './insights/DailyChart.svelte';
@@ -17,6 +18,7 @@
   let status = $state<'loading' | 'loaded' | 'error'>('loading');
   let error = $state('');
   let rangeOpen = $state(false);
+  let displayVersion = $state(0);
 
   let fetchToken = 0;
   let mounted = false;
@@ -36,6 +38,9 @@
       data = payload ?? EMPTY_INSIGHTS;
       status = 'loaded';
       error = '';
+      // Keep the previous range visible while its replacement loads, then
+      // give the refreshed figures one deliberate, reduced-motion-aware entry.
+      displayVersion += 1;
     } catch (err) {
       if (!mounted || token !== fetchToken) return;
       console.error('IPC get_insights failed:', err);
@@ -143,22 +148,20 @@
   </div>
 
   {#if status === 'error' && !data}
-    <div class="empty-state empty-state-error" role="alert" in:fade={{ duration: 220 }}>
+    <div class="empty-state empty-state-error" role="alert" in:fade={{ duration: motionMs(MOTION_MS.base) }}>
       <p class="empty-h">Could not load insights</p>
       <p class="empty-sub">The backend is unavailable right now. {error}</p>
       <button type="button" class="btn-ghost" onclick={() => load()}>Try again</button>
     </div>
   {:else if status === 'loading' && !data}
-    <div class="grid" aria-busy="true" aria-label="Loading insights">
-      <div class="skeleton span-4"></div>
-      <div class="skeleton span-4"></div>
-      <div class="skeleton span-4"></div>
-      <div class="skeleton span-8 tall"></div>
-      <div class="skeleton span-4 tall"></div>
-      <div class="skeleton span-12 tall"></div>
+    <div class="skeletons" aria-busy="true" aria-label="Loading insights">
+      <div class="skeleton skeleton-band"></div>
+      <div class="skeleton tall"></div>
+      <div class="skeleton"></div>
+      <div class="skeleton"></div>
     </div>
   {:else if data && isEmpty}
-    <div class="empty-state" in:fade={{ duration: 220 }}>
+    <div class="empty-state" in:fade={{ duration: motionMs(MOTION_MS.base) }}>
       <p class="empty-h">No dictations yet</p>
       <p class="empty-sub">Hold your hotkey and say something. Once you've dictated a few times, your streaks, speed, and cost estimates will show up here.</p>
     </div>
@@ -169,17 +172,17 @@
       <p class="fetch-status" role="status" aria-live="polite">Refreshing insights…</p>
     {/if}
 
-    <HeroStats {data} {rangeLabel} />
+    {#key displayVersion}
+      <div class="insights-results" in:fade={{ duration: motionMs(MOTION_MS.base) }}>
+        <HeroStats {data} {rangeLabel} />
 
-    <div class="grid">
-      <div class="span-8"><DailyChart daily={data.daily} {rangeLabel} /></div>
-      <div class="span-4"><StreakHeatmap daily={data.daily} streak={data.streak} /></div>
-      <div class="span-6"><CostBreakdown providers={data.providers} {rangeLabel} /></div>
-      <div class="span-6"><HourStrip hourly={data.hourly} /></div>
-      <div class="span-12">
+        <DailyChart daily={data.daily} {rangeLabel} />
+        <StreakHeatmap daily={data.streak_daily} streak={data.streak} historyStartedOn={data.history_started_on} />
+        <HourStrip hourly={data.hourly} />
         <WordStats words={data.words} cleanup={data.cleanup} totals={data.totals} />
+        <CostBreakdown providers={data.providers} {rangeLabel} />
       </div>
-    </div>
+    {/key}
   {/if}
 </div>
 
@@ -216,49 +219,61 @@
     --ui-dropdown-trigger-height: 28px;
   }
 
-  .range-picker .ui-dropdown-trigger {
-    --ui-dropdown-trigger-bg: transparent;
-    border-color: var(--line-strong);
-    border-radius: 6px;
-    font-size: 12px;
-  }
-
   .fetch-status { margin: 0 0 10px; font-size: 12px; color: var(--ink-mute); }
   .fetch-status-error { color: var(--danger); }
 
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(12, minmax(0, 1fr));
-    gap: 14px;
-  }
-
-  /* display:flex + a flex:1 child makes each card fill the tallest sibling in
-     its row (e.g. cost breakdown's table vs. the shorter hour strip), instead
-     of every card sizing to its own content. */
-  .span-4,
-  .span-6,
-  .span-8,
-  .span-12 {
-    min-width: 0;
+  /* Section shell for every child component. Owned here rather than repeated
+     in each of them, so the page's visual weight has a single lever. These are
+     sections in an editorial page — a serif sub-heading over a hairline rule,
+     sitting on bare paper — not cards. Elevation stays reserved for modals and
+     popovers, per DESIGN.md. */
+  .content-inner :global(.card) {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+    margin-bottom: 30px;
   }
-  .span-4  { grid-column: span 4; }
-  .span-6  { grid-column: span 6; }
-  .span-8  { grid-column: span 8; }
-  .span-12 { grid-column: span 12; }
 
-  .span-4 :global(.card),
-  .span-6 :global(.card),
-  .span-8 :global(.card),
-  .span-12 :global(.card) {
-    flex: 1;
+  .content-inner :global(.card:last-child) { margin-bottom: 0; }
+
+  .insights-results { min-width: 0; }
+
+  .content-inner :global(.card-head) {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+    padding-bottom: 8px;
+    margin-bottom: 14px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  /* Matches .settings-subhead — 17px was a card title, this is a section head. */
+  .content-inner :global(.card-h) {
+    font-family: var(--serif);
+    font-size: 14px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink-soft);
+    letter-spacing: -0.01em;
+  }
+
+  .content-inner :global(.card-sub) {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    line-height: 1.4;
+    color: var(--ink-mute);
+  }
+
+  .skeletons {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
   }
 
   .skeleton {
-    height: 118px;
-    border-radius: var(--r-md);
-    border: 1px solid var(--line);
+    height: 96px;
+    border-radius: var(--r-sm);
     background: linear-gradient(
       100deg,
       var(--bg-elev) 30%,
@@ -268,7 +283,8 @@
     background-size: 300% 100%;
     animation: shimmer 1.4s linear infinite;
   }
-  .skeleton.tall { height: 232px; }
+  .skeleton.tall { height: 200px; }
+  .skeleton-band { height: 116px; }
 
   @keyframes shimmer {
     from { background-position: 150% 0; }
@@ -302,8 +318,6 @@
   }
 
   @media (max-width: 900px) {
-    .grid { grid-template-columns: 1fr; }
-    .span-4, .span-6, .span-8, .span-12 { grid-column: span 1; }
     .head { flex-direction: column; }
   }
 

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -272,38 +272,6 @@
     max-width: 360px;
   }
 
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
-
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-
   @media (max-width: 1060px) {
     .snip-layout {
       grid-template-columns: 1fr;

--- a/src/lib/views/dictionary/DictionaryList.svelte
+++ b/src/lib/views/dictionary/DictionaryList.svelte
@@ -185,16 +185,4 @@
     max-width: 360px;
   }
 
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
 </style>

--- a/src/lib/views/dictionary/DictionaryModal.svelte
+++ b/src/lib/views/dictionary/DictionaryModal.svelte
@@ -342,35 +342,4 @@
 
   @keyframes spin { to { transform: rotate(360deg); } }
 
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
 </style>

--- a/src/lib/views/dictionary/DictionaryToolbar.svelte
+++ b/src/lib/views/dictionary/DictionaryToolbar.svelte
@@ -183,25 +183,6 @@
   .sort-pill.active { color: var(--accent-ink); }
   .sort-pill.active:hover { background: transparent; }
 
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
-
   @media (max-width: 720px) {
     .search { flex-basis: 100%; }
     .sort-pills { order: 3; width: 100%; overflow-x: auto; }

--- a/src/lib/views/home/GlobalMessageBanner.svelte
+++ b/src/lib/views/home/GlobalMessageBanner.svelte
@@ -19,8 +19,8 @@
   .notice-wrap { position: relative; margin-bottom: 22px; }
   .global-banner {
     display: flex;
-    align-items: flex-start;
-    gap: 10px;
+    align-items: center;
+    gap: 12px;
     padding: 12px 18px;
     background: var(--warn-bg, rgba(196, 116, 42, 0.08));
     border: 1px solid var(--warn-line, rgba(196, 116, 42, 0.35));
@@ -31,14 +31,14 @@
   .global-icon {
     display: inline-grid;
     place-items: center;
-    flex: 0 0 18px;
-    height: 18px;
+    flex: 0 0 24px;
+    height: 24px;
     border-radius: 50%;
     color: var(--warning, #c4742a);
   }
   .global-icon svg {
-    width: 15px;
-    height: 15px;
+    width: 18px;
+    height: 18px;
   }
   .global-text { flex: 1; font-family: var(--serif); font-weight: 500; }
 </style>

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -270,6 +270,7 @@
             <button
               class="dismiss-btn"
               onclick={onDismissCancelled}
+              disabled={resumingCancelled}
               title="Discard"
               aria-label="Discard"
             >
@@ -319,7 +320,7 @@
             {item.label}
           </div>
         {:else if item.type === 'row'}
-          <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
+          <div use:measureItem={item.key} class="day-row" class:first-in-table={index === 0 || flatItems[index - 1]?.type === 'header'}>
             <div class="day-time">{fmtTime(item.entry.created_at)}</div>
             <div class="day-text">{item.entry.clean_text}</div>
             <button

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -320,7 +320,7 @@
             {item.label}
           </div>
         {:else if item.type === 'row'}
-          <div use:measureItem={item.key} class="day-row" class:first-in-table={index === 0 || flatItems[index - 1]?.type === 'header'}>
+          <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
             <div class="day-time">{fmtTime(item.entry.created_at)}</div>
             <div class="day-text">{item.entry.clean_text}</div>
             <button

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -8,16 +8,22 @@
 
   export let recents: Entry[];
   export let failedEntry: { created_at: string } | null;
+  export let cancelledEntry: { created_at: string } | null;
   export let loading: boolean;
   export let hasMoreHistory: boolean;
   export let loadingMore: boolean;
   export let retrying: boolean;
+  export let resumingCancelled: boolean;
   export let copiedId: number | null;
   export let hk1: string;
   export let hk2: string;
   export let onRetry: () => void;
+  export let onContinueCancelled: () => void;
+  export let onDismissCancelled: () => void;
   export let onLoadOlder: () => void;
   export let onCopy: (entry: Entry) => void;
+
+  $: hasBanner = !!failedEntry || !!cancelledEntry;
 
   let flatItems: RenderItem[] = [];
   $: {
@@ -32,7 +38,7 @@
       }
       if (!seenHeaders.has(dayKey)) {
         seenHeaders.add(dayKey);
-        if (!(failedEntry && label === 'Today')) {
+        if (!(hasBanner && label === 'Today')) {
           acc.push({ type: 'header', label, key: `header-${dayKey}` });
         }
       }
@@ -162,7 +168,7 @@
     container;
     listContainer;
     appStore.updateInfo;
-    failedEntry;
+    hasBanner;
     updateLayout();
     updateVirtualList();
     // Recalculate list offset after the DOM has updated to handle banner toggles
@@ -246,27 +252,57 @@
 {#if loading}
   <div class="empty-state">Loading history…</div>
 {:else}
-  {#if failedEntry}
+  {#if hasBanner}
     <div class="day-head">Today</div>
     <div class="day-table">
-      <div
-        class="day-row"
-        transition:fly={{ y: -10, duration: 400, easing: expoOut }}
-      >
-        <div class="day-time">{fmtTime(failedEntry.created_at)}</div>
-        <div class="day-text error-msg">Looks like your last transcription failed.</div>
-        <button
-          class="retry-btn"
-          onclick={onRetry}
-          disabled={retrying}
+      {#if cancelledEntry}
+        <div
+          class="day-row"
+          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
         >
-          {retrying ? '…' : 'Retry'}
-        </button>
-      </div>
+          <div class="day-time">{fmtTime(cancelledEntry.created_at)}</div>
+          <div class="day-text error-msg">You cancelled a recording — pick it back up?</div>
+          <div class="row-actions">
+            <button
+              class="dismiss-btn"
+              onclick={onDismissCancelled}
+              title="Discard"
+              aria-label="Discard"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+                <path d="M6 6l12 12M6 18 18 6"/>
+              </svg>
+            </button>
+            <button
+              class="retry-btn"
+              onclick={onContinueCancelled}
+              disabled={resumingCancelled}
+            >
+              {resumingCancelled ? '…' : 'Continue'}
+            </button>
+          </div>
+        </div>
+      {/if}
+      {#if failedEntry}
+        <div
+          class="day-row"
+          transition:fly={{ y: -10, duration: 400, easing: expoOut }}
+        >
+          <div class="day-time">{fmtTime(failedEntry.created_at)}</div>
+          <div class="day-text error-msg">Looks like your last transcription failed.</div>
+          <button
+            class="retry-btn"
+            onclick={onRetry}
+            disabled={retrying}
+          >
+            {retrying ? '…' : 'Retry'}
+          </button>
+        </div>
+      {/if}
     </div>
   {/if}
 
-  {#if recents.length === 0 && !failedEntry}
+  {#if recents.length === 0 && !hasBanner}
     <div class="empty-state">
       No dictations yet. Hold <kbd>{hk1}</kbd> <kbd>{hk2}</kbd> to get started.
     </div>
@@ -275,11 +311,11 @@
       <div style="height: {topSpacerHeight}px;"></div>
       {#each visibleItems as { item, index } (item.key)}
         {#if item.type === 'header'}
-          <div use:measureItem={item.key} class="day-head" class:muted={index > 0 || !!failedEntry}>
+          <div use:measureItem={item.key} class="day-head" class:muted={index > 0 || hasBanner}>
             {item.label}
           </div>
         {:else if item.type === 'row'}
-          <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !failedEntry) || flatItems[index - 1]?.type === 'header'}>
+          <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
             <div class="day-time">{fmtTime(item.entry.created_at)}</div>
             <div class="day-text">{item.entry.clean_text}</div>
             <button
@@ -412,6 +448,28 @@
     cursor: not-allowed;
   }
 
+  .row-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .dismiss-btn {
+    all: unset;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    color: var(--ink-mute);
+    transition: color 0.12s, background 0.12s;
+  }
+  .dismiss-btn:hover { color: var(--ink-strong); background: var(--control-active); }
+  .dismiss-btn svg { width: 11px; height: 11px; }
+
   .empty-state {
     padding: 32px 4px;
     font-size: 13px;
@@ -429,19 +487,6 @@
     padding: 1px 5px;
     color: var(--ink);
   }
-
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
 
   @media (max-width: 720px) {
     .day-row {

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -168,7 +168,11 @@
     container;
     listContainer;
     appStore.updateInfo;
-    hasBanner;
+    // Depend on the entries directly, not the derived `hasBanner` boolean —
+    // swapping one banner for the other keeps the boolean true, so the block
+    // would otherwise not re-run and `listOffset` would go stale.
+    failedEntry;
+    cancelledEntry;
     updateLayout();
     updateVirtualList();
     // Recalculate list offset after the DOM has updated to handle banner toggles

--- a/src/lib/views/insights/AnimatedNumber.svelte
+++ b/src/lib/views/insights/AnimatedNumber.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { tweened } from 'svelte/motion';
+  import { expoOut } from 'svelte/easing';
+  import { motionMs } from '../../motion';
+
+  let {
+    value,
+    format = (n: number) => Math.round(n).toLocaleString(),
+  }: { value: number; format?: (n: number) => string } = $props();
+
+  // Only the value at mount seeds the tween; every later change is picked up
+  // by the $effect below, which is the point — silence the reactivity lint.
+  const display = tweened(untrack(() => value), { duration: motionMs(700), easing: expoOut });
+
+  $effect(() => {
+    display.set(value);
+  });
+</script>
+
+<span class="animated-num">{format($display)}</span>

--- a/src/lib/views/insights/ChartTooltip.svelte
+++ b/src/lib/views/insights/ChartTooltip.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  /*
+   * Lightweight floating tooltip shared by the hour strip and streak heatmap.
+   * Replaces native `title` attributes, which have an OS hover delay and can't
+   * be themed — this appears immediately and matches the app's popover style.
+   */
+  let {
+    x,
+    y,
+    visible,
+    children,
+  }: { x: number; y: number; visible: boolean; children?: import('svelte').Snippet } = $props();
+</script>
+
+<div class="chart-tooltip" class:visible style:left="{x}px" style:top="{y}px" aria-hidden="true">
+  {@render children?.()}
+</div>
+
+<style>
+  .chart-tooltip {
+    position: absolute;
+    transform: translate(-50%, calc(-100% - 9px)) scale(0.94);
+    background: var(--bg-elev);
+    border: 1px solid var(--line-strong);
+    border-radius: 6px;
+    box-shadow: var(--shadow-popover);
+    padding: 5px 9px;
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--ink);
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    z-index: 5;
+    transition: opacity 80ms var(--ui-ease-out), transform 80ms var(--ui-ease-out);
+  }
+
+  .chart-tooltip.visible {
+    opacity: 1;
+    transform: translate(-50%, calc(-100% - 9px)) scale(1);
+  }
+
+  .chart-tooltip :global(strong) {
+    color: var(--ink);
+    font-weight: 500;
+  }
+
+  .chart-tooltip :global(.tooltip-dim) {
+    color: var(--ink-mute);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chart-tooltip { transition-duration: 1ms; }
+  }
+</style>

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  import { estimateCost } from './pricing';
+  import { fmtDuration, fmtNumber, fmtUsd } from './helpers';
+  import DonutChart, { type DonutSegment } from './DonutChart.svelte';
+  import type { InsightsProviderUsage } from './types';
+
+  let { providers, rangeLabel }: { providers: InsightsProviderUsage[]; rangeLabel: string } = $props();
+
+  const summary = $derived(estimateCost(providers));
+
+  /* Accent-derived ramp — the accent is user-swappable, so no fixed hues. */
+  function segmentColor(index: number, count: number): string {
+    if (count <= 1) return 'var(--accent)';
+    const pct = 100 - Math.round((index / Math.max(1, count - 1)) * 62);
+    return `color-mix(in srgb, var(--accent) ${pct}%, var(--paper-2))`;
+  }
+
+  const segments = $derived.by((): DonutSegment[] => {
+    const priced = summary.rows.filter((row) => (row.cost ?? 0) > 0);
+    return priced.map((row, i) => ({
+      id: `${row.model}:${row.task}`,
+      name: row.model,
+      color: segmentColor(i, priced.length),
+      value: row.cost ?? 0,
+      valueLabel: fmtUsd(row.cost),
+    }));
+  });
+
+  function usageLabel(row: InsightsProviderUsage): string {
+    if (row.audio_ms > 0) return fmtDuration(row.audio_ms);
+    const tokens = (row.input_chars + row.output_chars) / 4;
+    return `~${fmtNumber(tokens)} tokens`;
+  }
+</script>
+
+<section class="card">
+  <header class="card-head">
+    <div>
+      <h2 class="card-h">Estimated API cost</h2>
+      <p class="card-sub">{rangeLabel} · billed by your provider, not by Verenu</p>
+    </div>
+  </header>
+
+  {#if segments.length === 0}
+    <p class="foot">No priced API usage in this range.</p>
+  {:else}
+    <DonutChart {segments} primaryLabel={fmtUsd(summary.total)} secondaryLabel="total" />
+
+    <table class="cost-table">
+      <thead>
+        <tr>
+          <th scope="col">Model</th>
+          <th scope="col" class="num">Calls</th>
+          <th scope="col" class="num">Usage</th>
+          <th scope="col" class="num">Est. cost</th>
+          <th scope="col" class="num">Share</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each summary.rows as row}
+          <tr>
+            <th scope="row">
+              <span class="model">{row.model}</span>
+              <span class="task">{row.task}</span>
+            </th>
+            <td class="num">{fmtNumber(row.calls)}</td>
+            <td class="num">{usageLabel(row)}</td>
+            <td class="num">{fmtUsd(row.cost)}</td>
+            <td class="num">{row.cost === null ? '—' : `${(row.share * 100).toFixed(1)}%`}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+
+    {#if summary.hasUnpriced}
+      <p class="foot">Models shown as — have no published rate on file, so they are missing from the total.</p>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 15px 18px 14px;
+    min-width: 0;
+  }
+
+  .card-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .card-h {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+
+  .card-sub {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    line-height: 1.4;
+  }
+
+  .cost-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 16px;
+    font-size: 11.5px;
+  }
+  .cost-table th,
+  .cost-table td {
+    text-align: left;
+    padding: 7px 6px;
+    border-bottom: 1px solid var(--line);
+    font-weight: 400;
+  }
+  .cost-table thead th {
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+  }
+  .cost-table tbody tr:last-child th,
+  .cost-table tbody tr:last-child td { border-bottom: 0; }
+
+  .num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-soft);
+    white-space: nowrap;
+  }
+
+  .model {
+    display: block;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink);
+  }
+  .task {
+    font-size: 10.5px;
+    color: var(--ink-mute);
+  }
+
+  .foot {
+    margin: 12px 0 0;
+    font-size: 11px;
+    color: var(--ink-mute);
+    line-height: 1.45;
+  }
+
+</style>

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -33,6 +33,17 @@
     const tokens = (row.input_chars + row.output_chars) / 4;
     return `~${fmtNumber(tokens)} tokens`;
   }
+
+  function averageUsageLabel(row: InsightsProviderUsage): string {
+    if (row.calls <= 0) return '—';
+    if (row.audio_ms > 0) return `${fmtDuration(row.audio_ms / row.calls)} / transcription`;
+    const tokens = (row.input_chars + row.output_chars) / 4;
+    return `~${fmtNumber(tokens / row.calls)} tokens / cleanup`;
+  }
+
+  function averageCostLabel(row: { calls: number; cost: number | null }): string {
+    return row.calls > 0 && row.cost !== null ? fmtUsd(row.cost / row.calls) : '—';
+  }
 </script>
 
 <section class="card">
@@ -54,9 +65,10 @@
       <thead>
         <tr>
           <th scope="col">Model</th>
-          <th scope="col" class="num">Calls</th>
-          <th scope="col" class="num">Usage</th>
+          <th scope="col" class="num">Total usage</th>
+          <th scope="col" class="num">Average usage</th>
           <th scope="col" class="num">Est. cost</th>
+          <th scope="col" class="num">Avg. cost</th>
           <th scope="col" class="num">Share</th>
         </tr>
       </thead>
@@ -65,11 +77,12 @@
           <tr>
             <th scope="row">
               <span class="model">{row.model}</span>
-              <span class="task">{row.task}</span>
+              <span class="task">{row.task} · {row.provider} · {fmtNumber(row.calls)} calls</span>
             </th>
-            <td class="num">{fmtNumber(row.calls)}</td>
             <td class="num">{usageLabel(row)}</td>
+            <td class="num avg-usage">{averageUsageLabel(row)}</td>
             <td class="num">{fmtUsd(row.cost)}</td>
+            <td class="num">{averageCostLabel(row)}</td>
             <td class="num">{row.cost === null ? '—' : `${(row.share * 100).toFixed(1)}%`}</td>
           </tr>
         {/each}
@@ -83,43 +96,14 @@
 </section>
 
 <style>
-  .card {
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 15px 18px 14px;
-    min-width: 0;
-  }
-
-  .card-head {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 14px;
-  }
-
-  .card-h {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0;
-    color: var(--ink);
-    letter-spacing: -0.01em;
-  }
-
-  .card-sub {
-    margin: 3px 0 0;
-    font-size: 11.5px;
-    color: var(--ink-mute);
-    line-height: 1.4;
-  }
+  /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte. */
 
   .cost-table {
     width: 100%;
     border-collapse: collapse;
     margin-top: 16px;
     font-size: 11.5px;
+    table-layout: fixed;
   }
   .cost-table th,
   .cost-table td {
@@ -128,6 +112,7 @@
     border-bottom: 1px solid var(--line);
     font-weight: 400;
   }
+  .cost-table th:first-child { width: 34%; }
   .cost-table thead th {
     font-size: 10px;
     letter-spacing: 0.06em;
@@ -151,8 +136,14 @@
     color: var(--ink);
   }
   .task {
+    display: block;
     font-size: 10.5px;
     color: var(--ink-mute);
+  }
+
+  @media (max-width: 760px) {
+    .cost-table { table-layout: auto; }
+    .avg-usage { display: none; }
   }
 
   .foot {

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -43,10 +43,12 @@
     </div>
   </header>
 
-  {#if segments.length === 0}
-    <p class="foot">No priced API usage in this range.</p>
+  {#if summary.rows.length === 0}
+    <p class="foot">No API usage recorded in this range.</p>
   {:else}
-    <DonutChart {segments} primaryLabel={fmtUsd(summary.total)} secondaryLabel="total" />
+    {#if segments.length > 0}
+      <DonutChart {segments} primaryLabel={fmtUsd(summary.total)} secondaryLabel="total" />
+    {/if}
 
     <table class="cost-table">
       <thead>

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -18,7 +18,9 @@
   const segments = $derived.by((): DonutSegment[] => {
     const priced = summary.rows.filter((row) => (row.cost ?? 0) > 0);
     return priced.map((row, i) => ({
-      id: `${row.model}:${row.task}`,
+      // Provider must be part of the id — the same model+task can exist under
+      // different providers, and DonutChart keys its internal Maps by id.
+      id: `${row.provider}:${row.model}:${row.task}`,
       name: row.model,
       color: segmentColor(i, priced.length),
       value: row.cost ?? 0,

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -66,7 +66,7 @@
         <tr>
           <th scope="col">Model</th>
           <th scope="col" class="num">Total usage</th>
-          <th scope="col" class="num">Average usage</th>
+          <th scope="col" class="num avg-usage">Average usage</th>
           <th scope="col" class="num">Est. cost</th>
           <th scope="col" class="num">Avg. cost</th>
           <th scope="col" class="num">Share</th>

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -165,16 +165,11 @@
           stroke="var(--accent)" stroke-width="1" stroke-dasharray="3 3" opacity="0.55"
           vector-effect="non-scaling-stroke"
         />
-        {#if !asBars}
-          <circle
-            cx={x(hover)} cy={y(daily[hover].words)} r="4.5"
-            fill="var(--accent)" stroke="var(--bg-elev)" stroke-width="2.5"
-            vector-effect="non-scaling-stroke"
-            class="hover-dot"
-          />
-        {/if}
       {/if}
     </svg>
+    {#if hoverPos && !asBars}
+      <span class="hover-dot" style:left="{hoverPos.x}px" style:top="{hoverPos.y}px" aria-hidden="true"></span>
+    {/if}
     <div class="axis">
       <span>{daily.length ? fmtDayLong(daily[0].day) : ''}</span>
       <span>{daily.length > 1 ? fmtDayLong(daily[daily.length - 1].day) : ''}</span>
@@ -189,38 +184,7 @@
 </section>
 
 <style>
-  .card {
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 15px 18px 13px;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .card-head {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 10px;
-  }
-
-  .card-h {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0;
-    color: var(--ink);
-    letter-spacing: -0.01em;
-  }
-
-  .card-sub {
-    margin: 3px 0 0;
-    font-size: 11.5px;
-    color: var(--ink-mute);
-  }
+  /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte. */
 
   .readout {
     text-align: right;
@@ -267,6 +231,15 @@
   }
 
   .hover-dot {
+    position: absolute;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2.5px solid var(--bg-elev);
+    box-sizing: border-box;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
     filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--accent) 55%, transparent));
   }
 </style>

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import { fmtDayLong, fmtNumber, niceCeiling } from './helpers';
+  import AnimatedNumber from './AnimatedNumber.svelte';
+  import ChartTooltip from './ChartTooltip.svelte';
+  import type { InsightsDay } from './types';
+
+  let { daily, rangeLabel }: { daily: InsightsDay[]; rangeLabel: string } = $props();
+
+  // Unique per instance so multiple charts on the page never share a <mask> id.
+  const gradientId = `daily-edge-fade-${Math.random().toString(36).slice(2)}`;
+
+  /* Fixed viewBox + preserveAspectRatio="none" makes the chart fully fluid with
+     no resize observer; vector-effect keeps strokes an even width regardless. */
+  const W = 600;
+  const H = 170;
+  const PAD_TOP = 12;
+  const PAD_BOTTOM = 22;
+
+  /* Below this many points a line reads as noise — discrete bars are clearer. */
+  const BAR_THRESHOLD = 14;
+
+  const max = $derived(niceCeiling(Math.max(...daily.map((d) => d.words), 0)));
+  const asBars = $derived(daily.length <= BAR_THRESHOLD);
+  const plotH = H - PAD_TOP - PAD_BOTTOM;
+
+  function x(i: number): number {
+    if (daily.length <= 1) return W / 2;
+    // Bars sit in the middle of their slot so the first and last aren't clipped
+    // by the viewBox edge; the line spans edge to edge.
+    if (asBars) return (i + 0.5) * (W / daily.length);
+    return (i / (daily.length - 1)) * W;
+  }
+
+  function y(words: number): number {
+    return PAD_TOP + plotH * (1 - words / max);
+  }
+
+  /* Catmull-Rom control points → cubic bezier, so the area reads as a curve
+     without pulling above the data the way a naive spline does. */
+  const linePath = $derived.by(() => {
+    if (daily.length === 0) return '';
+    if (daily.length === 1) return `M 0 ${y(daily[0].words)} L ${W} ${y(daily[0].words)}`;
+    const pts = daily.map((d, i) => [x(i), y(d.words)] as const);
+    let path = `M ${pts[0][0]} ${pts[0][1]}`;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[i - 1] ?? pts[i];
+      const p1 = pts[i];
+      const p2 = pts[i + 1];
+      const p3 = pts[i + 2] ?? p2;
+      const c1x = p1[0] + (p2[0] - p0[0]) / 6;
+      const c1y = p1[1] + (p2[1] - p0[1]) / 6;
+      const c2x = p2[0] - (p3[0] - p1[0]) / 6;
+      const c2y = p2[1] - (p3[1] - p1[1]) / 6;
+      path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${p2[0]} ${p2[1]}`;
+    }
+    return path;
+  });
+
+  const areaPath = $derived(
+    linePath ? `${linePath} L ${W} ${H - PAD_BOTTOM} L 0 ${H - PAD_BOTTOM} Z` : ''
+  );
+
+  const barWidth = $derived(daily.length > 0 ? Math.min(28, (W / daily.length) * 0.55) : 0);
+
+  let hover = $state<number | null>(null);
+  let hoverPos = $state<{ x: number; y: number } | null>(null);
+  const active = $derived(hover !== null ? daily[hover] : null);
+
+  function onMove(event: PointerEvent) {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    if (rect.width === 0 || daily.length === 0) return;
+    const ratio = (event.clientX - rect.left) / rect.width;
+    const idx = Math.min(daily.length - 1, Math.max(0, Math.round(ratio * (daily.length - 1))));
+    hover = idx;
+    // The svg's CSS height matches the viewBox height 1:1, only width is
+    // fluid, so x scales by the rendered width and y needs no conversion.
+    const px = (x(idx) / W) * rect.width;
+    const py = daily[idx].words > 0 ? y(daily[idx].words) : H - PAD_BOTTOM;
+    hoverPos = { x: px, y: py };
+  }
+
+  const total = $derived(daily.reduce((sum, d) => sum + d.words, 0));
+  const best = $derived(daily.reduce<InsightsDay | null>((b, d) => (!b || d.words > b.words ? d : b), null));
+  const summary = $derived(
+    daily.length === 0
+      ? 'No daily activity in this range.'
+      : `Words dictated per day, ${rangeLabel.toLowerCase()}. ${fmtNumber(total)} words across ${daily.length} days, peaking at ${fmtNumber(best?.words ?? 0)} on ${best ? fmtDayLong(best.day) : '—'}.`
+  );
+</script>
+
+<section class="card">
+  <header class="card-head">
+    <div>
+      <h2 class="card-h">Words per day</h2>
+      <p class="card-sub">{rangeLabel}</p>
+    </div>
+    <div class="readout" aria-live="polite">
+      {#if active}
+        <span class="readout-num">{fmtNumber(active.words)}</span>
+        <span class="readout-day">{fmtDayLong(active.day)}</span>
+      {:else}
+        <span class="readout-num"><AnimatedNumber value={total} /></span>
+        <span class="readout-day">total</span>
+      {/if}
+    </div>
+  </header>
+
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="plot"
+    role="img"
+    aria-label={summary}
+    onpointermove={onMove}
+    onpointerleave={() => { hover = null; hoverPos = null; }}
+  >
+    <svg viewBox="0 0 {W} {H}" preserveAspectRatio="none">
+      <defs>
+        <!-- Fades the area fill's hard vertical edges instead of cutting it off flush. -->
+        <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stop-color="white" stop-opacity="0" />
+          <stop offset="4%" stop-color="white" stop-opacity="1" />
+          <stop offset="96%" stop-color="white" stop-opacity="1" />
+          <stop offset="100%" stop-color="white" stop-opacity="0" />
+        </linearGradient>
+        <mask id="{gradientId}-mask" maskUnits="userSpaceOnUse" x="0" y="0" width={W} height={H}>
+          <rect x="0" y="0" width={W} height={H} fill="url(#{gradientId})" />
+        </mask>
+      </defs>
+      <line
+        x1="0" y1={H - PAD_BOTTOM} x2={W} y2={H - PAD_BOTTOM}
+        stroke="var(--line)" stroke-width="1" vector-effect="non-scaling-stroke"
+      />
+      {#if asBars}
+        {#each daily as d, i}
+          <rect
+            x={x(i) - barWidth / 2}
+            y={d.words > 0 ? y(d.words) : H - PAD_BOTTOM - 1}
+            width={barWidth}
+            height={d.words > 0 ? Math.max(1, H - PAD_BOTTOM - y(d.words)) : 1}
+            fill={hover === i ? 'var(--accent)' : 'color-mix(in srgb, var(--accent) 55%, transparent)'}
+          ><title>{fmtDayLong(d.day)} — {fmtNumber(d.words)} words</title></rect>
+        {/each}
+      {:else}
+        <path d={areaPath} fill="color-mix(in srgb, var(--accent) 18%, transparent)" mask="url(#{gradientId}-mask)" class="area-path" />
+        <path
+          d={linePath}
+          fill="none"
+          stroke="var(--accent)"
+          stroke-width="1.5"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+          class="line-path"
+        />
+      {/if}
+      {#if hover !== null && daily[hover]}
+        <line
+          x1={x(hover)} y1={PAD_TOP - 6} x2={x(hover)} y2={H - PAD_BOTTOM}
+          stroke="var(--accent)" stroke-width="1" stroke-dasharray="3 3" opacity="0.55"
+          vector-effect="non-scaling-stroke"
+        />
+        {#if !asBars}
+          <circle
+            cx={x(hover)} cy={y(daily[hover].words)} r="4.5"
+            fill="var(--accent)" stroke="var(--bg-elev)" stroke-width="2.5"
+            vector-effect="non-scaling-stroke"
+            class="hover-dot"
+          />
+        {/if}
+      {/if}
+    </svg>
+    <div class="axis">
+      <span>{daily.length ? fmtDayLong(daily[0].day) : ''}</span>
+      <span>{daily.length > 1 ? fmtDayLong(daily[daily.length - 1].day) : ''}</span>
+    </div>
+    {#if hoverPos && active}
+      <ChartTooltip x={hoverPos.x} y={hoverPos.y} visible={true}>
+        <strong>{fmtNumber(active.words)}</strong> words
+        <div class="tooltip-dim">{fmtDayLong(active.day)}</div>
+      </ChartTooltip>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 15px 18px 13px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+  }
+
+  .card-h {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+
+  .card-sub {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+  }
+
+  .readout {
+    text-align: right;
+    white-space: nowrap;
+  }
+  .readout-num {
+    display: block;
+    font-family: var(--serif);
+    font-size: 20px;
+    font-weight: 500;
+    color: var(--ink);
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+  }
+  .readout-day {
+    font-size: 11px;
+    color: var(--ink-mute);
+  }
+
+  .plot { flex: 1; position: relative; }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 170px;
+    overflow: visible;
+  }
+
+  .axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10.5px;
+    color: var(--ink-mute);
+    margin-top: 2px;
+  }
+
+  rect { transition: fill var(--ui-duration-fast) var(--ui-ease-out), y var(--ui-duration-base) var(--ui-ease-out), height var(--ui-duration-base) var(--ui-ease-out); }
+
+  /* Progressive enhancement: browsers that support animating `d` glide to a
+     new shape when the range or a fresh dictation changes the data. */
+  .area-path,
+  .line-path {
+    transition: d var(--ui-duration-base) var(--ui-ease-out);
+  }
+
+  .hover-dot {
+    filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--accent) 55%, transparent));
+  }
+</style>

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -70,7 +70,12 @@
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
     if (rect.width === 0 || daily.length === 0) return;
     const ratio = (event.clientX - rect.left) / rect.width;
-    const idx = Math.min(daily.length - 1, Math.max(0, Math.round(ratio * (daily.length - 1))));
+    // Bars fill equal-width slots spanning [i/n, (i+1)/n), so floor maps the
+    // pointer into its slot; line charts align points at i/(n-1), so round
+    // to the nearest point.
+    const idx = asBars
+      ? Math.min(daily.length - 1, Math.max(0, Math.floor(ratio * daily.length)))
+      : Math.min(daily.length - 1, Math.max(0, Math.round(ratio * (daily.length - 1))));
     hover = idx;
     // The svg's CSS height matches the viewBox height 1:1, only width is
     // fluid, so x scales by the rendered width and y needs no conversion.

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -19,7 +19,9 @@
   /* Below this many points a line reads as noise — discrete bars are clearer. */
   const BAR_THRESHOLD = 14;
 
-  const max = $derived(niceCeiling(Math.max(...daily.map((d) => d.words), 0)));
+  // Reduce rather than Math.max(...spread) — an all-time range can exceed the
+  // call-stack limit for spread arguments on a very long daily series.
+  const max = $derived(niceCeiling(daily.reduce((m, d) => Math.max(m, d.words), 0)));
   const asBars = $derived(daily.length <= BAR_THRESHOLD);
   const plotH = H - PAD_TOP - PAD_BOTTOM;
 

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -1,0 +1,497 @@
+<script lang="ts">
+  /*
+   * Canvas donut with filleted (rounded-cap) segments, gap-separated sweeps,
+   * a value tween on data change, and a soft hover interaction that widens
+   * the hovered segment and dims the rest — both from the ring and from the
+   * legend. No chart library; the ring is hand-drawn per frame.
+   */
+  import { onMount, onDestroy } from 'svelte';
+  import { reducedMotionEnabled } from '../../motion';
+
+  export interface DonutSegment {
+    id: string;
+    name: string;
+    color: string;
+    value: number;
+    valueLabel: string;
+  }
+
+  let {
+    segments,
+    primaryLabel,
+    secondaryLabel = '',
+    size = 136,
+  }: { segments: DonutSegment[]; primaryLabel: string; secondaryLabel?: string; size?: number } = $props();
+
+  const TAU = Math.PI * 2;
+  const TWEEN_MS = 320;
+  const HOVER_MS = 120;
+  const STROKE_FRACTION = 0.11;
+  const RADIUS_FRACTION = 0.335;
+  const GAP = 3.5;
+  const CORNER = 2.75;
+  const HOVER_WIDEN = 6;
+  const HOVER_POP = 5;
+  const DIM_ALPHA = 0.32;
+
+  const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+
+  interface Point { x: number; y: number }
+  interface Fillet { filletCenter: Point; flatFacePoint: Point; ringPoint: Point; angle: number }
+
+  /**
+   * atan2 always returns a value in (-π, π], but segment boundaries are
+   * cumulative and range well past that (a ring can sweep past 3π/2 before
+   * wrapping back to 12 o'clock). Re-expressing the wrapped result as the
+   * angle nearest `reference` keeps boundaries monotonically increasing
+   * across the whole sweep — without this, any segment whose end crossed
+   * the ±π seam got a start/end pair that looked "backwards" and silently
+   * failed to render.
+   */
+  function unwrapNear(angle: number, reference: number): number {
+    let a = angle;
+    while (a - reference > Math.PI) a -= TAU;
+    while (a - reference < -Math.PI) a += TAU;
+    return a;
+  }
+
+  function makeFillet(
+    center: Point,
+    boundaryAngle: number,
+    capOffset: number,
+    inward: number,
+    circleRadius: number,
+    outer: boolean,
+    corner: number,
+  ): Fillet {
+    const nx = Math.cos(boundaryAngle);
+    const ny = Math.sin(boundaryAngle);
+    const tx = -ny;
+    const ty = nx;
+    const filletRadius = outer ? circleRadius - corner : circleRadius + corner;
+    const tangentOffset = capOffset + inward * corner;
+    const radialOffset = Math.sqrt(Math.max(0, filletRadius * filletRadius - tangentOffset * tangentOffset));
+    const filletCenter = {
+      x: center.x + nx * radialOffset + tx * tangentOffset,
+      y: center.y + ny * radialOffset + ty * tangentOffset,
+    };
+    const flatFacePoint = {
+      x: center.x + nx * radialOffset + tx * capOffset,
+      y: center.y + ny * radialOffset + ty * capOffset,
+    };
+    const circleScale = circleRadius / filletRadius;
+    const ringPoint = {
+      x: center.x + (filletCenter.x - center.x) * circleScale,
+      y: center.y + (filletCenter.y - center.y) * circleScale,
+    };
+    const rawAngle = Math.atan2(ringPoint.y - center.y, ringPoint.x - center.x);
+    return { filletCenter, flatFacePoint, ringPoint, angle: unwrapNear(rawAngle, boundaryAngle) };
+  }
+
+  /** Shortest-path arc between two points around a shared small-radius center — the fillet corners. */
+  function minorArc(path: Path2D, center: Point, radius: number, from: Point, to: Point) {
+    const a0 = Math.atan2(from.y - center.y, from.x - center.x);
+    const a1raw = Math.atan2(to.y - center.y, to.x - center.x);
+    let diff = a1raw - a0;
+    while (diff > Math.PI) diff -= TAU;
+    while (diff < -Math.PI) diff += TAU;
+    path.arc(center.x, center.y, radius, a0, a0 + diff, diff < 0);
+  }
+
+  function donutSegmentPath(
+    cx: number, cy: number, startBoundary: number, endBoundary: number,
+    radius: number, width: number, gap: number, corner: number,
+  ): Path2D | null {
+    const center = { x: cx, y: cy };
+    const outerRadius = radius + width / 2;
+    const innerRadius = radius - width / 2;
+    const sO = makeFillet(center, startBoundary, gap / 2, 1, outerRadius, true, corner);
+    const sI = makeFillet(center, startBoundary, gap / 2, 1, innerRadius, false, corner);
+    const eO = makeFillet(center, endBoundary, -gap / 2, -1, outerRadius, true, corner);
+    const eI = makeFillet(center, endBoundary, -gap / 2, -1, innerRadius, false, corner);
+    if (eO.angle <= sO.angle || eI.angle <= sI.angle) return null;
+    const p = new Path2D();
+    p.moveTo(sO.ringPoint.x, sO.ringPoint.y);
+    p.arc(cx, cy, outerRadius, sO.angle, eO.angle, false);
+    minorArc(p, eO.filletCenter, corner, eO.ringPoint, eO.flatFacePoint);
+    p.lineTo(eI.flatFacePoint.x, eI.flatFacePoint.y);
+    minorArc(p, eI.filletCenter, corner, eI.flatFacePoint, eI.ringPoint);
+    p.arc(cx, cy, innerRadius, eI.angle, sI.angle, true);
+    minorArc(p, sI.filletCenter, corner, sI.ringPoint, sI.flatFacePoint);
+    p.lineTo(sO.flatFacePoint.x, sO.flatFacePoint.y);
+    minorArc(p, sO.filletCenter, corner, sO.flatFacePoint, sO.ringPoint);
+    p.closePath();
+    return p;
+  }
+
+  /** Exact annular sector, no fillet — the fallback for slices too thin for the corner treatment. */
+  function sectorPath(cx: number, cy: number, startBoundary: number, endBoundary: number, radius: number, width: number): Path2D {
+    const outerRadius = radius + width / 2;
+    const innerRadius = radius - width / 2;
+    const p = new Path2D();
+    p.arc(cx, cy, outerRadius, startBoundary, endBoundary, false);
+    p.arc(cx, cy, innerRadius, endBoundary, startBoundary, true);
+    p.closePath();
+    return p;
+  }
+
+  // One probe element resolves any CSS color (including color-mix()) to a
+  // concrete value canvas can always paint — canvas fillStyle parsing is
+  // less permissive than CSS in some WebView builds.
+  let colorProbe: HTMLDivElement | null = null;
+  function resolveColor(css: string): string {
+    if (typeof document === 'undefined') return css;
+    if (!colorProbe) {
+      colorProbe = document.createElement('div');
+      colorProbe.style.position = 'absolute';
+      colorProbe.style.visibility = 'hidden';
+      colorProbe.style.pointerEvents = 'none';
+      document.body.appendChild(colorProbe);
+    }
+    colorProbe.style.color = css;
+    return getComputedStyle(colorProbe).color || css;
+  }
+
+  let canvasEl = $state<HTMLCanvasElement | null>(null);
+  let ctx: CanvasRenderingContext2D | null = null;
+  let rafId = 0;
+
+  let hoveredId = $state<string | null>(null);
+
+  let animFrom = new Map<string, number>();
+  let animTo = new Map<string, number>();
+  let animStart = 0;
+  let resolvedColors = new Map<string, string>();
+
+  let dimming = false; // is *something* currently hovered, for the dim tween
+  let dimStart = 0;
+  let dimFromAlpha = 1;
+
+  // Per-segment widen/pop progress (0..1), tracked individually so the
+  // previously-focused segment eases back down instead of snapping when the
+  // hover target changes — only the "grow in" direction had a tween before.
+  let widenFrom = new Map<string, number>();
+  let widenTarget = new Map<string, number>();
+  let widenStart = new Map<string, number>();
+
+  function currentWiden(id: string): number {
+    const from = widenFrom.get(id) ?? 0;
+    const target = widenTarget.get(id) ?? 0;
+    const start = widenStart.get(id) ?? 0;
+    const t = easeOutCubic(Math.min(1, (performance.now() - start) / HOVER_MS));
+    return from + (target - from) * t;
+  }
+
+  function startValueTween() {
+    const next = new Map<string, number>();
+    for (const seg of segments) {
+      next.set(seg.id, animTo.get(seg.id) ?? 0);
+    }
+    animFrom = next;
+    animTo = new Map(segments.map((s) => [s.id, s.value]));
+    animStart = performance.now();
+    resolvedColors = new Map(segments.map((s) => [s.id, resolveColor(s.color)]));
+    scheduleFrame();
+  }
+
+  $effect(() => {
+    // Re-run whenever the segment set or its values change.
+    segments;
+    startValueTween();
+  });
+
+  function setHover(id: string | null) {
+    if (id === hoveredId) return;
+    const wasActive = hoveredId !== null;
+    const nowActive = id !== null;
+    if (wasActive !== nowActive) {
+      dimming = nowActive;
+      dimFromAlpha = currentDimAlpha();
+      dimStart = performance.now();
+    }
+    const now = performance.now();
+    // The old target eases back to 0; the new one eases up to 1 — both
+    // captured from wherever they currently sit, so a fast re-hover doesn't
+    // jump.
+    if (hoveredId !== null) {
+      widenFrom.set(hoveredId, currentWiden(hoveredId));
+      widenTarget.set(hoveredId, 0);
+      widenStart.set(hoveredId, now);
+    }
+    if (id !== null) {
+      widenFrom.set(id, currentWiden(id));
+      widenTarget.set(id, 1);
+      widenStart.set(id, now);
+    }
+    hoveredId = id;
+    scheduleFrame();
+  }
+
+  function currentDimAlpha(): number {
+    const t = easeOutCubic(Math.min(1, (performance.now() - dimStart) / HOVER_MS));
+    const target = dimming ? DIM_ALPHA : 1;
+    return dimFromAlpha + (target - dimFromAlpha) * t;
+  }
+
+  function scheduleFrame() {
+    if (rafId) return;
+    rafId = requestAnimationFrame(paint);
+  }
+
+  function paint() {
+    rafId = 0;
+    if (!ctx || !canvasEl) return;
+    const now = performance.now();
+    const reduced = reducedMotionEnabled();
+
+    const tweenT = reduced ? 1 : easeOutCubic(Math.min(1, (now - animStart) / TWEEN_MS));
+    const values = segments.map((s) => {
+      const from = animFrom.get(s.id) ?? 0;
+      const to = animTo.get(s.id) ?? s.value;
+      return from + (to - from) * tweenT;
+    });
+    const total = values.reduce((a, b) => a + b, 0);
+
+    const dimT = reduced ? (dimming ? 1 : 0) : easeOutCubic(Math.min(1, (now - dimStart) / HOVER_MS));
+    const dimAlpha = reduced
+      ? (dimming ? DIM_ALPHA : 1)
+      : dimFromAlpha + ((dimming ? DIM_ALPHA : 1) - dimFromAlpha) * dimT;
+
+    const w = size;
+    const h = size;
+    ctx.clearRect(0, 0, w, h);
+    const cx = w / 2;
+    const cy = h / 2;
+    const radius = size * RADIUS_FRACTION;
+    const stroke = size * STROKE_FRACTION;
+
+    // Track ring underneath — keeps the shape legible with zero/tiny data.
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, TAU);
+    ctx.strokeStyle = resolveColor('var(--control-hover)');
+    ctx.lineWidth = stroke;
+    ctx.stroke();
+
+    if (total > 0) {
+      let cursor = -Math.PI / 2; // 12 o'clock
+      segments.forEach((seg, i) => {
+        const fraction = values[i] / total;
+        const start = cursor;
+        const end = cursor + fraction * TAU;
+        cursor = end;
+        if (fraction <= 0) return;
+
+        const dimmed = hoveredId !== null && hoveredId !== seg.id;
+        // Every segment eases its own widen/pop toward whatever it's
+        // currently targeting (1 while hovered, 0 otherwise) — a pure width
+        // increase (growing equally in/out) reads as barely-there at this
+        // scale, so it pops outward too, and the *previous* hover target
+        // eases back down instead of snapping when you move to a new slice.
+        const widenT = reduced ? (widenTarget.get(seg.id) ?? 0) : currentWiden(seg.id);
+        const width = stroke + HOVER_WIDEN * widenT;
+        const segRadius = radius + HOVER_POP * widenT;
+
+        const sweep = end - start;
+        const minSweepForFillet = ((GAP + CORNER * 2) / radius) * 1.4;
+        const path =
+          sweep > minSweepForFillet
+            ? donutSegmentPath(cx, cy, start, end, segRadius, width, GAP, CORNER)
+            : sectorPath(cx, cy, start + 0.01, end - 0.01, segRadius, width);
+
+        ctx!.globalAlpha = dimmed ? dimAlpha : 1;
+        ctx!.fillStyle = resolvedColors.get(seg.id) ?? seg.color;
+        if (path) ctx!.fill(path);
+      });
+      ctx.globalAlpha = 1;
+    }
+
+    const widenSettled = reduced || segments.every((s) => {
+      const from = widenFrom.get(s.id) ?? 0;
+      const target = widenTarget.get(s.id) ?? 0;
+      return from === target || currentWiden(s.id) === target;
+    });
+    const stillTweening = tweenT < 1 || dimT < 1 || !widenSettled;
+    if (stillTweening) scheduleFrame();
+  }
+
+  function segmentAtPoint(x: number, y: number): string | null {
+    const cx = size / 2;
+    const cy = size / 2;
+    const dx = x - cx;
+    const dy = y - cy;
+    const dist = Math.hypot(dx, dy);
+    const radius = size * RADIUS_FRACTION;
+    const stroke = size * STROKE_FRACTION;
+    if (Math.abs(dist - radius) > stroke * 0.7) return null;
+
+    const total = segments.reduce((a, b) => a + b.value, 0);
+    if (total <= 0) return null;
+
+    const raw = Math.atan2(dy, dx);
+    const angle = (((raw + Math.PI / 2) % TAU) + TAU) % TAU;
+    let cursor = 0;
+    for (const seg of segments) {
+      const fraction = seg.value / total;
+      const next = cursor + fraction * TAU;
+      if (angle >= cursor && angle < next) return seg.id;
+      cursor = next;
+    }
+    return null;
+  }
+
+  function onCanvasMove(event: PointerEvent) {
+    if (!canvasEl) return;
+    const rect = canvasEl.getBoundingClientRect();
+    const scaleX = size / rect.width;
+    const scaleY = size / rect.height;
+    const x = (event.clientX - rect.left) * scaleX;
+    const y = (event.clientY - rect.top) * scaleY;
+    setHover(segmentAtPoint(x, y));
+  }
+
+  onMount(() => {
+    if (!canvasEl) return;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    canvasEl.width = size * dpr;
+    canvasEl.height = size * dpr;
+    canvasEl.style.width = `${size}px`;
+    canvasEl.style.height = `${size}px`;
+    ctx = canvasEl.getContext('2d');
+    ctx?.scale(dpr, dpr);
+    startValueTween();
+  });
+
+  onDestroy(() => {
+    if (rafId) cancelAnimationFrame(rafId);
+    colorProbe?.remove();
+  });
+</script>
+
+<div class="donut">
+  <div
+    class="donut-ring-wrap"
+    style:width="{size}px"
+    style:height="{size}px"
+    role="img"
+    aria-label={`${primaryLabel}${secondaryLabel ? ' ' + secondaryLabel : ''}, split across ${segments.length} segments.`}
+  >
+    <canvas
+      bind:this={canvasEl}
+      onpointermove={onCanvasMove}
+      onpointerleave={() => setHover(null)}
+    ></canvas>
+    <div class="donut-centre">
+      <span class="donut-primary">{primaryLabel}</span>
+      {#if secondaryLabel}<span class="donut-secondary">{secondaryLabel}</span>{/if}
+    </div>
+  </div>
+
+  <ul class="donut-legend">
+    {#each segments as seg}
+      <li
+        class:focused={hoveredId === seg.id}
+        class:dimmed={hoveredId !== null && hoveredId !== seg.id}
+        onpointerenter={() => setHover(seg.id)}
+        onpointerleave={() => setHover(null)}
+      >
+        <span class="swatch" style:background={seg.color}></span>
+        <span class="legend-name">{seg.name}</span>
+        <span class="legend-value">{seg.valueLabel}</span>
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .donut {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+  }
+
+  .donut-ring-wrap {
+    position: relative;
+    flex: 0 0 auto;
+  }
+
+  canvas {
+    display: block;
+    cursor: default;
+  }
+
+  .donut-centre {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    pointer-events: none;
+  }
+  .donut-primary {
+    font-family: var(--serif);
+    font-size: 19px;
+    font-weight: 500;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .donut-secondary {
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+  }
+
+  .donut-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex: 1 1 200px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .donut-legend li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 4px 6px;
+    margin: 0 -6px;
+    border-radius: 6px;
+    transition: background-color var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-fast) var(--ui-ease-out),
+      opacity var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .donut-legend li.focused {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    transform: translateX(2px);
+  }
+  .donut-legend li.dimmed { opacity: 0.55; }
+
+  .swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 3px;
+    flex: 0 0 auto;
+  }
+  .legend-name {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-soft);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .legend-value {
+    margin-left: auto;
+    font-size: 11.5px;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -269,7 +269,7 @@
     });
     const total = values.reduce((a, b) => a + b, 0);
 
-    const dimT = reduced ? (dimming ? 1 : 0) : easeOutCubic(Math.min(1, (now - dimStart) / HOVER_MS));
+    const dimT = reduced ? 1 : easeOutCubic(Math.min(1, (now - dimStart) / HOVER_MS));
     const dimAlpha = reduced
       ? (dimming ? DIM_ALPHA : 1)
       : dimFromAlpha + ((dimming ? DIM_ALPHA : 1) - dimFromAlpha) * dimT;

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -148,6 +148,10 @@
       colorProbe.style.pointerEvents = 'none';
       document.body.appendChild(colorProbe);
     }
+    // Clear any previous inline color first — CSSOM silently ignores an
+    // invalid assignment, so without a reset a failed resolve would leave the
+    // previous call's color behind and report that instead.
+    colorProbe.style.color = '';
     colorProbe.style.color = css;
     return getComputedStyle(colorProbe).color || css;
   }

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -298,10 +298,16 @@
 
         const sweep = end - start;
         const minSweepForFillet = ((GAP + CORNER * 2) / radius) * 1.4;
-        const path =
+        // For sub-fillet sweeps, shrink the arc bounds by a tiny amount so
+        // the exact-annulus fallback never draws over its own boundary — but
+        // never so much that start passes end (that would invert the arc and
+        // sweep nearly 360 degrees).
+        const inset = Math.min(0.01, sweep / 3);
+        const filletPath =
           sweep > minSweepForFillet
             ? donutSegmentPath(cx, cy, start, end, segRadius, width, GAP, CORNER)
-            : sectorPath(cx, cy, start + 0.01, end - 0.01, segRadius, width);
+            : null;
+        const path = filletPath ?? sectorPath(cx, cy, start + inset, end - inset, segRadius, width);
 
         ctx!.globalAlpha = dimmed ? dimAlpha : 1;
         ctx!.fillStyle = resolvedColors.get(seg.id) ?? seg.color;

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -202,6 +202,14 @@
   $effect(() => {
     // Re-run whenever the segment set or its values change.
     segments;
+    // A hovered segment may no longer exist after a data change (e.g. range
+    // filter removed it) — a stale id would dim the whole chart and legend
+    // until the next hover. Drop it and any dim state.
+    if (hoveredId !== null && !segments.some((s) => s.id === hoveredId)) {
+      hoveredId = null;
+      dimming = false;
+      dimFromAlpha = 1;
+    }
     startValueTween();
   });
 

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -358,7 +358,7 @@
     if (!canvasEl) return;
     syncCanvasSize();
     ctx = canvasEl.getContext('2d');
-    ctx?.scale(Math.max(1, window.devicePixelRatio || 1), Math.max(1, window.devicePixelRatio || 1));
+    applyDprScale();
     startValueTween();
   });
 
@@ -368,11 +368,18 @@
   $effect(() => {
     size;
     if (!ctx || !canvasEl) return;
-    const dpr = Math.max(1, window.devicePixelRatio || 1);
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    // Resizing width/height resets the context state and transform matrix to
+    // identity, so the DPR scale must be re-applied *after* the resize.
     syncCanvasSize();
+    applyDprScale();
     scheduleFrame();
   });
+
+  function applyDprScale() {
+    if (!ctx) return;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
 
   function syncCanvasSize() {
     if (!canvasEl) return;

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -162,6 +162,10 @@
   let animTo = new Map<string, number>();
   let animStart = 0;
   let resolvedColors = new Map<string, string>();
+  // Resolved once per data change (with the segment colors) rather than on
+  // every paint frame — getComputedStyle() on each rAF tick forces style
+  // recalc/reflow at 60–120fps.
+  let trackColor = '';
 
   let dimming = false; // is *something* currently hovered, for the dim tween
   let dimStart = 0;
@@ -191,6 +195,7 @@
     animTo = new Map(segments.map((s) => [s.id, s.value]));
     animStart = performance.now();
     resolvedColors = new Map(segments.map((s) => [s.id, resolveColor(s.color)]));
+    trackColor = resolveColor('var(--control-hover)');
     scheduleFrame();
   }
 
@@ -268,7 +273,7 @@
     // Track ring underneath — keeps the shape legible with zero/tiny data.
     ctx.beginPath();
     ctx.arc(cx, cy, radius, 0, TAU);
-    ctx.strokeStyle = resolveColor('var(--control-hover)');
+    ctx.strokeStyle = trackColor || resolveColor('var(--control-hover)');
     ctx.lineWidth = stroke;
     ctx.stroke();
 

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -356,19 +356,39 @@
 
   onMount(() => {
     if (!canvasEl) return;
+    syncCanvasSize();
+    ctx = canvasEl.getContext('2d');
+    ctx?.scale(Math.max(1, window.devicePixelRatio || 1), Math.max(1, window.devicePixelRatio || 1));
+    startValueTween();
+  });
+
+  // The size prop can change at runtime (responsive layout) — re-sync the
+  // canvas backing store, CSS size, and the DPR context scale so paint()
+  // never draws onto a stale/clipped buffer.
+  $effect(() => {
+    size;
+    if (!ctx || !canvasEl) return;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    syncCanvasSize();
+    scheduleFrame();
+  });
+
+  function syncCanvasSize() {
+    if (!canvasEl) return;
     const dpr = Math.max(1, window.devicePixelRatio || 1);
     canvasEl.width = size * dpr;
     canvasEl.height = size * dpr;
     canvasEl.style.width = `${size}px`;
     canvasEl.style.height = `${size}px`;
-    ctx = canvasEl.getContext('2d');
-    ctx?.scale(dpr, dpr);
-    startValueTween();
-  });
+  }
 
   onDestroy(() => {
     if (rafId) cancelAnimationFrame(rafId);
     colorProbe?.remove();
+    // Null it out too — a destroyed probe is a detached node, and any later
+    // resolveColor() must create a fresh element rather than reuse it.
+    colorProbe = null;
   });
 </script>
 

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -373,7 +373,11 @@
     syncCanvasSize();
     ctx = canvasEl.getContext('2d');
     applyDprScale();
-    startValueTween();
+    // Don't call startValueTween() here — the $effect tracking `segments`
+    // already does on mount, and a second call would reset animFrom to the
+    // target values (animTo already set by the first), skipping the initial
+    // 0-to-value entrance. Just ensure a frame paints once the context is up.
+    scheduleFrame();
   });
 
   // The size prop can change at runtime (responsive layout) — re-sync the

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -503,7 +503,10 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    flex: 1 1 200px;
+    /* Keep model prices beside their names instead of distributing them over
+       the full editorial measure on wide windows. */
+    flex: 0 1 560px;
+    width: min(100%, 560px);
     min-width: 0;
     display: flex;
     flex-direction: column;

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -68,7 +68,7 @@
       <!-- Sits low in the arc's hollow, where the semicircle is widest, so
            a 3-digit reading never reaches the curve above it. No "wpm"
            suffix — the label right below already says it. -->
-      <text x="64" y="63" class="gauge-value" text-anchor="middle">{wpm || '—'}</text>
+      <text x="64" y="63" class="gauge-value" text-anchor="middle">{wpm > 0 ? wpm : '—'}</text>
     </svg>
     <p class="tile-label">words per minute</p>
     <p class="tile-note">

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -90,7 +90,13 @@
     <p class="tile-label">total words dictated</p>
     <p class="tile-note">
       {#if books >= 1}
-        That's {books.toFixed(books < 10 ? 1 : 0)} full-length {books >= 2 ? 'books' : 'book'} of writing.
+        <!-- Pluralize off the displayed amount: "1 book" is singular, but
+             "1.5 books" isn't. -->
+        {#if books === 1}
+          That's 1 full-length book of writing.
+        {:else}
+          That's {books.toFixed(books < 10 ? 1 : 0)} full-length books of writing.
+        {/if}
       {:else if data.totals.total_words > 0}
         {Math.round(books * 100)}% of a full-length book so far.
       {:else}

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { tweened } from 'svelte/motion';
+  import { expoOut } from 'svelte/easing';
+  import { motionMs } from '../../motion';
+  import { fmtCompact, fmtNumber, bookEquivalent, pctDelta } from './helpers';
+  import AnimatedNumber from './AnimatedNumber.svelte';
+  import type { InsightsPayload } from './types';
+
+  let { data, rangeLabel }: { data: InsightsPayload; rangeLabel: string } = $props();
+
+  /* Gauge spans 0–200 wpm. The average speaking pace (~100 wpm) sits dead
+     centre, so most readings land mid-arc with room on both sides for
+     unusually slow or fast talkers. */
+  const GAUGE_MAX = 200;
+  const GAUGE_MID = 100;
+  const ARC_LENGTH = Math.PI * 52; // r=52 semicircle
+
+  // Tweened so the arc — and everything derived from it — glides to a new
+  // reading instead of snapping when a fresh dictation lands.
+  const wpmT = tweened(untrack(() => data.totals.avg_wpm), { duration: motionMs(650), easing: expoOut });
+  $effect(() => { wpmT.set(data.totals.avg_wpm); });
+
+  const totalWordsT = tweened(untrack(() => data.totals.total_words), { duration: motionMs(700), easing: expoOut });
+  $effect(() => { totalWordsT.set(data.totals.total_words); });
+
+  const wpm = $derived(Math.round($wpmT));
+  const gaugeFill = $derived(Math.min(1, Math.max(0, wpm / GAUGE_MAX)));
+
+  const words = $derived(fmtCompact($totalWordsT));
+  const books = $derived(bookEquivalent(data.totals.total_words));
+  const delta = $derived(pctDelta(data.totals.words_in_range, data.totals.words_prev_range));
+</script>
+
+<div class="hero">
+  <section class="tile tile-gauge" aria-label="Average words per minute">
+    <svg class="gauge" viewBox="-10 -12 148 98" role="img" aria-hidden="true">
+      <path
+        d="M 12 70 A 52 52 0 0 1 116 70"
+        fill="none"
+        stroke="var(--control-hover)"
+        stroke-width="11"
+        stroke-linecap="round"
+      />
+      <path
+        d="M 12 70 A 52 52 0 0 1 116 70"
+        fill="none"
+        stroke="var(--accent)"
+        stroke-width="11"
+        stroke-linecap="round"
+        stroke-dasharray="{ARC_LENGTH * gaugeFill} {ARC_LENGTH}"
+        class="gauge-fill"
+      />
+      <!-- Scale labels — 0 / 100 / 200 wpm — so the arc reads as a fixed
+           reference, not a bare unlabelled sweep. Each centred on its own
+           mark so "0" and "200" sit at identical, mirrored distances from
+           the arc's two ends. -->
+      <text x="4" y="86" class="gauge-tick" text-anchor="middle">0</text>
+      <text x="64" y="0" class="gauge-tick gauge-tick-mid" text-anchor="middle">{GAUGE_MID}</text>
+      <text x="124" y="86" class="gauge-tick" text-anchor="middle">{GAUGE_MAX}</text>
+      <!-- Sits low in the arc's hollow, where the semicircle is widest, so
+           a 3-digit reading never reaches the curve above it. No "wpm"
+           suffix — the label right below already says it. -->
+      <text x="64" y="63" class="gauge-value" text-anchor="middle">{wpm || '—'}</text>
+    </svg>
+    <p class="tile-label">words per minute</p>
+    <p class="tile-note">
+      {#if data.totals.best_wpm > 0}
+        Your best is {Math.round(data.totals.best_wpm)} wpm
+      {:else}
+        Speak a little longer to measure this
+      {/if}
+    </p>
+  </section>
+
+  <section class="tile tile-relative" aria-label="Total words dictated">
+    {#if delta !== null}
+      <span class="delta" class:down={delta < 0}>
+        <svg class="delta-arrow" class:flip={delta < 0} width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 19V5M5 12l7-7 7 7"/>
+        </svg>
+        {Math.abs(delta).toFixed(1)}%
+      </span>
+    {/if}
+    <div class="tile-head">
+      <span class="big">{words.value}{#if words.suffix}<small>{words.suffix}</small>{/if}</span>
+    </div>
+    <p class="tile-label">total words dictated</p>
+    <p class="tile-note">
+      {#if books >= 1}
+        That's {books.toFixed(books < 10 ? 1 : 0)} full-length {books >= 2 ? 'books' : 'book'} of writing.
+      {:else if data.totals.total_words > 0}
+        {Math.round(books * 100)}% of a full-length book so far.
+      {:else}
+        Your first dictation starts the count.
+      {/if}
+    </p>
+    <p class="tile-note tile-note-dim">
+      {fmtNumber(data.totals.words_in_range)} words · {rangeLabel.toLowerCase()}
+    </p>
+  </section>
+
+  <section class="tile" aria-label="Fixes made by Verenu">
+    <div class="tile-head">
+      <span class="big"><AnimatedNumber value={data.cleanup.edits_applied} /></span>
+    </div>
+    <p class="tile-label">fixes made by Verenu</p>
+    <div class="sub-rows">
+      <div class="stat-line">
+        <span class="stat-num"><AnimatedNumber value={data.cleanup.dictionary_fixes} /></span>
+        <span class="stat-label">dictionary fixes</span>
+      </div>
+      <div class="stat-line">
+        <span class="stat-num"><AnimatedNumber value={data.cleanup.auto_learned_terms} /></span>
+        <span class="stat-label">terms auto-learned</span>
+      </div>
+    </div>
+  </section>
+</div>
+
+<style>
+  .hero {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+    margin-bottom: 14px;
+  }
+
+  .tile {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 16px 18px 15px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tile-head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .big {
+    font-family: var(--serif);
+    font-size: 34px;
+    font-weight: 500;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+  }
+  .big small {
+    font-size: 18px;
+    color: var(--ink-mute);
+    font-weight: 400;
+  }
+
+  .tile-relative { position: relative; }
+
+  .delta {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .delta.down {
+    background: var(--danger-bg);
+    color: var(--danger);
+  }
+
+  .delta-arrow.flip { transform: rotate(180deg); }
+
+  .tile-label {
+    margin: 9px 0 0;
+    font-size: 10.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+  }
+
+  .tile-note {
+    margin: 8px 0 0;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--ink-soft);
+  }
+  .tile-note-dim {
+    margin-top: auto;
+    padding-top: 8px;
+    color: var(--ink-mute);
+    font-size: 11.5px;
+  }
+
+  .tile-gauge {
+    align-items: center;
+    text-align: center;
+  }
+
+  .gauge {
+    width: 100%;
+    max-width: 150px;
+    height: auto;
+    display: block;
+  }
+  .gauge-fill {
+    transition: stroke-dasharray var(--ui-duration-base) var(--ui-ease-out);
+  }
+
+  .gauge-tick {
+    font-family: var(--serif);
+    font-size: 10px;
+    font-weight: 600;
+    fill: var(--ink-mute);
+    font-variant-numeric: tabular-nums;
+  }
+  .gauge-tick-mid {
+    font-size: 11px;
+    fill: var(--ink-soft);
+  }
+
+  .gauge-value {
+    font-family: var(--serif);
+    font-size: 27px;
+    font-weight: 500;
+    fill: var(--ink);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .sub-rows {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .stat-line {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    border-top: 1px solid var(--line);
+    padding-top: 8px;
+  }
+
+  .stat-num {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-label {
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    margin-left: auto;
+  }
+
+  @media (max-width: 900px) {
+    .hero { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -31,6 +31,11 @@
   // Derived from the tweened count so the book equivalent stays in sync with
   // the animating word number instead of snapping to the target immediately.
   const books = $derived(bookEquivalent($totalWordsT));
+  // The exact string shown in the note; pluralization keys off its parsed
+  // value (so 80,080 words → "1.0" → singular) rather than a fragile strict
+  // equality against the raw float.
+  const booksLabel = $derived(books < 10 ? books.toFixed(1) : String(Math.round(books)));
+  const isOneBook = $derived(Number(booksLabel) === 1);
   const delta = $derived(pctDelta(data.totals.words_in_range, data.totals.words_prev_range));
 </script>
 
@@ -90,12 +95,12 @@
     <p class="tile-label">total words dictated</p>
     <p class="tile-note">
       {#if books >= 1}
-        <!-- Pluralize off the displayed amount: "1 book" is singular, but
-             "1.5 books" isn't. -->
-        {#if books === 1}
+        <!-- Pluralize off the displayed amount: "1" is singular, but "1.5"
+             isn't. -->
+        {#if isOneBook}
           That's 1 full-length book of writing.
         {:else}
-          That's {books.toFixed(books < 10 ? 1 : 0)} full-length books of writing.
+          That's {booksLabel} full-length books of writing.
         {/if}
       {:else if data.totals.total_words > 0}
         {Math.round(books * 100)}% of a full-length book so far.

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -50,7 +50,7 @@
         stroke="var(--accent)"
         stroke-width="11"
         stroke-linecap="round"
-        stroke-dasharray="{ARC_LENGTH * gaugeFill} {ARC_LENGTH}"
+        stroke-dasharray={`${ARC_LENGTH * gaugeFill} ${ARC_LENGTH}`}
         class="gauge-fill"
       />
       <!-- Scale labels — 0 / 100 / 200 wpm — so the arc reads as a fixed

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -132,21 +132,27 @@
 </div>
 
 <style>
+  /* A summary band on bare paper, not three cards: columns are separated by
+     the same 1px hairline the rest of the app uses between rows, and the band
+     itself is closed off by a rule before the first section below it. */
   .hero {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 14px;
-    margin-bottom: 14px;
+    gap: clamp(18px, 3vw, 32px);
+    padding-bottom: 20px;
+    margin-bottom: 26px;
+    border-bottom: 1px solid var(--line);
   }
 
   .tile {
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 16px 18px 15px;
     min-width: 0;
     display: flex;
     flex-direction: column;
+  }
+
+  .tile + .tile {
+    border-left: 1px solid var(--line);
+    padding-left: clamp(18px, 3vw, 32px);
   }
 
   .tile-head {
@@ -175,8 +181,8 @@
 
   .delta {
     position: absolute;
-    top: 14px;
-    right: 14px;
+    top: 0;
+    right: 0;
     display: inline-flex;
     align-items: center;
     gap: 3px;
@@ -284,5 +290,19 @@
 
   @media (max-width: 900px) {
     .hero { grid-template-columns: 1fr; }
+    /* Stacked, the vertical rules become horizontal ones — same trick
+       StatsCard uses when its row collapses. */
+    .tile + .tile {
+      border-left: 0;
+      padding-left: 0;
+      border-top: 1px solid var(--line);
+      padding-top: clamp(18px, 3vw, 32px);
+    }
+    /* Stacked, the gauge lines up with the other two rather than floating
+       centred in its own row. */
+    .tile-gauge {
+      align-items: flex-start;
+      text-align: left;
+    }
   }
 </style>

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -28,13 +28,15 @@
   const gaugeFill = $derived(Math.min(1, Math.max(0, wpm / GAUGE_MAX)));
 
   const words = $derived(fmtCompact($totalWordsT));
-  const books = $derived(bookEquivalent(data.totals.total_words));
+  // Derived from the tweened count so the book equivalent stays in sync with
+  // the animating word number instead of snapping to the target immediately.
+  const books = $derived(bookEquivalent($totalWordsT));
   const delta = $derived(pctDelta(data.totals.words_in_range, data.totals.words_prev_range));
 </script>
 
 <div class="hero">
   <section class="tile tile-gauge" aria-label="Average words per minute">
-    <svg class="gauge" viewBox="-10 -12 148 98" role="img" aria-hidden="true">
+    <svg class="gauge" viewBox="-10 -12 148 98" aria-hidden="true">
       <path
         d="M 12 70 A 52 52 0 0 1 116 70"
         fill="none"

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -85,32 +85,7 @@
 </section>
 
 <style>
-  .card {
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 15px 18px 14px;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .card-head { margin-bottom: 14px; }
-
-  .card-h {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0;
-    color: var(--ink);
-    letter-spacing: -0.01em;
-  }
-
-  .card-sub {
-    margin: 3px 0 0;
-    font-size: 11.5px;
-    color: var(--ink-mute);
-  }
+  /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte. */
 
   .strip {
     position: relative;

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -3,11 +3,16 @@
   import AnimatedNumber from './AnimatedNumber.svelte';
   import ChartTooltip from './ChartTooltip.svelte';
 
-  let { hourly }: { hourly: number[] } = $props();
+  let { hourly = Array.from({ length: 24 }, () => 0) }: { hourly?: number[] } = $props();
 
-  const max = $derived(Math.max(...hourly, 0));
-  const total = $derived(hourly.reduce((sum, n) => sum + n, 0));
-  const peak = $derived(max > 0 ? hourly.indexOf(max) : -1);
+  // Default destructure above normalizes a missing/null prop; guard the
+  // derivations against a non-array payload too.
+  const series = $derived(
+    Array.isArray(hourly) ? hourly : Array.from({ length: 24 }, () => 0),
+  );
+  const max = $derived(Math.max(...series, 0));
+  const total = $derived(series.reduce((sum, n) => sum + n, 0));
+  const peak = $derived(max > 0 ? series.indexOf(max) : -1);
   const peakSharePct = $derived(Math.round((max / Math.max(1, total)) * 100));
 
   let hover = $state<number | null>(null);
@@ -39,7 +44,7 @@
       ? `Words by hour of day. Peak activity at ${fmtHour(peak)} with ${fmtNumber(max)} words.`
       : 'No hourly activity recorded yet.'}
   >
-    {#each hourly as words, hour}
+    {#each series as words, hour}
       <div
         class="col"
         role="presentation"
@@ -54,13 +59,13 @@
         ></span>
       </div>
     {/each}
-    {#if hover !== null && hourly[hover] !== undefined}
+    {#if hover !== null && series[hover] !== undefined}
       <ChartTooltip
         x={hoverX}
-        y={stripHeight - (Math.max(2, max > 0 ? (hourly[hover] / max) * 100 : 2) / 100) * stripHeight}
+        y={stripHeight - (Math.max(2, max > 0 ? (series[hover] / max) * 100 : 2) / 100) * stripHeight}
         visible={true}
       >
-        <strong>{fmtNumber(hourly[hover])}</strong> words
+        <strong>{fmtNumber(series[hover])}</strong> words
         <div class="tooltip-dim">{fmtHour(hover)}</div>
       </ChartTooltip>
     {/if}

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { fmtHour, fmtNumber } from './helpers';
+  import AnimatedNumber from './AnimatedNumber.svelte';
+  import ChartTooltip from './ChartTooltip.svelte';
+
+  let { hourly }: { hourly: number[] } = $props();
+
+  const max = $derived(Math.max(...hourly, 0));
+  const total = $derived(hourly.reduce((sum, n) => sum + n, 0));
+  const peak = $derived(max > 0 ? hourly.indexOf(max) : -1);
+  const peakSharePct = $derived(Math.round((max / Math.max(1, total)) * 100));
+
+  let hover = $state<number | null>(null);
+  let hoverX = $state(0);
+  let stripHeight = $state(96);
+
+  function onEnter(hour: number, event: PointerEvent) {
+    hover = hour;
+    const strip = (event.currentTarget as HTMLElement).parentElement;
+    const stripRect = strip?.getBoundingClientRect();
+    const colRect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    hoverX = stripRect ? colRect.left - stripRect.left + colRect.width / 2 : 0;
+    stripHeight = stripRect?.height ?? 96;
+  }
+</script>
+
+<section class="card">
+  <header class="card-head">
+    <div>
+      <h2 class="card-h">When you dictate</h2>
+      <p class="card-sub">Words by hour of day</p>
+    </div>
+  </header>
+
+  <div
+    class="strip"
+    role="img"
+    aria-label={peak >= 0
+      ? `Words by hour of day. Peak activity at ${fmtHour(peak)} with ${fmtNumber(max)} words.`
+      : 'No hourly activity recorded yet.'}
+  >
+    {#each hourly as words, hour}
+      <div
+        class="col"
+        role="presentation"
+        onpointerenter={(e) => onEnter(hour, e)}
+        onpointerleave={() => (hover = null)}
+      >
+        <span
+          class="bar"
+          class:peak={hour === peak}
+          class:hovered={hover === hour}
+          style:height={`${max > 0 ? Math.max(2, (words / max) * 100) : 2}%`}
+        ></span>
+      </div>
+    {/each}
+    {#if hover !== null}
+      <ChartTooltip
+        x={hoverX}
+        y={stripHeight - (Math.max(2, max > 0 ? (hourly[hover] / max) * 100 : 2) / 100) * stripHeight}
+        visible={true}
+      >
+        <strong>{fmtNumber(hourly[hover])}</strong> words
+        <div class="tooltip-dim">{fmtHour(hover)}</div>
+      </ChartTooltip>
+    {/if}
+  </div>
+
+  <div class="axis">
+    <span>12 AM</span><span>6 AM</span><span>12 PM</span><span>6 PM</span><span>11 PM</span>
+  </div>
+
+  <p class="foot">
+    {#if peak >= 0}
+      You dictate most around {fmtHour(peak)} — <AnimatedNumber value={peakSharePct} format={(n) => Math.round(n).toString()} />% of your words land in that hour.
+    {:else}
+      Hourly patterns appear once you've dictated a few times.
+    {/if}
+  </p>
+</section>
+
+<style>
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 15px 18px 14px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-head { margin-bottom: 14px; }
+
+  .card-h {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+
+  .card-sub {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+  }
+
+  .strip {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(24, minmax(0, 1fr));
+    gap: 3px;
+    flex: 1;
+    min-height: 96px;
+    align-items: end;
+  }
+
+  .col {
+    display: flex;
+    align-items: flex-end;
+    height: 100%;
+    min-width: 0;
+  }
+
+  .bar {
+    display: block;
+    width: 100%;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--accent) 45%, transparent);
+    transition: height var(--ui-duration-base) var(--ui-ease-out), background-color var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .bar.peak { background: var(--accent); }
+  .bar.hovered { background: var(--accent); }
+
+  .axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10.5px;
+    color: var(--ink-mute);
+    margin-top: 6px;
+  }
+
+  .foot {
+    margin: 0;
+    padding-top: 10px;
+    font-size: 11.5px;
+    color: var(--ink-soft);
+    line-height: 1.45;
+  }
+</style>

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -54,7 +54,7 @@
         ></span>
       </div>
     {/each}
-    {#if hover !== null}
+    {#if hover !== null && hourly[hover] !== undefined}
       <ChartTooltip
         x={hoverX}
         y={stripHeight - (Math.max(2, max > 0 ? (hourly[hover] / max) * 100 : 2) / 100) * stripHeight}

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -1,26 +1,36 @@
 <script lang="ts">
-  import { accentStep, fmtDay, fmtDayLong, fmtNumber, intensityLevel, parseLocalDay } from './helpers';
+  import { onMount } from 'svelte';
+  import { fmtDay, fmtDayLong, fmtNumber, parseLocalDay } from './helpers';
   import AnimatedNumber from './AnimatedNumber.svelte';
   import ChartTooltip from './ChartTooltip.svelte';
   import type { InsightsDay, InsightsStreak } from './types';
 
-  let { daily, streak }: { daily: InsightsDay[]; streak: InsightsStreak } = $props();
+  let {
+    daily,
+    streak,
+    historyStartedOn,
+  }: { daily: InsightsDay[]; streak: InsightsStreak; historyStartedOn: string | null } = $props();
 
-  const CELL = 11;
-  const GAP = 3;
+  const CELL = 12;
+  const GAP = 4;
   const STEP = CELL + GAP;
+  const MIN_WEEKS = 18;
+  const RIGHT_GUTTER = 10;
   const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   /* Minimum grid width, in weeks — short ranges (a 7-day view is only one
      column) would otherwise leave the card looking mostly empty. */
-  const MIN_COLUMNS = 10;
 
   // Reduce rather than Math.max(...spread) — an all-time range can exceed the
   // call-stack limit for spread arguments on a very long daily series.
-  const max = $derived(daily.reduce((m, d) => Math.max(m, d.words), 0));
+  interface GridCell { day: string; words: number; noData: boolean; streakDays: number }
 
-  interface GridCell { day: string; words: number; noData: boolean }
+  function streakColor(days: number, longest: number): string {
+    if (days <= 0) return 'var(--control-hover)';
+    const pct = longest <= 1 ? 100 : 8 + (days / longest) * 92;
+    return `color-mix(in srgb, var(--accent) ${pct.toFixed(2)}%, var(--paper-2))`;
+  }
 
   /*
    * Every cell is a real calendar date, generated as one unbroken sequence —
@@ -30,7 +40,7 @@
    * correct by construction and there's nothing to hover that isn't an
    * actual date.
    */
-  const cells = $derived.by((): GridCell[] => {
+  const allCells = $derived.by((): GridCell[] => {
     const pad = (n: number) => String(n).padStart(2, '0');
     const toKey = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 
@@ -43,7 +53,7 @@
 
     const firstRealDate = daily.length > 0 ? parseLocalDay(daily[0].day) : lastDate;
     const daysSpanningReal = Math.round((endDate.getTime() - firstRealDate.getTime()) / 86_400_000) + 1;
-    const totalWeeks = Math.max(MIN_COLUMNS, Math.ceil(daysSpanningReal / 7));
+    const totalWeeks = Math.ceil(daysSpanningReal / 7);
 
     const startDate = new Date(endDate);
     startDate.setDate(startDate.getDate() - (totalWeeks * 7 - 1));
@@ -51,17 +61,47 @@
     const byDay = new Map(daily.map((d) => [d.day, d]));
     const list: GridCell[] = [];
     const cursor = new Date(startDate);
+    let run = 0;
     for (let i = 0; i < totalWeeks * 7; i++) {
       const key = toKey(cursor);
       const real = byDay.get(key);
-      list.push(real ? { day: key, words: real.words, noData: false } : { day: key, words: 0, noData: true });
+      const outsideHistory = !historyStartedOn || key < historyStartedOn || cursor > today;
+      if (real && !outsideHistory) {
+        run = real.words > 0 ? run + 1 : 0;
+        list.push({ day: key, words: real.words, noData: false, streakDays: run });
+      } else {
+        run = 0;
+        list.push({ day: key, words: 0, noData: true, streakDays: 0 });
+      }
       cursor.setDate(cursor.getDate() + 1);
     }
     return list;
   });
 
+  let gridHost = $state<HTMLDivElement | null>(null);
+  let availableWidth = $state(640);
+  const visibleWeekCount = $derived(
+    Math.max(MIN_WEEKS, Math.min(53, Math.floor((availableWidth - RIGHT_GUTTER + GAP) / STEP)))
+  );
+  const cells = $derived(allCells.slice(-visibleWeekCount * 7));
+  const longestVisibleScale = $derived(Math.max(1, allCells.reduce((max, cell) => Math.max(max, cell.streakDays), 0)));
+  const legendDays = $derived(Array.from(new Set([
+    1,
+    Math.max(1, Math.ceil(longestVisibleScale / 3)),
+    Math.max(1, Math.ceil(longestVisibleScale * 2 / 3)),
+    longestVisibleScale,
+  ])));
   const columnCount = $derived(Math.ceil(cells.length / 7));
   const gridWidth = $derived(columnCount * STEP - GAP);
+
+  onMount(() => {
+    if (!gridHost) return;
+    const update = () => { availableWidth = gridHost?.clientWidth ?? 640; };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(gridHost);
+    return () => observer.disconnect();
+  });
 
   /* One label per month the grid spans, positioned above that month's first
      column. A month change landing mid-week would otherwise put two labels on
@@ -110,6 +150,17 @@
     return { name: WEEKDAY_NAMES[averages.indexOf(peak)], avg: peak };
   });
 
+  const rangeActivity = $derived.by(() => {
+    const active = cells.filter((day) => !day.noData && day.words > 0);
+    const words = active.reduce((sum, day) => sum + day.words, 0);
+    return { days: active.length, average: active.length > 0 ? words / active.length : 0 };
+  });
+  const visibleActiveDays = $derived(cells.filter((day) => !day.noData && day.words > 0).length);
+  const visibleRangeLabel = $derived.by(() => {
+    if (cells.length === 0) return 'recent activity';
+    return `${fmtDay(cells[0].day)} to ${fmtDay(cells[cells.length - 1].day)}`;
+  });
+
   let hover = $state<GridCell | null>(null);
   let hoverPos = $state<{ x: number; y: number } | null>(null);
 
@@ -142,7 +193,7 @@
   <header class="card-head">
     <div>
       <h2 class="card-h"><AnimatedNumber value={streak.current_days} /> day streak</h2>
-      <p class="card-sub">{fmtNumber(streak.active_days)} active days all time</p>
+      <p class="card-sub">{fmtNumber(visibleActiveDays)} active days shown · {visibleRangeLabel}</p>
     </div>
     <div class="best">
       <span class="best-num"><AnimatedNumber value={streak.longest_days} /></span>
@@ -150,15 +201,18 @@
     </div>
   </header>
 
-  <div class="grid-row">
+  <div class="heat-layout">
+   <div class="heat-main">
+    <div class="grid-row">
     <div class="weekday-col" aria-hidden="true">
       {#each WEEKDAY_LABELS as label}
         <span>{label}</span>
       {/each}
     </div>
 
-    <div class="grid-scroll scroll-styled" onscroll={clearHover}>
-      <div class="month-row" style:width="{gridWidth}px" aria-hidden="true">
+    <div class="grid-scroll" bind:this={gridHost}>
+     <div class="calendar-content" style:width="{gridWidth}px">
+      <div class="month-row" aria-hidden="true">
         {#each monthLabels as m}
           <span style:left="{m.col * STEP}px">{m.label}</span>
         {/each}
@@ -181,56 +235,71 @@
             <span
               class="cell"
               role="presentation"
-              style:background={accentStep(intensityLevel(cell.words, max))}
+              style:background={streakColor(cell.streakDays, longestVisibleScale)}
               onpointerenter={(e) => onEnter(cell, e)}
               onpointerleave={clearHover}
             ></span>
           {/if}
         {/each}
       </div>
+     </div>
     </div>
+    </div>
+
+    <div class="legend">
+      <span class="legend-label">Day 1</span>
+      {#each legendDays as day}
+        <span class="cell cell-key" style:background={streakColor(day, longestVisibleScale)} aria-hidden="true"></span>
+      {/each}
+      <span class="legend-label legend-label-more">Day {longestVisibleScale}</span>
+      <span class="legend-gap"></span>
+      <span class="cell cell-nodata" aria-hidden="true"></span>
+      <span class="legend-label">Not tracked</span>
+    </div>
+   </div>
+
+   <div class="heat-side">
+    {#if daily.length === 0}
+      <p class="foot">No activity to chart yet.</p>
+    {:else if streak.longest_days === 0}
+      <p class="foot">Dictate on two days in a row to start a streak.</p>
+    {:else}
+      <div class="streak-stats">
+        <div class="stat">
+          <span class="stat-label">Longest streak</span>
+          <span class="stat-value">{streak.longest_days} {streak.longest_days === 1 ? 'day' : 'days'}</span>
+          <span class="stat-sub">{fmtNumber(streak.longest_words)} words{#if longestRange} · {longestRange}{/if}</span>
+        </div>
+        {#if bestWeekday}
+          <div class="stat">
+            <span class="stat-label">Best day</span>
+            <span class="stat-value">{bestWeekday.name}</span>
+            <span class="stat-sub">{fmtNumber(bestWeekday.avg)} words on average</span>
+          </div>
+        {/if}
+        <div class="stat">
+          <span class="stat-label">Average active day</span>
+          <span class="stat-sub">{fmtNumber(rangeActivity.average)} words per active day</span>
+        </div>
+      </div>
+    {/if}
+   </div>
   </div>
+
   {#if hoverPos && hover}
     <ChartTooltip x={hoverPos.x} y={hoverPos.y} visible={true}>
       {#if hover.noData}
-        <strong>No data</strong>
+        <strong>Not tracked</strong>
       {:else}
-        <strong>{fmtNumber(hover.words)}</strong> words
+        {#if hover.streakDays > 0}
+          <strong>Day {hover.streakDays} of streak</strong>
+          <div class="tooltip-dim">{fmtNumber(hover.words)} words</div>
+        {:else}
+          <strong>No dictation</strong>
+        {/if}
       {/if}
       <div class="tooltip-dim">{fmtDayLong(hover.day)}</div>
     </ChartTooltip>
-  {/if}
-
-  <div class="legend">
-    <span class="legend-label">Less</span>
-    {#each [0, 1, 2, 3, 4] as level}
-      <span class="cell cell-key" style:background={accentStep(level as 0 | 1 | 2 | 3 | 4)} aria-hidden="true"></span>
-    {/each}
-    <span class="legend-label legend-label-more">More</span>
-    <span class="legend-gap"></span>
-    <span class="cell cell-nodata" aria-hidden="true"></span>
-    <span class="legend-label">No data</span>
-  </div>
-
-  {#if daily.length === 0}
-    <p class="foot">No activity to chart yet.</p>
-  {:else if streak.longest_days === 0}
-    <p class="foot">Dictate on two days in a row to start a streak.</p>
-  {:else}
-    <div class="streak-stats">
-      <div class="stat">
-        <span class="stat-label">Longest streak</span>
-        <span class="stat-value">{streak.longest_days} {streak.longest_days === 1 ? 'day' : 'days'}</span>
-        <span class="stat-sub">{fmtNumber(streak.longest_words)} words{#if longestRange} · {longestRange}{/if}</span>
-      </div>
-      {#if bestWeekday}
-        <div class="stat">
-          <span class="stat-label">Best day</span>
-          <span class="stat-value">{bestWeekday.name}</span>
-          <span class="stat-sub">{fmtNumber(bestWeekday.avg)} words on average</span>
-        </div>
-      {/if}
-    </div>
   {/if}
 
   <table class="sr-only">
@@ -245,39 +314,10 @@
 </section>
 
 <style>
-  .card {
-    position: relative;
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 15px 18px 13px;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .card-head {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 14px;
-  }
-
-  .card-h {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0;
-    color: var(--ink);
-    letter-spacing: -0.01em;
-  }
-
-  .card-sub {
-    margin: 3px 0 0;
-    font-size: 11.5px;
-    color: var(--ink-mute);
-  }
+  /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte —
+     except position, which the hover tooltip anchors against via
+     closest('.card'). */
+  .card { position: relative; }
 
   .best { text-align: right; }
   .best-num {
@@ -296,36 +336,58 @@
     color: var(--ink-mute);
   }
 
+  /* Calendar left, streak figures in a ruled right rail. The calendar has an
+     intrinsic width (fixed 12px cells), so left-aligning it and giving the
+     leftover width to the rail keeps the row filled instead of stranding a
+     small grid in the middle of the page. */
+  .heat-layout {
+    display: flex;
+    gap: clamp(18px, 3vw, 32px);
+    align-items: flex-start;
+  }
+
+  .heat-main { flex: 1 1 auto; min-width: 0; }
+
+  .heat-side {
+    flex: 0 0 clamp(200px, 24%, 300px);
+    border-left: 1px solid var(--line);
+    padding-left: clamp(18px, 3vw, 32px);
+  }
+
   .grid-row {
     display: flex;
     gap: 6px;
-    justify-content: center;
   }
 
   .weekday-col {
     display: grid;
-    grid-template-rows: repeat(7, 11px);
-    gap: 3px;
-    flex: 0 0 auto;
+    grid-template-rows: repeat(7, 12px);
+    gap: 4px;
+    flex: 0 0 25px;
     padding-top: 16px; /* clears the month-row above the grid */
   }
   .weekday-col span {
     font-size: 9px;
-    line-height: 11px;
+    line-height: 12px;
     color: var(--ink-mute);
     white-space: nowrap;
   }
 
   .grid-scroll {
-    overflow-x: auto;
-    padding-bottom: 2px;
+    overflow: hidden;
     min-width: 0;
+    flex: 1;
+  }
+
+  .calendar-content {
+    margin-left: auto;
+    margin-right: 10px;
   }
 
   .month-row {
     position: relative;
-    height: 13px;
-    margin-bottom: 3px;
+    height: 15px;
+    margin-bottom: 4px;
   }
   .month-row span {
     position: absolute;
@@ -334,19 +396,24 @@
     color: var(--ink-mute);
     white-space: nowrap;
   }
+  /* A month can begin in the final visible week. Keep that final label inside
+     the clipped chart instead of letting its text run past the stats rail. */
+  .month-row span:last-child {
+    left: auto !important;
+    right: 0;
+  }
 
   .grid {
-    position: relative;
     display: grid;
-    grid-template-rows: repeat(7, 11px);
+    grid-template-rows: repeat(7, 12px);
     grid-auto-flow: column;
-    grid-auto-columns: 11px;
-    gap: 3px;
+    grid-auto-columns: 12px;
+    gap: 4px;
   }
 
   .cell {
-    width: 11px;
-    height: 11px;
+    width: 12px;
+    height: 12px;
     border-radius: 3px;
     display: block;
     /* A flat fill at 0-intensity nearly disappears against the card
@@ -358,8 +425,8 @@
      reads as "no data" at a glance instead of blending in as a low-activity
      day — --paper-2 was too close to the accent-tinted cells' own dark end. */
   .cell-nodata {
-    background: color-mix(in srgb, var(--ink) 14%, transparent);
-    box-shadow: inset 0 0 0 1px var(--line);
+    background: color-mix(in srgb, var(--ink) 11%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ink) 20%, transparent);
   }
 
   .legend {
@@ -367,7 +434,6 @@
     align-items: center;
     gap: 3px;
     margin-top: 14px;
-    justify-content: center;
   }
   .legend-label {
     font-size: 10.5px;
@@ -377,8 +443,21 @@
   .legend-label-more { margin-left: 3px; }
   .legend-gap { width: 10px; }
 
+  /* Stacked, the rail's vertical rule becomes a horizontal one. */
+  @media (max-width: 900px) {
+    .heat-layout { flex-direction: column; }
+    .heat-side {
+      flex: 1 1 auto;
+      align-self: stretch;
+      border-left: 0;
+      padding-left: 0;
+      border-top: 1px solid var(--line);
+      padding-top: 14px;
+    }
+  }
+
   .foot {
-    margin: 10px 0 0;
+    margin: 0;
     font-size: 11.5px;
     color: var(--ink-soft);
     line-height: 1.45;
@@ -388,11 +467,8 @@
      its own value and sub-line so it can be read at a glance. */
   .streak-stats {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px 16px;
-    margin-top: 14px;
-    padding-top: 12px;
-    border-top: 1px solid var(--line);
+    grid-template-columns: minmax(0, 1fr);
+    gap: 14px;
   }
   .stat {
     display: flex;

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -16,7 +16,9 @@
      column) would otherwise leave the card looking mostly empty. */
   const MIN_COLUMNS = 10;
 
-  const max = $derived(Math.max(...daily.map((d) => d.words), 0));
+  // Reduce rather than Math.max(...spread) — an all-time range can exceed the
+  // call-stack limit for spread arguments on a very long daily series.
+  const max = $derived(daily.reduce((m, d) => Math.max(m, d.words), 0));
 
   interface GridCell { day: string; words: number; noData: boolean }
 
@@ -65,7 +67,9 @@
      column. A month change landing mid-week would otherwise put two labels on
      the same column (or in immediately adjacent 14px columns, whose text
      overlaps), so a label is only placed when its column is clear of the
-     previous one. */
+     previous one. lastMonth advances on every boundary so each month is
+     considered exactly once — a skipped label is omitted, never misplaced
+     above a mid-month column. */
   const monthLabels = $derived.by(() => {
     const labels: Array<{ col: number; label: string }> = [];
     let lastMonth = -1;
@@ -73,14 +77,11 @@
     cells.forEach((cell, i) => {
       const month = parseLocalDay(cell.day).getMonth();
       if (month !== lastMonth) {
+        lastMonth = month;
         const col = Math.floor(i / 7);
-        // Only advance lastMonth when a label is actually placed — otherwise
-        // a month whose first column is too close to the previous label
-        // would be permanently omitted even if a later column fits.
         if (col >= lastCol + 2) {
           labels.push({ col, label: parseLocalDay(cell.day).toLocaleDateString([], { month: 'short' }) });
           lastCol = col;
-          lastMonth = month;
         }
       }
     });
@@ -93,6 +94,10 @@
     const sums = new Array(7).fill(0);
     const counts = new Array(7).fill(0);
     for (const d of daily) {
+      // Only days with actual dictation count toward the average and the
+      // minimum-activity gate — zero-word days (no-data padding or quiet
+      // days) would otherwise inflate the weekday coverage.
+      if (d.words <= 0) continue;
       const dow = parseLocalDay(d.day).getDay();
       sums[dow] += d.words;
       counts[dow] += 1;

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -61,14 +61,23 @@
   const columnCount = $derived(Math.ceil(cells.length / 7));
   const gridWidth = $derived(columnCount * STEP - GAP);
 
-  /* One label per month the grid spans, positioned above that month's first column. */
+  /* One label per month the grid spans, positioned above that month's first
+     column. A month change landing mid-week would otherwise put two labels on
+     the same column (or in immediately adjacent 14px columns, whose text
+     overlaps), so a label is only placed when its column is clear of the
+     previous one. */
   const monthLabels = $derived.by(() => {
     const labels: Array<{ col: number; label: string }> = [];
     let lastMonth = -1;
+    let lastCol = -Infinity;
     cells.forEach((cell, i) => {
       const month = parseLocalDay(cell.day).getMonth();
       if (month !== lastMonth) {
-        labels.push({ col: Math.floor(i / 7), label: parseLocalDay(cell.day).toLocaleDateString([], { month: 'short' }) });
+        const col = Math.floor(i / 7);
+        if (col >= lastCol + 2) {
+          labels.push({ col, label: parseLocalDay(cell.day).toLocaleDateString([], { month: 'short' }) });
+          lastCol = col;
+        }
         lastMonth = month;
       }
     });
@@ -140,7 +149,7 @@
       {/each}
     </div>
 
-    <div class="grid-scroll scroll-styled">
+    <div class="grid-scroll scroll-styled" onscroll={clearHover}>
       <div class="month-row" style:width="{gridWidth}px" aria-hidden="true">
         {#each monthLabels as m}
           <span style:left="{m.col * STEP}px">{m.label}</span>

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -214,7 +214,7 @@
      <div class="calendar-content" style:width="{gridWidth}px">
       <div class="month-row" aria-hidden="true">
         {#each monthLabels as m}
-          <span style:left="{m.col * STEP}px">{m.label}</span>
+          <span class:edge={m.col >= columnCount - 2} style:left="{m.col * STEP}px">{m.label}</span>
         {/each}
       </div>
       <div
@@ -398,7 +398,7 @@
   }
   /* A month can begin in the final visible week. Keep that final label inside
      the clipped chart instead of letting its text run past the stats rail. */
-  .month-row span:last-child {
+  .month-row span.edge {
     left: auto !important;
     right: 0;
   }

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -74,11 +74,14 @@
       const month = parseLocalDay(cell.day).getMonth();
       if (month !== lastMonth) {
         const col = Math.floor(i / 7);
+        // Only advance lastMonth when a label is actually placed — otherwise
+        // a month whose first column is too close to the previous label
+        // would be permanently omitted even if a later column fits.
         if (col >= lastCol + 2) {
           labels.push({ col, label: parseLocalDay(cell.day).toLocaleDateString([], { month: 'short' }) });
           lastCol = col;
+          lastMonth = month;
         }
-        lastMonth = month;
       }
     });
     return labels;

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+  import { accentStep, fmtDay, fmtDayLong, fmtNumber, intensityLevel, parseLocalDay } from './helpers';
+  import AnimatedNumber from './AnimatedNumber.svelte';
+  import ChartTooltip from './ChartTooltip.svelte';
+  import type { InsightsDay, InsightsStreak } from './types';
+
+  let { daily, streak }: { daily: InsightsDay[]; streak: InsightsStreak } = $props();
+
+  const CELL = 11;
+  const GAP = 3;
+  const STEP = CELL + GAP;
+  const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+  /* Minimum grid width, in weeks — short ranges (a 7-day view is only one
+     column) would otherwise leave the card looking mostly empty. */
+  const MIN_COLUMNS = 10;
+
+  const max = $derived(Math.max(...daily.map((d) => d.words), 0));
+
+  interface GridCell { day: string; words: number; noData: boolean }
+
+  /*
+   * Every cell is a real calendar date, generated as one unbroken sequence —
+   * no separate "alignment padding" vs "filler" concept. The grid always
+   * ends on the Saturday containing the last real day (or today, if there's
+   * no data at all) and always starts on a Sunday, so weekday rows are
+   * correct by construction and there's nothing to hover that isn't an
+   * actual date.
+   */
+  const cells = $derived.by((): GridCell[] => {
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const toKey = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const lastDate = daily.length > 0 ? parseLocalDay(daily[daily.length - 1].day) : today;
+
+    const endDate = new Date(lastDate);
+    endDate.setDate(endDate.getDate() + (6 - endDate.getDay())); // extend to that week's Saturday
+
+    const firstRealDate = daily.length > 0 ? parseLocalDay(daily[0].day) : lastDate;
+    const daysSpanningReal = Math.round((endDate.getTime() - firstRealDate.getTime()) / 86_400_000) + 1;
+    const totalWeeks = Math.max(MIN_COLUMNS, Math.ceil(daysSpanningReal / 7));
+
+    const startDate = new Date(endDate);
+    startDate.setDate(startDate.getDate() - (totalWeeks * 7 - 1));
+
+    const byDay = new Map(daily.map((d) => [d.day, d]));
+    const list: GridCell[] = [];
+    const cursor = new Date(startDate);
+    for (let i = 0; i < totalWeeks * 7; i++) {
+      const key = toKey(cursor);
+      const real = byDay.get(key);
+      list.push(real ? { day: key, words: real.words, noData: false } : { day: key, words: 0, noData: true });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return list;
+  });
+
+  const columnCount = $derived(Math.ceil(cells.length / 7));
+  const gridWidth = $derived(columnCount * STEP - GAP);
+
+  /* One label per month the grid spans, positioned above that month's first column. */
+  const monthLabels = $derived.by(() => {
+    const labels: Array<{ col: number; label: string }> = [];
+    let lastMonth = -1;
+    cells.forEach((cell, i) => {
+      const month = parseLocalDay(cell.day).getMonth();
+      if (month !== lastMonth) {
+        labels.push({ col: Math.floor(i / 7), label: parseLocalDay(cell.day).toLocaleDateString([], { month: 'short' }) });
+        lastMonth = month;
+      }
+    });
+    return labels;
+  });
+
+  /* Which day of the week tends to be busiest — a second read on the same
+     data the grid already has, so the card earns its space beyond the grid. */
+  const bestWeekday = $derived.by(() => {
+    const sums = new Array(7).fill(0);
+    const counts = new Array(7).fill(0);
+    for (const d of daily) {
+      const dow = parseLocalDay(d.day).getDay();
+      sums[dow] += d.words;
+      counts[dow] += 1;
+    }
+    const averages = sums.map((s, i) => (counts[i] > 0 ? s / counts[i] : 0));
+    const peak = Math.max(...averages);
+    if (peak <= 0) return null;
+    const activeDays = counts.filter((c) => c > 0).length;
+    if (activeDays < 3) return null;
+    return { name: WEEKDAY_NAMES[averages.indexOf(peak)], avg: peak };
+  });
+
+  let hover = $state<GridCell | null>(null);
+  let hoverPos = $state<{ x: number; y: number } | null>(null);
+
+  function onEnter(cell: GridCell, event: PointerEvent) {
+    hover = cell;
+    // Positioned relative to the card, not the scrollable grid — the grid's
+    // horizontal auto-scroll also clips vertical overflow per the CSS spec,
+    // which would cut the tooltip off above short streaks.
+    const card = (event.currentTarget as HTMLElement).closest('.card');
+    const cardRect = card?.getBoundingClientRect();
+    const cellRect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    hoverPos = cardRect
+      ? { x: cellRect.left - cardRect.left + CELL / 2, y: cellRect.top - cardRect.top }
+      : null;
+  }
+
+  function clearHover() {
+    hover = null;
+    hoverPos = null;
+  }
+
+  const longestRange = $derived(
+    streak.longest_started_on && streak.longest_ended_on
+      ? `${fmtDay(streak.longest_started_on)} – ${fmtDay(streak.longest_ended_on)}`
+      : null
+  );
+</script>
+
+<section class="card">
+  <header class="card-head">
+    <div>
+      <h2 class="card-h"><AnimatedNumber value={streak.current_days} /> day streak</h2>
+      <p class="card-sub">{fmtNumber(streak.active_days)} active days all time</p>
+    </div>
+    <div class="best">
+      <span class="best-num"><AnimatedNumber value={streak.longest_days} /></span>
+      <span class="best-label">longest</span>
+    </div>
+  </header>
+
+  <div class="grid-row">
+    <div class="weekday-col" aria-hidden="true">
+      {#each WEEKDAY_LABELS as label}
+        <span>{label}</span>
+      {/each}
+    </div>
+
+    <div class="grid-scroll scroll-styled">
+      <div class="month-row" style:width="{gridWidth}px" aria-hidden="true">
+        {#each monthLabels as m}
+          <span style:left="{m.col * STEP}px">{m.label}</span>
+        {/each}
+      </div>
+      <div
+        class="grid"
+        style:width="{gridWidth}px"
+        role="img"
+        aria-label={`Daily activity calendar. Current streak ${streak.current_days} days, longest ${streak.longest_days} days.`}
+      >
+        {#each cells as cell}
+          {#if cell.noData}
+            <span
+              class="cell cell-nodata"
+              role="presentation"
+              onpointerenter={(e) => onEnter(cell, e)}
+              onpointerleave={clearHover}
+            ></span>
+          {:else}
+            <span
+              class="cell"
+              role="presentation"
+              style:background={accentStep(intensityLevel(cell.words, max))}
+              onpointerenter={(e) => onEnter(cell, e)}
+              onpointerleave={clearHover}
+            ></span>
+          {/if}
+        {/each}
+      </div>
+    </div>
+  </div>
+  {#if hoverPos && hover}
+    <ChartTooltip x={hoverPos.x} y={hoverPos.y} visible={true}>
+      {#if hover.noData}
+        <strong>No data</strong>
+      {:else}
+        <strong>{fmtNumber(hover.words)}</strong> words
+      {/if}
+      <div class="tooltip-dim">{fmtDayLong(hover.day)}</div>
+    </ChartTooltip>
+  {/if}
+
+  <div class="legend">
+    <span class="legend-label">Less</span>
+    {#each [0, 1, 2, 3, 4] as level}
+      <span class="cell cell-key" style:background={accentStep(level as 0 | 1 | 2 | 3 | 4)} aria-hidden="true"></span>
+    {/each}
+    <span class="legend-label legend-label-more">More</span>
+    <span class="legend-gap"></span>
+    <span class="cell cell-nodata" aria-hidden="true"></span>
+    <span class="legend-label">No data</span>
+  </div>
+
+  {#if daily.length === 0}
+    <p class="foot">No activity to chart yet.</p>
+  {:else if streak.longest_days === 0}
+    <p class="foot">Dictate on two days in a row to start a streak.</p>
+  {:else}
+    <div class="streak-stats">
+      <div class="stat">
+        <span class="stat-label">Longest streak</span>
+        <span class="stat-value">{streak.longest_days} {streak.longest_days === 1 ? 'day' : 'days'}</span>
+        <span class="stat-sub">{fmtNumber(streak.longest_words)} words{#if longestRange} · {longestRange}{/if}</span>
+      </div>
+      {#if bestWeekday}
+        <div class="stat">
+          <span class="stat-label">Best day</span>
+          <span class="stat-value">{bestWeekday.name}</span>
+          <span class="stat-sub">{fmtNumber(bestWeekday.avg)} words on average</span>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <table class="sr-only">
+    <caption>Words dictated per day</caption>
+    <thead><tr><th scope="col">Day</th><th scope="col">Words</th></tr></thead>
+    <tbody>
+      {#each daily as d}
+        <tr><th scope="row">{fmtDayLong(d.day)}</th><td>{fmtNumber(d.words)}</td></tr>
+      {/each}
+    </tbody>
+  </table>
+</section>
+
+<style>
+  .card {
+    position: relative;
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 15px 18px 13px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .card-h {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+
+  .card-sub {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+  }
+
+  .best { text-align: right; }
+  .best-num {
+    display: block;
+    font-family: var(--serif);
+    font-size: 20px;
+    font-weight: 500;
+    color: var(--ink);
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+  }
+  .best-label {
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+  }
+
+  .grid-row {
+    display: flex;
+    gap: 6px;
+    justify-content: center;
+  }
+
+  .weekday-col {
+    display: grid;
+    grid-template-rows: repeat(7, 11px);
+    gap: 3px;
+    flex: 0 0 auto;
+    padding-top: 16px; /* clears the month-row above the grid */
+  }
+  .weekday-col span {
+    font-size: 9px;
+    line-height: 11px;
+    color: var(--ink-mute);
+    white-space: nowrap;
+  }
+
+  .grid-scroll {
+    overflow-x: auto;
+    padding-bottom: 2px;
+    min-width: 0;
+  }
+
+  .month-row {
+    position: relative;
+    height: 13px;
+    margin-bottom: 3px;
+  }
+  .month-row span {
+    position: absolute;
+    top: 0;
+    font-size: 9.5px;
+    color: var(--ink-mute);
+    white-space: nowrap;
+  }
+
+  .grid {
+    position: relative;
+    display: grid;
+    grid-template-rows: repeat(7, 11px);
+    grid-auto-flow: column;
+    grid-auto-columns: 11px;
+    gap: 3px;
+  }
+
+  .cell {
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    display: block;
+    /* A flat fill at 0-intensity nearly disappears against the card
+       background — an outline keeps every day visible in the grid. */
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ink) 12%, transparent);
+    transition: background-color var(--ui-duration-base) var(--ui-ease-out);
+  }
+  /* A true neutral grey (mixed from --ink, not the warm accent ramp) so it
+     reads as "no data" at a glance instead of blending in as a low-activity
+     day — --paper-2 was too close to the accent-tinted cells' own dark end. */
+  .cell-nodata {
+    background: color-mix(in srgb, var(--ink) 14%, transparent);
+    box-shadow: inset 0 0 0 1px var(--line);
+  }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    margin-top: 14px;
+    justify-content: center;
+  }
+  .legend-label {
+    font-size: 10.5px;
+    color: var(--ink-mute);
+  }
+  .legend-label:first-child { margin-right: 3px; }
+  .legend-label-more { margin-left: 3px; }
+  .legend-gap { width: 10px; }
+
+  .foot {
+    margin: 10px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-soft);
+    line-height: 1.45;
+  }
+
+  /* Two labelled stat blocks instead of a run-on sentence — each fact gets
+     its own value and sub-line so it can be read at a glance. */
+  .streak-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px 16px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--line);
+  }
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .stat-label {
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+  }
+  .stat-value {
+    font-family: var(--serif);
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--ink);
+    line-height: 1.2;
+  }
+  .stat-sub {
+    font-size: 11px;
+    color: var(--ink-soft);
+    line-height: 1.35;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -112,8 +112,10 @@
             —
           {:else if trimPct < 0}
             trimmed <AnimatedNumber value={Math.abs(trimPct)} format={(n) => `${n.toFixed(1)}%`} />
-          {:else}
+          {:else if trimPct > 0}
             grew <AnimatedNumber value={trimPct} format={(n) => `${n.toFixed(1)}%`} />
+          {:else}
+            no change
           {/if}
         </dd>
       </div>

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -126,30 +126,7 @@
 </section>
 
 <style>
-  .card {
-    background: var(--bg-elev);
-    border: 1px solid var(--line);
-    border-radius: var(--r-md);
-    padding: 15px 18px 16px;
-    min-width: 0;
-  }
-
-  .card-head { margin-bottom: 14px; }
-
-  .card-h {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
-    margin: 0;
-    color: var(--ink);
-    letter-spacing: -0.01em;
-  }
-
-  .card-sub {
-    margin: 3px 0 0;
-    font-size: 11.5px;
-    color: var(--ink-mute);
-  }
+  /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte. */
 
   .split {
     display: grid;

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+  import { slide } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
+  import { motionMs } from '../../motion';
+  import { fmtNumber } from './helpers';
+  import AnimatedNumber from './AnimatedNumber.svelte';
+  import type { InsightsCleanup, InsightsTotals, InsightsWords } from './types';
+
+  let {
+    words,
+    cleanup,
+    totals,
+  }: { words: InsightsWords; cleanup: InsightsCleanup; totals: InsightsTotals } = $props();
+
+  const max = $derived(Math.max(...words.top.map((w) => w.count), 0));
+
+  /* Negative means cleanup trimmed the dictation; positive means it grew
+     (snippet expansions can outweigh filler removal). */
+  const trimPct = $derived(
+    cleanup.raw_words > 0 ? ((cleanup.clean_words - cleanup.raw_words) / cleanup.raw_words) * 100 : null
+  );
+
+  /*
+   * The card truncates the longest word with CSS ellipsis by default — that
+   * alone handles normal-length words. The click-to-expand is the safety net
+   * for a malformed dictation (e.g. a run of CJK text with no spaces, which
+   * counts as one "word"): a hard char cap keeps even that case from ever
+   * rendering thousands of characters into the DOM.
+   */
+  const HARD_CHAR_CAP = 300;
+  let wordExpanded = $state(false);
+  const rawWord = $derived.by(() => {
+    const w = words.longest_word ?? '';
+    return w.length > HARD_CHAR_CAP ? `${w.slice(0, HARD_CHAR_CAP)}…` : w;
+  });
+</script>
+
+<section class="card">
+  <header class="card-head">
+    <div>
+      <h2 class="card-h">Your vocabulary</h2>
+      <p class="card-sub">Most-used words, everyday filler excluded</p>
+    </div>
+  </header>
+
+  <div class="split">
+    {#if words.top.length > 0}
+      <ul class="word-list">
+        {#each words.top as entry}
+          <li>
+            <span class="word-bar" style:width={`${max > 0 ? Math.max(14, (entry.count / max) * 100) : 0}%`}>
+              <span class="word">{entry.word}</span>
+            </span>
+            <span class="word-count">{fmtNumber(entry.count)}</span>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="foot">Not enough dictation yet to find your favourite words.</p>
+    {/if}
+
+    <dl class="figures">
+      <div>
+        <dt>Unique words</dt>
+        <dd><AnimatedNumber value={words.unique_words} /></dd>
+      </div>
+      <div>
+        <dt>Average word length</dt>
+        <dd>
+          {#if words.avg_word_length > 0}
+            <AnimatedNumber value={words.avg_word_length} format={(n) => `${n.toFixed(1)} chars`} />
+          {:else}
+            —
+          {/if}
+        </dd>
+      </div>
+      <div class="longest-word-field">
+        <dt>Longest word</dt>
+        {#if !rawWord}
+          <dd class="dd-word">—</dd>
+        {:else}
+          <dd class="dd-word">
+            <button
+              type="button"
+              class="word-toggle"
+              class:open={wordExpanded}
+              aria-expanded={wordExpanded}
+              onclick={() => (wordExpanded = !wordExpanded)}
+              title={wordExpanded ? 'Click to collapse' : 'Click to see the full word'}
+            >
+              <span class="word-toggle-text">{rawWord}</span>
+              <svg class="word-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="m6 9 6 6 6-6"/>
+              </svg>
+            </button>
+            {#if wordExpanded}
+              <div class="word-full scroll-styled" transition:slide={{ duration: motionMs(220), easing: cubicOut }}>
+                {rawWord}
+              </div>
+            {/if}
+          </dd>
+        {/if}
+      </div>
+      <div>
+        <dt>Words per dictation</dt>
+        <dd><AnimatedNumber value={totals.avg_words_per_transcription} /></dd>
+      </div>
+      <div>
+        <dt>Cleanup effect</dt>
+        <dd>
+          {#if trimPct === null}
+            —
+          {:else if trimPct < 0}
+            trimmed <AnimatedNumber value={Math.abs(trimPct)} format={(n) => `${n.toFixed(1)}%`} />
+          {:else}
+            grew <AnimatedNumber value={trimPct} format={(n) => `${n.toFixed(1)}%`} />
+          {/if}
+        </dd>
+      </div>
+      <div>
+        <dt>Dictations</dt>
+        <dd><AnimatedNumber value={totals.total_transcriptions} /></dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
+<style>
+  .card {
+    background: var(--bg-elev);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 15px 18px 16px;
+    min-width: 0;
+  }
+
+  .card-head { margin-bottom: 14px; }
+
+  .card-h {
+    font-family: var(--serif);
+    font-size: 17px;
+    font-weight: 500;
+    margin: 0;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+
+  .card-sub {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+  }
+
+  .split {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: start;
+  }
+
+  .word-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+  .word-list li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .word-bar {
+    display: flex;
+    align-items: center;
+    height: 24px;
+    padding: 0 9px;
+    border-radius: 5px;
+    background: color-mix(in srgb, var(--accent) 30%, transparent);
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .word {
+    font-size: 11.5px;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .word-count {
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .figures {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px 18px;
+  }
+  .figures div { min-width: 0; }
+  .figures dt {
+    font-size: 10.5px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    margin-bottom: 4px;
+  }
+  .figures dd {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--ink);
+    line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .dd-word { font-size: 15px; }
+
+  .longest-word-field { overflow: hidden; }
+
+  .word-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+    color: var(--ink);
+    text-align: left;
+  }
+  .word-toggle-text {
+    min-width: 0;
+    flex: 1;
+    font-family: var(--serif);
+    font-size: 15px;
+    font-weight: 500;
+    color: inherit;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-bottom: 1px dashed var(--line-strong);
+    transition: color var(--ui-duration-fast) var(--ui-ease-out), border-color var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .word-toggle:hover .word-toggle-text {
+    color: var(--accent-ink);
+    border-color: var(--accent-ink);
+  }
+  .word-chevron {
+    flex: 0 0 auto;
+    color: var(--ink-mute);
+    transition: transform var(--ui-duration-base) var(--ui-ease-out);
+  }
+  .word-toggle.open .word-chevron { transform: rotate(180deg); }
+
+  .word-full {
+    margin-top: 8px;
+    padding-right: 6px;
+    max-height: 130px;
+    overflow-y: auto;
+    font-family: var(--serif);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ink);
+    line-height: 1.45;
+    word-break: break-word;
+  }
+
+  .foot {
+    margin: 0;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+  }
+
+  @media (max-width: 860px) {
+    .split { grid-template-columns: 1fr; gap: 20px; }
+  }
+</style>

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -50,7 +50,16 @@ export function niceCeiling(max: number): number {
   // IEEE-754 rounding can nudge an exact boundary (0.2/0.1) just past it, so
   // compare with a small tolerance instead of raw <=.
   const normalized = max / magnitude;
-  const step = normalized <= 1 + 1e-9 ? 1 : normalized <= 2 + 1e-9 ? 2 : normalized <= 5 + 1e-9 ? 5 : 10;
+  let step: number;
+  if (normalized <= 1 + 1e-9) {
+    step = 1;
+  } else if (normalized <= 2 + 1e-9) {
+    step = 2;
+  } else if (normalized <= 5 + 1e-9) {
+    step = 5;
+  } else {
+    step = 10;
+  }
   return step * magnitude;
 }
 

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -44,7 +44,7 @@ export function fmtDuration(ms: number): string {
 
 /** null when there is no previous window to compare against. */
 export function pctDelta(current: number, previous: number): number | null {
-  if (previous <= 0) return null;
+  if (!Number.isFinite(previous) || previous <= 0) return null;
   return ((current - previous) / previous) * 100;
 }
 
@@ -75,7 +75,18 @@ export function niceCeiling(max: number): number {
 /** Parse a local "YYYY-MM-DD" without the UTC shift `new Date(str)` would apply. */
 export function parseLocalDay(day: string): Date {
   const [y, m, d] = day.split('-').map(Number);
-  return new Date(y, (m ?? 1) - 1, d ?? 1);
+  // Guard malformed/empty strings: `new Date(0, 0, 1)` silently becomes the
+  // year 1900 rather than throwing, so the callers' try/catch fallback would
+  // never fire. Reject with an Invalid Date so `toLocaleDateString` throws
+  // and `fmtDay`/`fmtDayLong` fall back to the raw string.
+  if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d) || y < 1) {
+    return new Date(NaN);
+  }
+  const date = new Date(y, m - 1, d);
+  // Reject invalid calendar dates (e.g. month 13, day 32) that JS normalizes.
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d
+    ? date
+    : new Date(NaN);
 }
 
 export function fmtDay(day: string): string {

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -47,7 +47,7 @@ export function fmtDuration(ms: number): string {
 
 /** null when there is no previous window to compare against. */
 export function pctDelta(current: number, previous: number): number | null {
-  if (!Number.isFinite(previous) || previous <= 0) return null;
+  if (!Number.isFinite(current) || !Number.isFinite(previous) || previous <= 0) return null;
   return ((current - previous) / previous) * 100;
 }
 

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -33,6 +33,9 @@ export function fmtUsd(n: number | null): string {
 
 /** "3h 12m" / "12m 04s" / "48s" */
 export function fmtDuration(ms: number): string {
+  // Guard non-finite/negative inputs — Math.floor of a negative would
+  // produce malformed strings like "-5s".
+  if (!Number.isFinite(ms) || ms < 0) return '0s';
   const totalSeconds = Math.round(ms / 1000);
   const h = Math.floor(totalSeconds / 3600);
   const m = Math.floor((totalSeconds % 3600) / 60);
@@ -54,7 +57,7 @@ export function bookEquivalent(words: number): number {
 
 /** Round a max value up to a readable axis ceiling (1/2/5 × 10^n). */
 export function niceCeiling(max: number): number {
-  if (max <= 0) return 1;
+  if (!Number.isFinite(max) || max <= 0) return 1;
   const magnitude = 10 ** Math.floor(Math.log10(max));
   // IEEE-754 rounding can nudge an exact boundary (0.2/0.1) just past it, so
   // compare with a small tolerance instead of raw <=.

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -1,0 +1,105 @@
+/** Average words in a published novel — the unit behind "you've written N books". */
+const WORDS_PER_BOOK = 80_000;
+
+export function fmtNumber(n: number): string {
+  return Math.round(n).toLocaleString();
+}
+
+/** Compact form for hero tiles: 1.2k, 3.4M. Exact below 1000. */
+export function fmtCompact(n: number): { value: string; suffix: string } {
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return { value: (n / 1e6).toFixed(1), suffix: 'M' };
+  if (abs >= 1000) return { value: (n / 1000).toFixed(1), suffix: 'k' };
+  return { value: String(Math.round(n)), suffix: '' };
+}
+
+export function fmtUsd(n: number | null): string {
+  if (n === null) return '—';
+  if (n === 0) return '$0.00';
+  if (n < 0.01) return '<$0.01';
+  return `$${n.toFixed(2)}`;
+}
+
+/** "3h 12m" / "12m 04s" / "48s" */
+export function fmtDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}
+
+/** null when there is no previous window to compare against. */
+export function pctDelta(current: number, previous: number): number | null {
+  if (previous <= 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+export function bookEquivalent(words: number): number {
+  return words / WORDS_PER_BOOK;
+}
+
+/** Round a max value up to a readable axis ceiling (1/2/5 × 10^n). */
+export function niceCeiling(max: number): number {
+  if (max <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(max));
+  const normalized = max / magnitude;
+  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return step * magnitude;
+}
+
+/** Parse a local "YYYY-MM-DD" without the UTC shift `new Date(str)` would apply. */
+export function parseLocalDay(day: string): Date {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+export function fmtDay(day: string): string {
+  try {
+    return parseLocalDay(day).toLocaleDateString([], { month: 'short', day: 'numeric' });
+  } catch {
+    return day;
+  }
+}
+
+export function fmtDayLong(day: string): string {
+  try {
+    return parseLocalDay(day).toLocaleDateString([], {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return day;
+  }
+}
+
+/** 0 → "12 AM", 13 → "1 PM" */
+export function fmtHour(hour: number): string {
+  const suffix = hour < 12 ? 'AM' : 'PM';
+  const h = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h} ${suffix}`;
+}
+
+/**
+ * Four accent-derived intensity steps. The accent is user-swappable, so every
+ * chart colour is mixed from var(--accent) rather than hardcoded.
+ */
+export function accentStep(level: 0 | 1 | 2 | 3 | 4): string {
+  if (level === 0) return 'var(--control-hover)';
+  const pct = [0, 22, 45, 70, 100][level];
+  return `color-mix(in srgb, var(--accent) ${pct}%, var(--paper-2))`;
+}
+
+/** Bucket a value into 0–4 against the series max, where 0 means "no activity". */
+export function intensityLevel(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
+  if (value <= 0) return 0;
+  if (max <= 0) return 1;
+  const ratio = value / max;
+  if (ratio > 0.66) return 4;
+  if (ratio > 0.33) return 3;
+  if (ratio > 0.12) return 2;
+  return 1;
+}

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -8,8 +8,11 @@ export function fmtNumber(n: number): string {
 /** Compact form for hero tiles: 1.2k, 3.4M. Exact below 1000. */
 export function fmtCompact(n: number): { value: string; suffix: string } {
   const abs = Math.abs(n);
-  if (abs >= 1e6) return { value: (n / 1e6).toFixed(1), suffix: 'M' };
-  if (abs >= 1000) return { value: (n / 1000).toFixed(1), suffix: 'k' };
+  // Each tier's threshold accounts for the rounding of the tier below it:
+  // 999.6 renders as "1.0k" (not "1000") and 999_950 as "1.0M" (not
+  // "1000.0k").
+  if (Math.round(abs / 1000) >= 1000) return { value: (n / 1e6).toFixed(1), suffix: 'M' };
+  if (Math.round(abs) >= 1000) return { value: (n / 1000).toFixed(1), suffix: 'k' };
   return { value: String(Math.round(n)), suffix: '' };
 }
 
@@ -19,6 +22,12 @@ export function fmtUsd(n: number | null): string {
   // Only small *positive* amounts render as "<$0.01" — a negative amount
   // must format normally instead of being swallowed by the tiny-value branch.
   if (n > 0 && n < 0.01) return '<$0.01';
+  if (n < 0) {
+    // Keep the minus before the dollar sign, and let a value that rounds to
+    // zero (e.g. -0.004) render as plain $0.00 rather than "$-0.00".
+    const abs = n.toFixed(2).replace('-', '');
+    return abs === '0.00' ? '$0.00' : `-$${abs}`;
+  }
   return `$${n.toFixed(2)}`;
 }
 

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -16,7 +16,9 @@ export function fmtCompact(n: number): { value: string; suffix: string } {
 export function fmtUsd(n: number | null): string {
   if (n === null) return '—';
   if (n === 0) return '$0.00';
-  if (n < 0.01) return '<$0.01';
+  // Only small *positive* amounts render as "<$0.01" — a negative amount
+  // must format normally instead of being swallowed by the tiny-value branch.
+  if (n > 0 && n < 0.01) return '<$0.01';
   return `$${n.toFixed(2)}`;
 }
 
@@ -45,8 +47,10 @@ export function bookEquivalent(words: number): number {
 export function niceCeiling(max: number): number {
   if (max <= 0) return 1;
   const magnitude = 10 ** Math.floor(Math.log10(max));
+  // IEEE-754 rounding can nudge an exact boundary (0.2/0.1) just past it, so
+  // compare with a small tolerance instead of raw <=.
   const normalized = max / magnitude;
-  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  const step = normalized <= 1 + 1e-9 ? 1 : normalized <= 2 + 1e-9 ? 2 : normalized <= 5 + 1e-9 ? 5 : 10;
   return step * magnitude;
 }
 

--- a/src/lib/views/insights/pricing.ts
+++ b/src/lib/views/insights/pricing.ts
@@ -1,0 +1,93 @@
+import type { InsightsProviderUsage } from './types';
+
+/*
+ * ponytail: static price table. Published list rates, checked against provider
+ * pricing pages; they drift. Upgrade path is a rates file shipped with the app
+ * (or fetched from api.verenu.com alongside provider-status) if drift ever
+ * matters — not a runtime OpenRouter lookup, which doesn't price audio models.
+ *
+ * Everything here is an ESTIMATE and must be labelled as such in the UI.
+ * Verenu never bills anyone; users pay their provider directly.
+ */
+
+type Rate =
+  | { kind: 'audio'; usd_per_hour: number }
+  | { kind: 'token'; usd_per_m_in: number; usd_per_m_out: number };
+
+export const PRICING: Record<string, Rate> = {
+  // Transcription — billed on audio duration
+  'whisper-large-v3-turbo': { kind: 'audio', usd_per_hour: 0.04 },
+  'whisper-large-v3': { kind: 'audio', usd_per_hour: 0.111 },
+  'distil-whisper-large-v3-en': { kind: 'audio', usd_per_hour: 0.02 },
+  'whisper-1': { kind: 'audio', usd_per_hour: 0.36 },
+  'gpt-4o-transcribe': { kind: 'audio', usd_per_hour: 0.36 },
+  'gpt-4o-mini-transcribe': { kind: 'audio', usd_per_hour: 0.18 },
+
+  // Cleanup — billed on tokens
+  'llama-3.3-70b-versatile': { kind: 'token', usd_per_m_in: 0.59, usd_per_m_out: 0.79 },
+  'gpt-4o-mini': { kind: 'token', usd_per_m_in: 0.15, usd_per_m_out: 0.6 },
+  'gemini-3.5-flash': { kind: 'token', usd_per_m_in: 0.3, usd_per_m_out: 2.5 },
+};
+
+/*
+ * Gemini's transcription path sends audio inline rather than as text tokens,
+ * so the token-priced `gemini-3.5-flash` entry above doesn't apply there —
+ * this task-scoped override kicks in instead. Keyed as "model#task".
+ */
+const TASK_OVERRIDES: Record<string, Rate> = {
+  'gemini-3.5-flash#transcription': { kind: 'audio', usd_per_hour: 1.0 },
+};
+
+/** Rough tokenizer stand-in. Good to ~±15% for English prose, which is all an estimate needs. */
+const CHARS_PER_TOKEN = 4;
+
+/** Backend model ids may carry a provider prefix ("groq/whisper-large-v3-turbo",
+ * "models/gemini-3.5-flash") or inconsistent casing — normalize before lookup. */
+function normalizeModelId(model: string): string {
+  return model.trim().toLowerCase().replace(/^.*\//, '');
+}
+
+function lookupRate(usage: InsightsProviderUsage): Rate | null {
+  const key = normalizeModelId(usage.model);
+  return TASK_OVERRIDES[`${key}#${usage.task}`] ?? PRICING[key] ?? null;
+}
+
+/** Cost in USD for one model's usage, or null when the model has no known rate. */
+export function modelCost(usage: InsightsProviderUsage): number | null {
+  const rate = lookupRate(usage);
+  if (!rate) return null;
+  if (rate.kind === 'audio') {
+    return (usage.audio_ms / 3_600_000) * rate.usd_per_hour;
+  }
+  const inTokens = usage.input_chars / CHARS_PER_TOKEN;
+  const outTokens = usage.output_chars / CHARS_PER_TOKEN;
+  return (inTokens / 1e6) * rate.usd_per_m_in + (outTokens / 1e6) * rate.usd_per_m_out;
+}
+
+export interface CostRow extends InsightsProviderUsage {
+  cost: number | null;
+  /** Fraction of the priced total, 0–1. Zero for unpriced models. */
+  share: number;
+}
+
+export interface CostSummary {
+  rows: CostRow[];
+  total: number;
+  /** True when at least one model had no rate, so `total` understates reality. */
+  hasUnpriced: boolean;
+}
+
+export function estimateCost(providers: InsightsProviderUsage[]): CostSummary {
+  const priced = providers.map((usage) => ({ usage, cost: modelCost(usage) }));
+  const total = priced.reduce((sum, p) => sum + (p.cost ?? 0), 0);
+
+  const rows: CostRow[] = priced
+    .map(({ usage, cost }) => ({
+      ...usage,
+      cost,
+      share: cost !== null && total > 0 ? cost / total : 0,
+    }))
+    .sort((a, b) => (b.cost ?? -1) - (a.cost ?? -1));
+
+  return { rows, total, hasUnpriced: priced.some((p) => p.cost === null) };
+}

--- a/src/lib/views/insights/pricing.ts
+++ b/src/lib/views/insights/pricing.ts
@@ -43,20 +43,20 @@ const CHARS_PER_TOKEN = 4;
 
 /** Backend model ids may carry a provider prefix ("groq/whisper-large-v3-turbo",
  * "models/gemini-3.5-flash") or inconsistent casing — normalize before lookup. */
-function normalizeModelId(model: string): string {
-  return model.trim().toLowerCase().replace(/^.*\//, '');
+function normalizeModelId(model: string | null | undefined): string {
+  return String(model ?? '').trim().toLowerCase().replace(/^.*\//, '');
 }
 
 function lookupRate(usage: InsightsProviderUsage): Rate | null {
   const key = normalizeModelId(usage.model);
   // The backend writes tasks in lowercase, but normalize defensively so a
   // mixed-case or whitespace-padded value still matches the override keys.
-  const task = usage.task.trim().toLowerCase();
+  const task = String(usage.task ?? '').trim().toLowerCase();
   return TASK_OVERRIDES[`${key}#${task}`] ?? PRICING[key] ?? null;
 }
 
 /** Cost in USD for one model's usage, or null when the model has no known rate. */
-export function modelCost(usage: InsightsProviderUsage): number | null {
+function modelCost(usage: InsightsProviderUsage): number | null {
   const rate = lookupRate(usage);
   if (!rate) return null;
   if (rate.kind === 'audio') {

--- a/src/lib/views/insights/pricing.ts
+++ b/src/lib/views/insights/pricing.ts
@@ -49,7 +49,10 @@ function normalizeModelId(model: string): string {
 
 function lookupRate(usage: InsightsProviderUsage): Rate | null {
   const key = normalizeModelId(usage.model);
-  return TASK_OVERRIDES[`${key}#${usage.task}`] ?? PRICING[key] ?? null;
+  // The backend writes tasks in lowercase, but normalize defensively so a
+  // mixed-case or whitespace-padded value still matches the override keys.
+  const task = usage.task.trim().toLowerCase();
+  return TASK_OVERRIDES[`${key}#${task}`] ?? PRICING[key] ?? null;
 }
 
 /** Cost in USD for one model's usage, or null when the model has no known rate. */

--- a/src/lib/views/insights/types.ts
+++ b/src/lib/views/insights/types.ts
@@ -39,7 +39,7 @@ export interface InsightsDay {
 
 export interface InsightsProviderUsage {
   model: string;
-  provider: 'groq' | 'openai' | 'google' | 'local';
+  provider: 'groq' | 'openai' | 'google' | 'assemblyai' | 'local';
   task: 'transcription' | 'cleanup';
   calls: number;
   audio_ms: number;

--- a/src/lib/views/insights/types.ts
+++ b/src/lib/views/insights/types.ts
@@ -69,6 +69,10 @@ export interface InsightsPayload {
   streak: InsightsStreak;
   /** One row per calendar day in range, zero days included, ascending. */
   daily: InsightsDay[];
+  /** Compact rolling year; the heatmap displays only the weeks that fit. */
+  streak_daily: InsightsDay[];
+  /** First locally recorded transcription date, used to distinguish pre-history from quiet days. */
+  history_started_on: string | null;
   /** Length 24 — words per hour-of-day, local time. */
   hourly: number[];
   providers: InsightsProviderUsage[];
@@ -98,6 +102,8 @@ export const EMPTY_INSIGHTS: InsightsPayload = {
     active_days: 0,
   },
   daily: [],
+  streak_daily: [],
+  history_started_on: null,
   hourly: new Array(24).fill(0),
   providers: [],
   cleanup: {

--- a/src/lib/views/insights/types.ts
+++ b/src/lib/views/insights/types.ts
@@ -1,0 +1,118 @@
+/*
+ * Contract for the `get_insights` command. The backend owns every number here;
+ * the Insights page does no aggregation of its own beyond formatting.
+ *
+ * Day bucketing is the backend's job and must use date(created_at, 'localtime')
+ * — created_at is stored UTC-naive (see query_stats in data/db/transcriptions.rs).
+ */
+
+export type InsightsRange = 7 | 30 | 90 | 0; // 0 = all time
+
+export interface InsightsTotals {
+  /** Lifetime, from the lifetime_stats table — never shrinks with retention pruning. */
+  total_words: number;
+  total_transcriptions: number;
+  total_speaking_ms: number;
+  avg_words_per_transcription: number;
+  avg_wpm: number;
+  best_wpm: number;
+  words_in_range: number;
+  /** Same-length window immediately before the range, for the delta pill. */
+  words_prev_range: number;
+}
+
+export interface InsightsStreak {
+  current_days: number;
+  longest_days: number;
+  longest_started_on: string | null; // "YYYY-MM-DD"
+  longest_ended_on: string | null;
+  longest_words: number;
+  active_days: number;
+}
+
+export interface InsightsDay {
+  day: string; // "YYYY-MM-DD", local
+  words: number;
+  transcriptions: number;
+  speaking_ms: number;
+}
+
+export interface InsightsProviderUsage {
+  model: string;
+  provider: 'groq' | 'openai' | 'google' | 'local';
+  task: 'transcription' | 'cleanup';
+  calls: number;
+  audio_ms: number;
+  input_chars: number;
+  output_chars: number;
+}
+
+export interface InsightsCleanup {
+  raw_words: number;
+  clean_words: number;
+  edits_applied: number;
+  dictionary_fixes: number;
+  auto_learned_terms: number;
+}
+
+export interface InsightsWords {
+  top: Array<{ word: string; count: number }>;
+  unique_words: number;
+  longest_word: string | null;
+  avg_word_length: number;
+}
+
+export interface InsightsPayload {
+  range_days: number;
+  generated_at: string; // "YYYY-MM-DD HH:MM:SS", UTC-naive like created_at
+  totals: InsightsTotals;
+  streak: InsightsStreak;
+  /** One row per calendar day in range, zero days included, ascending. */
+  daily: InsightsDay[];
+  /** Length 24 — words per hour-of-day, local time. */
+  hourly: number[];
+  providers: InsightsProviderUsage[];
+  cleanup: InsightsCleanup;
+  words: InsightsWords;
+}
+
+export const EMPTY_INSIGHTS: InsightsPayload = {
+  range_days: 30,
+  generated_at: '',
+  totals: {
+    total_words: 0,
+    total_transcriptions: 0,
+    total_speaking_ms: 0,
+    avg_words_per_transcription: 0,
+    avg_wpm: 0,
+    best_wpm: 0,
+    words_in_range: 0,
+    words_prev_range: 0,
+  },
+  streak: {
+    current_days: 0,
+    longest_days: 0,
+    longest_started_on: null,
+    longest_ended_on: null,
+    longest_words: 0,
+    active_days: 0,
+  },
+  daily: [],
+  hourly: new Array(24).fill(0),
+  providers: [],
+  cleanup: {
+    raw_words: 0,
+    clean_words: 0,
+    edits_applied: 0,
+    dictionary_fixes: 0,
+    auto_learned_terms: 0,
+  },
+  words: { top: [], unique_words: 0, longest_word: null, avg_word_length: 0 },
+};
+
+export const RANGE_OPTIONS: Array<{ value: InsightsRange; label: string }> = [
+  { value: 7, label: 'Last 7 days' },
+  { value: 30, label: 'Last 30 days' },
+  { value: 90, label: 'Last 90 days' },
+  { value: 0, label: 'All time' },
+];

--- a/src/lib/views/snippets/SnippetList.svelte
+++ b/src/lib/views/snippets/SnippetList.svelte
@@ -161,19 +161,6 @@
     max-width: 360px;
   }
 
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-
   @media (max-width: 720px) {
     .snip-row {
       grid-template-columns: 1fr;

--- a/src/lib/views/snippets/SnippetModal.svelte
+++ b/src/lib/views/snippets/SnippetModal.svelte
@@ -399,35 +399,4 @@
   }
   .instructions-input:focus { border-color: var(--arm-400); border-style: solid; }
 
-  .btn-ghost {
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-family: var(--sans);
-    color: var(--ink-soft);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .btn-ghost:hover { background: var(--control-hover); color: var(--ink-strong); }
-
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
 </style>

--- a/src/lib/views/snippets/SnippetToolbar.svelte
+++ b/src/lib/views/snippets/SnippetToolbar.svelte
@@ -186,25 +186,6 @@
   .sort-pill.active { color: var(--accent-ink); }
   .sort-pill.active:hover { background: transparent; }
 
-  .btn-primary {
-    background: var(--ink);
-    color: var(--amber-50);
-    border: 0;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 12.5px;
-    font-weight: 500;
-    font-family: var(--sans);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.15s;
-  }
-  .btn-primary:disabled { opacity: 0.4; cursor: default; }
-  .btn-primary:not(:disabled):hover { opacity: 0.82; }
-
   @media (max-width: 720px) {
     .search {
       flex-basis: 100%;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.svelte';
 import { invoke } from './lib/tauri';
 import './theme.css';
 import './app.css';
+import './ui.css';
 
 const app = mount(App, {
   target: document.getElementById('app') as HTMLElement,

--- a/src/ui.css
+++ b/src/ui.css
@@ -1,0 +1,214 @@
+/*
+ * Shared interactive-control primitives.
+ *
+ * Keep component-specific layout in its owning Svelte file. Visual treatment,
+ * state feedback, focus behavior, and motion belong here so one adjustment
+ * reaches every use of these primitives. See DESIGN.md for the public API.
+ */
+
+:root {
+  --ui-duration-fast: 150ms;
+  --ui-duration-base: 220ms;
+  --ui-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ui-focus-ring: 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+:where(button).btn-primary,
+:where(button).btn-ghost,
+:where(button).btn-danger {
+  align-items: center;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  gap: 6px;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 30px;
+  padding: 6px 14px;
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    border-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out),
+    opacity var(--ui-duration-fast) var(--ui-ease-out),
+    transform var(--ui-duration-fast) var(--ui-ease-out);
+  white-space: nowrap;
+}
+
+:where(button).btn-primary {
+  background: var(--ink);
+  border: 1px solid var(--ink);
+  color: var(--amber-50);
+  font-weight: 500;
+}
+
+:where(button).btn-primary:not(:disabled):hover {
+  background: var(--ink-strong);
+  border-color: var(--ink-strong);
+}
+
+:where(button).btn-ghost {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--ink-soft);
+}
+
+:where(button).btn-ghost:not(:disabled):hover {
+  background: var(--control-hover);
+  color: var(--ink-strong);
+}
+
+:where(button).btn-danger {
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-line);
+  color: var(--danger);
+  font-weight: 500;
+}
+
+:where(button).btn-danger:not(:disabled):hover {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: var(--on-accent);
+}
+
+:where(button).btn-compact {
+  border-radius: 6px;
+  font-size: 12px;
+  min-height: 28px;
+  padding: 5px 12px;
+}
+
+:where(button).btn-primary:disabled,
+:where(button).btn-ghost:disabled,
+:where(button).btn-danger:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+:where(button).btn-primary:focus-visible,
+:where(button).btn-ghost:focus-visible,
+:where(button).btn-danger:focus-visible,
+.ui-dropdown-trigger:focus-visible,
+.ui-dropdown-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: var(--ui-focus-ring);
+}
+
+/* Composite dropdown anatomy. Behaviour remains local when option content,
+   keyboard navigation, or selection side effects differ by feature. */
+.ui-dropdown {
+  position: relative;
+  flex-shrink: 0;
+}
+
+:where(button).ui-dropdown-trigger {
+  align-items: center;
+  background: var(--ui-dropdown-trigger-bg, var(--paper-2));
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  color: var(--ink);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  gap: 8px;
+  min-height: var(--ui-dropdown-trigger-height, 32px);
+  padding: 0 12px;
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    border-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out);
+}
+
+:where(button).ui-dropdown-trigger:hover,
+:where(button).ui-dropdown-trigger[aria-expanded='true'] {
+  background: var(--ui-dropdown-trigger-hover-bg, var(--control-hover));
+  border-color: var(--line-strong);
+}
+
+.ui-dropdown-trigger svg {
+  flex: 0 0 auto;
+  transition: transform var(--ui-duration-fast) var(--ui-ease-out);
+}
+
+.ui-dropdown-trigger[aria-expanded='true'] svg {
+  transform: rotate(180deg);
+}
+
+.ui-dropdown-menu {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-popover);
+  max-height: var(--ui-dropdown-menu-max-height, 240px);
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+}
+
+:where(button).ui-dropdown-option {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-strong);
+  cursor: pointer;
+  display: block;
+  font-family: var(--sans);
+  font-size: 12px;
+  overflow: hidden;
+  padding: 8px 12px;
+  text-align: left;
+  text-overflow: ellipsis;
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out);
+  white-space: nowrap;
+  width: 100%;
+}
+
+.ui-dropdown-option:last-child {
+  border-bottom: 0;
+}
+
+:where(button).ui-dropdown-option:hover {
+  background: var(--control-hover);
+}
+
+:where(button).ui-dropdown-option.active,
+:where(button).ui-dropdown-option.is-active {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  font-weight: 500;
+}
+
+.ui-dropdown-menu--padded {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+}
+
+.ui-dropdown-menu--padded .ui-dropdown-option {
+  border-bottom: 0;
+  border-radius: var(--r-sm);
+  color: var(--ink-soft);
+  font-size: 12.5px;
+  padding: 6px 10px;
+}
+
+.ui-dropdown-menu--padded .ui-dropdown-option:hover {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ui-duration-fast: 80ms;
+    --ui-duration-base: 120ms;
+  }
+}


### PR DESCRIPTION
Adds the Insights analytics page: usage analytics, cost breakdown, streak heatmap, and word stats.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789555433&installation_model_id=432577&pr_number=256&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F256&signature=7e0e19236ed477bc46578e2e83e0b9a1574384fe6b9e9c1ee1d14ff627494acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->