### PR TITLE
Fix context group menu interactions

### DIFF
--- a/tests/integration/playwright-test-context-menu-dev.cjs
+++ b/tests/integration/playwright-test-context-menu-dev.cjs
@@ -1,0 +1,59 @@
+'use strict';
+
+const { chromium } = require('playwright');
+const { tauriMock, APP_VERSION } = require('../smoke/_tauri-mock.cjs');
+
+const TARGET_URL = process.env.TEST_URL || 'http://localhost:1420';
+const TIMEOUT = 10_000;
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const errors = [];
+
+  await page.addInitScript(tauriMock, { appVersion: APP_VERSION });
+  page.on('pageerror', (error) => errors.push(`Page exception: ${error.message}`));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(`Console error: ${message.text()}`);
+  });
+
+  try {
+    await page.goto(TARGET_URL, { waitUntil: 'networkidle', timeout: TIMEOUT });
+
+    const row = page.locator('.ctx-row-wrap').filter({ hasText: 'Work' }).first();
+    await row.waitFor({ state: 'visible', timeout: TIMEOUT });
+    await row.hover();
+
+    const kebab = row.getByRole('button', { name: 'More actions for Work' });
+    await kebab.click();
+
+    const menu = page.locator('.ctx-menu');
+    await menu.waitFor({ state: 'visible', timeout: 2_000 });
+    await menu.getByRole('menuitem', { name: 'Edit' }).click();
+
+    const modal = page.locator('.context-modal[role="dialog"]');
+    await modal.waitFor({ state: 'visible', timeout: 3_000 });
+    if (await modal.locator('#context-name').inputValue() !== 'Work') {
+      errors.push('Edit opened the wrong context group');
+    }
+
+    await modal.getByRole('button', { name: 'Cancel' }).click();
+    await modal.waitFor({ state: 'hidden', timeout: 3_000 });
+
+    const home = page.getByRole('button', { name: 'Home' });
+    await home.click();
+    await page.locator('h1.page-h:has-text("Welcome back")').waitFor({ state: 'visible', timeout: 3_000 });
+
+    if (errors.length > 0) {
+      console.error('\nFAIL:');
+      errors.forEach((error) => console.error(`  ${error}`));
+      process.exit(1);
+    }
+    console.log('PASS - pinned context menu opens, edits, closes, and releases the UI.');
+  } catch (error) {
+    console.error(`FAIL - test threw: ${error.message}`);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/integration/playwright-test-context-menu-dev.cjs
+++ b/tests/integration/playwright-test-context-menu-dev.cjs
@@ -18,7 +18,7 @@ const TIMEOUT = 10_000;
   });
 
   try {
-    await page.goto(TARGET_URL, { waitUntil: 'networkidle', timeout: TIMEOUT });
+    await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded', timeout: TIMEOUT });
 
     const row = page.locator('.ctx-row-wrap').filter({ hasText: 'Work' }).first();
     await row.waitFor({ state: 'visible', timeout: TIMEOUT });
@@ -47,12 +47,12 @@ const TIMEOUT = 10_000;
     if (errors.length > 0) {
       console.error('\nFAIL:');
       errors.forEach((error) => console.error(`  ${error}`));
-      process.exit(1);
+      process.exitCode = 1;
     }
     console.log('PASS - pinned context menu opens, edits, closes, and releases the UI.');
   } catch (error) {
     console.error(`FAIL - test threw: ${error.message}`);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a Svelte frontend and Tauri backend.
> - This change is in the Contexts sidebar and context-group editor UI.
> - The pinned-row kebab could miss clicks, and Edit could leave the page unresponsive after the menu closed.
> - The fix makes the kebab a stable hit target, keeps menu clicks inside the menu boundary, and resolves Edit by context ID.
> - This pull request adds browser regression coverage for the pinned menu, edit modal, close path, and post-modal navigation.

## What Changed

- Hardened the pinned context kebab hit target and menu outside-click boundary.
- Made the Edit action resolve the current context by stable ID.
- Added a Playwright regression test for open, edit, close, and subsequent navigation.

## Verification

- npm run check
- npm run build
- node tests/integration/playwright-test-context-menu-dev.cjs
- node tests/smoke/playwright-test-ui.cjs

## Risks

- Low risk. The change is limited to sidebar menu event handling and test coverage.
- No screenshots were captured because this is an interaction regression with deterministic browser coverage.

## Model Used

- OpenAI Codex, GPT-5.6, repository inspection and Playwright verification.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked docs/ROADMAP.md
- [x] npm run check passes
- [ ] npm run lint not run
- [ ] npm run test:rust not run
- [x] Relevant UI smoke test passes
- [x] Tests added where applicable
- [ ] UI screenshots not captured
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above