### PR TITLE
Fix home search app dropdown

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -104,7 +104,13 @@
     const target = e.target instanceof Element
       ? e.target
       : (e.target as Node)?.parentElement;
-    if (target && root?.contains(target)) return;
+    // Do not rely solely on the element that was focused when the menu opened.
+    // On some WebViews a pointer click does not focus the trigger, leaving
+    // `root` unset. The opening click then reaches this window listener after
+    // the menu is mounted and immediately closes it again. Resolve the scope
+    // from the click target as a fallback so mouse-opened menus stay usable.
+    const targetRoot = target?.closest(closeSelector || '.ui-dropdown');
+    if (target && (root?.contains(target) || targetRoot)) return;
     open = false;
   }
 

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import { fly, slide } from 'svelte/transition';
+  import { scale, slide } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import Dropdown from '../../components/Dropdown.svelte';
   import { formatAppLabel } from './helpers';
-  import { motionMs, motionPx, MOTION_MS, MOTION_PX } from '../../motion';
+  import { motionMs, MOTION_MS } from '../../motion';
 
   type Props = {
     search: string;
@@ -268,5 +268,19 @@
 
   @media (max-width: 560px) {
     .history-search-group.expanded { flex-basis: 100%; max-width: none; }
+  }
+
+  /* A compositor-backed reveal keeps the menu animation visible in WebKit,
+     including the macOS Tauri window. The Svelte transition still provides
+     the matching exit animation. */
+  .history-app-menu { animation: history-app-menu-enter var(--ui-duration-fast) var(--ui-ease-out); transform-origin: top right; will-change: opacity, transform; }
+
+  @keyframes history-app-menu-enter {
+    from { opacity: 0; transform: translate3d(0, -6px, 0) scale(0.98); }
+    to { opacity: 1; transform: translate3d(0, 0, 0) scale(1); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .history-app-menu { animation: none; will-change: auto; }
   }
 </style>

--- a/src/lib/views/home/HistoryToolbar.svelte
+++ b/src/lib/views/home/HistoryToolbar.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import { scale, slide } from 'svelte/transition';
+  import { fly, slide } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import Dropdown from '../../components/Dropdown.svelte';
   import { formatAppLabel } from './helpers';
-  import { motionMs, MOTION_MS } from '../../motion';
+  import { motionMs, motionPx, MOTION_MS, MOTION_PX } from '../../motion';
 
   type Props = {
     search: string;


### PR DESCRIPTION
## Thinking Path
> - Verenu is a Windows and macOS AI dictation app with a Svelte/Tauri UI.
> - The home history toolbar owns the search and app-filter dropdown.
> - On WebKit, an opening click could be treated as an outside click when the trigger was not focused.
> - That made the menu close immediately and prevented its animation from being usable.
> - This pull request scopes outside-click detection to the actual target and adds a WebKit-safe macOS reveal.
> - The result is a usable, animated home search app filter.

## What Changed
- Prevented the dropdown opening click from immediately closing the menu.
- Added a compositor-backed macOS/WebKit reveal with reduced-motion support.

## Verification
- `npm run check` passes.
- `but branch show m-branch-1-dropdown-fix --check` passes.
- Browser integration test was not run locally because Playwright Chromium is not installed.

## Risks
Low risk: scoped to the shared dropdown outside-click fallback and home search menu styling.

## Model Used
OpenAI Codex, GPT-5.6, tool-assisted coding.

## Checklist
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] `npm run check` passes
- [x] Risks documented
- [ ] Full browser integration test unavailable locally due missing Playwright Chromium.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790274609&installation_model_id=432577&pr_number=293&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F293&signature=802d3ca623dabb886f1fcd9c850b034a47866008f4d22ef38c2931ef69f98e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->