### PR TITLE
Docs: document the Contexts system in depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ It records locally, sends audio and text only to the AI providers you choose, ke
 - Local history, insights, local settings, and local data export/import
 - Optional auto-learn from repeated manual corrections
 
-Contexts are the main place to configure app-specific behavior. They replace the old standalone Dictionary, Snippets, and App Mappings pages with one group that follows you into the apps and websites where you use it. The old pages remain available as legacy pages for existing setups.
+Contexts are the main place to configure app-specific behavior. They connect apps and websites to cleanup, tone, custom instructions, vocabulary, and snippets. The old standalone pages remain available only as legacy compatibility pages.
 
-For more details: [Contexts](docs/CONTEXTS.md), [Cleanup Levels](docs/CLEANUP_LEVELS.md), and [Local Transcription](docs/LOCAL_TRANSCRIPTION.md).
+For more details: [Contexts](docs/CONTEXTS.md), [Vocabulary](docs/VOCABULARY.md), [Snippets](docs/SNIPPETS.md), [Cleanup Levels](docs/CLEANUP_LEVELS.md), and [Local Transcription](docs/LOCAL_TRANSCRIPTION.md).
 
 ## Platform Support
 

--- a/docs/APP_MAPPINGS.md
+++ b/docs/APP_MAPPINGS.md
@@ -1,42 +1,7 @@
-# Legacy: App Mappings & Profiles
+# App mappings page moved
 
-> **Legacy page.** App Mappings has been superseded by [Contexts](CONTEXTS.md), which covers the same per-app (and per-website) tone/cleanup overrides plus vocabulary and snippets in one place. The standalone App Mappings page is hidden by default; turn on **Settings → General → Legacy pages** to bring it back if you still rely on it directly.
+The old standalone App Mappings page has been replaced by [Contexts](CONTEXTS.md).
 
-App Mappings let Verenu automatically switch its tone — and optionally its cleanup intensity — based on which app you're dictating into.
+Contexts can match both apps and websites and can apply tone, cleanup, custom instructions, vocabulary, and snippets as one set of rules.
 
-## Why use this
-
-The way you write a Slack message is different from the way you write an email or a line of code. Instead of changing your settings every time you switch apps, you set it up once per app and Verenu handles the rest.
-
-## Setting up a mapping
-
-1. Turn on **Settings → General → Legacy pages**, then open **Settings → App Mappings**.
-2. Add an app — pick from your installed apps, or enter one manually.
-3. Choose a **tone** for that app: Casual, Formal, or Very Casual.
-4. Optionally, choose a **cleanup intensity** override (Verbatim, Light, Medium, or Direct) — or leave it as "Default" to use your global cleanup setting.
-
-## Example setup
-
-| App | Tone | Cleanup intensity |
-| --- | --- | --- |
-| Email client | Formal | Light |
-| Chat / messaging apps | Casual | Medium |
-| Code editor | — | Verbatim |
-
-With this setup, dictating into your email client produces polished, professional text with light editing, while dictating into your code editor leaves your words untouched — perfect for comments or commit messages where exact wording matters.
-
-## How app detection works
-
-Verenu identifies the app you're dictating into by its executable name (Windows) or application bundle (macOS) — the same name shown next to each entry in App Mappings. If an app isn't in your installed-apps list, you can still add it manually.
-
-## Next step
-
-Revisit [Cleanup Levels](CLEANUP_LEVELS.md) to choose the right intensity for each app, or check [Privacy & Data](PRIVACY_SUMMARY.md) to understand what Verenu does with your data.
-
-## Related Docs
-
-<p align="center">
-  <a href="CONTEXTS.md"><img alt="Contexts" src="https://img.shields.io/badge/Contexts-Guide-a3352b"></a>
-  <a href="CLEANUP_LEVELS.md"><img alt="Cleanup Levels" src="https://img.shields.io/badge/Cleanup-Levels-c44632"></a>
-  <a href="PRIVACY_SUMMARY.md"><img alt="Privacy Summary" src="https://img.shields.io/badge/Privacy-Summary-2b2422"></a>
-</p>
+To maintain the old page in an existing installation, turn on **Settings -> General -> Legacy pages**. New app-specific setup belongs in Contexts.

