### PR TITLE
UI/UX coherence: keyboard navigation and focus

### DIFF
--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -371,3 +371,42 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handsfree_stop_guard_consumes_the_followup_click_but_not_escape() {
+        let now = Instant::now();
+        let mut guard = HandsfreeStopGuard::default();
+        guard.arm(now);
+
+        for event in [
+            HotkeyEvent::Press,
+            HotkeyEvent::Release,
+            HotkeyEvent::HandlessToggle,
+            HotkeyEvent::Cancel,
+        ] {
+            assert!(guard.suppresses(event, now + Duration::from_millis(1)));
+        }
+        assert!(!guard.suppresses(HotkeyEvent::EscapeCancel, now + Duration::from_millis(1)));
+        assert!(!guard.suppresses(HotkeyEvent::CopyLast, now + Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn handsfree_stop_guard_expires_after_the_double_tap_window() {
+        let now = Instant::now();
+        let mut guard = HandsfreeStopGuard::default();
+        guard.arm(now);
+
+        assert!(!guard.suppresses(
+            HotkeyEvent::Press,
+            now + HANDSFREE_STOP_GUARD + Duration::from_millis(1),
+        ));
+        assert!(!guard.suppresses(
+            HotkeyEvent::Press,
+            now + HANDSFREE_STOP_GUARD + Duration::from_millis(2),
+        ));
+    }
+}

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -1,4 +1,5 @@
 use std::sync::MutexGuard;
+use std::time::{Duration, Instant};
 
 use crate::core::window_geometry::WindowTarget;
 use crate::pipeline::{self, hide_pill, start_recording_session, AppState, SharedState};
@@ -15,19 +16,54 @@ fn lock_app_state(state: &SharedState) -> Option<MutexGuard<'_, AppState>> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum HotkeyEvent {
+    Press,
+    Release,
+    HandlessToggle,
+    Cancel,
+    EscapeCancel,
+    CopyLast,
+}
+
+/// A hands-free stop is itself a quick tap, so the next click can still be
+/// part of the same physical double-click. Without this fence, resetting the
+/// hook's tap state makes that second click look like a fresh Press, which can
+/// interrupt the transcription that the first click just started.
+const HANDSFREE_STOP_GUARD: Duration = Duration::from_millis(350);
+
+#[derive(Default)]
+struct HandsfreeStopGuard {
+    until: Option<Instant>,
+}
+
+impl HandsfreeStopGuard {
+    fn arm(&mut self, now: Instant) {
+        self.until = Some(now + HANDSFREE_STOP_GUARD);
+    }
+
+    fn suppresses(&mut self, event: HotkeyEvent, now: Instant) -> bool {
+        let Some(until) = self.until else {
+            return false;
+        };
+        if now >= until {
+            self.until = None;
+            return false;
+        }
+        matches!(
+            event,
+            HotkeyEvent::Press
+                | HotkeyEvent::Release
+                | HotkeyEvent::HandlessToggle
+                | HotkeyEvent::Cancel
+        )
+    }
+}
+
 pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
     // The WH_KEYBOARD_LL hook callback must return within Windows' hook timeout
     // (~300ms) or the hook is silently removed. All real work happens in a Tokio
     // task below; callbacks only send a lightweight channel message.
-    enum HotkeyEvent {
-        Press,
-        Release,
-        HandlessToggle,
-        Cancel,
-        EscapeCancel,
-        CopyLast,
-    }
-
     let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::unbounded_channel::<HotkeyEvent>();
     let tx_press = hotkey_tx.clone();
     let tx_handless = hotkey_tx.clone();
@@ -78,7 +114,12 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
     let state_hk = shared;
 
     tauri::async_runtime::spawn(async move {
+        let mut handsfree_stop_guard = HandsfreeStopGuard::default();
         while let Some(event) = hotkey_rx.recv().await {
+            if handsfree_stop_guard.suppresses(event, Instant::now()) {
+                log::debug!("hotkey: ignored follow-up input after hands-free stop");
+                continue;
+            }
             match event {
                 HotkeyEvent::Press => {
                     pipeline::clear_handless_hold_marker(&state_hk);
@@ -204,6 +245,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // Quick tap while in handsfree = stop. Clear chord state
                         // immediately so the still-open double-tap window can't
                         // re-trigger a fresh handsfree session.
+                        handsfree_stop_guard.arm(Instant::now());
                         crate::core::hotkey::set_handless_active(false);
                         crate::core::hotkey::reset_chord_state();
                         tauri::async_runtime::spawn(pipeline::run_pipeline(

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -66,6 +66,21 @@
     });
   });
 
+  // The wizard is the first thing in the app and unmounts when it finishes;
+  // without this, focus drops to <body> and a keyboard user lands nowhere.
+  // Land on the first rail entry (Home) only on a real completion transition
+  // (wizard → app), so a normal app start never gets an unexpected focus ring.
+  let prevSetupComplete = appStore.setupComplete;
+  $effect(() => {
+    const complete = appStore.setupComplete;
+    if (!prevSetupComplete && complete) {
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>('.sidebar .nav-item')?.focus();
+      });
+    }
+    prevSetupComplete = complete;
+  });
+
   async function pingConnectivity() {
     try {
       const online = await invoke<boolean>('check_connectivity');

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -4,15 +4,53 @@
   let {
     open = $bindable(false),
     closeSelector = '',
+    restoreFocus = true,
+    optionSelector = '.ui-dropdown-option',
     children,
-  }: { open: boolean; closeSelector?: string; children?: import('svelte').Snippet } = $props();
+  }: {
+    open: boolean;
+    closeSelector?: string;
+    restoreFocus?: boolean;
+    optionSelector?: string;
+    children?: import('svelte').Snippet;
+  } = $props();
+
+  let trigger: HTMLElement | null = null;
+  let root: HTMLElement | null = null;
+  let wasOpen = false;
 
   $effect(() => {
+    if (open) {
+      // The trigger is whatever has focus when the menu opens — the button that
+      // was clicked or keyboard-activated. Its .ui-dropdown ancestor scopes all
+      // menu interactions so nested menus never cross-talk. This is
+      // gesture-dependent: a future consumer that opens the menu programmatically
+      // (no user gesture) would capture null and lose restore/arrow-nav.
+      trigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      root = trigger ? trigger.closest(closeSelector || '.ui-dropdown') : null;
+    }
+
+    if (wasOpen && !open) {
+      // Close happened. If focus fell out of the page (option unmounted) or is
+      // still inside the menu shell, hand it back to the trigger. If another
+      // control claimed focus (outside click, a modal that just opened), leave
+      // it alone — racing a modal's trap would yank focus out of the dialog.
+      requestAnimationFrame(() => {
+        if (!restoreFocus || !trigger?.isConnected) return;
+        const active = document.activeElement;
+        const claimed = active instanceof HTMLElement && active !== document.body && !(root?.contains(active));
+        if (!claimed) trigger.focus();
+      });
+    }
+    wasOpen = open;
+
     if (!open) return;
 
     let disposed = false;
     tick().then(() => {
-      if (!disposed) window.addEventListener('click', handleOutsideClick);
+      if (disposed) return;
+      window.addEventListener('click', handleOutsideClick);
+      focusOptionOnOpen();
     });
     window.addEventListener('keydown', handleWindowKeydown);
 
@@ -22,6 +60,24 @@
       window.removeEventListener('keydown', handleWindowKeydown);
     };
   });
+
+  function focusOptionOnOpen() {
+    if (!root) return;
+    const options = Array.from(root.querySelectorAll<HTMLElement>(optionSelector));
+    if (options.length === 0) return;
+    const selected = options.find((option) => option.getAttribute('aria-selected') === 'true');
+    const target = selected ?? options[0];
+    target.focus();
+    setOptionTabindexes(options, target);
+  }
+
+  // The menu is an overlay, so its options are not in the page tab order —
+  // only the option that currently has focus keeps a tabindex, so a long menu
+  // (e.g. the 57-language list) can't turn Tab into a maze. Arrow keys still
+  // rove through every option.
+  function setOptionTabindexes(options: HTMLElement[], active: HTMLElement | null) {
+    for (const option of options) option.tabIndex = option === active ? 0 : -1;
+  }
 
   function handleOutsideClick(e: MouseEvent) {
     // closest() only exists on Element; a click target can be a Text node or
@@ -35,7 +91,51 @@
   }
 
   function handleWindowKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') open = false;
+    if (e.key === 'Escape') {
+      if (!open) return;
+      // Close the menu before page-level Escape handlers run. Note that
+      // stopPropagation on a window listener does not stop other window
+      // listeners (e.g. Settings' close-on-Escape) — those are already
+      // protected by their own `[aria-expanded="true"]` guard, which still
+      // reads true during this dispatch.
+      e.stopPropagation();
+      open = false;
+      return;
+    }
+
+    if (!open || !root) return;
+    const target = e.target instanceof Element ? e.target : null;
+    const option = target?.closest<HTMLElement>(optionSelector);
+    if (!option) return;
+    const menuRoot = option.closest(closeSelector || '.ui-dropdown');
+    if (menuRoot !== root) return;
+
+    const options = Array.from(root.querySelectorAll<HTMLElement>(optionSelector));
+    const index = options.indexOf(option);
+    if (index === -1) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setOptionTabindexes(options, options[(index + 1) % options.length]);
+        options[(index + 1) % options.length].focus();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setOptionTabindexes(options, options[(index - 1 + options.length) % options.length]);
+        options[(index - 1 + options.length) % options.length].focus();
+        break;
+      case 'Home':
+        e.preventDefault();
+        setOptionTabindexes(options, options[0]);
+        options[0].focus();
+        break;
+      case 'End':
+        e.preventDefault();
+        setOptionTabindexes(options, options[options.length - 1]);
+        options[options.length - 1].focus();
+        break;
+    }
   }
 </script>
 

