### PR TITLE
Stop the Insights page scrolling far past its content

### DIFF
--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -304,7 +304,8 @@
     </ChartTooltip>
   {/if}
 
-  <table class="sr-only">
+  <div class="sr-only">
+  <table>
     <caption>Words dictated per day</caption>
     <thead><tr><th scope="col">Day</th><th scope="col">Words</th></tr></thead>
     <tbody>
@@ -313,6 +314,7 @@
       {/each}
     </tbody>
   </table>
+  </div>
 </section>
 
 <style>
@@ -497,6 +499,9 @@
     line-height: 1.35;
   }
 
+  /* Must wrap the table rather than be the table: width/height:1px are only a
+     *minimum* on a table box, so an .sr-only <table> keeps its full content
+     height (thousands of px here) and inflates the page's scroll height. */
   .sr-only {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: UI — the Insights page and its `StreakHeatmap` section
> - `StreakHeatmap` renders a visually-hidden `<table>` of per-day word counts so screen readers get the heatmap data as real tabular content
> - That table carried `.sr-only` directly, but `width`/`height: 1px` are only a *minimum* on a table box, so the table kept its full content height (~8900px measured) instead of collapsing
> - The oversized hidden box inflated the scroll container: Insights scrolled several screens past its last section into blank space
> - This pull request wraps the table in an `.sr-only` `<div>` — a block box does honour `1px` plus `overflow: hidden` — and leaves the table's markup and semantics untouched
> - The benefit is Insights now stops scrolling at the end of its content, with no accessibility regression

## What Changed

- Moved `class="sr-only"` off the `<table>` in `src/lib/views/insights/StreakHeatmap.svelte` onto a wrapping `<div>`, with a comment explaining why a table cannot carry it

## Verification

- Measured `.content` in a headless Chromium against the dev server, on the Insights page with real history: `scrollHeight` 9511 -> 1979 against an unchanged `clientHeight` of 706 and unchanged content height of 1979
- `npm run check` passes (185 files, 0 errors)
- Manual: scroll to the bottom of Insights — the page now ends at the cost-breakdown footnote instead of continuing into blank space

## Risks

Low risk. CSS/markup only, one component, no behaviour or data change. The table is still in the accessibility tree with its caption, headers and scopes; only the hidden wrapper changed. No smoke-test selectors touched.

## Model Used

- Anthropic Claude Opus 5 (`claude-opus-5`) via Claude Code, extended thinking + tool use

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable — n/a, CSS-only fix
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: n/a
- [x] Relevant documentation updated to reflect changes — n/a
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777278&installation_model_id=432577&pr_number=274&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F274&signature=90ab4a9dc56760fa667ba6c9119b828999b87789fd35007ad689319c52a602e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->