--- a/docs/CLEANUP_LEVELS.md
+++ b/docs/CLEANUP_LEVELS.md
@@ -23,7 +23,7 @@ This is separate from **tone** (Casual, Formal, or Very Casual), which controls 
 
 ## Next step
 
-Explore [Contexts](CONTEXTS.md) to scope cleanup, tone, vocabulary, and snippets to specific apps and sites.
+Explore [Contexts](CONTEXTS.md) to scope cleanup and tone, then see [Vocabulary](VOCABULARY.md) and [Snippets](SNIPPETS.md) for the content that belongs in each context.
 
 ## Related Docs
 

--- a/docs/CONTEXTS.md
+++ b/docs/CONTEXTS.md
@@ -1,39 +1,70 @@
 # Contexts
 
-Contexts are named groups for the apps and websites where you dictate. Each group can have its own tone, cleanup intensity, custom instructions, vocabulary, and snippets.
+Contexts are Verenu's main way to control what happens in different places. A context group connects a set of apps or websites with the tone, cleanup level, instructions, vocabulary, and snippets you want there.
 
-## Why use this
+For example, you might create:
 
-Contexts replaced the old standalone App Mappings, Dictionary, and Snippets pages as the main way to configure app-specific behavior. A single group keeps its targets, cleanup preferences, vocabulary, and snippets together, so a "Work" setup can follow you across the apps and websites where you need it.
+- **Development** for your editor and terminal, with Verbatim cleanup and technical vocabulary.
+- **Writing** for your document apps, with Medium cleanup and a formal tone.
+- **Support** for your help desk, with custom instructions for dates, names, and reply style.
 
-Every install starts with an **Everywhere** context group — the fallback used when nothing more specific matches — plus whatever groups you create.
+## How context matching works
 
-## Setting up a context group
+Verenu chooses one active context for each dictation:
 
-1. Open **Contexts** in the main navigation and click **New context group**.
-2. Give it a name (30 characters max) and, optionally, an icon and color.
-3. Attach apps and/or websites — the group activates automatically when you dictate into one of them.
-4. Optionally override the **tone** and **cleanup intensity** for this group; leave either as "Use default" to fall back to your global setting.
-5. Add vocabulary and snippets scoped to this group from its Vocabulary and Snippets tabs.
+1. If the active browser tab matches a context website, that website context wins.
+2. Otherwise, if the foreground app matches a context app, that app context wins.
+3. If nothing matches, Verenu uses **Everywhere**.
 
-## App and website matching
+Website matching is more specific than app matching. A website target such as `mail.google.com` can therefore use a different context from the rest of the browser. Verenu reads the active tab's domain from the browser address bar. No browser extension is required.
 
-- Apps are matched by executable name (Windows) or bundle identifier (macOS).
-- Websites are matched by domain. When you dictate inside a supported browser, Verenu reads the active tab's address bar to determine the domain — no browser extension required.
-- A domain you add is checked for DNS existence before it's accepted, so a typo can't silently create a website target that will never match anything.
-- An app or website can only belong to one context group at a time; assigning it to a new group removes it from its previous one.
+The app target is the executable name on Windows or the bundle identifier on macOS. Context targets are normalized when saved. A website is normalized to its hostname, and Verenu checks that the domain exists before saving it.
 
-## Legacy pages
+## The Everywhere context
 
-The standalone App Mappings, Dictionary, and Snippets pages are hidden by default. Turn on **Settings → General → Legacy pages** to bring them back for an older setup or a one-off migration. New configuration belongs in Contexts.
+Every install has an **Everywhere** context. It is the fallback when no app or website context matches.
 
-## Next step
+Everywhere can contain vocabulary and snippets that should apply to ordinary dictation. It cannot have app or website targets because it already covers everything else.
 
-Check [Cleanup Levels](CLEANUP_LEVELS.md) to choose the right cleanup intensity for a context group, or [Privacy & Data](PRIVACY_SUMMARY.md) to understand what a website check sends off device.
+## Create a context
 
