### PR TITLE
Fix context target add controls

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -325,7 +325,7 @@
   $effect(() => {
     if (!contextMenu) return;
     const handleClose = (event: Event) => {
-      if (event.target instanceof Element && event.target.closest('.ctx-kebab')) return;
+      if (event.target instanceof Element && event.target.closest('.ctx-kebab, .ctx-menu')) return;
       closeContextMenu();
     };
     const timeout = window.setTimeout(() => {
@@ -344,6 +344,11 @@
     contextsStore.modalRequest = { mode: 'edit', id: context.id };
     appStore.currentPage = 'contexts';
     closeContextMenu();
+  }
+
+  function editContextById(id: number) {
+    const context = contextsStore.contexts.find((candidate) => candidate.id === id);
+    if (context) editContext(context);
   }
 
   async function togglePin(context: Context) {
@@ -683,7 +688,7 @@
     in:fly={{ y: motionPx(6), duration: motionMs(MOTION_MS.fast) }}
     out:fly={{ y: motionPx(4), duration: motionMs(120) }}
   >
-    <button class="ui-dropdown-option" type="button" role="menuitem" onclick={() => editContext(menuContext)}>Edit</button>
+    <button class="ui-dropdown-option" type="button" role="menuitem" onclick={() => editContextById(menuContext.id)}>Edit</button>
     <button class="ui-dropdown-option" type="button" role="menuitem" onclick={() => void togglePin(menuContext)}>
       {menuContext.pinned_at ? 'Unpin' : 'Pin'}
     </button>
@@ -1216,8 +1221,9 @@
     background: transparent;
     color: var(--ink-mute);
     cursor: pointer;
-    pointer-events: none;
+    pointer-events: auto;
     opacity: 0;
+    z-index: 1;
     transform: translateY(-50%) scale(0.82);
     transition: opacity 150ms ease, transform 170ms cubic-bezier(0.33, 1, 0.68, 1), background-color 140ms ease, color 140ms ease;
   }

--- a/src/lib/views/Contexts.svelte
+++ b/src/lib/views/Contexts.svelte
@@ -156,7 +156,6 @@
     }, 320);
   }
 
-  let checkingDomain = $state(false);
 
   const atContextLimit = $derived(contexts.filter((c) => !c.is_everywhere).length >= MAX_USER_CONTEXTS);
   const selectedContext = $derived(
@@ -627,7 +626,6 @@
   let modalWebsiteError = $state('');
 
   async function addModalWebsite() {
-    if (checkingDomain) return;
     const domain = normalizeDomainInput(modalWebsiteInput);
     if (!domain || !isLikelyValidDomain(domain)) return;
     if (modalWebsites.includes(domain)) {
@@ -635,19 +633,6 @@
       return;
     }
     modalWebsiteError = '';
-    checkingDomain = true;
-    try {
-      const exists = await invoke<boolean>('check_domain_exists', { domain });
-      if (!exists) {
-        modalWebsiteError = "This domain doesn't seem to exist.";
-        return;
-      }
-    } catch {
-      // A failed check (not a resolved "doesn't exist") shouldn't block the
-      // user — fail open rather than punish them for a flaky local network.
-    } finally {
-      checkingDomain = false;
-    }
     modalWebsites = [...modalWebsites, domain];
     markRecentlyAdded(domain);
     modalWebsiteInput = '';
@@ -855,7 +840,6 @@
   }
 
   async function assignWebsite() {
-    if (checkingDomain) return;
     if (!selectedContext || selectedContext.is_everywhere) return;
     const domain = normalizeDomainInput(websiteInput);
     if (!domain || !isLikelyValidDomain(domain)) {
@@ -863,18 +847,6 @@
       return;
     }
     websiteError = '';
-    checkingDomain = true;
-    try {
-      const exists = await invoke<boolean>('check_domain_exists', { domain });
-      if (!exists) {
-        websiteError = "This domain doesn't seem to exist.";
-        return;
-      }
-    } catch {
-      // Fail open — see addModalWebsite for why.
-    } finally {
-      checkingDomain = false;
-    }
     try {
       const site = await invoke<ContextWebsiteTarget>('assign_context_website', {
         contextId: selectedContext.id,
@@ -1015,7 +987,6 @@
                     placeholder="mail.google.com"
                     bind:value={websiteInput}
                     bind:this={websiteInputEl}
-                    disabled={checkingDomain}
                     oninput={() => websiteError = ''}
                     onkeydown={handleWebsiteInputKeydown}
                     autocomplete="off"
@@ -1031,7 +1002,7 @@
                     </p>
                   {/if}
                   {#if websiteError}<p class="save-error">{websiteError}</p>{/if}
-                  <button class="btn-primary btn-compact" type="button" onclick={() => void assignWebsite()} disabled={!websiteValid || checkingDomain}>{checkingDomain ? 'Checking…' : 'Add'}</button>
+                  <button class="btn-primary btn-compact" type="button" onclick={() => void assignWebsite()} disabled={!websiteValid}>Add</button>
                 </div>
               {/if}
             </div>
@@ -1512,8 +1483,8 @@
           </div>
         {/if}
         <div class="website-input-row">
-          <input id="context-website" class="ui-input" type="text" placeholder="mail.google.com" bind:value={modalWebsiteInput} autocomplete="off" disabled={checkingDomain} oninput={() => modalWebsiteError = ''} onkeydown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void addModalWebsite(); } }} />
-          <button class="btn-ghost btn-compact website-add-btn" class:is-visible={modalWebsiteValid} type="button" onclick={() => void addModalWebsite()} disabled={!modalWebsiteValid || checkingDomain} tabindex={modalWebsiteValid ? 0 : -1}>{checkingDomain ? 'Checking…' : 'Add'}</button>
+          <input id="context-website" class="ui-input" type="text" placeholder="mail.google.com" bind:value={modalWebsiteInput} autocomplete="off" oninput={() => modalWebsiteError = ''} onkeydown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void addModalWebsite(); } }} />
+          <button class="btn-ghost btn-compact website-add-btn" class:is-visible={modalWebsiteValid} type="button" onclick={() => void addModalWebsite()} disabled={!modalWebsiteValid} tabindex={modalWebsiteValid ? 0 : -1}>Add</button>
         </div>
         {#if modalWebsiteError}
           <p class="save-error">{modalWebsiteError}</p>
@@ -1663,8 +1634,8 @@
   }
   .context-stats strong { color: var(--ink-soft); font-weight: 550; font-variant-numeric: tabular-nums; }
   .context-stat-sep { color: var(--ink-faint); }
