### PR TITLE
feat: add Gemini 3.5 Transcribe model

### DIFF
--- a/src-tauri/src/api/gemini_types.rs
+++ b/src-tauri/src/api/gemini_types.rs
@@ -35,6 +35,24 @@ pub struct GeminiTranscribeReq {
     pub generation_config: Option<GeminiGenConfig>,
 }
 
+/// Request body for Google's dedicated audio transcription model. Unlike
+/// general Gemini audio understanding, this model is exposed through the
+/// Interactions API rather than generateContent.
+#[derive(Serialize, Debug)]
+pub struct GeminiInteractionTranscribeReq {
+    pub model: String,
+    pub input: Vec<GeminiInteractionInput>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type")]
+pub enum GeminiInteractionInput {
+    #[serde(rename = "audio")]
+    Audio { data: String, mime_type: String },
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GeminiGenerateReq {

--- a/src-tauri/src/api/transcription.rs
+++ b/src-tauri/src/api/transcription.rs
@@ -172,7 +172,101 @@ async fn transcribe_gemini(
 ) -> Result<String> {
     let language_label = crate::data::store::transcription_language_label(language);
     let prompt = get_transcription_prompt("google", model, language_label);
+    if model == "gemini-3.5-transcribe" {
+        return transcribe_gemini_dedicated(wav, api_key, &prompt, model, gen).await;
+    }
     transcribe_gemini_with_prompt(wav, api_key, &prompt, model, gen).await
+}
+
+async fn transcribe_gemini_dedicated(
+    wav: Bytes,
+    api_key: &str,
+    prompt: &str,
+    model: &str,
+    gen: u64,
+) -> Result<String> {
+    let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wav);
+    let body = super::gemini_types::GeminiInteractionTranscribeReq {
+        model: model.to_owned(),
+        input: vec![
+            super::gemini_types::GeminiInteractionInput::Audio {
+                data: encoded,
+                mime_type: "audio/wav".to_owned(),
+            },
+            super::gemini_types::GeminiInteractionInput::Text {
+                text: prompt.to_owned(),
+            },
+        ],
+    };
+    log::debug!(
+        "transcription: gemini dedicated request gen={} model={} wav_bytes={} prompt_chars={}",
+        gen,
+        model,
+        wav.len(),
+        prompt.chars().count()
+    );
+
+    let request_started = std::time::Instant::now();
+    let resp = super::client::get()
+        .post("https://generativelanguage.googleapis.com/v1beta/interactions")
+        .header("x-goog-api-key", api_key)
+        .json(&body)
+        .send()
+        .await?;
+    let status = resp.status();
+    let request_id = super::response_request_id(&resp);
+    log::debug!(
+        "transcription: gemini dedicated response gen={} status={} request_id={} latency_ms={}",
+        gen,
+        status,
+        request_id,
+        request_started.elapsed().as_millis()
+    );
+    let resp = match super::ensure_provider_success(resp, "Google", Some(("Google", model))).await {
+        Ok(resp) => resp,
+        Err(super::ProviderHttpError::Quota(e)) => return Err(e),
+        Err(super::ProviderHttpError::Auth { error, .. }) => return Err(error),
+        Err(super::ProviderHttpError::NonSuccess {
+            source,
+            status,
+            request_id,
+            preview,
+        }) => {
+            return Err(anyhow::Error::new(source).context(format!(
+                "Gemini Transcribe error status={} request_id={} body_preview={}",
+                status, request_id, preview
+            )))
+        }
+    };
+    let body: serde_json::Value = resp.json().await?;
+    parse_gemini_interaction_text(&body)
+        .ok_or_else(|| anyhow::anyhow!("Gemini Transcribe returned no transcript"))
+}
+
+fn parse_gemini_interaction_text(body: &serde_json::Value) -> Option<String> {
+    if let Some(text) = body.get("output_text").and_then(|v| v.as_str()) {
+        if !text.trim().is_empty() {
+            return Some(text.trim().to_owned());
+        }
+    }
+    let text = body
+        .get("steps")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter(|step| step.get("type").and_then(|v| v.as_str()) == Some("model_output"))
+        .flat_map(|step| {
+            step.get("content")
+                .and_then(|v| v.as_array())
+                .into_iter()
+                .flatten()
+        })
+        .filter_map(|content| content.get("text").and_then(|v| v.as_str()))
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!text.is_empty()).then_some(text)
 }
 
 async fn transcribe_gemini_with_prompt(
@@ -598,5 +692,40 @@ mod tests {
         );
         assert_eq!(json["generationConfig"]["maxOutputTokens"], 2048);
         assert_eq!(json["generationConfig"]["temperature"], 0.0);
+    }
+
+    #[test]
+    fn dedicated_gemini_interaction_request_uses_audio_input() {
+        let body = super::super::gemini_types::GeminiInteractionTranscribeReq {
+            model: "gemini-3.5-transcribe".to_string(),
+            input: vec![
+                super::super::gemini_types::GeminiInteractionInput::Audio {
+                    data: "ZmFrZQ==".to_string(),
+                    mime_type: "audio/wav".to_string(),
+                },
+                super::super::gemini_types::GeminiInteractionInput::Text {
+                    text: "transcribe this".to_string(),
+                },
+            ],
+        };
+        let json = serde_json::to_value(body).unwrap();
+        assert_eq!(json["model"], "gemini-3.5-transcribe");
+        assert_eq!(json["input"][0]["type"], "audio");
+        assert_eq!(json["input"][0]["mime_type"], "audio/wav");
+        assert_eq!(json["input"][1]["type"], "text");
+    }
+
+    #[test]
+    fn dedicated_gemini_interaction_parser_reads_output_text_and_steps() {
+        assert_eq!(
+            super::parse_gemini_interaction_text(&serde_json::json!({"output_text":" hello "})),
+            Some("hello".to_string())
+        );
+        assert_eq!(
+            super::parse_gemini_interaction_text(&serde_json::json!({
+                "steps": [{"type":"model_output", "content":[{"type":"text", "text":"hello"}, {"type":"text", "text":"world"}]}]
+            })),
+            Some("hello world".to_string())
+        );
     }
 }

