### PR TITLE
fix(ui): center toggle dot vertically

### DIFF
--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -50,8 +50,9 @@
     height: 12px;
     background: var(--bg-elev);
     border-radius: 50%;
-    top: 2px;
+    top: 50%;
     left: 2px;
+    transform: translateY(-50%);
     transition: left 0.35s cubic-bezier(0.22, 1, 0.36, 1);
     box-shadow: 0 1px 2px color-mix(in srgb, var(--ink) 15%, transparent);
   }


### PR DESCRIPTION
## Summary
- Settings toggle dot was positioned with a fixed `top: 2px` offset; switched to `top: 50%; transform: translateY(-50%)` so it's centered regardless of any subpixel rounding.

## Test plan
- [ ] Visually confirm toggle dot is centered in both on/off states in Settings

Co-authored-by: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296358&installation_model_id=432577&pr_number=297&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F297&signature=40dc8c7f16012bc1f70ada419c491e7252267b060c3e5ae63df06ee00771fff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->