### PR TITLE
Clarify AI review completion status

### DIFF
--- a/scripts/verenu-ai-review.mjs
+++ b/scripts/verenu-ai-review.mjs
@@ -199,11 +199,12 @@ async function upsertStateComment(prNumber, existing, summary, state) {
   }
 }
 
-async function updateProgress(prNumber, existing, summary, state) {
+async function updateProgress(prNumber, existing, summary, state, { warning = null } = {}) {
   try {
     return (await upsertStateComment(prNumber, existing, summary, state)) || existing;
   } catch (err) {
     console.error(`failed to update review progress comment: ${err.message}`);
+    if (warning) console.log(`::warning::${warning}`);
     return existing;
   }
 }
@@ -646,11 +647,19 @@ async function main() {
     await postFindings(prNumber, pr, findings);
     const outcome = reviewOutcome(findings);
     const finalStage = outcome.hasFindings ? "findings" : "complete";
+    const finalSummary = formatProgressSummary({
+      stage: finalStage,
+      model: activeModel,
+      mode,
+      findings: outcome.count,
+      headSha: pr.head.sha,
+    });
+    console.log(finalSummary);
 
     stateComment = await updateProgress(
       prNumber,
       stateComment,
-      formatProgressSummary({ stage: finalStage, model: activeModel, mode, findings: outcome.count, headSha: pr.head.sha }),
+      finalSummary,
       {
         ...baseState,
         model: activeModel,
@@ -662,6 +671,7 @@ async function main() {
         timestamp: new Date().toISOString(),
         completed: true,
       },
+      { warning: "AI review completed, but GitHub could not publish the final result comment; see the review job logs for the outcome." },
     );
     if (outcome.hasFindings) {
       console.error(`OCR review found ${outcome.count} finding${outcome.count === 1 ? "" : "s"}`);


### PR DESCRIPTION
## Thinking Path

> - Verenu uses a GitHub Actions AI review workflow to inspect pull requests.
> - The review runner publishes progress and final outcomes through a state comment.
> - Comment API failures were previously swallowed, leaving a clean run with no visible result.
> - This PR makes the final outcome explicit in workflow logs while keeping comment publication best-effort.
> - The benefit is clearer review results without turning comment delivery issues into review failures.

## What Changed

- Log the final AI review summary for every completed review.
- Emit a GitHub Actions warning when the final result comment cannot be published.
- Preserve the existing non-failing behavior for comment API errors.

## Verification

- `node --test scripts/verenu-ai-review-logic.test.mjs`
- `node --check scripts/verenu-ai-review.mjs`
- `git diff --check`

## Risks

- Low risk. This changes review reporting only; findings, exit codes, and comment retry behavior are unchanged.

## Model Used

- OpenAI Codex, GPT-5.6, tool use and code analysis.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Tests added or updated where applicable
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790210303&installation_model_id=432577&pr_number=288&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F288&signature=eabe38d34cf00b773c21252914ca2646d80d36df1ff06ebaec3289b9f7b8da03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->