### PR TITLE
Pill polish

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -438,3 +438,78 @@ pub async fn copy_paste_failure_to_clipboard(
     pipeline::clear_paste_failure(state.inner());
     Ok(())
 }
+
+/// Resizes the pill window to fit its visible content. The frontend measures
+/// the actual rendered content (pill capsule + profile label above it + error
+/// text) and reports the size in CSS px (== logical points on the pill's
+/// monitor), so the transparent click-capture zone around the pill stays
+/// exactly as wide as the pill itself instead of a fixed 380px band that
+/// swallows or forwards stray clicks — the floating pill grows for wide
+/// content (long error messages, handsfree buttons) and shrinks back when
+/// it's just the bare recording capsule. Height changes grow the window
+/// upward so the pill itself stays visually pinned in place.
+#[tauri::command]
+pub fn set_pill_size(
+    app: AppHandle,
+    state: tauri::State<'_, SharedState>,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    let Some(pill) = app.get_webview_window("pill") else {
+        return Ok(());
+    };
+
+    // Upper bounds are backstops against a bad frontend measurement, not the
+    // expected size — they must clear the largest real layout, which is the
+    // error card: it wraps at a fixed column width and grows upward for up to
+    // seven lines, so it needs far more vertical room than the single-line
+    // capsule every other state uses.
+    let width_points = if width.is_finite() {
+        width.clamp(60.0, 440.0).round()
+    } else {
+        60.0
+    };
+    let height_points = if height.is_finite() {
+        height.clamp(44.0, 260.0).round()
+    } else {
+        44.0
+    };
+
+    // Recompute the ideal centered placement from the monitor directly
+    // rather than offsetting from the window's current position — content-fit
+    // resizing fires many times per second during a width transition, and
+    // deriving each new position from the previous one let small rounding/race
+    // errors compound into a visible rightward drift. This recomputation is
+    // idempotent: every call lands on the same correct center.
+    //
+    // If no monitor resolves at all, still apply the *size* (anchored on the
+    // window's current center) rather than bailing. The frontend has already
+    // recorded this size as sent and won't re-send it, so dropping the resize
+    // here would strand the window too small for its content and clip the pill
+    // until something else happened to change its size.
+    let placement =
+        crate::pipeline::placement_for_current_monitor(&pill, width_points, height_points)
+            .unwrap_or_else(|| {
+                let scale = pill.scale_factor().unwrap_or(1.0).max(0.1);
+                let cur_pos = pill.outer_position().unwrap_or_default();
+                let w = (width_points * scale).round() as i32;
+                let h = (height_points * scale).round() as i32;
+                let (cur_w, cur_h) = pill
+                    .outer_size()
+                    .map(|size| (size.width as f64, size.height as f64))
+                    .unwrap_or((w as f64, h as f64));
+                crate::pipeline::PillPlacement {
+                    x: cur_pos.x + ((cur_w - w as f64) / 2.0).round() as i32,
+                    y: cur_pos.y + (cur_h - h as f64).round() as i32,
+                    width: w,
+                    height: h,
+                }
+            });
+    crate::pipeline::apply_pill_placement(&pill, placement);
+
+    let mut st = lock_state(&state)?;
+    st.pill_width_points = width_points;
+    st.pill_height_points = height_points;
+    st.pill_placement = Some(placement);
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -260,6 +260,8 @@ fn main() {
         target: WindowTarget::default(),
         pill_placement: None,
         pill_placement_stale: false,
+        pill_width_points: pipeline::DEFAULT_PILL_WIDTH_POINTS,
+        pill_height_points: pipeline::DEFAULT_PILL_HEIGHT_POINTS,
         retry_capture: None,
         cancelled_capture: None,
         paste_failure: None,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -539,6 +539,7 @@ fn main() {
             commands::resume_cancelled_capture,
             commands::dismiss_cancelled_capture,
             commands::copy_paste_failure_to_clipboard,
+            commands::set_pill_size,
             commands::get_installed_apps,
             commands::get_app_mappings,
             commands::save_app_mappings,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -38,8 +38,13 @@ use gates::{
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
     silence_floor_gate_rms, strip_hallucinated_suffix, MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
-pub(crate) use pill::{hide_pill, show_copied_pill, show_pill, update_pill_state};
+pub(crate) use pill::{
+    emit_pill_profile, emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
+};
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
+pub(crate) use pill_position::{
+    apply_pill_placement, placement_for_current_monitor, PillPlacement,
+};
 pub use session::*;
 use stages::*;
 pub use state::*;
@@ -254,6 +259,15 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     crate::media::sound::cancel_pending_start();
     crate::media::sound::coordinated_unmute();
     show_pill(&app, "processing");
+    // Label the pill "Transcribing…" from the moment processing starts, not
+    // once the transcription call actually begins. Audio encoding and the
+    // local Silero VAD gate both run first and both scale with recording
+    // length — the VAD gate alone reprocesses the *entire* buffer frame by
+    // frame, so on a multi-minute hands-free dictation this stretch can run
+    // several seconds. Until this moved, the pill had no stage mounted for
+    // that whole span and simply went blank, then jumped straight to
+    // "Transcribing…" once the real network call started.
+    emit_pill_stage(&app, "transcribing");
 
     // Keep the quiet-audio gate permissive at high gain. Whisper recordings can
     // still have low post-denoise RMS, even after amplification.

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -111,6 +111,7 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
         anyhow::bail!(message);
     }
 
+    emit_pill_stage(&app, "transcribing");
     let mut transcribed: Option<String> = None;
     let mut last_err: Option<anyhow::Error> = None;
     for (provider_id, model) in transcription_model_chain(&cfg) {

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -36,7 +36,7 @@ pub use fixture::{
 use gates::{
     effective_recording_rms, has_spoken_content, is_transcription_hallucination,
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
-    silence_floor_gate_rms, strip_hallucinated_suffix, MIN_RECORDING_MS, MIN_RECORDING_RMS,
+    silence_floor_gate_rms, strip_hallucinated_suffix, strip_trailing_hallucination, MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
     emit_pill_profile, emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -21,6 +21,7 @@ mod gates;
 mod pill;
 mod pill_animation;
 mod pill_position;
+mod repair;
 mod session;
 mod stages;
 mod state;
@@ -36,18 +37,17 @@ pub use fixture::{
 use gates::{
     effective_recording_rms, has_spoken_content, is_transcription_hallucination,
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
-    silence_floor_gate_rms, strip_hallucinated_suffix,
+    silence_floor_gate_rms, strip_hallucinated_suffix, strip_trailing_hallucination,
     MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
-    emit_pill_stage, hide_pill, show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
+    emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
 };
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
 pub use session::*;
-pub(crate) use repair::*;
 use stages::*;
 pub use state::*;
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -36,16 +36,18 @@ pub use fixture::{
 use gates::{
     effective_recording_rms, has_spoken_content, is_transcription_hallucination,
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
-    silence_floor_gate_rms, strip_hallucinated_suffix, strip_trailing_hallucination, MIN_RECORDING_MS, MIN_RECORDING_RMS,
+    silence_floor_gate_rms, strip_hallucinated_suffix,
+    MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
-    emit_pill_profile, emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
+    emit_pill_stage, hide_pill, show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
 };
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
 pub use session::*;
+pub(crate) use repair::*;
 use stages::*;
 pub use state::*;
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -40,14 +40,13 @@ use gates::{
     MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
-    emit_pill_profile, emit_pill_stage, hide_pill, show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
+    emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
 };
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
 pub use session::*;
-pub(crate) use repair::*;
 use stages::*;
 pub use state::*;
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -21,7 +21,6 @@ mod gates;
 mod pill;
 mod pill_animation;
 mod pill_position;
-mod repair;
 mod session;
 mod stages;
 mod state;
@@ -37,17 +36,18 @@ pub use fixture::{
 use gates::{
     effective_recording_rms, has_spoken_content, is_transcription_hallucination,
     normalize_transcription_math_artifacts, preview_text, recording_gate_rms,
-    silence_floor_gate_rms, strip_hallucinated_suffix, strip_trailing_hallucination,
+    silence_floor_gate_rms, strip_hallucinated_suffix,
     MIN_RECORDING_MS, MIN_RECORDING_RMS,
 };
 pub(crate) use pill::{
-    emit_pill_stage, hide_pill, show_copied_pill, show_pill, update_pill_state,
+    emit_pill_profile, emit_pill_stage, hide_pill, show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
 };
 use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
 pub use session::*;
+pub(crate) use repair::*;
 use stages::*;
 pub use state::*;
 

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -8,8 +8,11 @@ use crate::pipeline::pill_position::PillPlacement;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 
-const PILL_WIDTH_POINTS: f64 = 380.0;
-const PILL_HEIGHT_POINTS: f64 = 44.0;
+/// Initial window size at creation. Kept in step with the state defaults so
+/// the window is never created wider than the content it will hold — the
+/// frontend re-reports the real content size as soon as it mounts.
+const PILL_WIDTH_POINTS: f64 = super::DEFAULT_PILL_WIDTH_POINTS;
+const PILL_HEIGHT_POINTS: f64 = super::DEFAULT_PILL_HEIGHT_POINTS;
 
 /// Guards the animated path's deferred reveal against being overtaken by a
 /// newer `show_pill_msg` call. The animated cross-monitor move (see
@@ -132,12 +135,11 @@ pub(crate) fn update_pill_state(app: &AppHandle, state: &str) {
 }
 
 /// Shows the pill window in the given state, optionally carrying an error
-/// message. The window is always kept at the same width regardless of state
-/// (room enough for the error text to expand into), so within a single
-/// monitor it never needs to resize or reposition after its first
-/// appearance. Handsfree's click-capture zone is therefore wider than the
-/// visible pill; clicks in the empty space around it are swallowed instead
-/// of passing through while handsfree is active. Moving to a different
+/// message. The window is sized to whatever the frontend last reported as its
+/// visible content width (see `commands::recording::set_pill_size`), so the
+/// transparent click-capture zone tracks the pill rather than a fixed band —
+/// in a button-bearing state like handsfree, only the capsule itself swallows
+/// clicks, and everything beside it passes through. Moving to a different
 /// monitor, whether or not its scale factor differs, animates the move on
 /// Windows (see `pill_animation.rs`) instead of jumping instantly, since an
 /// instant cross-monitor move on this window either visibly snapped
@@ -226,7 +228,8 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     // Click-through for passive states so nothing behind the pill is blocked.
     // Handsfree, error (Retry), and cancelled (Undo/Dismiss) all have real
     // buttons that need real cursor events.
-    let has_clickable_buttons = matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed");
+    let has_clickable_buttons =
+        matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed");
     pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
 
     // Show the window before emitting state so WebView2 is active when it
@@ -287,11 +290,13 @@ fn next_pill_placement<R: Runtime>(
     app: &AppHandle,
     pill: &WebviewWindow<R>,
 ) -> Option<PillPlacement> {
-    let (target_point, cached, stale) = {
+    let (target_point, width_points, height_points, cached, stale) = {
         let state = app.try_state::<SharedState>()?;
         let guard = state.lock().ok()?;
         (
             guard.target.display_point,
+            guard.pill_width_points,
+            guard.pill_height_points,
             guard.pill_placement,
             guard.pill_placement_stale,
         )
@@ -301,7 +306,13 @@ fn next_pill_placement<R: Runtime>(
         return None;
     }
 
-    let resolved = super::pill_position::resolve_pill_placement(pill, target_point).or(cached);
+    let resolved = super::pill_position::resolve_pill_placement(
+        pill,
+        target_point,
+        width_points,
+        height_points,
+    )
+    .or(cached);
 
     if let Some(placement) = resolved {
         if stale || cached != Some(placement) {
@@ -329,6 +340,11 @@ pub(crate) fn hide_pill(app: &AppHandle) {
         super::pill_animation::cancel_pending_pill_tween();
 
         pill.emit("pill-state", "idle").ok();
+        // Re-enable click-through: after a button-bearing state (handsfree,
+        // error, cancelled, paste_failed) reveal_pill left the window
+        // click-capturing. Idle is invisible, so it must never swallow clicks
+        // in the pill's zone even though the pill content has disappeared.
+        pill.set_ignore_cursor_events(true).ok();
         // Do not call pill.hide() - hiding the window suspends the WebView2
         // renderer. The next show_pill("recording") emit would then be lost
         // before WebView2 wakes up, causing only "processing" to appear.
@@ -367,6 +383,26 @@ pub(crate) fn show_copied_pill(app: &AppHandle, msg: &str) {
         crate::media::sound::play(crate::media::sound::SoundCue::Stop);
     }
     show_pill_msg(app, "copied", Some(msg));
+}
+
+/// Emits the current processing sub-stage to the pill window. The pill is
+/// already showing `processing`; this only refines what it displays
+/// ("Transcribing…" / "Cleaning…" / "Pasting…"). Payload is a bare stage id
+/// string; the frontend maps it to a label, so adding a stage never requires
+/// an IPC schema change.
+pub(crate) fn emit_pill_stage(app: &AppHandle, stage: &str) {
+    if let Some(pill) = app.get_webview_window("pill") {
+        pill.emit("pill-stage", stage).ok();
+    }
+}
+
+/// Emits the resolved tone profile (e.g. "casual") to the pill window so it
+/// can show which style will apply to the current dictation. Emitted from the
+/// pipeline itself — the frontend never re-resolves it.
+pub(crate) fn emit_pill_profile(app: &AppHandle, profile: &str) {
+    if let Some(pill) = app.get_webview_window("pill") {
+        pill.emit("pill-profile", profile).ok();
+    }
 }
 
 pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -229,7 +229,7 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     // Handsfree, error (Retry), and cancelled (Undo/Dismiss) all have real
     // buttons that need real cursor events.
     let has_clickable_buttons =
-        matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed");
+        matches!(state, "handsfree" | "error" | "cancelled" | "paste_failed" | "copied");
     pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
 
     // Show the window before emitting state so WebView2 is active when it

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -396,15 +396,6 @@ pub(crate) fn emit_pill_stage(app: &AppHandle, stage: &str) {
     }
 }
 
-/// Emits the resolved tone profile (e.g. "casual") to the pill window so it
-/// can show which style will apply to the current dictation. Emitted from the
-/// pipeline itself — the frontend never re-resolves it.
-pub(crate) fn emit_pill_profile(app: &AppHandle, profile: &str) {
-    if let Some(pill) = app.get_webview_window("pill") {
-        pill.emit("pill-profile", profile).ok();
-    }
-}
-
 pub(super) async fn show_error_pill(app: &AppHandle, msg: &str) {
     log::error!("pipeline error: {msg}");
     app.emit("verenu:error", msg).ok();

--- a/src-tauri/src/pipeline/pill_position.rs
+++ b/src-tauri/src/pipeline/pill_position.rs
@@ -1,8 +1,6 @@
 use crate::core::window_geometry::DesktopPoint;
 use tauri::{Runtime, WebviewWindow};
 
-const PILL_WIDTH_POINTS: f64 = 380.0;
-const PILL_HEIGHT_POINTS: f64 = 44.0;
 const PILL_BOTTOM_GAP_POINTS: f64 = 16.0;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -39,9 +37,13 @@ fn round_to_physical(points: f64, scale_factor: f64) -> i32 {
     (points * scale_factor).round() as i32
 }
 
-fn placement_for_monitor(monitor: MonitorSnapshot) -> PillPlacement {
-    let width = round_to_physical(PILL_WIDTH_POINTS, monitor.scale_factor);
-    let height = round_to_physical(PILL_HEIGHT_POINTS, monitor.scale_factor);
+fn placement_for_monitor(
+    monitor: MonitorSnapshot,
+    width_points: f64,
+    height_points: f64,
+) -> PillPlacement {
+    let width = round_to_physical(width_points, monitor.scale_factor);
+    let height = round_to_physical(height_points, monitor.scale_factor);
     let gap = round_to_physical(PILL_BOTTOM_GAP_POINTS, monitor.scale_factor);
     let work_width = monitor.work_width as f64;
     let target_x = monitor.work_x + ((work_width - width as f64) / 2.0).round() as i32;
@@ -65,6 +67,8 @@ fn choose_monitor(
 pub(super) fn resolve_pill_placement<R: Runtime>(
     pill: &WebviewWindow<R>,
     target_point: Option<DesktopPoint>,
+    width_points: f64,
+    height_points: f64,
 ) -> Option<PillPlacement> {
     let target_monitor = target_point.and_then(|point| {
         pill.monitor_from_point(point.x, point.y)
@@ -78,7 +82,7 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
         .flatten()
         .map(|monitor| MonitorSnapshot::from(&monitor));
     let monitor = choose_monitor(target_monitor, primary_monitor)?;
-    let placement = placement_for_monitor(monitor);
+    let placement = placement_for_monitor(monitor, width_points, height_points);
 
     // Temporary diagnostic for issue #161 (pill clipped on first cross-monitor
     // reveal) - coordinates/scale factors only, nothing sensitive, so this is
@@ -91,6 +95,36 @@ pub(super) fn resolve_pill_placement<R: Runtime>(
     }
 
     Some(placement)
+}
+
+/// Recomputes the pill's ideal centered placement for a given content size,
+/// purely from the monitor it currently sits on — never from the window's
+/// own current position. `set_pill_size` used to derive the new position by
+/// offsetting from the window's current geometry (`cur_pos + (cur_size -
+/// new_size) / 2`), which is only correct if that current geometry was
+/// itself exactly centered; content-fit resizing fires many times per
+/// second during a width transition, and out-of-order/concurrent command
+/// invocations could read back a stale position mid-flight, so small
+/// rounding/race errors compounded into a persistent rightward drift on any
+/// state whose pill width transitions (every state but the bare recording
+/// capsule). Recomputing from the monitor's work area every time is
+/// idempotent — each call lands on the same correct center regardless of
+/// what the window's geometry was a moment ago, so nothing can compound.
+pub(crate) fn placement_for_current_monitor<R: Runtime>(
+    pill: &WebviewWindow<R>,
+    width_points: f64,
+    height_points: f64,
+) -> Option<PillPlacement> {
+    let monitor = pill
+        .current_monitor()
+        .ok()
+        .flatten()
+        .or_else(|| pill.primary_monitor().ok().flatten())?;
+    Some(placement_for_monitor(
+        MonitorSnapshot::from(&monitor),
+        width_points,
+        height_points,
+    ))
 }
 
 /// Reads the pill's actual on-screen geometry right now. Used by the
@@ -152,11 +186,12 @@ pub(super) fn should_animate_cross_monitor_move(
 
 /// Moves/resizes the pill to `placement` if it isn't already there. Returns
 /// `true` if a native resize or reposition was actually issued. Used as-is
-/// for the synchronous same-monitor path; the animated cross-monitor path in
+/// for the synchronous same-monitor path and by `set_pill_size` for
+/// frontend-reported content-fit resizes; the animated cross-monitor path in
 /// `pill_animation.rs` has its own per-frame `SetWindowPos` calls instead,
 /// since every tween frame must apply unconditionally to progress the
 /// animation rather than skip via this function's no-op check.
-pub(super) fn apply_pill_placement<R: Runtime>(
+pub(crate) fn apply_pill_placement<R: Runtime>(
     pill: &WebviewWindow<R>,
     placement: PillPlacement,
 ) -> bool {
@@ -225,9 +260,14 @@ pub(super) fn apply_pill_placement<R: Runtime>(
     #[cfg(not(target_os = "windows"))]
     {
         if needs_resize {
+            // `placement` is physical px; Tauri's set_size takes logical
+            // points on non-Windows. The Windows path uses SetWindowPos with
+            // the physical values directly; here convert back so the
+            // variable-width pill sizes correctly on macOS too.
+            let scale = pill.scale_factor().unwrap_or(1.0).max(0.1);
             pill.set_size(tauri::LogicalSize::new(
-                PILL_WIDTH_POINTS,
-                PILL_HEIGHT_POINTS,
+                placement.width as f64 / scale,
+                placement.height as f64 / scale,
             ))
             .ok();
         }
@@ -287,7 +327,7 @@ mod tests {
 
     #[test]
     fn centers_on_secondary_monitor_with_positive_coordinates() {
-        let placement = placement_for_monitor(monitor(1920, 0, 2560, 1400, 1.0));
+        let placement = placement_for_monitor(monitor(1920, 0, 2560, 1400, 1.0), 380.0, 44.0);
 
         assert_eq!(placement.width, 380);
         assert_eq!(placement.height, 44);
@@ -297,7 +337,7 @@ mod tests {
 
     #[test]
     fn centers_on_monitor_with_negative_coordinates() {
-        let placement = placement_for_monitor(monitor(-2560, 0, 2560, 1400, 1.0));
+        let placement = placement_for_monitor(monitor(-2560, 0, 2560, 1400, 1.0), 380.0, 44.0);
 
         assert_eq!(placement.x, -1470);
         assert_eq!(placement.y, 1340);
@@ -305,7 +345,7 @@ mod tests {
 
     #[test]
     fn respects_retina_scaling() {
-        let placement = placement_for_monitor(monitor(0, 0, 2880, 1800, 2.0));
+        let placement = placement_for_monitor(monitor(0, 0, 2880, 1800, 2.0), 380.0, 44.0);
 
         assert_eq!(placement.width, 760);
         assert_eq!(placement.height, 88);
@@ -315,9 +355,40 @@ mod tests {
 
     #[test]
     fn uses_work_area_bottom_instead_of_full_monitor_height() {
-        let placement = placement_for_monitor(monitor(0, 40, 1920, 1040, 1.0));
+        let placement = placement_for_monitor(monitor(0, 40, 1920, 1040, 1.0), 380.0, 44.0);
 
         assert_eq!(placement.y, 1020);
+    }
+
+    #[test]
+    fn content_width_places_narrower_pill_centered() {
+        // A content-sized pill (e.g. 92px for the bare recording capsule)
+        // must still be centered on the work area, not anchored left.
+        let placement = placement_for_monitor(monitor(0, 0, 1920, 1040, 1.0), 92.0, 44.0);
+
+        assert_eq!(placement.width, 92);
+        assert_eq!(placement.x, 914);
+        assert_eq!(placement.y, 980);
+    }
+
+    #[test]
+    fn content_width_scales_into_physical_pixels() {
+        let placement = placement_for_monitor(monitor(0, 0, 2880, 1800, 1.5), 92.0, 44.0);
+
+        assert_eq!(placement.width, 138);
+        assert_eq!(placement.x, 1371);
+    }
+
+    #[test]
+    fn taller_pill_window_rises_off_the_work_area_bottom() {
+        // A taller window (profile label floating above the capsule) keeps its
+        // bottom pinned to the same work-area gap as the 44px default.
+        let tall = placement_for_monitor(monitor(0, 0, 1920, 1040, 1.0), 92.0, 64.0);
+        let normal = placement_for_monitor(monitor(0, 0, 1920, 1040, 1.0), 92.0, 44.0);
+
+        assert_eq!(tall.height, 64);
+        assert_eq!(tall.y, normal.y - 20);
+        assert_eq!(tall.x, normal.x);
     }
 
     fn placement(x: i32, y: i32, width: i32, height: i32) -> PillPlacement {

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -15,11 +15,37 @@ pub(super) const CANCEL_RESUME_WINDOW: std::time::Duration = std::time::Duration
 pub(super) const PASTE_FAILURE_WINDOW: std::time::Duration = std::time::Duration::from_secs(300);
 // ---------- shared state ----------
 
+/// Default pill window width (logical points) before the frontend reports the
+/// real content width. Deliberately the *smallest* content width (the bare
+/// recording capsule, matching PillApp.svelte's MIN_PILL_WINDOW_W) rather than
+/// the historical fixed 380: the frontend widens the window within a frame of
+/// mounting whenever it needs more, so starting small means the very first
+/// reveal never flashes a 380px-wide transparent click-capture band around a
+/// 72px pill.
+pub const DEFAULT_PILL_WIDTH_POINTS: f64 = 96.0;
+
+/// Default pill window height (logical points) — the bare 34px capsule plus
+/// vertical shadow/entrance-transform margin (PillApp.svelte's
+/// MIN_PILL_WINDOW_H). Grows when the profile label floats above the pill
+/// (see `pill_height_points`).
+pub const DEFAULT_PILL_HEIGHT_POINTS: f64 = 54.0;
+
 pub struct AppState {
     pub lifecycle: DictationLifecycle,
     pub target: WindowTarget,
     pub pill_placement: Option<PillPlacement>,
     pub pill_placement_stale: bool,
+    /// Width (logical points / CSS px) the pill window should be sized to —
+    /// reported by the frontend from the measured visible content so the
+    /// transparent click-capture zone around the pill stays as small as the
+    /// pill itself (see `commands::recording::set_pill_size`). Used by the
+    /// placement math so reveals and cross-monitor moves size to the content
+    /// instead of snapping back to the old fixed 380px.
+    pub pill_width_points: f64,
+    /// Height (logical points) the pill window should be sized to. Tracks the
+    /// profile label floating above the capsule; the window grows upward so
+    /// the pill itself stays visually pinned.
+    pub pill_height_points: f64,
     pub retry_capture: Option<RetryCapture>,
     pub cancelled_capture: Option<CancelledCapture>,
     pub paste_failure: Option<PasteFailure>,
@@ -602,6 +628,8 @@ mod tests {
             target: WindowTarget::default(),
             pill_placement: None,
             pill_placement_stale: false,
+            pill_width_points: DEFAULT_PILL_WIDTH_POINTS,
+            pill_height_points: DEFAULT_PILL_HEIGHT_POINTS,
             retry_capture: None,
             cancelled_capture: None,
             paste_failure: None,

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -634,7 +634,10 @@
         // A fresh recording starts a brand-new dictation: drop the previous
         // one's profile/stage. Terminal states are no longer "in progress", so
         // they clear too (idle is handled by goIdle).
-        if (incoming !== 'processing') {
+        if (
+          incoming !== 'processing' &&
+          incoming !== 'loading_local_model'
+        ) {
           clearStage();
         }
         if (incoming === 'recording') {

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -219,21 +219,24 @@
   // stutter the window. A newer size while one is in flight just overwrites
   // the pending slot, so only the latest value gets sent once the current
   // call resolves.
-  let pillSizeInFlight = false;
-  let pillSizePending: { w: number; h: number } | null = null;
+    let pillSizeInFlight = false;
+    let pillSizeInFlightTarget: { w: number; h: number } | null = null;
+    let pillSizePending: { w: number; h: number } | null = null;
 
-  function sendPillSize(w: number, h: number) {
-    pillSizeInFlight = true;
-    import('@tauri-apps/api/core')
+    function sendPillSize(w: number, h: number) {
+      pillSizeInFlight = true;
+      pillSizeInFlightTarget = { w, h };
+      import('@tauri-apps/api/core')
       .then(({ invoke }) => invoke('set_pill_size', { width: w, height: h }))
       .then(() => {
         lastSentWidth = w;
         lastSentHeight = h;
       })
       .catch(() => {})
-      .finally(() => {
-        pillSizeInFlight = false;
-        if (pillSizePending) {
+        .finally(() => {
+          pillSizeInFlight = false;
+          pillSizeInFlightTarget = null;
+          if (pillSizePending) {
           const next = pillSizePending;
           pillSizePending = null;
           sendPillSize(next.w, next.h);

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -257,10 +257,11 @@
 
   function reportPillSize(width: number, height: number) {
     const w = windowWidthFor(width);
-    const h = windowHeightFor(height);
-    if (pillSizeInFlight) {
-      pillSizePending = w === lastSentWidth && h === lastSentHeight ? null : { w, h };
-      return;
+      const h = windowHeightFor(height);
+      if (pillSizeInFlight) {
+        pillSizePending =
+          pillSizeInFlightTarget?.w === w && pillSizeInFlightTarget.h === h ? null : { w, h };
+        return;
     }
     if (w === lastSentWidth && h === lastSentHeight) return;
     sendPillSize(w, h);

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -125,13 +125,24 @@
   // value — an over-large guess cost an extra native resize on every entry
   // into processing, purely to correct the guess.
   const STAGE_FALLBACK_W = 72;
+  // The live label being measured against sits in .stage-sizer, a plain
+  // (untransformed) element — but the ACTIVE label the width actually has to
+  // fit lives inside .stage-roll, which carries a permanent `transform:
+  // translateY(...)` for the counter-roll effect. That transform promotes it
+  // to its own compositing layer, and text on a composited layer measures a
+  // little wider in Chromium than the same text laid out normally — measured
+  // at ~0.7–1.4px in testing. Small and constant, not a transition artifact,
+  // so it doesn't resolve on its own; it read as every stage label having its
+  // last pixel or two of tail (often the "…") shaved off, permanently. A
+  // small fixed pad absorbs it without the pill visibly gaining width.
+  const STAGE_WIDTH_SAFETY_PX = 3;
 
   function readStageWidths(node: HTMLElement) {
     const next = { ...stageWidthByLabel };
     let changed = false;
     node.querySelectorAll<HTMLElement>('[data-stage-label]').forEach((row) => {
       const label = row.dataset.stageLabel;
-      const w = Math.ceil(row.getBoundingClientRect().width);
+      const w = Math.ceil(row.getBoundingClientRect().width) + STAGE_WIDTH_SAFETY_PX;
       if (label && w > 0 && next[label] !== w) {
         next[label] = w;
         changed = true;
@@ -1094,6 +1105,27 @@
     overflow: hidden;
     width: 100vw; height: 100vh;
     font-family: var(--sans);
+  }
+
+  /* Click-through is OFF for handsfree/error/cancelled/paste_failed (see
+     pill.rs's has_clickable_buttons) so their Retry/Dismiss/Confirm buttons
+     are real, clickable controls — which means WebView2 receives real mouse
+     events there, and nothing had ever told it not to behave like a normal
+     web page about it. Two default browser behaviors both rendered as a
+     stray blue rounded box floating behind the pill, easy to mistake for a
+     completely unrelated system overlay: dragging across the pill text
+     produced an ordinary text selection highlight, and clicking a button
+     left it holding focus, which draws Chromium's default blue
+     :focus-visible ring around the nearest focusable ancestor. This is a
+     floating notification overlay, not a page — nothing in it needs to be
+     selectable or keyboard-focused, so both are simply off. */
+  :global(*) {
+    user-select: none;
+    -webkit-user-select: none;
+  }
+  :global(*:focus),
+  :global(*:focus-visible) {
+    outline: none;
   }
 
   .wrap {

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { getProfileLabel } from './lib/appMappings';
 
   type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied';
   let state: PillState = 'idle';
   let errorMsg = '';
   let errOpen = false;
   let errWidth = 0;
+  let errHeight = 34;
+  let errLines = 1;
+  let errScroll = false;
   let errTextEl: HTMLSpanElement | null = null;
+  let errSizerEl: HTMLSpanElement | null = null;
   let errorTimer: ReturnType<typeof setTimeout> | null = null;
   let showHfButtons = false;
   let hfTimer: ReturnType<typeof setTimeout> | null = null;
@@ -24,7 +29,244 @@
   let dying = false;
   let dyingTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Resolved tone profile for the current dictation (label form, e.g. "Casual"),
+  // emitted by the backend from the pipeline's own resolution.
+  let profileLabel: string | null = null;
+
+  // Processing sub-stage ("Transcribing…" / "Cleaning…" / "Pasting…"), driven
+  // by real `pill-stage` events from the pipeline. Rows for the stages that
+  // have occurred stay mounted in a stack (see .stage-roll) and the active one
+  // is selected by position, so a stage change is a pure transform roll — the
+  // text never remounts, which is what keeps the transition flicker-free. Only
+  // stages that actually ran are mounted, so a skipped one is never scrolled
+  // through (see seenStages). A stage only replaces the
+  // previous one once it has been visible a minimum time, so a sub-400ms stage
+  // (e.g. cleanup resolving instantly when disabled) can't flash; the newest
+  // pending stage always wins and terminal states clear everything.
+  const STAGE_MIN_MS = 400;
+  const STAGE_ROWS = ['Transcribing…', 'Cleaning…', 'Pasting…'] as const;
+  const STAGE_INDEX: Record<string, number> = {
+    transcribing: 0,
+    cleaning: 1,
+    pasting: 2,
+  };
+  // 16, not 14: at 11px/weight-600 the row's own clip window (.stage-counter,
+  // overflow:hidden) was cutting into descenders — the tail of "g" in
+  // "Cleaning…" and the low-sitting "…" dots. A tight 14px line-height for an
+  // 11px bold face doesn't leave enough room below the baseline; must stay in
+  // sync with .stage-counter/.stage-row's height and line-height in the CSS
+  // section below, since this drives the roll's translateY math.
+  const STAGE_ROW_H = 16;
+  let stageIndex = -1;
+  let pendingStageIndex: number | null = null;
+  let stageTimer: ReturnType<typeof setTimeout> | null = null;
+  let stageShownAt = 0;
+
+  // Which stages this dictation has actually reached, in pipeline order. Rows
+  // are mounted as their stage occurs rather than all three up front: with a
+  // fixed three-row stack, rolling from "Transcribing…" to "Pasting…" scrolled
+  // *through* the "Cleaning…" row, so a run with cleanup disabled still flashed
+  // a stage the backend correctly never emitted.
+  let seenStages: number[] = [];
+
+  function commitStage(idx: number) {
+    if (!seenStages.includes(idx)) {
+      seenStages = [...seenStages, idx].sort((a, b) => a - b);
+    }
+    stageIndex = idx;
+    stageShownAt = performance.now();
+  }
+
+  function onPillStage(stageName: string) {
+    const idx = STAGE_INDEX[stageName];
+    if (
+      idx === undefined ||
+      (state !== 'processing' && state !== 'loading_local_model') ||
+      stageIndex === idx
+    ) return;
+    if (stageIndex === -1 || performance.now() - stageShownAt >= STAGE_MIN_MS) {
+      commitStage(idx);
+      pendingStageIndex = null;
+      return;
+    }
+    pendingStageIndex = idx;
+    if (stageTimer) return;
+    const remaining = STAGE_MIN_MS - (performance.now() - stageShownAt);
+    stageTimer = setTimeout(() => {
+      stageTimer = null;
+      if (pendingStageIndex !== null) {
+        commitStage(pendingStageIndex);
+        pendingStageIndex = null;
+      }
+    }, remaining);
+  }
+
+  function clearStage() {
+    if (stageTimer) {
+      clearTimeout(stageTimer);
+      stageTimer = null;
+    }
+    pendingStageIndex = null;
+    stageIndex = -1;
+    seenStages = [];
+  }
+
+  // Natural width of each stage label, measured from the hidden sizer rather
+  // than hardcoded, since the widths depend on the user's font rendering and
+  // not just the string. The capsule sizes itself to whichever label is showing
+  // instead of standing at one width sized for the longest — at a fixed width
+  // "Pasting…" sat in a wide field of empty pill. Keyed by label, not index:
+  // the roll mounts rows as stages occur so positions shift, but a label's
+  // width never does.
+  let stageWidthByLabel: Record<string, number> = {};
+  // Only used for the frame between the pill mounting and the sizer being
+  // measured. Kept close to the real widest label ("Transcribing…" ≈ 70px at
+  // 11px/600) so that frame picks the same quantized window as the measured
+  // value — an over-large guess cost an extra native resize on every entry
+  // into processing, purely to correct the guess.
+  const STAGE_FALLBACK_W = 72;
+
+  function readStageWidths(node: HTMLElement) {
+    const next = { ...stageWidthByLabel };
+    let changed = false;
+    node.querySelectorAll<HTMLElement>('[data-stage-label]').forEach((row) => {
+      const label = row.dataset.stageLabel;
+      const w = Math.ceil(row.getBoundingClientRect().width);
+      if (label && w > 0 && next[label] !== w) {
+        next[label] = w;
+        changed = true;
+      }
+    });
+    if (changed) stageWidthByLabel = next;
+  }
+
+  function measureStageRows(node: HTMLElement) {
+    readStageWidths(node);
+    // Re-measure once webfonts land. The first pass runs at mount, which can be
+    // while the fallback face is still active; the real face is usually wider,
+    // and sizing the pill to the fallback measurement clipped the tail of the
+    // longest label ("Transcribing…" lost its ellipsis).
+    document.fonts?.ready
+      .then(() => {
+        if (node.isConnected) readStageWidths(node);
+      })
+      .catch(() => {});
+    // Anything else that changes text metrics (a cross-monitor DPI change)
+    // resizes the roll, so re-measure from that too. This cannot feed back:
+    // .stage-roll is flex-shrink:0, so its width tracks its own content and
+    // never the pill width we derive from it.
+    const ro =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => readStageWidths(node))
+        : null;
+    ro?.observe(node);
+    return {
+      destroy() {
+        ro?.disconnect();
+      },
+    };
+  }
+  // Widest label overall — drives the steady window width during processing.
+  $: stageMaxW = Object.keys(stageWidthByLabel).length
+    ? Math.max(...Object.values(stageWidthByLabel))
+    : STAGE_FALLBACK_W;
+  // Visible capsule width follows the stage on screen. Before the first stage
+  // arrives it sits at the widest, so the pill only ever narrows into it.
+  $: stageW = stageWidthByLabel[STAGE_ROWS[stageIndex] ?? ''] ?? stageMaxW;
+
+  // Rows actually mounted, and where the current stage sits among them.
+  $: activeStageRows = seenStages.map((i) => STAGE_ROWS[i]);
+  $: rollPos = Math.max(0, seenStages.indexOf(stageIndex));
+
   const BARS = 12;
+
+  // --- Content-fit window sizing -------------------------------------------
+  // The pill window's native size follows the visible content (capsule +
+  // profile label floating above it + expanded error text) so the transparent
+  // click-capture zone around the pill never exceeds the pill itself.
+  // Measured here (CSS px == logical points on the pill's monitor) and pushed
+  // to the backend, which resizes the window center-anchored horizontally and
+  // bottom-anchored vertically, so the pill never moves while it grows.
+  // `offsetWidth/offsetHeight` are layout dimensions, so the entrance/exit
+  // scale transforms don't pollute the measurement.
+  const PILL_PAD_W = 20; // shadow bleed margin (10px per side)
+  const PILL_PAD_H = 20; // shadow + entrance-transform bleed (10px top + bottom)
+  const MIN_PILL_WINDOW_W = 96; // smallest capsule (recording) + PAD_W, on-step
+  const MIN_PILL_WINDOW_H = 54; // bare capsule + PAD_H
+  // Native window widths are quantized to this step. A CSS width transition
+  // fires the ResizeObserver every animation frame, and issuing a native
+  // SetWindowPos per frame is what made WebView2 present stale/clipped frames
+  // mid-morph — the "half the pill is missing" artifact. Rounding up to a step
+  // turns a ~15-resize transition into 2-3, while keeping the click-capture
+  // zone within one step of the real pill instead of the old fixed 380px band.
+  const PILL_STEP_W = 24;
+  const windowWidthFor = (contentW: number) =>
+    Math.max(Math.ceil((contentW + PILL_PAD_W) / PILL_STEP_W) * PILL_STEP_W, MIN_PILL_WINDOW_W);
+  const windowHeightFor = (contentH: number) =>
+    Math.max(Math.round(contentH + PILL_PAD_H), MIN_PILL_WINDOW_H);
+  let clusterEl: HTMLDivElement | null = null;
+  let lastSentWidth = 0;
+  let lastSentHeight = 0;
+  // Deferred "final size" report: growth is sent immediately (so content is
+  // never clipped mid-transition), but shrinking waits for ~100ms of quiet —
+  // a shrinking pill's ResizeObserver fires every animation frame, and chasing
+  // it with a native resize per frame is exactly the flicker this avoids.
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // At most one set_pill_size call is ever in flight — content-fit resizing
+  // fires on every animation frame of a width transition, and firing an
+  // invoke per frame let concurrent/out-of-order native resizes visibly
+  // stutter the window. A newer size while one is in flight just overwrites
+  // the pending slot, so only the latest value gets sent once the current
+  // call resolves.
+  let pillSizeInFlight = false;
+  let pillSizePending: { w: number; h: number } | null = null;
+
+  function sendPillSize(w: number, h: number) {
+    pillSizeInFlight = true;
+    import('@tauri-apps/api/core')
+      .then(({ invoke }) => invoke('set_pill_size', { width: w, height: h }))
+      .then(() => {
+        lastSentWidth = w;
+        lastSentHeight = h;
+      })
+      .catch(() => {})
+      .finally(() => {
+        pillSizeInFlight = false;
+        if (pillSizePending) {
+          const next = pillSizePending;
+          pillSizePending = null;
+          sendPillSize(next.w, next.h);
+        }
+      });
+  }
+
+  function reportPillSize(width: number, height: number) {
+    const w = windowWidthFor(width);
+    const h = windowHeightFor(height);
+    if (pillSizeInFlight) {
+      pillSizePending = w === lastSentWidth && h === lastSentHeight ? null : { w, h };
+      return;
+    }
+    if (w === lastSentWidth && h === lastSentHeight) return;
+    sendPillSize(w, h);
+  }
+
+  function measureAndResize() {
+    if (!clusterEl) return;
+    const w = windowWidthFor(clusterEl.offsetWidth);
+    const h = windowHeightFor(clusterEl.offsetHeight);
+    if (w > lastSentWidth || h > lastSentHeight) {
+      reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
+    }
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => {
+      settleTimer = null;
+      if (clusterEl) reportPillSize(clusterEl.offsetWidth, clusterEl.offsetHeight);
+    }, 100);
+  }
+
+  let pillResizeObserver: ResizeObserver | null = null;
 
   // Snap CSS-px lengths to a whole number of device pixels. On fractional DPI
   // scaling (e.g. 1.25×/1.5×) a hardcoded 3px bar maps to a fractional device
@@ -50,6 +292,35 @@
   const snap = (px: number, d: number) => Math.round(px * d) / d;
   $: barW = snap(3, dpr);
   $: barGap = snap(2, dpr);
+
+  // Full rendered width of the expanded handsfree pill (mirrors
+  // .pill.handsfree.hf-expanded's width calc exactly) — needed in JS so the
+  // native window can be locked to it for the whole handsfree state (see
+  // steady-width-hf below) instead of resizing when the Cancel/Confirm
+  // buttons reveal.
+  $: hfExpandedW = 12 * barW + 11 * barGap + 54;
+  // Full width of the fixed "Loading model" pill (mirrors .pill.loading-local).
+  const LOADING_LOCAL_W = 144;
+  // The native window for the processing state must stay wide enough for
+  // BOTH the widest stage label at rest AND the starting width of whichever
+  // from-* entrance is actually playing. Handsfree and loading-local's pills
+  // are both wider than "Transcribing…" + chrome, so a window sized only for
+  // the steady state was too narrow for the first frame of those entrances —
+  // the pill wanted to render wider than the window allowed, forcing a
+  // grow-then-shrink native resize as the entrance keyframe played out. That
+  // double resize is what read as "processing teleports/adjusts right as it
+  // appears."
+  //
+  // Gated on prevState (which entrance is actually about to play), not an
+  // unconditional max of every possible entrance: unconditionally including
+  // loading-local's width made the WINDOW pay for a keyframe that wasn't
+  // running, forcing a resize on the ordinary recording/handsfree path that
+  // didn't need one — the exact class of bug this is fixing, just relocated.
+  $: processingSteadyW = Math.max(
+    stageMaxW + 24,
+    prevState === 'handsfree' ? hfExpandedW : 0,
+    prevState === 'loading_local_model' ? LOADING_LOCAL_W : 0
+  );
 
   // matchMedia watcher for cross-monitor DPI changes. Kept at component scope
   // (not inside onMount) so refreshDpr can re-arm it: a (resolution: Xdppx)
@@ -89,18 +360,34 @@
     return 0.45 + center + Math.random() * 0.2;
   });
 
-  let barHeights: number[] = Array(BARS).fill(2);
+  const BAR_MIN_H = 3;
+  const BAR_MAX_H = 16;
+  let barHeights: number[] = Array(BARS).fill(BAR_MIN_H);
   let targetLevel = 0;
   let smoothed = 0;
-  let lastLevelTime = 0;
-  let targetNoiseArr: number[] = Array.from({ length: BARS }, () => Math.random());
-  let currentNoiseArr: number[] = [...targetNoiseArr];
-  let lastNoiseT = 0;
   let rafId = 0;
   const PEAK_FLOOR = 0.07;
   let adaptivePeak = PEAK_FLOOR;
 
   let lastAnimTime = 0;
+
+  // Spatially-continuous shimmer: three sine waves of different spatial
+  // frequencies drifting at different speeds, sampled once per bar. Because
+  // it's a smooth function of (position, time), neighbouring bars always move
+  // together as one flowing waveform. What this replaces gave every bar its
+  // own independent random walk, re-rolled every 400ms and lerped between
+  // rolls — which is why a steady voice read as a row of unrelated twitching
+  // dots instead of audio, and why it managed to look both too static (the
+  // walk barely travelled between rolls) and too restless (neighbours never
+  // agreed on a direction). Being pure (u, t) math it also keeps the row alive
+  // at a dead-constant input level, with no per-frame Math.random() at all.
+  function shimmerAt(u: number, t: number): number {
+    const wave =
+      Math.sin(u * 3.1 + t * 1.9) * 0.5 +
+      Math.sin(u * 6.3 - t * 1.3) * 0.3 +
+      Math.sin(u * 1.7 + t * 2.7) * 0.2;
+    return 0.72 + wave * 0.28; // ≈ 0.44 … 1.00
+  }
 
   function animateBars(time: number) {
     if (!lastAnimTime) lastAnimTime = time;
@@ -110,50 +397,42 @@
     // Keep bar snapping aligned to whichever monitor the pill is currently on.
     refreshDpr();
 
-    // Extremely smooth, premium rise and fall (high inertia)
-    // Rise: ~12% per 16ms frame (takes ~100-150ms to swell up smoothly)
-    const riseRate = 1 - Math.pow(0.88, dt / 16.66);
-    // Fall: ~3% per 16ms frame (takes almost a full second to melt down, very lingering)
-    const fallRate = 1 - Math.pow(0.97, dt / 16.66);
-    
+    // Rise stays quick so the bars catch speech onsets. The fall used to decay
+    // at 0.97/frame — ~1.3s to bottom out, so the row went on melting long
+    // after the sound stopped and every syllable smeared into the next.
+    // 0.90 lands in ~400ms: still smooth, but it actually tracks the voice.
+    const riseRate = 1 - Math.pow(0.84, dt / 16.66);
+    const fallRate = 1 - Math.pow(0.9, dt / 16.66);
+
     if (targetLevel > smoothed) {
       smoothed += (targetLevel - smoothed) * riseRate;
     } else {
       smoothed += (targetLevel - smoothed) * fallRate;
     }
 
-    if (smoothed > adaptivePeak) adaptivePeak = smoothed;
+    // Soft noise gate: subtract the floor rather than branching on it. The old
+    // `if (smoothed < GATE) fill(3)` snapped all twelve bars flat in a single
+    // frame the instant the level crossed the threshold, so a fading tail
+    // stopped mid-fall and collapsed — the "drifts down slowly, then just
+    // compacts" artifact. Subtracting is continuous, so the bars simply reach
+    // the floor and stay there.
+    const gated = Math.max(0, smoothed - GATE);
 
-    // Peak decays very slowly to maintain a steady visual baseline
-    adaptivePeak = Math.max(PEAK_FLOOR, adaptivePeak * Math.pow(0.9997, dt / 16.66));
+    if (gated > adaptivePeak) adaptivePeak = gated;
+    // Re-adapt within a sentence or two. At the old 0.9997 the peak took ~40s
+    // to forget a single loud moment, so everything after a cough or a laugh
+    // normalised against it and sat near-flat.
+    adaptivePeak = Math.max(PEAK_FLOOR, adaptivePeak * Math.pow(0.9985, dt / 16.66));
 
-    // Slow down the organic "lava lamp" noise shift (was 140ms, now 400ms)
-    if (time - lastNoiseT > 400) {
-      targetNoiseArr = targetNoiseArr.map(v => v * 0.7 + Math.random() * 0.3);
-      lastNoiseT = time;
-    }
+    // Normalize against the adaptive peak so quiet mics still drive bars to
+    // full height; ease the mapping (pow 1.5) so small noises stay gentle.
+    const eased = Math.pow(Math.min(gated / adaptivePeak, 1), 1.5);
+    const t = time / 1000;
 
-    // Interpolate noise very slowly for a gentle breathing ripple
-    const noiseLerpRate = 1 - Math.pow(0.95, dt / 16.66);
-    for (let i = 0; i < BARS; i++) {
-      currentNoiseArr[i] += (targetNoiseArr[i] - currentNoiseArr[i]) * noiseLerpRate;
-    }
-
-    // Gate on raw smoothed to suppress background noise; normalize against the
-    // adaptive peak so quiet mics still drive bars to full height.
-    if (smoothed < GATE) {
-      barHeights = Array(BARS).fill(3);
-    } else {
-      const normalized = Math.min(smoothed / adaptivePeak, 1.0);
-      // Ease the volume mapping (pow 1.5) so small noises are gentle
-      const eased = Math.pow(normalized, 1.5);
-      
-      barHeights = barGains.map((gain, i) => {
-        // Reduced noise influence (from 0.55 to 0.4) so it's less chaotic, more structured
-        const energy = eased * gain * (0.6 + currentNoiseArr[i] * 0.4);
-        return 3 + energy * 13;
-      });
-    }
+    barHeights = barGains.map((gain, i) => {
+      const energy = eased * gain * shimmerAt(i / (BARS - 1), t);
+      return BAR_MIN_H + energy * (BAR_MAX_H - BAR_MIN_H);
+    });
 
     rafId = requestAnimationFrame(animateBars);
   }
@@ -162,7 +441,7 @@
     if (rafId === 0) { lastAnimTime = 0; rafId = requestAnimationFrame(animateBars); }
   }
   function stopRaf() {
-    if (rafId !== 0) { cancelAnimationFrame(rafId); rafId = 0; barHeights = Array(BARS).fill(3); }
+    if (rafId !== 0) { cancelAnimationFrame(rafId); rafId = 0; barHeights = Array(BARS).fill(BAR_MIN_H); }
   }
 
 
@@ -174,9 +453,14 @@
       dyingTimer = null;
       prevState = state;
       state = 'idle';
+      clearStage();
+      profileLabel = null;
       smoothed = 0;
       errOpen = false;
       errWidth = 0;
+      errHeight = 34;
+      errLines = 1;
+      errScroll = false;
       errorMsg = '';
       if (errorTimer) {
         clearTimeout(errorTimer);
@@ -213,22 +497,36 @@
     }, 200);
   }
 
-  // Error pill dimensions in px — mirror .pill.error's CSS (width / gap / max-width).
-  const ERROR_COLLAPSED_WIDTH = 42;
-  const ERROR_GAP = 8;
-  const ERROR_MAX_WIDTH = 356;
-  // Retry button (18px) + the flex gap in front of it — reserved
-  // unconditionally since the button always shows once the pill is open.
-  const ERROR_RETRY_BTN_WIDTH = 26;
+  // Error surface geometry, in px — mirrors .pill.error's CSS. No status icon
+  // (removed — the red palette plus Dismiss/Retry on either side already
+  // read as "error" without it), so the collapsed capsule is bare padding
+  // and briefly empty for the one frame before it opens.
+  const ERROR_COLLAPSED_WIDTH = 28;
+  // Everything in the row that is not the message: dismiss (18) + retry (18)
+  // + the two 8px flex gaps flanking the text (dismiss↔text, text↔retry) +
+  // 14px padding either side.
+  const ERROR_CHROME_W = 80;
+  // Width the message column wraps at. Past this the pill stops widening and
+  // starts growing upward into a card instead.
+  const ERROR_TEXT_MAX_W = 250;
+  const ERROR_LINE_H = 15;
+  // Beyond this the card stops growing and the message scrolls inside it.
+  const ERROR_MAX_LINES = 7;
+  const ERROR_CARD_PAD_V = 22; // 10px top + 10px bottom + a little slack
+  const ERROR_SINGLE_H = 34; // the bare capsule — same as .pill's base height
 
-  // Opens the error pill: render collapsed (icon-only), measure the message
-  // text, then grow to its natural width so the CSS width transition has a
-  // starting value to animate from. pill-error and pill-state arrive as
-  // separate events in unspecified order, so openError() can be invoked
-  // again before or after a prior call finishes. The task id lets a stale
-  // call bail out instead of clobbering a newer one's measurement, and
-  // wasOpen skips the collapse phase on a re-trigger so an already-open pill
-  // resizes in place instead of visibly collapsing and re-expanding.
+  // Opens the error pill: render collapsed (icon-only), measure the message,
+  // then grow to fit it so the CSS transitions have a starting value to
+  // animate from. Short messages stay a single-line capsule and only widen;
+  // longer ones cap their width, wrap, and grow upward into a rounded card;
+  // past ERROR_MAX_LINES the card stops growing and the text scrolls.
+  //
+  // pill-error and pill-state arrive as separate events in unspecified order,
+  // so openError() can be invoked again before or after a prior call
+  // finishes. The task id lets a stale call bail out instead of clobbering a
+  // newer one's measurement, and wasOpen skips the collapse phase on a
+  // re-trigger so an already-open pill resizes in place rather than visibly
+  // collapsing and re-expanding.
   let openErrorTaskId = 0;
   async function openError() {
     const taskId = ++openErrorTaskId;
@@ -236,27 +534,62 @@
     if (!wasOpen) {
       errOpen = false;
       errWidth = ERROR_COLLAPSED_WIDTH;
+      errHeight = ERROR_SINGLE_H;
+      errLines = 1;
+      errScroll = false;
     }
     await tick();
     if (taskId !== openErrorTaskId || state !== 'error') return;
 
-    const applyWidth = () => {
-      const textW = errTextEl?.scrollWidth ?? 0;
-      const errWidthNatural = textW > 0
-        ? Math.min(ERROR_COLLAPSED_WIDTH + ERROR_GAP + textW + ERROR_RETRY_BTN_WIDTH, ERROR_MAX_WIDTH)
-        : ERROR_COLLAPSED_WIDTH;
-      errWidth = errWidthNatural;
+    const applySize = () => {
+      // Measured off the hidden sizer, not the live .err-text: the live one is
+      // a flex item squeezed to ~0 inside the collapsed capsule, so it can only
+      // report a scrollWidth, which says nothing about how many lines the
+      // message needs once it is allowed to wrap.
+      const box = errSizerEl?.getBoundingClientRect();
+      const textW = box ? Math.ceil(box.width) : 0;
+      const lines = box ? Math.max(1, Math.round(box.height / ERROR_LINE_H)) : 1;
+
+      if (textW <= 0) {
+        errWidth = ERROR_COLLAPSED_WIDTH;
+        errHeight = ERROR_SINGLE_H;
+        errScroll = false;
+      } else if (lines <= 1) {
+        errWidth = textW + ERROR_CHROME_W;
+        errHeight = ERROR_SINGLE_H;
+        errScroll = false;
+      } else {
+        errWidth = ERROR_TEXT_MAX_W + ERROR_CHROME_W;
+        const shown = Math.min(lines, ERROR_MAX_LINES);
+        errHeight = shown * ERROR_LINE_H + ERROR_CARD_PAD_V;
+        errScroll = lines > ERROR_MAX_LINES;
+      }
+      errLines = lines;
       errOpen = true;
+      // Eagerly size the native window to the target before the CSS
+      // transition starts, so the growing pill is never clipped while the
+      // ResizeObserver catch-up lags behind the animation.
+      reportPillSize(errWidth, errHeight);
     };
 
     if (wasOpen) {
-      applyWidth();
+      applySize();
     } else {
       requestAnimationFrame(() => {
         if (taskId !== openErrorTaskId || state !== 'error') return;
-        applyWidth();
+        applySize();
       });
     }
+
+    // Re-measure once webfonts land. The first pass can run against the
+    // fallback face, and the real face is usually wider — sizing to the
+    // fallback is what truncated even short messages ("No speech detect…").
+    document.fonts?.ready
+      .then(() => {
+        if (taskId !== openErrorTaskId || state !== 'error') return;
+        applySize();
+      })
+      .catch(() => {});
   }
 
   onMount(() => {
@@ -267,12 +600,39 @@
     // refreshDpr can re-arm it as the pill moves between displays).
     armDprWatch();
 
+    // Track the rendered content size so the native window stays snug around
+    // it. Fires on every width transition/animation frame of the pill, on
+    // label/stage text appearing, and on the initial idle mount (which
+    // pre-sizes the window to the minimum before the first reveal).
+    if (clusterEl && typeof ResizeObserver !== 'undefined') {
+      pillResizeObserver = new ResizeObserver(() => measureAndResize());
+      pillResizeObserver.observe(clusterEl);
+    }
+
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
 
       const l1 = await listen<string>('pill-state', (ev) => {
         const incoming = (ev.payload as PillState) || 'idle';
         if (hfTimer !== null) { clearTimeout(hfTimer); hfTimer = null; }
+
+        // A fresh recording starts a brand-new dictation: drop the previous
+        // one's profile/stage. Terminal states are no longer "in progress", so
+        // they clear too (idle is handled by goIdle).
+        if (incoming !== 'processing') {
+          clearStage();
+        }
+        if (incoming === 'recording') {
+          profileLabel = null;
+        } else if (
+          incoming === 'error' ||
+          incoming === 'cancelled' ||
+          incoming === 'paste_failed' ||
+          incoming === 'copied'
+        ) {
+          clearStage();
+          profileLabel = null;
+        }
 
         if (incoming === 'idle' && state !== 'idle') {
           stopRaf();
@@ -313,6 +673,9 @@
           errorMsg = '';
           errOpen = false;
           errWidth = 0;
+          errHeight = 34;
+          errLines = 1;
+          errScroll = false;
         }
 
         if (state === 'cancelled') {
@@ -357,10 +720,14 @@
             copiedTimer = null;
           }
           if (copyBtnTimer) clearTimeout(copyBtnTimer);
+          // A brief beat (not the 1.2s this replaced) so the pill still reads
+          // as "message, then it widens" rather than popping in fully formed
+          // — but short enough that the widen reads as part of the entrance,
+          // not as a second, disconnected animation arriving a while later.
           copyBtnTimer = setTimeout(() => {
             copyBtnTimer = null;
             if (state === 'paste_failed') showCopyBtn = true;
-          }, 1200);
+          }, 180);
           if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
           pasteFailedDismissTimer = setTimeout(() => {
             pasteFailedDismissTimer = null;
@@ -407,10 +774,22 @@
 
       const l3 = await listen<number>('audio-level', (ev) => {
         targetLevel = ev.payload ?? 0;
-        lastLevelTime = performance.now();
       });
       if (!mounted) { l3(); return; }
       unlisteners.push(l3);
+
+      const l5 = await listen<string>('pill-profile', (ev) => {
+        const profile = ev.payload;
+        profileLabel = profile && profile !== 'unknown' ? getProfileLabel(profile) : null;
+      });
+      if (!mounted) { l5(); return; }
+      unlisteners.push(l5);
+
+      const l6 = await listen<string>('pill-stage', (ev) => {
+        onPillStage(ev.payload);
+      });
+      if (!mounted) { l6(); return; }
+      unlisteners.push(l6);
 
       // Fired when the cancelled capture is resumed or dismissed from
       // *another* window (Home's banner) — if this toast is still showing,
@@ -424,10 +803,17 @@
 
     return () => {
       mounted = false;
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+        settleTimer = null;
+      }
+      pillResizeObserver?.disconnect();
+      pillResizeObserver = null;
       mq?.removeEventListener('change', onDprChange);
       cancelAnimationFrame(rafId);
       if (errorTimer) clearTimeout(errorTimer);
       if (dyingTimer) clearTimeout(dyingTimer);
+      if (stageTimer) clearTimeout(stageTimer);
       if (hfTimer) clearTimeout(hfTimer);
       if (cancelBtnTimer) clearTimeout(cancelBtnTimer);
       if (cancelDismissTimer) clearTimeout(cancelDismissTimer);
@@ -464,6 +850,14 @@
     });
   }
 
+  // Manual early-out for the error toast, mirroring dismissCancelled below —
+  // the 10s auto-dismiss timer is a fallback for "walked away", not a floor
+  // on how long the pill has to sit there once the user has already seen it.
+  function dismissError() {
+    if (errorTimer) { clearTimeout(errorTimer); errorTimer = null; }
+    goIdle();
+  }
+
   async function continueCancelled() {
     if (cancelDismissTimer) { clearTimeout(cancelDismissTimer); cancelDismissTimer = null; }
     const { invoke } = await import('@tauri-apps/api/core');
@@ -495,11 +889,34 @@
       // run out its normal auto-dismiss timer.
     }
   }
+
+  // Manual early-outs for the remaining transient/notification pills, mirroring
+  // dismissError/dismissCancelled above — the auto-dismiss timers exist for
+  // "walked away", not as a floor on how long an already-seen toast must sit.
+  function dismissPasteFailed() {
+    if (copyBtnTimer) { clearTimeout(copyBtnTimer); copyBtnTimer = null; }
+    if (pasteFailedDismissTimer) { clearTimeout(pasteFailedDismissTimer); pasteFailedDismissTimer = null; }
+    if (copiedTimer) { clearTimeout(copiedTimer); copiedTimer = null; }
+    goIdle();
+  }
+
+  function dismissCopied() {
+    if (copiedPillTimer) { clearTimeout(copiedPillTimer); copiedPillTimer = null; }
+    goIdle();
+  }
 </script>
 
 <!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
      has no bars of its own) inherits the DPI-snapped values for its width calc. -->
-<div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px">
+<div class="wrap" style="--bar-w:{barW}px; --bar-gap:{barGap}px; --stage-w:{stageW}px; --processing-steady-w:{processingSteadyW}px; --hf-expanded-w:{hfExpandedW}px">
+  <div class="pill-cluster"
+       class:steady-width={state === 'processing'}
+       class:steady-width-hf={state === 'handsfree'}
+       bind:this={clusterEl}>
+    {#if profileLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
+      <span class="pill-profile">{profileLabel}</span>
+    {/if}
+
   {#if state === 'recording'}
     <div class="pill recording" class:dying={dying}>
       {#each barHeights as h, i (i)}
@@ -513,7 +930,25 @@
          class:from-hf={prevState === 'handsfree'}
          class:from-loading={prevState === 'loading_local_model'}
          class:dying={dying}>
-      <div class="scan-line"></div>
+      <div class="stage-counter" aria-hidden="true">
+        <!-- Hidden, always-complete copy of every label. The visible roll only
+             mounts stages that actually ran, so it can't measure a stage that
+             hasn't happened yet — but the window needs the widest label up
+             front to hold one size for the whole processing state. -->
+        <div class="stage-sizer" use:measureStageRows aria-hidden="true">
+          {#each STAGE_ROWS as label (label)}
+            <span class="stage-row" data-stage-label={label}>{label}</span>
+          {/each}
+        </div>
+        <div class="stage-roll" style="transform: translateY({rollPos * -STAGE_ROW_H}px)">
+          {#each activeStageRows as label (label)}
+            <span class="stage-row">
+              <span class="stage-label">{label}</span>
+              <span class="stage-label stage-shine" aria-hidden="true">{label}</span>
+            </span>
+          {/each}
+        </div>
+      </div>
     </div>
 
   {:else if state === 'loading_local_model'}
@@ -523,11 +958,27 @@
     </div>
 
   {:else if state === 'error'}
-    <div class="pill error" class:err-open={errOpen} class:dying={dying}
-         style={errWidth ? `width:${errWidth}px` : ''}>
-      <svg class="err-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/>
-      </svg>
+    <!-- Hidden copy of the message, allowed to wrap at the real column width.
+         The live .err-text cannot be measured for this: inside the collapsed
+         capsule it is a flex item squeezed to ~0, so it can report a
+         scrollWidth but never a truthful line count. -->
+    <span class="err-sizer" bind:this={errSizerEl} aria-hidden="true">{errorMsg || 'Something went wrong'}</span>
+    <div class="pill error" class:err-open={errOpen} class:err-card={errLines > 1} class:err-scroll={errScroll} class:dying={dying}
+         style={errWidth ? `width:${errWidth}px; height:${errHeight}px` : ''}>
+      {#if errOpen}
+        <!-- No status icon — the red palette plus Dismiss/Retry on either
+             side already say "error" without a redundant exclamation mark.
+             Dismiss sits at the left with Retry pinned to the opposite
+             (right) edge — a passive "close" and an active "do something
+             about it" read better kept apart than stacked on one side.
+             Manual early-out: the pill otherwise sits for the full 10s
+             auto-dismiss even once the user has already read it. -->
+        <button class="hf-btn err-dismiss" onclick={dismissError} aria-label="Dismiss">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <path d="M6 6l12 12M6 18 18 6"/>
+          </svg>
+        </button>
+      {/if}
       <span class="err-text" bind:this={errTextEl}>{errorMsg || 'Something went wrong'}</span>
       {#if errOpen}
         <button class="hf-btn err-retry" onclick={retryFailed} aria-label="Retry">
@@ -571,6 +1022,11 @@
             {/if}
           </svg>
         </button>
+        <button class="hf-btn pf-dismiss" onclick={dismissPasteFailed} aria-label="Dismiss">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <path d="M6 6l12 12M6 18 18 6"/>
+          </svg>
+        </button>
       {/if}
     </div>
 
@@ -580,6 +1036,11 @@
         <polyline points="20 6 9 17 4 12"/>
       </svg>
       <span class="copied-text">{errorMsg || 'Copied last dictation to clipboard'}</span>
+      <button class="hf-btn copied-dismiss" onclick={dismissCopied} aria-label="Dismiss">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+          <path d="M6 6l12 12M6 18 18 6"/>
+        </svg>
+      </button>
     </div>
 
   {:else if state === 'handsfree'}
@@ -605,23 +1066,98 @@
       {/if}
     </div>
   {/if}
+  </div>
 </div>
 
 <style>
   :global(*, *::before, *::after) { box-sizing: border-box; }
+
+  /* The pill window is a transparent floating capsule with no page background
+     of its own. theme.css declares `color-scheme: light` on :root for the main
+     app, and under a light color-scheme the UA paints the viewport canvas
+     WHITE wherever html/body are transparent — so every native resize briefly
+     showed white in the newly exposed area before the page composited over it.
+     That is the flash when a narrow recording capsule jumps straight to a wide
+     error pill. `normal` opts out of the UA canvas colour entirely and leaves
+     it transparent. The selector is doubled deliberately: theme.css sets this
+     on a plain `:root`, and `html` (below) or a single `:root` would tie or
+     lose — tying leaves the winner up to stylesheet injection order, which is
+     a build detail we should not depend on. `:root:root` outranks it outright. */
+  :global(:root:root) { color-scheme: normal; }
+
   :global(html, body, #pill-root) {
     margin: 0; padding: 0;
     background: transparent;
     overflow: hidden;
-    width: 100vw; height: 44px;
+    width: 100vw; height: 100vh;
     font-family: var(--sans);
   }
 
   .wrap {
-    width: 100vw; height: 44px;
+    width: 100vw; height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  /* Measured wrapper — the backend sizes the native window to this element's
+     size (see measureAndResize) so the transparent click-capture zone stays
+     as small as the visible content. Column layout: the profile label floats
+     above the capsule (centered) instead of pushing it off-center. */
+  .pill-cluster {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    /* containing block for .err-sizer, which must stay out of flow so it
+       never contributes to the measured cluster size */
+    position: relative;
+  }
+  /* While processing, hold the measured cluster at processingSteadyW so the
+     native window keeps one size for the whole state. The capsule itself
+     still animates narrower per stage — only the invisible window stays put.
+     Resizing per stage moved the window horizontally (it is re-centred on
+     every size change) and WebView2 can present the previous frame at the new
+     geometry, which read as the pill twitching sideways a few px and snapping
+     back, most visibly on the big transcribing→pasting jump. processingSteadyW
+     (computed in JS) is the max of the widest stage label AND the widest
+     from-* entrance's starting width (handsfree/loading-local pills are both
+     wider than "Transcribing…" + chrome) — sizing only for the steady state
+     left the window too narrow for the first frame of those entrances, so the
+     window had to grow then immediately shrink back as the entrance keyframe
+     played out. */
+  .pill-cluster.steady-width {
+    min-width: var(--processing-steady-w, 144px);
+  }
+  /* Same idea for handsfree: it has exactly two widths (collapsed / button-
+     expanded) that it CSS-transitions between, same shape as processing's
+     per-stage widths, so it gets the same fix — hold the window at the wider
+     (expanded) size for the whole state rather than resizing when the
+     Cancel/Confirm buttons reveal ~150ms after mount. */
+  .pill-cluster.steady-width-hf {
+    min-width: var(--hf-expanded-w, 132px);
+  }
+
+  /* Resolved tone profile, shown as a small floating tag above the pill so
+     the otherwise-invisible style setting stays legible without crowding or
+     offsetting the pill capsule itself. Fades in softly so its appearance
+     reads as the pill growing, not a new element popping in. */
+  .pill-profile {
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--pill-muted);
+    background: var(--pill-bg);
+    border-radius: 999px;
+    padding: 2px 8px;
+    white-space: nowrap;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.35);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+    animation: chipIn 0.18s ease-out both;
+  }
+  @keyframes chipIn {
+    from { opacity: 0; transform: translateY(-3px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 
   .pill {
@@ -636,14 +1172,17 @@
     animation: pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
 
+  /* Translate distances stay inside the window's vertical padding (PILL_PAD_H
+     / 2 per side). At the old 8px/6px against a 5px pad the pill's bottom edge
+     was clipped by the window for the whole entrance and exit. */
   @keyframes pillIn {
-    from { transform: translateY(8px) scale(0.92); opacity: 0; }
+    from { transform: translateY(6px) scale(0.94); opacity: 0; }
     to   { transform: translateY(0) scale(1); opacity: 1; }
   }
 
   @keyframes pillOut {
     from { transform: translateY(0) scale(1); opacity: 1; }
-    to   { transform: translateY(6px) scale(0.88); opacity: 0; }
+    to   { transform: translateY(5px) scale(0.9); opacity: 0; }
   }
 
   .pill.recording.dying,
@@ -680,46 +1219,69 @@
     /* Instant response — no CSS transition so bars snap cleanly */
   }
 
-  /* Processing */
-  .pill.processing { width: 100px; padding: 0 14px; }
+  /* Processing: the stage text fills and centers in the pill (same center as
+     the recording bars) — nothing appears to slide sideways between
+     recording and processing. */
+  /* Width follows the active stage label (--stage-w, measured in
+     measureStageRows) instead of a fixed 140px sized for the longest one, so
+     a short stage like "Pasting…" is a short pill. The transition carries it
+     between stages; the from-* entrance keyframes below deliberately use
+     `backwards` fill so this base width — not a baked-in end value — governs
+     once the entrance finishes. */
+  .pill.processing {
+    width: calc(var(--stage-w, 116px) + 24px);
+    padding: 0 12px;
+    position: relative;
+    transition: width 0.26s cubic-bezier(0.22, 1, 0.36, 1);
+  }
   .pill.loading-local { width: 144px; padding: 0 14px; gap: 9px; }
 
-  /* Recording→processing: grow in width */
+  /* Recording→processing: grow in width. No overshoot — see .pill.error's
+     transition comment; a bouncy width keyframe chases the native window
+     resize the same way a bouncy width transition does. */
+  /* These entrance keyframes declare only `from` and use `backwards` fill, so
+     each animates into the element's own base width and then hands control
+     back to it. With a baked-in `to` and `both` fill the filled end value
+     would outrank the base rule forever, freezing the pill at that width and
+     killing every later stage-to-stage width transition.
+
+     Each is paired with pillIn (comma-separated, not a replacement — see the
+     loading-spinner rule below for the same pattern) so entering processing
+     gets the same scale/opacity fade every other pill state gets. Without it,
+     the whole handsfree capsule (bars, buttons) just hard-cut to processing's
+     text mid-frame — the width eased, but nothing else did, so it read as
+     "no transition, it just appears" rather than one morph. pillIn only
+     touches transform/opacity, the width keyframes only touch width, so the
+     two apply to disjoint properties and don't fight each other. */
   .pill.processing.from-rec {
-    animation: processIn 0.32s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    animation: processIn 0.28s cubic-bezier(0.22, 1, 0.36, 1) backwards,
+               pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
   @keyframes processIn {
     /* start from the recording pill's DPI-snapped width so there's no jump */
     from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px); }
-    to   { width: 100px; }
-  }
-  /* Scan line fades in after the pill has grown */
-  .pill.processing.from-rec .scan-line {
-    animation: scanIn 0.18s ease 0.18s both;
   }
 
   /* Handsfree→processing: pill shrinks slightly */
   .pill.processing.from-hf {
-    animation: processFromHf 0.25s ease-out both;
+    animation: processFromHf 0.25s ease-out backwards,
+               pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
   @keyframes processFromHf {
     /* start from the expanded handsfree pill's DPI-snapped width (bars + 54px of
        buttons/padding/gaps) so there's no jump at fractional DPI */
     from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 54px); }
-    to   { width: 100px; }
-  }
-  .pill.processing.from-hf .scan-line {
-    animation: scanIn 0.18s ease 0.08s both;
   }
 
   /* Processing→loading model: grow smoothly into the wider pill instead of
      popping in fresh, so a cold local model load reads as one continuous
      motion rather than two disconnected "new pill appeared" pops. */
   .pill.loading-local.from-processing {
-    animation: loadingLocalIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    animation: loadingLocalIn 0.26s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
   @keyframes loadingLocalIn {
-    from { width: 100px; }
+    /* start from whatever width the processing pill was actually showing */
+    from { width: calc(var(--stage-w, 116px) + 24px); }
     to   { width: 144px; }
   }
   /* Comma-separated, not a separate rule: the entrance fade and the
@@ -734,16 +1296,14 @@
   }
 
   /* Loading model→processing: shrink back down once the model is warm and
-     transcription/cleanup resumes, mirroring the handsfree→processing shrink. */
+     transcription/cleanup resumes, mirroring the handsfree→processing shrink.
+     Paired with pillIn for the same reason as from-rec/from-hf above. */
   .pill.processing.from-loading {
-    animation: processFromLoading 0.26s ease-out both;
+    animation: processFromLoading 0.26s ease-out backwards,
+               pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
   @keyframes processFromLoading {
     from { width: 144px; }
-    to   { width: 100px; }
-  }
-  .pill.processing.from-loading .scan-line {
-    animation: scanIn 0.18s ease 0.08s both;
   }
 
   /* If the pipeline exits idle mid-transition (e.g. cancelled right as a
@@ -758,27 +1318,110 @@
     animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
   }
 
-  /* Scan line: dim track with a bright light sweeping back and forth */
-  .scan-line {
+  /* Stage counter: the stages that have run stay mounted in one vertical
+     stack and the active one is picked by a translateY roll — no remounting,
+     no opacity flashes, just a mechanical-counter roll between stages. The
+     clip window is exactly one row tall. The counter fills the pill so the
+     text stays dead-centered — the same center as the recording bars — with
+     no other element to shift it sideways between states. */
+  .stage-counter {
     flex: 1;
-    height: 2px;
-    border-radius: 999px;
-    background: rgba(255,255,255,0.12);
-    position: relative;
+    height: 16px;
     overflow: hidden;
+    display: flex;
+    justify-content: center;
+    position: relative;
   }
-  .scan-line::after {
-    content: '';
+  /* Out of flow and invisible — exists purely to be measured. `align-items:
+     flex-start` is load-bearing: as block children the rows would stretch to
+     the container and every label would measure the same (widest) width. */
+  .stage-sizer {
     position: absolute;
-    top: 0; left: -40%;
-    width: 80%; height: 100%;
-    background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.9) 50%, transparent 100%);
-    border-radius: 999px;
-    animation: scan 1.1s ease-in-out infinite alternate;
+    top: 0;
+    left: 0;
+    visibility: hidden;
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
   }
-  @keyframes scan {
-    from { left: -40%; }
-    to   { left: 60%; }
+  /* `align-items: center` matters twice over: it lets each row shrink to its
+     own text (a stretched row would report the widest label's width, so the
+     per-stage measurement in measureStageRows would be useless), and it keeps
+     every label centered on the same axis while the pill resizes around it. */
+  .stage-roll {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    /* Never shrink to the counter. As a normal flex item the roll would be
+       squeezed whenever the pill was sized for a shorter stage, which both
+       clipped the longer labels and fed a smaller number back into the
+       measurement it was derived from. Holding its natural width lets it
+       overflow the clip window symmetrically instead, so the active (centered)
+       label always lands exactly inside it. */
+    flex-shrink: 0;
+    will-change: transform;
+    transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  /* Each stage row is two stacked copies of the same label: a fully legible
+     base (so the text never reads as dim/broken) plus a second copy clipped
+     to a moving gradient that rides on top as a soft highlight scanning back
+     and forth across the word — this is the sole "still working" indicator
+     for the pill's processing state, replacing a separate spinner icon.
+     Splitting these into two layers (rather than the single dim-text-with-
+     a-bright-band version this replaced) keeps the label readable at every
+     point in the animation instead of the whole word dipping toward
+     transparent between sweeps. */
+  .stage-row {
+    position: relative;
+    height: 16px;
+    line-height: 16px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+    display: block;
+  }
+  /* Dimmed base. --pill-fg is pure #fff, so painting a white highlight over a
+     full-brightness base made the sweep mathematically invisible — the label
+     just read as solid white until it rolled to the next stage. The base now
+     sits at 45% so the moving highlight has something to be brighter than. */
+  .stage-label {
+    display: block;
+    color: rgba(255, 255, 255, 0.45);
+  }
+  .stage-shine {
+    position: absolute;
+    inset: 0;
+    color: transparent;
+    /* Narrow scanning band, sized in px (not %) so it spans the same ~3
+       characters no matter how long the stage word is: a pure-white core with
+       half-white shoulders either side, fading out at both edges. */
+    background-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 0.5) 25%,
+      rgba(255, 255, 255, 1) 50%,
+      rgba(255, 255, 255, 0.5) 75%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    background-size: 24px 100%;
+    background-repeat: no-repeat;
+    background-clip: text;
+    -webkit-background-clip: text;
+    /* Fast enough that a short-lived stage still shows real travel — "Pasting…"
+       often lasts only a few hundred ms, and at the 1.9s this replaces the
+       band barely crept across it before the stage was gone. */
+    animation: stage-scan 1.05s ease-in-out infinite alternate;
+  }
+  /* Sweeps horizontally across the letters and back (alternate). The travel is
+     bounded so the band stays *on* the word at both ends — 0% puts its left
+     edge at the first letter, 100% its right edge at the last. Letting it run
+     clear of the text (the -24px … 100%+24px it replaced) left the whole label
+     sitting dim at each turnaround, which read as the text fading out rather
+     than as something scanning across it. */
+  @keyframes stage-scan {
+    from { background-position: 0% 0; }
+    to   { background-position: 100% 0; }
   }
   @keyframes scanIn {
     from { opacity: 0; }
@@ -812,19 +1455,29 @@
     to   { opacity: 1; }
   }
 
-  /* Error: dark red-tinted stadium pill, expands horizontally to reveal the message */
+  /* Error: dark red-tinted surface. A short message stays a single-line
+     capsule and only widens; a long one caps its width, wraps, and grows
+     upward into a rounded card. 17px is exactly half the 34px capsule height,
+     so the same radius reads as a perfect stadium when short and as softly
+     rounded corners once it grows — no radius animation needed, and no
+     awkward interpolation between two shapes. */
   .pill.error {
     width: 42px;
+    height: 34px;
     gap: 8px;
     padding: 0 14px;
     background: var(--pill-error-bg);
     color: var(--pill-error-fg);
-    border-radius: 999px;
+    border-radius: 17px;
     box-shadow: 0 0 0 1px var(--pill-error-border),
-                0 6px 18px rgba(0,0,0,0.28);
-    max-width: 356px;
+                0 2px 8px rgba(0,0,0,0.32);
     overflow: hidden;
-    transition: width 0.30s cubic-bezier(0.34, 1.56, 0.64, 1);
+    /* No overshoot here — a bouncy curve makes the measured content
+       transiently exceed its target mid-transition, which chases the native
+       window resize past-then-back and reads as flicker. */
+    transition: width 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+                height 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+                padding 0.3s cubic-bezier(0.22, 1, 0.36, 1);
   }
   .err-icon {
     flex-shrink: 0;
@@ -832,6 +1485,7 @@
   }
   .err-text {
     font-size: 11.5px; font-weight: 500;
+    line-height: 15px;
     color: var(--pill-error-fg);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     opacity: 0;
@@ -839,11 +1493,75 @@
   }
   .pill.error.err-open .err-text { opacity: 1; }
 
+  /* Card form: message wraps to its own column, buttons pin to the top so
+     they stay put as the body grows upward. */
+  .pill.error.err-card {
+    align-items: flex-start;
+    padding: 10px 14px;
+  }
+  .pill.error.err-card .err-text {
+    flex: 1;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    max-height: 100%;
+  }
+  /* Only past ERROR_MAX_LINES does the body actually scroll; below that the
+     card simply grew to fit, and a scrollbar would be dead chrome. */
+  /* Standard scrollbar properties only — Chromium ignores ::-webkit-scrollbar
+     entirely once scrollbar-width/-color are set, so the two cannot be
+     combined. The thumb is tinted from the error foreground rather than the
+     border colour, which was too close to the background to read as an
+     affordance that there is more text below. */
+  .pill.error.err-card.err-scroll .err-text {
+    overflow-y: auto;
+    padding-right: 6px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 143, 128, 0.45) transparent;
+  }
+  /* Both buttons pin to the card's top edge alongside the first line, rather
+     than stretching full-height or centering against a body that keeps
+     growing taller as the message wraps to more lines. */
+  .pill.error.err-card .err-retry,
+  .pill.error.err-card .err-dismiss {
+    margin-top: 1px;
+  }
+
+  /* Out of flow and invisible — the message at its real wrapping width, so
+     openError can read both the natural width and the true line count. */
+  .err-sizer {
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+    /* `width: max-content` is load-bearing. As an out-of-flow box the sizer's
+       shrink-to-fit width is bounded by its containing block — the pill
+       cluster, often under 100px — so with max-width alone every message
+       wrapped at the cluster's width and measured as far more lines than it
+       actually needs. max-content asks for the full single-line width and
+       lets max-width cap it at the real column. */
+    width: max-content;
+    max-width: 250px; /* ERROR_TEXT_MAX_W */
+    font-size: 11.5px;
+    font-weight: 500;
+    line-height: 15px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   .hf-btn.err-retry {
     color: var(--pill-error-fg);
-    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s both;
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.13s both;
   }
   .hf-btn.err-retry:hover { background: rgba(255,255,255,0.14); }
+
+  /* Delay is slightly ahead of err-retry's — dismiss now sits left of the
+     text and retry sits right of it, so the reveal reads left-to-right. */
+  .hf-btn.err-dismiss {
+    color: var(--pill-error-fg);
+    opacity: 0.75;
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.1s both;
+  }
+  .hf-btn.err-dismiss:hover { opacity: 1; background: rgba(255,255,255,0.14); }
 
   /* Cancelled: neutral stadium pill (not the red error palette) — starts as
      a dismiss (X) button only, expands to reveal the "Cancelled" label and
@@ -856,8 +1574,9 @@
     padding: 0 12px;
     border-radius: 999px;
     overflow: hidden;
-    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
-                padding 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    /* No overshoot — see .pill.error's transition comment. */
+    transition: width 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+                padding 0.26s cubic-bezier(0.22, 1, 0.36, 1);
   }
   .pill.cancelled.cancel-open {
     width: 158px;
@@ -876,7 +1595,10 @@
   /* Paste failed: same red-tinted stadium pill as .pill.error, message-first
      (no collapsed-icon entry — the message is a fixed short string, not a
      dynamic one to measure), then widens to reveal a Copy button after a
-     beat so "paste failed" registers before the fallback action appears. */
+     short beat (180ms — see copyBtnTimer) so "Not pasted" reads as arriving
+     first rather than the whole pill popping in fully formed. Long enough to
+     read as sequenced, short enough that the widen still feels like part of
+     one entrance instead of a second animation arriving a while later. */
   .pill.paste-failed {
     gap: 8px;
     padding: 0 14px;
@@ -884,14 +1606,17 @@
     color: var(--pill-error-fg);
     border-radius: 999px;
     box-shadow: 0 0 0 1px var(--pill-error-border),
-                0 6px 18px rgba(0,0,0,0.28);
+                0 2px 8px rgba(0,0,0,0.32);
     width: 128px;
     overflow: hidden;
-    transition: width 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
-                padding 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    /* No overshoot — see .pill.error's transition comment. */
+    transition: width 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+                padding 0.26s cubic-bezier(0.22, 1, 0.36, 1);
   }
+  /* +26px over the single-button version (18px dismiss button + one more
+     8px flex gap) now that Copy and Dismiss show together. */
   .pill.paste-failed.copy-open {
-    width: 158px;
+    width: 184px;
     padding: 0 8px 0 14px;
   }
   .paste-failed-text {
@@ -907,11 +1632,22 @@
   }
   .hf-btn.copy-btn:hover { background: rgba(255,255,255,0.14); }
 
+  .hf-btn.pf-dismiss {
+    color: var(--pill-error-fg);
+    opacity: 0.75;
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.03s both;
+  }
+  .hf-btn.pf-dismiss:hover { opacity: 1; background: rgba(255,255,255,0.14); }
+
   /* Copied confirmation: neutral (not error-red) stadium pill for the global
-     Ctrl+Alt+C / ⌥⌘C shortcut — fixed short message, auto-sized, no buttons. */
+     Ctrl+Alt+C / ⌥⌘C shortcut — fixed short message, auto-sized, plus a
+     dismiss button so it doesn't have to be waited out either. Width is
+     content-driven (no fixed value or open/collapsed states to juggle), so
+     the button just joins the flex row and the usual ResizeObserver sizing
+     picks up the extra space. */
   .pill.copied {
     gap: 8px;
-    padding: 0 14px;
+    padding: 0 8px 0 14px;
     white-space: nowrap;
   }
   .copied-icon { color: var(--accent); flex-shrink: 0; }
@@ -919,6 +1655,11 @@
     font-size: 11.5px; font-weight: 500;
     white-space: nowrap;
   }
+  .hf-btn.copied-dismiss {
+    color: var(--pill-muted);
+    animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.05s both;
+  }
+  .hf-btn.copied-dismiss:hover { color: var(--pill-muted-strong); background: rgba(255,255,255,0.14); }
 
   /* Handsfree: starts compact (mirrors recording — same DPI-snapped width so the
      recording→handsfree continuation doesn't jump), expands to 112px after 450ms */
@@ -926,7 +1667,8 @@
     width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px);
     padding: 0 7px;
     gap: 2px;
-    transition: width 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    /* No overshoot — see .pill.error's transition comment. */
+    transition: width 0.2s cubic-bezier(0.22, 1, 0.36, 1),
                 padding 0.18s ease,
                 gap 0.18s ease;
   }
@@ -951,9 +1693,11 @@
   .hf-btn.confirm:hover { color: var(--accent-ink); }
 
   @keyframes hfBtnIn {
-    from { opacity: 0; transform: scale(0.7); }
-    to   { opacity: 1; transform: scale(1); }
+    /* Gentle fade + tiny rise, deliberately no scale — a pop reads as the UI
+       switching elements on and off, a settle reads as the pill growing. */
+    from { opacity: 0; transform: translateY(3px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
-  .hf-btn.cancel  { animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) both; }
-  .hf-btn.confirm { animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.02s both; }
+  .hf-btn.cancel  { animation: hfBtnIn 0.16s ease-out both; }
+  .hf-btn.confirm { animation: hfBtnIn 0.16s ease-out 0.03s both; }
 </style>

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -86,7 +86,8 @@
     const target = e.target instanceof Element
       ? e.target
       : (e.target as Node)?.parentElement;
-    if (closeSelector && target?.closest(closeSelector)) return;
+    const containerSelector = closeSelector || '.ui-dropdown';
+    if (target?.closest(containerSelector)) return;
     open = false;
   }
 

--- a/src/lib/components/appMappings/AppMappingsAddForm.svelte
+++ b/src/lib/components/appMappings/AppMappingsAddForm.svelte
@@ -208,7 +208,7 @@
             <button
               type="button"
               class="app-picker-item"
-              onclick={() => pickApp(app)}
+              onclick={(event) => pickApp(app, event)}
               onkeydown={(event) =>
                 handleListboxOptionKeydown(event, APP_PICKER_MENU_ID, () => {
                   appPickerOpen = false;

--- a/src/lib/components/settings/CleanupPromptModal.svelte
+++ b/src/lib/components/settings/CleanupPromptModal.svelte
@@ -227,7 +227,11 @@
   // dialog is always one key away from dismissal (Settings' Escape guard
   // yields while [role="dialog"] is present).
   function onKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') handleClose();
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      handleClose();
+    }
   }
 
   const failedLiveResults = $derived(
@@ -255,6 +259,10 @@
     class="prompt-modal-backdrop"
     aria-hidden="true"
     onclick={onBackdropClick}
+    onkeydown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onBackdropClick(); } }}
+    role="button"
+    tabindex="0"
+    aria-label="Close dialog"
     in:modalBackdrop={{ duration: 180 }}
     out:modalBackdrop={{ duration: 160 }}
   ></div>

--- a/src/lib/components/settings/CleanupPromptModal.svelte
+++ b/src/lib/components/settings/CleanupPromptModal.svelte
@@ -257,7 +257,6 @@
 <div class="prompt-modal-wrap">
   <div
     class="prompt-modal-backdrop"
-    aria-hidden="true"
     onclick={onBackdropClick}
     onkeydown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onBackdropClick(); } }}
     role="button"

--- a/src/lib/components/settings/PresetCard.svelte
+++ b/src/lib/components/settings/PresetCard.svelte
@@ -139,7 +139,7 @@
   <!-- Renders above every surface it can open from: settings (z-60), the
        cleanup-prompt modal (z-70), and the setup wizard overlay (z-100). -->
   <div class="preset-confirm-wrap">
-    <div class="ui-modal-backdrop" in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></div>
+    <button type="button" class="ui-modal-backdrop" aria-label="Close dialog" onclick={() => (confirmDelete = false)} in:modalBackdrop={{ duration: 180 }} out:modalBackdrop={{ duration: 160 }}></button>
     <div
       class="modal-card ui-modal-card"
       use:modalFocusTrap={{

--- a/src/lib/setup/steps/LanguageStep.svelte
+++ b/src/lib/setup/steps/LanguageStep.svelte
@@ -98,7 +98,7 @@
           class:selected={language === lang.code}
           role="option"
           aria-selected={language === lang.code}
-          tabindex={language === lang.code ? 0 : -1}
+          tabindex={language === lang.code || (!filtered.some((item) => item.code === language) && lang === filtered[0]) ? 0 : -1}
           onclick={() => pick(lang.code)}
           onkeydown={(event) => handleListboxOptionKeydown(event, LANG_MENU_ID, restoreToSearchOrTrigger)}
         >

--- a/src/lib/setup/steps/TryItStep.svelte
+++ b/src/lib/setup/steps/TryItStep.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { invoke, listen } from '../../tauri';
   import { isMac } from '../../platform';
-  import { classifyIpcError } from '../../errors';
+  import { formatIpcError } from '../../stores.svelte';
   import { hotkeyCodes, hotkeyLabels, hotkeyWatchCodes, matchesHotkey } from '../../hotkey.svelte';
 
   const keyLabels = $derived(hotkeyLabels());
@@ -46,8 +46,9 @@
       }
       localRecording = true;
     } catch (err) {
-      if (!destroyed && classifyIpcError(err).kind !== 'already-recording') {
-        errorMessage = classifyIpcError(err).message;
+      const message = formatIpcError(err);
+      if (!destroyed && !message.toLowerCase().includes('already recording')) {
+        errorMessage = message;
       }
     } finally {
       localStartInFlight = false;
@@ -60,7 +61,7 @@
     try {
       await invoke('stop_setup_try_recording');
     } catch (err) {
-      errorMessage = classifyIpcError(err).message;
+      errorMessage = formatIpcError(err);
     }
   }
 
@@ -105,7 +106,7 @@
     listen<string>('verenu:error', (ev) => {
       if (destroyed) return;
       errorMessage = ev.payload
-        ? classifyIpcError(ev.payload).message
+        ? formatIpcError(ev.payload)
         : 'Something went wrong with that recording.';
     }).then((unsub) => {
       if (destroyed) unsub();

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -943,6 +943,8 @@ function devInsights(days: number): unknown {
       active_days: daily.filter((d) => d.words > 0).length + 96,
     },
     daily,
+    streak_daily: streakDaily,
+    history_started_on: streakDaily[0]?.day ?? null,
     hourly,
     providers: [
       {

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -5,7 +5,7 @@
    * the hovered segment and dims the rest — both from the ring and from the
    * legend. No chart library; the ring is hand-drawn per frame.
    */
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, untrack } from 'svelte';
   import { reducedMotionEnabled } from '../../motion';
 
   export interface DonutSegment {
@@ -209,12 +209,14 @@
     // A hovered segment may no longer exist after a data change (e.g. range
     // filter removed it) — a stale id would dim the whole chart and legend
     // until the next hover. Drop it and any dim state.
-    if (hoveredId !== null && !segments.some((s) => s.id === hoveredId)) {
-      hoveredId = null;
-      dimming = false;
-      dimFromAlpha = 1;
-    }
-    startValueTween();
+    untrack(() => {
+      if (hoveredId !== null && !segments.some((s) => s.id === hoveredId)) {
+        hoveredId = null;
+        dimming = false;
+        dimFromAlpha = 1;
+      }
+      startValueTween();
+    });
   });
 
   function setHover(id: string | null) {

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -234,10 +234,6 @@
     height: auto;
     display: block;
   }
-  .gauge-fill {
-    transition: stroke-dasharray var(--ui-duration-base) var(--ui-ease-out);
-  }
-
   .gauge-tick {
     font-family: var(--serif);
     font-size: 10px;

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -8,7 +8,9 @@
   // Default destructure above normalizes a missing/null prop; guard the
   // derivations against a non-array payload too.
   const series = $derived(
-    Array.isArray(hourly) ? hourly : Array.from({ length: 24 }, () => 0),
+    Array.isArray(hourly)
+      ? [...hourly.slice(0, 24), ...Array.from({ length: Math.max(0, 24 - hourly.length) }, () => 0)]
+      : Array.from({ length: 24 }, () => 0),
   );
   const max = $derived(Math.max(...series, 0));
   const total = $derived(series.reduce((sum, n) => sum + n, 0));

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -53,7 +53,7 @@
 
     const firstRealDate = daily.length > 0 ? parseLocalDay(daily[0].day) : lastDate;
     const daysSpanningReal = Math.round((endDate.getTime() - firstRealDate.getTime()) / 86_400_000) + 1;
-    const totalWeeks = Math.ceil(daysSpanningReal / 7);
+    const totalWeeks = Math.max(MIN_WEEKS, Math.ceil(daysSpanningReal / 7));
 
     const startDate = new Date(endDate);
     startDate.setDate(startDate.getDate() - (totalWeeks * 7 - 1));

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -94,7 +94,9 @@ export function parseLocalDay(day: string): Date {
 
 export function fmtDay(day: string): string {
   try {
-    return parseLocalDay(day).toLocaleDateString([], { month: 'short', day: 'numeric' });
+    const date = parseLocalDay(day);
+    if (Number.isNaN(date.getTime())) return day;
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
   } catch {
     return day;
   }
@@ -102,7 +104,9 @@ export function fmtDay(day: string): string {
 
 export function fmtDayLong(day: string): string {
   try {
-    return parseLocalDay(day).toLocaleDateString([], {
+    const date = parseLocalDay(day);
+    if (Number.isNaN(date.getTime())) return day;
+    return date.toLocaleDateString([], {
       weekday: 'short',
       month: 'short',
       day: 'numeric',


### PR DESCRIPTION
Pill fixes: stage rendering, resize/flicker/clipping, processing entry, and copied-pill dismissibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789555476&installation_model_id=432577&pr_number=262&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F262&signature=a6af3b9bb6d69a909b0e168664334ccfc474fcd907debf606783c210eab8b647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->