-## Related Docs
+1. Open **Contexts** from the sidebar and choose **New context group**.
+2. Enter a name. Names can be up to 30 characters.
+3. Optionally choose an icon and color.
+4. Choose a **Tone** override, or leave it at **Use default**.
+5. Choose a **Cleanup** override, or leave it at **Use default**.
+6. Add **Custom instructions** if this context needs a rule the normal cleanup settings do not cover. The field accepts up to 300 characters and is sent to the cleanup model whenever the context is active.
+7. Add apps and websites. You can add more from the context page later.
+8. Save the context group.
+
+The **Advanced** section has one context-specific option, **Disable smart formatting**. It turns off automatic spacing and capitalization for that context. Use it for destinations where Verenu should leave those decisions alone.
+
+## Add content to a context
+
+Each context has two tabs:
+
+- [Vocabulary](VOCABULARY.md) contains words and phrases Verenu should recognize or correct.
+- [Snippets](SNIPPETS.md) contains spoken triggers that expand into saved text.
+
+You can assign the same vocabulary entry or snippet to more than one context. Use a row's menu and choose **Move to...** when you want to remove it from the current context and place it in another one.
+
+Deleting a context removes its app and website targets. Its vocabulary and snippets are returned to Everywhere so they are not orphaned.
+
+## Change an existing context
+
+Select a context in the sidebar and use its context menu to edit, pin, recolor, or delete it. The context page shows its targets, word and dictation counts, vocabulary, and snippets.
+
+To move an app or website to another context, add it to the new context. Each executable and each hostname can belong to only one targeted context at a time. Assigning an existing target elsewhere moves that target.
+
+## When to use the old pages
+
+The standalone App Mappings, Dictionary, and Snippets pages are legacy compatibility pages. They are hidden by default under **Settings -> General -> Legacy pages**. Use Contexts for new setup and for managing existing content by location.
+
+## Related docs
 
 <p align="center">
-  <a href="CLEANUP_LEVELS.md"><img alt="Cleanup Levels" src="https://img.shields.io/badge/Cleanup-Levels-c44632"></a>
+  <a href="VOCABULARY.md"><img alt="Vocabulary" src="https://img.shields.io/badge/Vocabulary-Guide-a3352b"></a>
+  <a href="SNIPPETS.md"><img alt="Snippets" src="https://img.shields.io/badge/Snippets-Guide-c44632"></a>
+  <a href="CLEANUP_LEVELS.md"><img alt="Cleanup Levels" src="https://img.shields.io/badge/Cleanup-Levels-7e7266"></a>
   <a href="PRIVACY_SUMMARY.md"><img alt="Privacy Summary" src="https://img.shields.io/badge/Privacy-Summary-2b2422"></a>
 </p>

--- a/docs/DICTIONARY.md
+++ b/docs/DICTIONARY.md
@@ -1,39 +1,7 @@
-# Legacy: Dictionary
+# Dictionary page moved
 
-> **Legacy page.** The standalone Dictionary page is hidden by default. Manage the same vocabulary per context group from the [Contexts](CONTEXTS.md) page's Vocabulary tab. Turn on **Settings -> General -> Legacy pages** to bring this page back for an older setup.
+The old standalone Dictionary page has been replaced by the **Vocabulary** tab inside Contexts.
 
-The Dictionary is Verenu's personal vocabulary list. Add names, brands, jargon, or other terms the AI should recognize and spell correctly. Entries apply wherever their context is active. The built-in **Everywhere** context is the fallback for entries that should apply across your dictation.
+Read the current guide: [Vocabulary](VOCABULARY.md).
 