--- a/src-tauri/src/data/store/config.rs
+++ b/src-tauri/src/data/store/config.rs
@@ -48,7 +48,7 @@ pub fn default_transcription_model_for(provider: &str) -> &'static str {
     match provider {
         LOCAL => "parakeet-v3",
         OPENAI => "gpt-4o-transcribe",
-        GOOGLE => "gemini-3.5-flash",
+        GOOGLE => "gemini-3.5-transcribe",
         ASSEMBLYAI => "universal-3-5-pro",
         _ => "whisper-large-v3-turbo",
     }

--- a/src/lib/components/settings/models.ts
+++ b/src/lib/components/settings/models.ts
@@ -83,6 +83,7 @@ export const CATALOG: CatalogEntry[] = [
   { provider: 'openai', id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', tasks: ['cleanup'], tags: ['accurate'] },
   { provider: 'openai', id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', tasks: ['cleanup'], tags: ['fast'] },
   { provider: 'google', id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', tasks: ['transcription', 'cleanup'], tags: ['accurate'], tier: 'premium' },
+  { provider: 'google', id: 'gemini-3.5-transcribe', label: 'Gemini 3.5 Transcribe', tasks: ['transcription'], tags: ['accurate'] },
   { provider: 'google', id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', tasks: ['transcription', 'cleanup'], tags: ['fast', 'cheap'], tier: 'standard' },
   { provider: 'google', id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', tasks: ['transcription', 'cleanup'], tags: ['accurate'] },
   { provider: 'google', id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', tasks: ['transcription', 'cleanup'], tags: ['fast'] },


### PR DESCRIPTION
> Verenu is a Windows and macOS AI dictation app that routes captured speech through a transcription provider.
> Google now provides a dedicated speech-to-text model, but the existing integration only knew general Gemini audio models.
> The gap is that Gemini 3.5 Transcribe uses the Interactions API and was not selectable or routable in Verenu.
> This pull request adds the provider's actual transcription model and endpoint.
> The benefit is dedicated Google speech recognition with the existing cleanup pipeline preserved.

## What Changed

- Added Gemini 3.5 Transcribe to the transcription model catalog and Google default.
- Added the Interactions API request and response parsing path for the dedicated model.
- Added Rust coverage for request serialization and documented response shapes.

## Verification

- npm run check
- npm run test:unit
- cargo test --manifest-path src-tauri/Cargo.toml api::transcription::tests
- cargo clippy was attempted but blocked by an existing WindowsChrome.dll file lock in the native build step.

## Risks

- The dedicated Google path is limited to the exact model ID and keeps general Gemini cleanup on generateContent.
- Audio is sent in the existing WAV format with the API key in a header only.

## Model Used

- OpenAI GPT-5.6 Luna, tool use, web research.

## Checklist

- [x] Model used is specified
- [x] Tests added or updated
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant provider documentation verified

Co-authored-by: Codex <codex@openai.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790400318&installation_model_id=432577&pr_number=299&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F299&signature=94ceb4e9bf5d30405289d49d2721240682e5b07abc06fbb916cf5a4c601f0aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->