### PR TITLE
Detect offline during transcription and surface it clearly

### DIFF
--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -415,6 +415,28 @@ pub fn is_retryable_provider_error(e: &anyhow::Error) -> bool {
         || msg.contains(" 504")
 }
 
+/// Whether an error indicates the request never reached a reachable server — a
+/// local connection/DNS failure rather than a provider returning an HTTP
+/// response. Used to decide when an active connectivity probe is warranted
+/// (distinguishing "your internet is down" from "a provider is down").
+pub fn is_connectivity_error(e: &anyhow::Error) -> bool {
+    for cause in e.chain() {
+        if let Some(reqwest_err) = cause.downcast_ref::<reqwest::Error>() {
+            if reqwest_err.is_connect() || reqwest_err.is_request() {
+                return true;
+            }
+        }
+    }
+
+    let msg = e.to_string().to_lowercase();
+    msg.contains("error sending request")
+        || msg.contains("dns error")
+        || msg.contains("connection reset")
+        || msg.contains("connection refused")
+        || msg.contains("network is unreachable")
+        || msg.contains("failed to resolve")
+}
+
 fn extract_http_status_code(msg: &str) -> Option<u16> {
     for marker in ["status=", "status:"] {
         if let Some(idx) = msg.find(marker) {
@@ -558,5 +580,25 @@ mod tests {
         let long = "x".repeat(300);
         let msg = super::user_facing_message(&long);
         assert!(msg.chars().count() <= 121);
+    }
+
+    #[test]
+    fn connectivity_error_detected_from_request_text() {
+        // The Display string reqwest produces for a failed `.send()` — no
+        // downcastable reqwest::Error in the chain here, only the message.
+        let err = anyhow::anyhow!(
+            "error sending request for url (https://api.groq.com/openai/v1/audio/transcriptions)"
+        );
+        assert!(super::is_connectivity_error(&err));
+    }
+
+    #[test]
+    fn connectivity_error_not_detected_for_http_rejection() {
+        // A provider that answered with an HTTP error is reachable — this is
+        // not a connectivity problem and must not trigger an offline probe.
+        let err = anyhow::anyhow!(
+            "Transcription API error provider=Groq status=400 request_id=req body_preview=bad request"
+        );
+        assert!(!super::is_connectivity_error(&err));
     }
 }

--- a/src-tauri/src/pipeline/stages.rs
+++ b/src-tauri/src/pipeline/stages.rs
@@ -593,6 +593,22 @@ pub(super) async fn transcribe_any(
     .await
 }
 
+/// Active connectivity disambiguation: returns true when the user's own
+/// connection is down (not just one provider). Reads the Verenu service-check
+/// preference so the probe honors "don't contact Verenu" — falling back to
+/// google.com when Verenu checks are disabled, or when Verenu itself is the
+/// thing that's unreachable.
+async fn confirm_offline(app: &AppHandle) -> bool {
+    let checks_enabled = store::settings_snapshot(app)
+        .map(|s| {
+            s.get(store::VERENU_SERVICE_CHECKS_ENABLED)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true)
+        })
+        .unwrap_or(true);
+    crate::system::connectivity::confirm_offline(checks_enabled).await
+}
+
 pub(super) async fn run_transcription(
     app: &AppHandle,
     audio: &CapturedAudio,
@@ -632,6 +648,20 @@ pub(super) async fn run_transcription(
                 gen,
                 trim_err(&error.to_string())
             );
+            // Every provider in the chain just failed to be reached (a
+            // connect error, not an HTTP rejection). Before blaming the
+            // provider or showing a generic "nothing transcribed", actively
+            // probe whether the user's own connection is down so a dropped
+            // network reads as exactly that instead of a confusing error.
+            if crate::api::is_connectivity_error(&error) && confirm_offline(app).await {
+                emit_connectivity_recheck(app);
+                show_error_pill(
+                    app,
+                    "No internet connection — check your network and try again.",
+                )
+                .await;
+                return None;
+            }
             if crate::api::is_retryable_provider_error(&error) {
                 emit_provider_recheck(app);
             }
@@ -687,6 +717,7 @@ async fn run_dual_transcription_candidates(
     let mut next_index = 0usize;
     let mut in_flight = tokio::task::JoinSet::<CandidateOutcome>::new();
     let mut successes = Vec::<(usize, String, String, String)>::new();
+    let mut last_err: Option<anyhow::Error> = None;
 
     while next_index < chain.len() && in_flight.len() < 2 {
         spawn_transcription_candidate(
@@ -734,6 +765,7 @@ async fn run_dual_transcription_candidates(
                     model,
                     trim_err(&error.to_string())
                 );
+                last_err = Some(error);
             }
             Err(error) => {
                 log::warn!("pipeline: dual transcription task failed error={error}");
@@ -758,6 +790,12 @@ async fn run_dual_transcription_candidates(
     successes.sort_by_key(|(index, _, _, _)| *index);
     let Some((_, primary_text, primary_provider, primary_model)) = successes.first().cloned()
     else {
+        // Preserve the underlying provider error when one exists, so a
+        // connectivity outage can be detected upstream instead of being
+        // flattened into a generic "nothing transcribed".
+        if let Some(error) = last_err {
+            return Err(error);
+        }
         anyhow::bail!("Nothing transcribed - please try speaking more clearly");
     };
     let alternate = successes

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -629,6 +629,14 @@ pub(super) fn emit_provider_recheck(app: &AppHandle) {
     app.emit("verenu:recheck-provider-status", ()).ok();
 }
 
+/// Tells the frontend to re-check connectivity immediately because a pipeline
+/// call just failed with a connection error. The frontend re-runs its
+/// `check_connectivity` poll so the persistent "No internet connection" toast
+/// appears right away instead of on the next 60s interval.
+pub(super) fn emit_connectivity_recheck(app: &AppHandle) {
+    app.emit("verenu:recheck-connectivity", ()).ok();
+}
+
 /// Returns true if our own process currently owns the foreground window.
 /// Catches the case where the user opened the Verenu main window while
 /// transcribing — if we tried to Ctrl+V / Cmd+V in that state the paste would

--- a/src-tauri/src/system/connectivity.rs
+++ b/src-tauri/src/system/connectivity.rs
@@ -111,3 +111,35 @@ pub fn check_native() -> Option<bool> {
 pub fn check_native() -> Option<bool> {
     None
 }
+
+/// Active connectivity probe, used only after a real request has already
+/// failed, to distinguish "the user's internet is down" from "one provider is
+/// down". Unlike [`check_native`] this actually sends a request, so it costs a
+/// little traffic and is deliberately gated to the failure path.
+///
+/// Ordering follows the privacy preference: probe Verenu's own endpoint first
+/// when service checks are enabled, then google.com as an independent second
+/// opinion — covering both "Verenu is down but the user is fine" and the case
+/// where the user disabled Verenu checks entirely. Returns true only when
+/// every attempted probe failed (i.e. the connection itself is the problem).
+pub async fn confirm_offline(verenu_checks_enabled: bool) -> bool {
+    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(4);
+
+    if verenu_checks_enabled && probe("https://api.verenu.com/v1/health", PROBE_TIMEOUT).await {
+        return false;
+    }
+    !probe("https://www.google.com", PROBE_TIMEOUT).await
+}
+
+/// A probe counts as "online" when any HTTP response arrives at all — even a
+/// 4xx/5xx proves the host was reachable, which is all a connectivity check
+/// needs. Only a failed send (DNS/connect error, timeout) reads as "offline".
+async fn probe(url: &str, timeout: std::time::Duration) -> bool {
+    crate::api::client::get()
+        .get(url)
+        .header("User-Agent", "verenu")
+        .timeout(timeout)
+        .send()
+        .await
+        .is_ok()
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -150,6 +150,7 @@
     let mounted = true;
     let cleanupFn: (() => void) | undefined;
     let stopNotificationClickListener: (() => void) | undefined;
+    let stopConnectivityRecheckListener: (() => void) | undefined;
     let stopSettingsImportedListener: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
     let stopLocalSttListeners: (() => void) | undefined;
@@ -231,6 +232,20 @@
       })
       .catch((error) => { console.warn('Failed to listen for notification clicks:', error); });
 
+    // The backend fires this after a transcription request fails with a
+    // connection error and it has actively confirmed the connection is down —
+    // re-ping immediately so the persistent offline toast shows up now instead
+    // of on the next 60s interval.
+    listen('verenu:recheck-connectivity', () => void pingConnectivity())
+      .then((unlisten) => {
+        if (!mounted) {
+          unlisten();
+          return;
+        }
+        stopConnectivityRecheckListener = unlisten;
+      })
+      .catch((error) => { console.warn('Failed to listen for connectivity rechecks:', error); });
+
     // Synchronous: startAutomaticUpdateChecks fires its first check in the
     // background and returns the cleanup immediately, so there's no unmount
     // race to guard and the interval is always registered before we return.
@@ -280,6 +295,7 @@
       mounted = false;
       if (cleanupFn) cleanupFn();
       if (stopNotificationClickListener) stopNotificationClickListener();
+      if (stopConnectivityRecheckListener) stopConnectivityRecheckListener();
       if (stopSettingsImportedListener) stopSettingsImportedListener();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       if (stopLocalSttListeners) stopLocalSttListeners();


### PR DESCRIPTION
Detect offline during transcription and surface it clearly

When every transcription provider in the chain fails to be reached (a connect/DNS error, not an HTTP rejection), Verenu now actively probes connectivity before blaming the provider or showing a misleading "nothing transcribed" error.

What changed

- Active probe hits api.verenu.com/v1/health first, falling back to www.google.com when Verenu service checks are disabled or Verenu itself is unreachable. Offline is only reported when every probe fails.
- Dual transcription now preserves the underlying provider error instead of flattening it into "Nothing transcribed - please try speaking more clearly", so a connectivity outage is detectable upstream.
- On a confirmed connection drop, the pill shows "No internet connection — check your network and try again." and the main window's offline toast refreshes immediately instead of waiting for the 60s poll.

Verification

- cargo check clean
- cargo clippy -- -D warnings clean
- svelte-check 0 errors / 0 warnings
- cargo test api:: (156) and pipeline:: (123) pass

Note: the base of this PR is the `trunk` branch (in-progress dev work). It carries only this connectivity change on top of that trunk. The trunk itself has a separate, unrelated DB-schema test failure (open_self_heals_database_stuck_at_v2_with_legacy_dictionary, expects v15 vs v16) that is not touched by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789610251&installation_model_id=432577&pr_number=266&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F266&signature=76e8e7bdb2c611706500c2630fc103e05a5bafd6091ca885f545f74ea908655b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->