-## Adding entries manually
-
-Each entry has two parts:
-
-- **Term**: the correct spelling you want Verenu to use, such as "Kubernetes", "Bjork", or "ChatGPT".
-- **Often mistranscribed as** (optional): what the transcription model tends to write instead, such as "koobernetes" or "byork".
-
-You can leave the second field empty if you only want Verenu to know a term. Add it when you know a specific mistake the AI makes.
-
-## How corrections are applied
-
-When Verenu sees a known mistake in a transcription, it replaces it with the correct term and matches whole words only. A partial match inside another word, such as "kube" inside "kubelet", is not replaced by accident.
-
-## Auto-learn
-
-Verenu can learn corrections automatically. When this is enabled, it watches what happens to the text it pastes for a short time afterward. If you consistently retype a word it got wrong, Verenu can add the correction to the active context's vocabulary.
-
-- **Distinctive terms**, such as brand names and technical terms, can be learned after one correction.
-- **Ordinary words** need to be corrected the same way twice within a couple of days before Verenu learns them.
-
-Common everyday words are not silently replaced everywhere. Distinctive terms can use automatic find-and-replace. Ambiguous corrections are applied contextually during cleanup instead.
-
-## Next step
-
-For current app- and website-specific vocabulary, use the Vocabulary tab inside [Contexts](CONTEXTS.md).
-
-## Related Docs
-
-<p align="center">
-  <a href="CONTEXTS.md"><img alt="Contexts" src="https://img.shields.io/badge/Contexts-Guide-a3352b"></a>
-  <a href="CLEANUP_LEVELS.md"><img alt="Cleanup Levels" src="https://img.shields.io/badge/Cleanup-Levels-7e7266"></a>
-  <a href="README.md"><img alt="Docs Index" src="https://img.shields.io/badge/Docs-Index-2b2422"></a>
-</p>
+To maintain the old standalone page in an existing installation, turn on **Settings -> General -> Legacy pages**. New vocabulary should be created and assigned from a context group.

--- a/docs/PRIVACY_SUMMARY.md
+++ b/docs/PRIVACY_SUMMARY.md
@@ -7,7 +7,7 @@ Verenu doesn't run its own servers, doesn't have an account system, and doesn't 
 - Your API keys (Windows Credential Manager / macOS Keychain)
 - Your settings, provider preferences, context groups, targets, and tone preferences
 - Your transcription history
-- Your context vocabulary, snippets, and auto-learn data
+- Your context vocabulary, snippets, and Auto-learn data
 - Local logs, unless you explicitly export them
 
 ## What leaves your device

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,11 +13,13 @@ This directory contains user, contributor, release, and architecture docs for Ve
 ## Features
 
 - [Contexts](CONTEXTS.md)
+- [Vocabulary](VOCABULARY.md)
+- [Snippets](SNIPPETS.md)
 - [Cleanup Levels](CLEANUP_LEVELS.md)
 - [Local Transcription](LOCAL_TRANSCRIPTION.md)
 - [Privacy & Data summary](PRIVACY_SUMMARY.md)
 
-Contexts are the current home for app and website targets, cleanup settings, vocabulary, and snippets. The standalone [Dictionary](DICTIONARY.md), [Snippets](SNIPPETS.md), and [App Mappings & Profiles](APP_MAPPINGS.md) pages are kept as legacy references for older installations.
+Contexts are the current home for app and website targets, cleanup settings, vocabulary, and snippets. [Vocabulary](VOCABULARY.md) and [Snippets](SNIPPETS.md) explain the two content types inside a context. The old [Dictionary](DICTIONARY.md) and [App Mappings & Profiles](APP_MAPPINGS.md) pages are kept only as legacy compatibility references.
 
 ## Project And Contributor Docs
 

--- a/docs/SNIPPETS.md
+++ b/docs/SNIPPETS.md
@@ -1,42 +1,66 @@
-# Legacy: Snippets
+# Snippets
 
-> **Legacy page.** The standalone Snippets page is hidden by default — snippets can be managed per context group from the [Contexts](CONTEXTS.md) page's Snippets tab. Turn on **Settings → General → Legacy pages** to bring this page back if you prefer managing snippets separately.
+Snippets turn a short spoken trigger into saved text. They are useful for email addresses, signatures, boilerplate replies, code fragments, and other text you use often.
 
-Snippets let you say a short trigger phrase and have Verenu expand it into something longer — a signature, a boilerplate response, a piece of code, anything you type often.
+Snippets belong to a context. Add them to **Everywhere** for a trigger you want available across Verenu, or add them to a specific context for app- or website-specific text.
 
-## Creating a snippet
+## Create a snippet
 
