### PR TITLE
Center sidebar logo with the wordmark

### DIFF
--- a/src/lib/components/layout/Brand.svelte
+++ b/src/lib/components/layout/Brand.svelte
@@ -17,7 +17,7 @@
 </div>
 
 <style>
-  .brand { min-height: var(--native-titlebar-height, 32px); padding: 16px 18px 0 16px; display: flex; align-items: flex-start; gap: 10px; }
+  .brand { min-height: var(--native-titlebar-height, 32px); padding: 16px 18px 0 16px; display: flex; align-items: center; gap: 6px; }
   .brand-mark { width: 24px; height: 20px; color: var(--accent); }
   .brand-mark :global(svg) { display: block; }
   .brand-name { font-family: var(--serif); font-size: 17px; letter-spacing: -0.015em; font-weight: 500; color: var(--ink); white-space: nowrap; display: flex; align-items: flex-end; gap: 2px; }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: UI, specifically the sidebar brand block (`src/lib/components/layout/Brand.svelte`)
> - The logo mark and the "Verenu" wordmark were aligned on their bottom edges (`align-items: flex-start` on a block where the name is taller), so the mark read as sitting low and slightly detached from the text
> - It is the first thing visible in the sidebar on every launch, so the misalignment is on screen constantly
> - This pull request centers the mark against the wordmark and tightens the gap from 10px to 6px
> - The benefit is a brand lockup that reads as one unit instead of two loosely stacked pieces

## What Changed

- `.brand` in `Brand.svelte`: `align-items: flex-start` -> `center`, `gap: 10px` -> `6px`

## Verification

- `npm run check` passes (0 errors, 0 warnings)
- Visual: sidebar logo now vertically centered with "Verenu" and sitting closer to it
- `.brand-name`'s internal `align-items: flex-end` is untouched, so the BETA marker keeps its raised position

## Risks

Low risk. Two CSS property values in one component, no markup or class-name changes, so the sidebar smoke-test contract is unaffected. The collapsed-sidebar rule (`.brand { justify-content: center }` at the narrow breakpoint) still applies unchanged.

## Model Used

- Anthropic Claude Opus 5 (`claude-opus-5`) via Claude Code

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) - not run, CSS-only change
- [ ] `npm run test:rust` passes - not run, no Rust touched
- [ ] Smoke tests pass - not run; no asserted class names or selectors changed
- [ ] Tests added or updated where applicable - n/a
- [ ] UI changes include before/after screenshots - not attached
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: n/a
- [x] Relevant documentation updated to reflect changes - n/a
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789773821&installation_model_id=432577&pr_number=273&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F273&signature=174e9dd5875faa726add964a7c06d766f543f2b9f53e3187a8d8b57b525427de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->