--- a/src/lib/components/MacPermissions.svelte
+++ b/src/lib/components/MacPermissions.svelte
@@ -352,7 +352,11 @@
 {/snippet}
 
 {#if isMac}
-  <div class="mac-permissions">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- Escape collapses the open diagnostics panel no matter which control
+       inside it has focus (setup wizard, settings), one layer at a time.
+       preventDefault marks the key as handled for Settings' window guard. -->
+  <div class="mac-permissions" onkeydown={(event) => { if (event.key === 'Escape' && showDiagnostics) { event.preventDefault(); showDiagnostics = false; } }}>
   {#if variant === 'setup' && allGranted}
     <div class="permission-success" in:fly={{ y: -8, duration: motionMs(220), easing: expoOut }}>
       <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M3 8l3.5 3.5L13 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/lib/components/appMappings/AppMappingsAddForm.svelte
+++ b/src/lib/components/appMappings/AppMappingsAddForm.svelte
@@ -13,6 +13,7 @@
   } from '../../appMappings';
   import { customExeFromSearch, matchesAppSearch } from './helpers';
   import { focusListboxOption, handleListboxOptionKeydown } from './listbox';
+  import Dropdown from '../Dropdown.svelte';
 
   let {
     installedApps,
@@ -42,11 +43,10 @@
   let addProfile = $state('casual');
   let addCleanupIntensity = $state('');
   let appSearch = $state('');
+  let appSearchInput = $state<HTMLInputElement | null>(null);
   let appPickerOpen = $state(false);
   let profileDropdownOpen = $state(false);
   let cleanupDropdownOpen = $state(false);
-  let profileDropdownButton = $state<HTMLButtonElement | null>(null);
-  let cleanupDropdownButton = $state<HTMLButtonElement | null>(null);
 
   const pendingExe = $derived(addExe || (appSearch.trim() ? customExeFromSearch(appSearch) : ''));
   const pendingName = $derived(cleanAppName(addName || appSearch || pendingExe));
@@ -68,21 +68,37 @@
     cleanupDropdownOpen = false;
   }
 
-  function pickApp(app: InstalledApp) {
+  function pickApp(app: InstalledApp, event?: MouseEvent) {
     addExe = app.exe;
     addName = cleanAppName(app.name || app.exe);
     appSearch = addName;
     appPickerOpen = false;
+    // Keyboard-activated option clicks carry detail 0; return focus to the
+    // search box so the flow continues there (typing more or pressing Enter
+    // to add) instead of stranding focus on a now-hidden menu.
+    if (event?.detail === 0) appSearchInput?.focus();
   }
 
-  async function openProfileDropdown(preferLast = false) {
+  function openProfileDropdown(preferLast = false) {
     profileDropdownOpen = true;
-    await focusListboxOption(ADD_PROFILE_MENU_ID, preferLast);
+    if (preferLast) {
+      // The shared Dropdown focuses the selected-or-first option on open;
+      // ArrowUp opens to the last option instead, so move focus after the
+      // open effect has landed.
+      requestAnimationFrame(() => focusListboxOption(ADD_PROFILE_MENU_ID, true));
+    }
   }
 
-  async function openCleanupDropdown(preferLast = false) {
+  function openCleanupDropdown(preferLast = false) {
     cleanupDropdownOpen = true;
-    await focusListboxOption(ADD_CLEANUP_MENU_ID, preferLast);
+    if (preferLast) {
+      requestAnimationFrame(() => focusListboxOption(ADD_CLEANUP_MENU_ID, true));
+    }
+  }
+
+  async function openAppPicker(preferLast = false) {
+    appPickerOpen = true;
+    await focusListboxOption(APP_PICKER_MENU_ID, preferLast);
   }
 
   async function submit() {
@@ -108,63 +124,37 @@
     }
   }
 
-  function closeProfileDropdown(event: MouseEvent | PointerEvent) {
-    const target = event.target;
-    if (target instanceof Element && !target.closest('.profile-drop-wrap')) {
-      profileDropdownOpen = false;
-    }
-  }
-
-  function closeCleanupDropdown(event: MouseEvent | PointerEvent) {
-    const target = event.target;
-    if (target instanceof Element && !target.closest('.cleanup-drop-wrap')) {
-      cleanupDropdownOpen = false;
-    }
-  }
-
   function handleProfileButtonKeydown(event: KeyboardEvent) {
     if ((event.key === 'Enter' || event.key === ' ') && !profileDropdownOpen) {
       event.preventDefault();
-      void openProfileDropdown();
+      openProfileDropdown();
       return;
     }
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      void openProfileDropdown();
+      openProfileDropdown();
       return;
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
-      void openProfileDropdown(true);
-      return;
-    }
-    if (event.key === 'Escape' && profileDropdownOpen) {
-      profileDropdownOpen = false;
-      profileDropdownButton?.focus();
-      event.stopPropagation();
+      openProfileDropdown(true);
     }
   }
 
   function handleCleanupButtonKeydown(event: KeyboardEvent) {
     if ((event.key === 'Enter' || event.key === ' ') && !cleanupDropdownOpen) {
       event.preventDefault();
-      void openCleanupDropdown();
+      openCleanupDropdown();
       return;
     }
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      void openCleanupDropdown();
+      openCleanupDropdown();
       return;
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
-      void openCleanupDropdown(true);
-      return;
-    }
-    if (event.key === 'Escape' && cleanupDropdownOpen) {
-      cleanupDropdownOpen = false;
-      cleanupDropdownButton?.focus();
-      event.stopPropagation();
+      openCleanupDropdown(true);
     }
   }
 
@@ -178,32 +168,6 @@
     return () => {
       window.clearTimeout(timeout);
       window.removeEventListener('pointerdown', closeAppPicker);
-    };
-  });
-
-  $effect(() => {
-    if (!profileDropdownOpen) return;
-
-    const timeout = window.setTimeout(() => {
-      window.addEventListener('pointerdown', closeProfileDropdown);
-    });
-
-    return () => {
-      window.clearTimeout(timeout);
-      window.removeEventListener('pointerdown', closeProfileDropdown);
-    };
-  });
-
-  $effect(() => {
-    if (!cleanupDropdownOpen) return;
-
-    const timeout = window.setTimeout(() => {
-      window.addEventListener('pointerdown', closeCleanupDropdown);
-    });
-
-    return () => {
-      window.clearTimeout(timeout);
-      window.removeEventListener('pointerdown', closeCleanupDropdown);
     };
   });
 </script>