-Each snippet has:
+1. Open **Contexts** and select the context where the snippet belongs.
+2. Open the **Snippets** tab.
+3. Choose **+ Snippet**.
+4. Enter one or more **Trigger** phrases. Separate aliases with commas.
+5. Enter the **Expansion** that Verenu should insert.
+6. Optionally add **Cleanup instructions** for the expansion.
+7. Save the snippet.
 
-- **Trigger** — the phrase you say to activate it. You can list multiple aliases separated by commas (e.g. "Gemini Goal, Gemini Gold") so close transcriptions of the same phrase all work.
-- **Expansion** — the text that gets inserted in place of the trigger.
-- **Instructions** *(optional)* — extra formatting guidance for how the expansion should be applied.
+Triggers can be up to 300 characters. Expansion and instruction text can contain multiple lines.
 
-## How snippets fire
+For example:
 
-There are two ways a snippet can trigger, depending on what you say:
+| Field | Example |
+| --- | --- |
+| Trigger | `my email, email address` |
+| Expansion | `hello@example.com` |
+| Cleanup instructions | `Do not add a period after this address.` |
 
-1. **Whole-dictation match (fast path)** — If your entire dictation is just the trigger phrase, Verenu swaps it directly for the expansion and skips the cleanup step entirely. This is instant.
-2. **Trigger within a longer dictation** — If the trigger appears as part of something longer you said, Verenu passes its instructions to the cleanup step, so the expansion is woven into your sentence naturally rather than dropped in verbatim.
+You can dictate into the Trigger and Expansion fields with the microphone buttons.
 
-## Formatting instructions
+## How a snippet fires
 
-You can add plain-language formatting rules in the Instructions field, and Verenu enforces some of these mechanically after cleanup so they always apply:
+Verenu has two snippet paths:
 
-- **"all caps"** — the result is converted to uppercase.
-- **"no period"** — any trailing period is stripped from the result.
-- **"end with exclamation"** — the result ends with `!`.
+1. **The whole dictation is the trigger.** Verenu expands it directly and skips the cleanup model. This keeps a simple trigger fast and avoids a punctuation mark being added to the expansion.
+2. **The trigger appears inside a longer dictation.** Verenu passes the matched snippet's instructions into cleanup, then expands the trigger in the resulting text. This lets the expansion fit naturally into the sentence.
 
-You can also negate these (e.g. "don't use all caps") if a snippet's expansion would otherwise conflict with your tone settings.
+Matching is case-insensitive and accepts punctuation that transcription may add around the trigger. Triggers must still be standalone phrases. A trigger such as `test` does not match inside `testing` or `pre-test`.
 
-## Next step
+If multiple aliases or snippets match, Verenu prefers the longest matching trigger and ignores overlapping matches.
 
-For current app- and website-specific snippets, use the Snippets tab inside [Contexts](CONTEXTS.md).
+## Cleanup instructions
 
-## Related Docs
+Instructions are optional. They are added to the cleanup model's prompt only when the snippet is detected. Verenu also enforces a few narrow formatting rules after cleanup when it can identify them, including:
+
+- all caps
+- no final period
+- ending with an exclamation mark
+
+Write instructions as a direct request. For example, `Do not add a period after this phrase.`
+
+Use the context's **Custom instructions** when a rule applies to everything you dictate in that context. Use snippet instructions when the rule belongs only to one expansion.
+
+## Reuse and move snippets
+
+A snippet can belong to more than one context. Add the existing snippet to another context when you want to reuse it. From a snippet row menu, choose **Move to...** to remove it from the current context and assign it elsewhere.
+
+Deleting a snippet removes it from every context. Deleting a context moves its snippets to Everywhere instead.
+
+The Snippets list shows the usage count and the date the snippet was created. Search matches both triggers and expansions.
+
+## Related docs
 
 <p align="center">
   <a href="CONTEXTS.md"><img alt="Contexts" src="https://img.shields.io/badge/Contexts-Guide-a3352b"></a>
