### PR TITLE
Prevent passive pill click capture

### DIFF
--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -343,8 +343,10 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     PILL_VISUALLY_ACTIVE.store(true, Ordering::SeqCst);
 
     // Click-through for passive states so nothing behind the pill is blocked.
-    // Handsfree, error (Retry), and cancelled (Undo/Dismiss) all have real
-    // buttons that need real cursor events.
+    // Keep this list limited to states that actually render a live control.
+    // Some repair states are visual-only (for example the feedback prompt,
+    // applying, and done); treating those as interactive leaves an invisible
+    // click-capture surface over the app underneath the pill.
     let has_clickable_buttons = matches!(
         state,
         "handsfree"
@@ -352,14 +354,11 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
             | "cancelled"
             | "paste_failed"
             | "copied"
-            | "feedback_prompt"
             | "repair_input"
             | "repair_recording"
             | "repair_processing"
             | "repair_proposal"
-            | "repair_applying"
             | "repair_error"
-            | "repair_done"
     );
     pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
     // Re-assert every reveal, not just once at window creation: WebView2 has


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790574089&installation_model_id=432577&pr_number=308&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F308&signature=3f7d8908232cd166e2cb3cf9d61b515d108aedb1de48d968475fec04bfae330e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->