@@ -245,8 +209,14 @@
               type="button"
               class="app-picker-item"
               onclick={() => pickApp(app)}
+              onkeydown={(event) =>
+                handleListboxOptionKeydown(event, APP_PICKER_MENU_ID, () => {
+                  appPickerOpen = false;
+                  appSearchInput?.focus();
+                })}
               role="option"
               aria-selected={false}
+              tabindex="-1"
             >
               <span class="app-picker-name">{cleanAppName(app.name || app.exe)}</span>
               <span class="app-picker-exe-pill" aria-hidden="true">{app.exe}</span>
@@ -268,123 +238,111 @@
       {/if}
     </div>
 
-    <div class="ui-dropdown profile-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
-      <select class="profile-select profile-select-hidden" bind:value={addProfile} tabindex="-1" aria-hidden="true">
-        {#each profileOptions as profile}
-          <option value={profile.id}>{profile.label}</option>
-        {/each}
-      </select>
-      <button
-        bind:this={profileDropdownButton}
-        type="button"
-        class="ui-dropdown-trigger profile-drop-btn"
-        use:animateWidth={{ text: getProfileLabel(addProfile) }}
-        onclick={() => (profileDropdownOpen ? profileDropdownOpen = false : openProfileDropdown())}
-        onkeydown={handleProfileButtonKeydown}
-        aria-haspopup="listbox"
-        aria-expanded={profileDropdownOpen}
-        aria-controls={ADD_PROFILE_MENU_ID}
-      >
-        <span>{getProfileLabel(addProfile)}</span>
-        <svg class:open={profileDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="m6 9 6 6 6-6"/>
-        </svg>
-      </button>
-      {#if profileDropdownOpen}
-        <div
-          id={ADD_PROFILE_MENU_ID}
-          class="ui-dropdown-menu profile-drop-menu scroll-styled"
-          role="listbox"
-          tabindex="-1"
-          aria-label="Tone options"
-          onpointerdown={(event) => event.stopPropagation()}
-          in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
-          out:fade={{ duration: motionMs(100) }}
-        >
+    <Dropdown bind:open={profileDropdownOpen} closeSelector=".profile-drop-wrap">
+      <div class="ui-dropdown profile-drop-wrap" role="presentation">
+        <select class="profile-select profile-select-hidden" bind:value={addProfile} tabindex="-1" aria-hidden="true">
           {#each profileOptions as profile}
-            <button
-              type="button"
-              class="ui-dropdown-option profile-drop-item"
-              class:active={addProfile === profile.id}
-              onclick={() => {
-                addProfile = profile.id;
-                profileDropdownOpen = false;
-                profileDropdownButton?.focus();
-              }}
-              onkeydown={(event) =>
-                handleListboxOptionKeydown(event, ADD_PROFILE_MENU_ID, () => {
-                  profileDropdownOpen = false;
-                  profileDropdownButton?.focus();
-                })}
-              role="option"
-              aria-selected={addProfile === profile.id}
-              tabindex="-1"
-            >
-              {profile.label}
-            </button>
+            <option value={profile.id}>{profile.label}</option>
           {/each}
-        </div>
-      {/if}
-    </div>
-
-    <div class="ui-dropdown cleanup-drop-wrap" role="presentation" onclick={(event) => event.stopPropagation()}>
-      <select class="cleanup-select cleanup-select-hidden" bind:value={addCleanupIntensity} tabindex="-1" aria-hidden="true">
-        {#each cleanupIntensityChoices as choice}
-          <option value={choice.id}>{choice.label}</option>
-        {/each}
-      </select>
-      <button
-        bind:this={cleanupDropdownButton}
-        type="button"
-        class="ui-dropdown-trigger cleanup-drop-btn"
-        use:animateWidth={{ text: getCleanupIntensityLabel(addCleanupIntensity) }}
-        onclick={() => (cleanupDropdownOpen ? cleanupDropdownOpen = false : openCleanupDropdown())}
-        onkeydown={handleCleanupButtonKeydown}
-        aria-haspopup="listbox"
-        aria-expanded={cleanupDropdownOpen}
-        aria-controls={ADD_CLEANUP_MENU_ID}
-      >
-        <span>{getCleanupIntensityLabel(addCleanupIntensity)}</span>
-        <svg class:open={cleanupDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="m6 9 6 6 6-6"/>
-        </svg>
-      </button>
-      {#if cleanupDropdownOpen}
-        <div
-          id={ADD_CLEANUP_MENU_ID}
-          class="ui-dropdown-menu cleanup-drop-menu scroll-styled"
-          role="listbox"
-          tabindex="-1"
-          aria-label="Cleanup intensity options"
-          onpointerdown={(event) => event.stopPropagation()}
-          in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
-          out:fade={{ duration: motionMs(100) }}
+        </select>
+        <button
+          type="button"
+          class="ui-dropdown-trigger ui-dropdown-trigger--compact profile-drop-btn"
+          use:animateWidth={{ text: getProfileLabel(addProfile) }}
+          onclick={() => (profileDropdownOpen = !profileDropdownOpen)}
+          onkeydown={handleProfileButtonKeydown}
+          aria-haspopup="listbox"
+          aria-expanded={profileDropdownOpen}
+          aria-controls={ADD_PROFILE_MENU_ID}
         >
+          <span>{getProfileLabel(addProfile)}</span>
+          <svg class:open={profileDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+        </button>
+        {#if profileDropdownOpen}
+          <div
+            id={ADD_PROFILE_MENU_ID}
+            class="ui-dropdown-menu profile-drop-menu scroll-styled"
+            role="listbox"
+            tabindex="-1"
+            aria-label="Tone options"
+            onpointerdown={(event) => event.stopPropagation()}
+            in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+            out:fade={{ duration: motionMs(100) }}
+          >
+            {#each profileOptions as profile}
+              <button
+                type="button"
+                class="ui-dropdown-option profile-drop-item"
+                class:active={addProfile === profile.id}
+                onclick={() => {
+                  addProfile = profile.id;
+                  profileDropdownOpen = false;
+                }}
+                role="option"
+                aria-selected={addProfile === profile.id}
+              >
+                {profile.label}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </Dropdown>
+
+    <Dropdown bind:open={cleanupDropdownOpen} closeSelector=".cleanup-drop-wrap">
+      <div class="ui-dropdown cleanup-drop-wrap" role="presentation">
+        <select class="cleanup-select cleanup-select-hidden" bind:value={addCleanupIntensity} tabindex="-1" aria-hidden="true">
           {#each cleanupIntensityChoices as choice}
-            <button
-              type="button"
-              class="ui-dropdown-option cleanup-drop-item"
-              class:active={addCleanupIntensity === choice.id}
-              onclick={() => {
-                addCleanupIntensity = choice.id;
-                cleanupDropdownOpen = false;
-                cleanupDropdownButton?.focus();
-              }}
-              onkeydown={(event) =>
-                handleListboxOptionKeydown(event, ADD_CLEANUP_MENU_ID, () => {
-                  cleanupDropdownOpen = false;
-                  cleanupDropdownButton?.focus();
-                })}
-              role="option"
-              aria-selected={addCleanupIntensity === choice.id}
-              tabindex="-1"
-            >
-              {choice.label}
-            </button>
+            <option value={choice.id}>{choice.label}</option>
           {/each}
-        </div>
-      {/if}
-    </div>
+        </select>
+        <button
+          type="button"
+          class="ui-dropdown-trigger ui-dropdown-trigger--compact cleanup-drop-btn"
+          use:animateWidth={{ text: getCleanupIntensityLabel(addCleanupIntensity) }}
+          onclick={() => (cleanupDropdownOpen = !cleanupDropdownOpen)}
+          onkeydown={handleCleanupButtonKeydown}
+          aria-haspopup="listbox"
+          aria-expanded={cleanupDropdownOpen}
+          aria-controls={ADD_CLEANUP_MENU_ID}
+        >
+          <span>{getCleanupIntensityLabel(addCleanupIntensity)}</span>
+          <svg class:open={cleanupDropdownOpen} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+        </button>
+        {#if cleanupDropdownOpen}
+          <div
+            id={ADD_CLEANUP_MENU_ID}
+            class="ui-dropdown-menu cleanup-drop-menu scroll-styled"
+            role="listbox"
+            tabindex="-1"
+            aria-label="Cleanup intensity options"
+            onpointerdown={(event) => event.stopPropagation()}
+            in:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.fast), easing: expoOut }}
+            out:fade={{ duration: motionMs(100) }}
+          >
+            {#each cleanupIntensityChoices as choice}
+              <button
+                type="button"
+                class="ui-dropdown-option cleanup-drop-item"
+                class:active={addCleanupIntensity === choice.id}
+                onclick={() => {
+                  addCleanupIntensity = choice.id;
+                  cleanupDropdownOpen = false;
+                }}
+                role="option"
+                aria-selected={addCleanupIntensity === choice.id}
+              >
+                {choice.label}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </Dropdown>
 
     <button type="button" class="btn-primary btn-compact add-btn" onclick={submit} disabled={!addExe && !appSearch.trim()}>Add</button>
   </div>
@@ -485,6 +443,12 @@
   }
 
   .app-picker-item:hover {
+    background: var(--control-hover);
+  }
+
+  .app-picker-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
     background: var(--control-hover);
   }
 

--- a/src/lib/components/settings/CleanupPromptModal.svelte
+++ b/src/lib/components/settings/CleanupPromptModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { tick } from 'svelte';
   import { slide } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { invoke } from '../../tauri';
@@ -9,6 +8,7 @@
     cleanupPromptOverridesStore,
     closeCleanupPromptEditor,
   } from '../../stores.svelte';
+  import { modalFocusTrap } from '../../modalFocus';
   import {
     modalBackdrop,
     expandFromOrigin,
@@ -45,7 +45,6 @@
     | { status: 'failed'; report?: PromptTestReport; error?: string };
 
   let modalEl = $state<HTMLDivElement | null>(null);
-  let previousFocusEl: HTMLElement | null = null;
 
   let draft = $state('');
   let defaultText = $state('');
@@ -111,23 +110,15 @@
     loadDraft();
   });
 
+  // The textarea only mounts after the draft IPC returns (loading gate). The
+  // focus trap lands on the card while loading; hand focus to the editor once
+  // it exists, unless the user has already moved inside the dialog.
   $effect(() => {
-    if (!cleanupPromptEditor.open) return;
-    const target = previousFocusEl;
-    previousFocusEl = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-
-    tick().then(() => {
-      const textarea = modalEl?.querySelector<HTMLElement>('textarea');
-      (textarea ?? modalEl)?.focus();
-    });
-
-    return () => {
-      if (target?.isConnected) {
-        requestAnimationFrame(() => target.focus());
-      }
-    };
+    if (!cleanupPromptEditor.open || loading) return;
+    const textarea = modalEl?.querySelector<HTMLElement>('textarea');
+    if (!textarea) return;
+    const active = document.activeElement;
+    if (active === modalEl || active === document.body) textarea.focus();
   });
 
   async function loadDraft() {
@@ -232,37 +223,11 @@
     handleClose();
   }
 
-  function getFocusable(): HTMLElement[] {
-    if (!modalEl) return [];
-    const sel = [
-      'button:not([disabled])',
-      'textarea:not([disabled])',
-      'input:not([disabled])',
-      '[tabindex]:not([tabindex="-1"])',
-    ].join(',');
-    return Array.from(modalEl.querySelectorAll<HTMLElement>(sel)).filter(
-      (el) => el.offsetParent !== null
-    );
-  }
-
+  // The focus trap owns Tab cycling and focus restore; Escape stays here so a
+  // dialog is always one key away from dismissal (Settings' Escape guard
+  // yields while [role="dialog"] is present).
   function onKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      const active = e.target as HTMLElement | null;
-      if (active?.tagName === 'TEXTAREA') return;
-      handleClose();
-      return;
-    }
-    if (e.key !== 'Tab') return;
-    const focusable = getFocusable();
-    if (!focusable.length) { e.preventDefault(); modalEl?.focus(); return; }
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    const active = document.activeElement;
-    if (e.shiftKey && (active === first || active === modalEl)) {
-      e.preventDefault(); last.focus();
-    } else if (!e.shiftKey && active === last) {
-      e.preventDefault(); first.focus();
-    }
+    if (e.key === 'Escape') handleClose();
   }
 
   const failedLiveResults = $derived(
@@ -296,7 +261,11 @@
 
   <div
     bind:this={modalEl}
-    class="prompt-modal-card"
+    class="prompt-modal-card ui-modal-card"
+    use:modalFocusTrap={{
+      active: true,
+      initialFocus: () => modalEl?.querySelector<HTMLElement>('textarea') ?? modalEl,
+    }}
     role="dialog"
     aria-modal="true"
     aria-label="Edit cleanup prompt"

--- a/src/lib/components/settings/LocalCleanupDownloads.svelte
+++ b/src/lib/components/settings/LocalCleanupDownloads.svelte
@@ -166,7 +166,11 @@
   }
 </script>
 
-<div class="local-download-tile" class:task-open={opened}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- Escape collapses the open tile no matter which control inside it has
+     focus, so the key backs out one layer at a time (tile → Settings).
+     preventDefault marks the key as handled for Settings' window guard. -->
+<div class="local-download-tile" class:task-open={opened} onkeydown={(event) => { if (event.key === 'Escape' && opened) { event.preventDefault(); onToggleOpen(); } }}>
   <button class="tile-head" onclick={onToggleOpen} aria-expanded={opened}>
     <div class="head-left">
       <span class="head-title">Clean-up</span>

--- a/src/lib/components/settings/LocalTranscriptionDownloads.svelte
+++ b/src/lib/components/settings/LocalTranscriptionDownloads.svelte
@@ -119,7 +119,13 @@
   }
 </script>
 
-<div class="task-tile" class:task-open={opened}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- Escape collapses the open tile no matter which control inside it has
+     focus, so the key backs out one layer at a time (tile → Settings). The
+     per-model language disclosure handles Escape first (see .local-meta-toggle)
+     so the innermost layer always closes before the tile. preventDefault
+     marks the key as handled for Settings' window guard. -->
+<div class="task-tile" class:task-open={opened} onkeydown={(event) => { if (event.key === 'Escape' && opened) { event.preventDefault(); onToggleOpen(); } }}>
   <button class="tile-head" onclick={onToggleOpen} aria-expanded={opened}>
     <div class="head-left">
       <span class="head-title">Speech-to-text</span>
@@ -535,6 +541,11 @@
   .local-meta-toggle:hover {
     border-color: color-mix(in srgb, var(--accent) 20%, var(--line));
     color: var(--ink-soft);
+  }
+
+  .local-meta-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
   }
 
   .local-meta-toggle.is-open {

--- a/src/lib/components/settings/ModelTaskTile.svelte
+++ b/src/lib/components/settings/ModelTaskTile.svelte
@@ -87,7 +87,11 @@
   const cloudSections = $derived(providerSections.filter((section) => section.tasks.includes(type)));
 </script>
 
-<div class="task-tile" class:task-open={opened}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- Escape collapses the open tile no matter which control inside it has
+     focus, so the key backs out one layer at a time (tile → Settings).
+     preventDefault marks the key as handled for Settings' window guard. -->
+<div class="task-tile" class:task-open={opened} onkeydown={(event) => { if (event.key === 'Escape' && opened) { event.preventDefault(); onToggleOpen(type); } }}>
   <button class="tile-head" onclick={() => onToggleOpen(type)} aria-expanded={opened}>
     <div class="head-left">
       <span class="head-title">{taskLabel(type)}</span>

--- a/src/lib/components/settings/PresetCard.svelte
+++ b/src/lib/components/settings/PresetCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import EfficiencyBar from './EfficiencyBar.svelte';
   import type { Preset } from './modelPresets';
+  import { modalFocusTrap } from '../../modalFocus';
+  import { modalBackdrop, modalCard, MOTION_PX, motionPx } from '../../motion';
 
   let {
     preset,
@@ -45,17 +47,33 @@
   );
   const hoverLabel = $derived(cancelable ? 'Cancel download' : manageable ? 'Delete models' : '');
 
+  // Deleting downloaded models is destructive and irreversible, so it gets the
+  // same in-app confirm dialog as the other destructive settings actions
+  // instead of a blocking native browser confirm.
+  let confirmDelete = $state(false);
+  let confirmCancelButton = $state<HTMLButtonElement | null>(null);
+
   function handleAction(event: MouseEvent) {
     event.stopPropagation();
     if (cancelable) onCancelDownload?.();
-    else if (manageable) {
-      if (globalThis.confirm(`Delete downloaded models for ${preset.name}?`)) {
-        onDeleteModels?.();
-      }
-    }
+    else if (manageable) confirmDelete = true;
     else onSelect();
   }
+
+  function confirmDeleteModels() {
+    confirmDelete = false;
+    onDeleteModels?.();
+  }
+
+  // Same Escape contract as the other settings confirm dialogs: dismiss the
+  // dialog, never the page beneath it (Settings' own Escape guard yields
+  // while [role="dialog"] is present).
+  function handleDeleteModalKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && confirmDelete) confirmDelete = false;
+  }
 </script>
+
+<svelte:window onkeydown={handleDeleteModalKeydown} />
 
 {#if isAddKey}
   <div class="preset-card preset-info">
@@ -112,6 +130,42 @@
             {defaultLabel}
           {/if}
         </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if confirmDelete}
+  <!-- Renders above every surface it can open from: settings (z-60), the
+       cleanup-prompt modal (z-70), and the setup wizard overlay (z-100). -->
+  <div class="preset-confirm-wrap">
+    <div class="ui-modal-backdrop" in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></div>
+    <div
+      class="modal-card ui-modal-card"
+      use:modalFocusTrap={{
+        active: confirmDelete,
+        initialFocus: () => confirmCancelButton,
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="preset-delete-confirm-title"
+      tabindex="-1"
+      in:modalCard={{ duration: 220, distance: motionPx(MOTION_PX.panel), scaleFrom: 0.97 }}
+      out:modalCard={{ duration: 160, distance: motionPx(MOTION_PX.nudge), scaleFrom: 0.985 }}
+    >
+      <div class="ui-modal-head">
+        <h2 id="preset-delete-confirm-title" class="ui-modal-title">Delete downloaded models?</h2>
+      </div>
+      <div class="ui-modal-body">
+        <p class="ui-modal-copy">
+          This removes the downloaded model files for {preset.name} from this machine. Your settings and dictation history are untouched.
+        </p>
+      </div>
+      <div class="ui-modal-foot">
+        <div class="ui-modal-actions">
+          <button bind:this={confirmCancelButton} class="btn-ghost" onclick={() => (confirmDelete = false)}>Cancel</button>
+          <button class="btn-danger btn-compact" onclick={confirmDeleteModels}>Delete models</button>
+        </div>
       </div>
     </div>
   </div>
@@ -349,6 +403,12 @@
     .hover-mode:focus-visible .pa-hover {
       transform: none;
     }
+  }
+
+  .preset-confirm-wrap {
+    position: fixed;
+    inset: 0;
+    z-index: 120;
   }
 
   /* Narrow settings column: fold the right rail under the text. */

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -80,6 +80,20 @@ export function pageSwap(node: HTMLElement, params: MotionTransitionParams = {},
   const distance = params.distance ?? motionPx(MOTION_PX.page);
   const isOutro = options.direction === 'out';
 
+  // Apply the visibility state atomically when the transition is created, not
+  // on the first tick: an outgoing page must be inert + aria-hidden from the
+  // instant it starts leaving (the smoke contract reads it mid-transition),
+  // and an incoming page must be interactive from the instant it mounts.
+  if (isOutro) {
+    node.inert = true;
+    node.setAttribute('aria-hidden', 'true');
+    node.style.pointerEvents = 'none';
+  } else {
+    node.inert = false;
+    node.removeAttribute('aria-hidden');
+    node.style.pointerEvents = '';
+  }
+
   return {
     duration,
     easing: cubicOut,

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -116,7 +116,12 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape' && !modal) selected = null;
+    if (e.key === 'Escape' && !modal) {
+      selected = null;
+      // Escape is the "back out" key: disarm a pending destructive delete too,
+      // so re-selecting the same row doesn't resurrect the Confirm state.
+      deleteTarget = null;
+    }
   }
 
   function goToSnippets() {

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -108,20 +108,12 @@
       <p class="page-sub">How much you dictate, how fast, and what it costs. Everything here is computed locally from your own history — nothing leaves your machine.</p>
     </div>
 
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="ui-dropdown range-picker"
-      onclick={(event) => event.stopPropagation()}
-      onkeydown={(event) => {
-        if (event.key === 'Escape' && rangeOpen) {
-          rangeOpen = false;
-          event.stopPropagation();
-        }
-      }}
-    >
+    <!-- The shared Dropdown owns Escape, outside-click, and arrow navigation
+         for the range menu once it is open. -->
+    <div class="ui-dropdown range-picker">
       <button
         type="button"
-        class="ui-dropdown-trigger"
+        class="ui-dropdown-trigger ui-dropdown-trigger--compact"
         aria-expanded={rangeOpen}
         aria-haspopup="listbox"
         onclick={() => (rangeOpen = !rangeOpen)}

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -123,11 +123,20 @@
 
   function onWindowKeydown(e: KeyboardEvent) {
     if (appStore.settingsOpen && e.key === 'Escape') {
+      // An inner layer already consumed the key (dropdown, disclosure, tile,
+      // hotkey capture). Svelte-delegated element handlers flush state before
+      // this window listener runs, so the DOM guards below can no longer see
+      // the layer that handled it — defaultPrevented is the reliable signal.
+      if (e.defaultPrevented) return;
       const target = e.target as HTMLElement | null;
       if (target?.closest('input, textarea, select, [contenteditable="true"]')) {
         return;
       }
-      if (typeof document !== 'undefined' && document.querySelector('[aria-expanded="true"]')) {
+      // A dropdown menu or an open dialog owns Escape while it is up: closing
+      // Settings underneath the confirm dialogs (beta updates, delete history,
+      // cleanup off) would skip a layer and drop the user out of Settings
+      // entirely instead of just dismissing the dialog.
+      if (typeof document !== 'undefined' && document.querySelector('[aria-expanded="true"], [role="dialog"]')) {
         return;
       }
       close();

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -107,7 +107,12 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape' && !modal) selected = null;
+    if (e.key === 'Escape' && !modal) {
+      selected = null;
+      // Escape is the "back out" key: disarm a pending destructive delete too,
+      // so re-selecting the same row doesn't resurrect the Confirm state.
+      deleteTarget = null;
+    }
   }
 </script>
 

--- a/src/lib/views/Style.svelte
+++ b/src/lib/views/Style.svelte
@@ -67,6 +67,34 @@
     tab = id;
   }
 
+  // The tabs declare role="tab", so they get the full APG pattern: only the
+  // selected tab is in the tab order, and Left/Right/Home/End move and select
+  // with automatic activation (the panels are lightweight).
+  let tablistEl = $state<HTMLDivElement | null>(null);
+
+  function handleTablistKeydown(event: KeyboardEvent) {
+    const tabButtons = tablistEl?.querySelectorAll<HTMLButtonElement>('.tab') ?? [];
+    if (tabButtons.length === 0) return;
+    const index = Array.from(tabButtons).indexOf(document.activeElement as HTMLButtonElement);
+    if (index === -1) return;
+
+    let next: number | null = null;
+    if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = tabButtons.length - 1;
+    else if (event.key === 'ArrowLeft') next = (index - 1 + tabButtons.length) % tabButtons.length;
+    else if (event.key === 'ArrowRight') next = (index + 1) % tabButtons.length;
+    if (next === null) return;
+
+    event.preventDefault();
+    const target = tabButtons[next];
+    target.focus();
+    const id = target.id.replace('style-tab-', '');
+    if (id !== tab) {
+      tabDir = directionFromOrder(tab, id, STYLE_TAB_ORDER);
+      tab = id;
+    }
+  }
+
   $effect(() => {
     if (!mountedTabs[tab]) {
       mountedTabs = { ...mountedTabs, [tab]: true };
@@ -85,15 +113,24 @@
         tone, intensity, and app-specific overrides only apply during the cleanup step. Your
         choices below are kept, just not used.
       </p>
-      <button type="button" class="cleanup-off-link" onclick={() => emit('open-flow:open-settings-section', 'general')}>
+      <button type="button" class="cleanup-off-link ui-focus-ring" onclick={() => emit('open-flow:open-settings-section', 'general')}>
         Turn Cleanup back on in Settings → General
       </button>
     </div>
   {/if}
 
-  <div class="tabs">
+  <div class="tabs" role="tablist" tabindex="-1" bind:this={tablistEl} onkeydown={handleTablistKeydown}>
     {#each tabs as t}
-      <button class="tab" class:active={tab === t.id} onclick={() => selectTab(t.id)}>
+      <button
+        class="tab ui-focus-ring"
+        class:active={tab === t.id}
+        role="tab"
+        id="style-tab-{t.id}"
+        tabindex={tab === t.id ? 0 : -1}
+        aria-selected={tab === t.id}
+        aria-controls="style-panel-{t.id}"
+        onclick={() => selectTab(t.id)}
+      >
         {t.label}
         {#if t.pill}
           <span class="pill">{t.pill}</span>
@@ -109,6 +146,9 @@
     {#key tab}
       <div
         class="tab-wrapper"
+        role="tabpanel"
+        id="style-panel-{tab}"
+        aria-labelledby="style-tab-{tab}"
         in:pageSwap={{ axis: 'x', distance: tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.panel) }}
         out:pageSwap={{ axis: 'x', distance: -tabDir * motionPx(MOTION_PX.panel), duration: motionMs(MOTION_MS.base + 40) }}
       >

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -86,6 +86,12 @@
               class:open={wordExpanded}
               aria-expanded={wordExpanded}
               onclick={() => (wordExpanded = !wordExpanded)}
+              onkeydown={(event) => {
+                if (event.key === 'Escape' && wordExpanded) {
+                  event.preventDefault();
+                  wordExpanded = false;
+                }
+              }}
               title={wordExpanded ? 'Click to collapse' : 'Click to see the full word'}
             >
               <span class="word-toggle-text">{rawWord}</span>

--- a/src/lib/views/snippets/SnippetModal.svelte
+++ b/src/lib/views/snippets/SnippetModal.svelte
@@ -93,10 +93,6 @@
   }
 
   $effect(() => {
-    if (triggerInput) setTimeout(() => triggerInput?.focus(), 50);
-  });
-
-  $effect(() => {
     draftExpansion;
     autoGrow(expansionEl);
   });

--- a/src/ui.css
+++ b/src/ui.css
@@ -11,11 +11,36 @@
   --ui-duration-base: 220ms;
   --ui-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --ui-focus-ring: 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent);
+  --ui-disabled-opacity: 0.45;
+}
+
+/* Shared focus-ring helper for feature-local interactive controls that should
+   not invent their own ring language (rows, chips, dots, icon buttons). */
+.ui-focus-ring:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: var(--ui-focus-ring);
+}
+
+/* Shared keycap primitive. Feature surfaces may recolor the background or
+   scale the type for their own context (e.g. the hero panel), but the shape
+   stays the same everywhere so "key" reads as "key" across the app. */
+:where(kbd) {
+  background: var(--paper);
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 500;
+  padding: 1px 6px;
 }
 
 :where(button).btn-primary,
 :where(button).btn-ghost,
-:where(button).btn-danger {
+:where(button).btn-danger,
+:where(button).btn-accent {
   align-items: center;
   border-radius: var(--r-sm);
   cursor: pointer;
@@ -204,6 +229,163 @@
 .ui-dropdown-menu--padded .ui-dropdown-option:hover {
   background: var(--paper-2);
   color: var(--ink);
+}
+
+/* Compact trigger for dense surfaces (settings rows, insights range picker).
+   Local layout may still tune the height via --ui-dropdown-trigger-height. */
+:where(button).ui-dropdown-trigger--compact {
+  --ui-dropdown-trigger-bg: transparent;
+  border-color: var(--line-strong);
+  border-radius: 6px;
+  font-size: 12px;
+  min-height: 28px;
+}
+
+/* Shared chevron rotation for disclosure triggers that are not ui-dropdown
+   triggers (feature dropdowns, mapping badges, local-model toggles). */
+.ui-chevron {
+  transition: transform var(--ui-duration-fast) var(--ui-ease-out);
+}
+
+.ui-chevron.open,
+[aria-expanded='true'] > .ui-chevron {
+  transform: rotate(180deg);
+}
+
+/* Icon-button primitive: compact square close/cancel affordance (modal close,
+   prompt close). Row-density variants (copy/dismiss/clear in dense lists) keep
+   their own size for hierarchy; the treatment stays the same. */
+:where(button).icon-btn {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 26px;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out);
+  width: 26px;
+}
+
+:where(button).icon-btn:hover {
+  background: var(--control-active);
+  color: var(--ink-strong);
+}
+
+/* Text inputs: one base recipe so every field reads the same. Dense modifier
+   for toolbar search fields that live in an elevated strip. */
+:where(input, textarea).ui-input {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 8px 11px;
+  transition:
+    border-color var(--ui-duration-fast) var(--ui-ease-out),
+    box-shadow var(--ui-duration-fast) var(--ui-ease-out);
+}
+
+:where(input, textarea).ui-input::placeholder {
+  color: var(--ink-faint);
+}
+
+:where(input, textarea).ui-input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: var(--ui-focus-ring);
+  outline: none;
+}
+
+:where(input, textarea).ui-input:disabled {
+  opacity: var(--ui-disabled-opacity);
+}
+
+:where(input, textarea).ui-input--dense {
+  background: var(--bg-elev);
+  padding: 6px 10px;
+}
+
+/* Range sliders keep their per-feature track/thumb styling but share one
+   visible keyboard focus treatment (WebView2 renders the webkit thumb). */
+input[type='range'].ui-range:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Modal anatomy. Layout per modal stays local (wide editor card vs compact
+   confirm), but backdrop, card, header/body/footer, and the footer action row
+   are shared so five modals do not re-implement the same shell. */
+.ui-modal-backdrop,
+.modal-backdrop {
+  background: var(--overlay);
+  inset: 0;
+  position: fixed;
+  z-index: 50;
+}
+
+.ui-modal-card,
+.modal-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-elev);
+  isolation: isolate;
+  left: 50%;
+  max-height: calc(100vh - 40px);
+  overflow: hidden;
+  position: fixed;
+  top: 50%;
+  translate: -50% -50%;
+  width: min(var(--ui-modal-w, 420px), calc(100vw - 40px));
+  z-index: 51;
+}
+
+.ui-modal-card--wide {
+  --ui-modal-w: 500px;
+}
+
+.ui-modal-head {
+  padding: 20px 20px 0;
+}
+
+.ui-modal-title {
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  margin: 0;
+}
+
+.ui-modal-body {
+  overflow-y: auto;
+  padding: 10px 20px 18px;
+  scrollbar-width: thin;
+}
+
+.ui-modal-copy {
+  color: var(--ink-soft);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.ui-modal-foot {
+  padding: 0 20px 20px;
+}
+
+.ui-modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Keyboard navigation, Escape layering, focus management, and hands-free follow-up click guards.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789555472&installation_model_id=432577&pr_number=260&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F260&signature=38989b17fdf8244bd571f1cbe75b276fcb291e893c2f127ddeab448752d9e332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->