+  <a href="VOCABULARY.md"><img alt="Vocabulary" src="https://img.shields.io/badge/Vocabulary-Guide-c44632"></a>
   <a href="CLEANUP_LEVELS.md"><img alt="Cleanup Levels" src="https://img.shields.io/badge/Cleanup-Levels-7e7266"></a>
-  <a href="README.md"><img alt="Docs Index" src="https://img.shields.io/badge/Docs-Index-2b2422"></a>
 </p>

--- a/docs/VOCABULARY.md
+++ b/docs/VOCABULARY.md
@@ -1,0 +1,56 @@
+# Vocabulary
+
+Vocabulary tells Verenu about words that transcription models often miss, such as names, brands, product names, and technical terms.
+
+Vocabulary belongs to a context. Add it to **Everywhere** when it should apply to all dictation, or add it to a specific context when it only belongs in certain apps or websites.
+
+## Add a vocabulary entry
+
+1. Open **Contexts** and select the context where the term belongs.
+2. Open the **Vocabulary** tab.
+3. Choose **+ Term**.
+4. Enter the exact **Term** you want Verenu to use.
+5. Optionally enter one or more values in **Often mistranscribed as**. Separate multiple mistakes with commas.
+6. Save the term.
+
+Terms and mistranscriptions can each be up to 120 characters.
+
+The term field is the right choice when you want the cleanup model to recognize a word. The mistranscription field is useful when the transcription model repeatedly produces a specific wrong spelling. Leave it empty when there is no consistent mistake to replace.
+
+You can dictate into either field with the small microphone button beside it.
+
+## How vocabulary is used
+
+When a context is active, Verenu uses its vocabulary while preparing and cleaning the dictation. Distinctive corrections can also be applied mechanically after cleanup. Common, ambiguous corrections are handled contextually so a learned correction does not rewrite every ordinary use of a word.
+
+An entry can belong to several contexts. To reuse one, add it to another context rather than creating a duplicate. To remove it from the current context without deleting it, open the row menu and choose **Move to...**.
+
+Deleting the entry removes it from every context. Deleting a context moves its entries to Everywhere instead.
+
+## Auto-learned vocabulary
+
+When Auto-learn is enabled, Verenu watches the focused text field for corrections after a dictation. Repeated corrections can become vocabulary entries automatically.
+
+- Distinctive terms, such as brand names and technical words, can be promoted after one high-confidence correction.
+- Ordinary words need repeated corrections before Verenu promotes them.
+- Auto-learned entries show an indicator and confidence information in the Vocabulary list.
+
+Auto-learn monitors the text field after insertion. It does not send the monitoring data to a Verenu server.
+
+## Vocabulary or snippet?
+
+Use **Vocabulary** when the output should stay in the sentence but use the right spelling or term.
+
+Use a [Snippet](SNIPPETS.md) when a spoken trigger should insert a saved phrase, address, template, or block of text.
+
+## Legacy page
+
+Older installations may still show the standalone Dictionary page. It is hidden by default and is not the main setup path. Turn on **Settings -> General -> Legacy pages** only when you need to maintain an older view of the same local vocabulary data.
+
+## Related docs
+
+<p align="center">
+  <a href="CONTEXTS.md"><img alt="Contexts" src="https://img.shields.io/badge/Contexts-Guide-a3352b"></a>
+  <a href="SNIPPETS.md"><img alt="Snippets" src="https://img.shields.io/badge/Snippets-Guide-c44632"></a>
+  <a href="DATA_AND_PRIVACY.md"><img alt="Data and Privacy" src="https://img.shields.io/badge/Data-Privacy-5b554a"></a>
+</p>


### PR DESCRIPTION
## Summary\n- make Contexts the canonical documentation for app and website behavior\n- add the renamed Vocabulary guide with field limits, scoping, and Auto-learn behavior\n- replace stale Dictionary/App Mappings pages with compatibility pointers\n- document Snippet matching paths, cleanup instructions, reuse, and deletion behavior\n\n## Verification\n- all relative Markdown links resolve\n- git diff --check passed\n\nRelated: #289

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790213683&installation_model_id=432577&pr_number=290&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F290&signature=290fec73d89bde61b65aec0fa4f5aa5976eb26c4f71d977a92679e84d2ada711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->