### PR TITLE
Make pill hit testing follow visible controls

### DIFF
--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -343,16 +343,14 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     PILL_VISUALLY_ACTIVE.store(true, Ordering::SeqCst);
 
     // Click-through for passive states so nothing behind the pill is blocked.
-    // Keep this list limited to states that actually render a live control.
-    // Some repair states are visual-only (for example the feedback prompt,
-    // applying, and done); treating those as interactive leaves an invisible
-    // click-capture surface over the app underneath the pill.
+    // Keep this list limited to states that always render a live control.
+    // Handsfree, error, and paste-failed reveal their controls after a short
+    // visual transition; the frontend enables cursor events only once those
+    // controls are actually mounted. This prevents the compact/status phase
+    // from capturing clicks over the app underneath the pill.
     let has_clickable_buttons = matches!(
         state,
-        "handsfree"
-            | "error"
-            | "cancelled"
-            | "paste_failed"
+        "cancelled"
             | "copied"
             | "repair_input"
             | "repair_recording"

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -37,6 +37,13 @@
   let repairIdleTimer: ReturnType<typeof setTimeout> | null = null;
   let repairHotkeyLabel: string | null = null;
 
+  // Keep the native pill click-through until a state has a real control.
+  // Delayed notification controls enable cursor events when they mount.
+  async function setPillInteractive(interactive: boolean) {
+    const { getCurrentWindow } = await import('@tauri-apps/api/window');
+    await getCurrentWindow().setIgnoreCursorEvents(!interactive).catch(() => {});
+  }
+
   // Resolved context for the current dictation (e.g. "Slack", "Everywhere") —
   // where the text is headed, emitted by the backend's own resolution.
   let contextLabel: string | null = null;
@@ -592,6 +599,7 @@
       }
       errLines = lines;
       errOpen = true;
+      void setPillInteractive(true);
       // Eagerly size the native window to the target before the CSS
       // transition starts, so the growing pill is never clipped while the
       // ResizeObserver catch-up lags behind the animation.
@@ -762,10 +770,25 @@
 
         if (incoming === 'handsfree') {
           showHfButtons = false;
-          hfTimer = setTimeout(() => { showHfButtons = true; hfTimer = null; }, 150);
+          hfTimer = setTimeout(() => {
+            hfTimer = null;
+            if (state === 'handsfree') {
+              showHfButtons = true;
+              void setPillInteractive(true);
+            }
+          }, 150);
         }
         prevState = state;
         state = incoming;
+        void setPillInteractive(
+          incoming === 'cancelled' ||
+          incoming === 'copied' ||
+          incoming === 'repair_input' ||
+          incoming === 'repair_recording' ||
+          incoming === 'repair_processing' ||
+          incoming === 'repair_proposal' ||
+          incoming === 'repair_error'
+        );
         if (state === 'repair_proposal' || state === 'repair_error') {
           // The window now has real OS keyboard focus (see set_pill_focusable
           // in pill.rs), but nothing has DOM focus yet — without this, Escape
@@ -873,7 +896,10 @@
           // not as a second, disconnected animation arriving a while later.
           copyBtnTimer = setTimeout(() => {
             copyBtnTimer = null;
-            if (state === 'paste_failed') showCopyBtn = true;
+            if (state === 'paste_failed') {
+              showCopyBtn = true;
+              void setPillInteractive(true);
+            }
           }, 180);
           if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
           pasteFailedDismissTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary\n- Keep the floating pill click-through while handsfree/error/paste-failure controls are still hidden\n- Enable cursor events only after the corresponding controls are mounted\n- Preserve interactivity for states with always-visible controls\n\n## Verification\n- npm run check\n- cargo check --manifest-path src-tauri/Cargo.toml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790588180&installation_model_id=432577&pr_number=311&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F311&signature=93228d4761d18d407a108bc493c9cba826d78b576dc839f35e488e1e8979f33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->