-  .context-header { justify-content: space-between; gap: 16px; margin-bottom: 16px; }
-  .context-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; position: relative; }
+  .context-header { justify-content: space-between; gap: 16px; margin-bottom: 16px; position: relative; z-index: 2; }
+  .context-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; position: relative; z-index: 2; }
   .context-header h2 { font-family: var(--serif); font-size: 26px; font-weight: 500; letter-spacing: -.02em; line-height: 1.1; margin: 4px 0 4px; color: var(--ink); }
   .context-header p { color: var(--ink-mute); font-size: 12px; margin: 0; line-height: 1.45; }
   .target-strip { flex-wrap: wrap; gap: 6px; padding: 9px 0 14px; border-top: 1px solid var(--line-soft); }
@@ -1673,9 +1644,22 @@
   .target-chip button { display: grid; place-items: center; border: 0; background: transparent; color: var(--ink-faint); padding: 2px; cursor: pointer; border-radius: 4px; }
   .target-chip button:hover { color: var(--danger); background: var(--danger-bg); }
   .target-empty { color: var(--ink-faint); font-size: 11px; font-style: italic; }
-  .app-picker { position: absolute; z-index: 5; top: 100%; right: 0; margin-top: 6px; width: min(320px, calc(100vw - 64px)); display: flex; flex-direction: column; gap: 6px; padding: 8px; }
-  .app-picker-search { width: 100%; }
-  .app-picker-list { max-height: 240px; overflow: auto; display: flex; flex-direction: column; gap: 1px; }
+  .app-picker {
+    position: absolute;
+    z-index: 40;
+    top: 100%;
+    right: 0;
+    margin-top: 6px;
+    width: min(320px, calc(100vw - 64px));
+    max-height: min(360px, calc(100vh - 112px));
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+  }
+  .app-picker-search { flex: 0 0 auto; width: 100%; }
+  .app-picker-list { min-height: 0; max-height: 240px; overflow: auto; display: flex; flex-direction: column; gap: 1px; }
   .website-picker { width: min(280px, calc(100vw - 64px)); }
   .ui-dropdown-option { display: flex; align-items: center; gap: 8px; width: 100%; text-align: left; }
   .app-exe { color: var(--ink-faint); font-family: var(--mono); font-size: 10px; margin-left: auto; }


### PR DESCRIPTION
> - Verenu is a Windows and macOS AI dictation app that routes dictated text into the active app or website.
> - Contexts are the UI subsystem that maps apps and websites to context-specific dictation behavior.
> - The add-app and add-website popovers were being painted underneath later context sections, so list borders and tabs could cover their controls.
> - The website Add action could also be blocked by an optional DNS lookup, making valid domains appear broken when network access was unavailable.
> - This pull request fixes the popover stacking order and removes the network dependency from saving a syntactically valid website target.
> - The result is a usable context target picker with a stable search field and working Add controls.

## What Changed

- Raised the context header and target popover stacking layers above the animated context sections.
- Kept the app search field fixed while only the app results list scrolls.
- Let valid website domains save without waiting for or depending on DNS resolution.
- Preserved the related context sidebar menu interaction fix already on this task branch.

## Verification

- `npm run check`
- `npm run build`
- `npm run test:unit` (51 tests passed)
- `node tests/integration/playwright-test-context-menu-dev.cjs`
- Playwright UI capture confirmed the app search and website Add controls render above the tabs.
- [Before: app picker overlap](https://files.luhtwin.xyz/temporary/file-6980208c36875d21af229fdc3a685f97.png)
- [Before: website Add layout](https://files.luhtwin.xyz/temporary/file-9bf0f10c0e72f77c3ebd26900d6fd637.png)
- [App picker screenshot](https://files.luhtwin.xyz/temporary/file-31e74ce646e5d727d83b3db966de0af3.png)
- [Website picker screenshot](https://files.luhtwin.xyz/temporary/file-f97f86daaf208a120204253213db8533.png)

## Risks

Low risk. This changes frontend stacking and the website-target validation path only. Website input still requires a valid domain format before saving. No backend schema, credentials, or injection behavior changes.

## Model Used

- OpenAI GPT-5.6-luna, medium reasoning, tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`; this PR does not duplicate planned work
- [x] `npm run check` passes
- [ ] `npm run lint` not run; full Clippy lint is outside this focused frontend verification
- [ ] `npm run test:rust` not run; no Rust changes are included
- [ ] Full smoke suite not run; targeted context integration test passes
- [x] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] No version bump
- [x] Risks documented above
