### PR TITLE
Fix oversized "Add fallback" pill on custom models

### DIFF
--- a/src/lib/components/settings/ModelProviderGroup.svelte
+++ b/src/lib/components/settings/ModelProviderGroup.svelte
@@ -395,11 +395,7 @@
 
   .add-fallback-btn {
     appearance: none;
-    background: transparent;
-    border: 1px solid var(--line);
-    padding: 2px 7px;
-    font: inherit;
-    color: inherit;
+    line-height: 1.4;
     cursor: pointer;
   }
 


### PR DESCRIPTION
Adding a custom model rendered its "Add fallback" pill at body text size instead of the small uppercase pill used everywhere else.

`.add-fallback-btn` is declared after `.state-pill` at the same specificity, and its `font: inherit` shorthand blew away the pill's `font-size: 9px` / sans / 600 (and `color: inherit` killed the muted color). The rest of that rule duplicated `.state-pill` anyway, so the fix drops them and keeps only what a button needs.

CSS only, no behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789713499&installation_model_id=432577&pr_number=270&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F270&signature=9ae8b79da81002d6bdd93c7782bda31f1b3a133579c5fbe29a86985d9e10bdcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->