### PR TITLE
Fix Windows history dropdown clipping

### DIFF
--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -253,6 +253,16 @@
   .history-app-trigger[aria-expanded='true'] { background: var(--control-hover); border-color: transparent; }
 
   .history-app-menu { width: max-content; min-width: 180px; max-width: 280px; }
+  /* WebView2 reserves a native scrollbar gutter even while the custom thumb is
+     transparent. That leaves the selected row looking clipped on Windows.
+     The menu remains wheel/trackpad-scrollable without the gutter. */
+  :global(.app-windows) .history-app-menu {
+    scrollbar-width: none;
+  }
+  :global(.app-windows) .history-app-menu::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
   .history-app-menu.opens-up { bottom: calc(100% + 4px); top: auto; }
 
   .clear-filters-wrap { display: flex; align-items: center; height: 100%; flex-shrink: 0; }


### PR DESCRIPTION
Fixes the Windows WebView2 scrollbar gutter that cuts off the selected All apps highlight in the home history dropdown.

Verification: npm run check; npm run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790274201&installation_model_id=432577&pr_number=291&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F291&signature=5d777285fcbd2fb59edfd0b9c3f5ef0b5824b07e8d81cf1cbf0668cf5f51d558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->