### PR TITLE
Fix toggle thumb visibility and alignment

### DIFF
--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -38,6 +38,12 @@
   .toggle {
     width: 30px;
     height: 16px;
+    display: block;
+    box-sizing: border-box;
+    padding: 0;
+    border: 0;
+    appearance: none;
+    -webkit-appearance: none;
     background: var(--line-strong);
     border-radius: 999px;
     position: relative;

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -19,7 +19,8 @@
   }
 </script>
 
-<div
+<button
+  type="button"
   class="toggle"
   class:on={checked}
   role="switch"
@@ -31,7 +32,7 @@
   onkeyup={handleToggleKeyup}
 >
   <span class="toggle-thumb" aria-hidden="true"></span>
-</div>
+</button>
 
 <style>
   .toggle {

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -19,8 +19,7 @@
   }
 </script>
 
-<button
-  type="button"
+<div
   class="toggle"
   class:on={checked}
   role="switch"
@@ -32,18 +31,12 @@
   onkeyup={handleToggleKeyup}
 >
   <span class="toggle-thumb" aria-hidden="true"></span>
-</button>
+</div>
 
 <style>
   .toggle {
     width: 30px;
     height: 16px;
-    display: block;
-    box-sizing: border-box;
-    padding: 0;
-    border: 0;
-    appearance: none;
-    -webkit-appearance: none;
     background: var(--line-strong);
     border-radius: 999px;
     position: relative;
@@ -58,11 +51,13 @@
     height: 12px;
     background: var(--bg-elev);
     border-radius: 50%;
-    top: 2px;
+    top: 50%;
     left: 2px;
+    transform: translateY(-50%);
     transition: left 0.35s cubic-bezier(0.22, 1, 0.36, 1);
     box-shadow: 0 1px 2px color-mix(in srgb, var(--ink) 15%, transparent);
   }
+
   .toggle.on {
     background: var(--accent);
   }


### PR DESCRIPTION
## Summary`n- render toggle thumbs as a real child element`n- center thumbs vertically across toggle sizes`n- preserve the existing accessible switch contract`n`n## Verification`n- npm run check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790634920&installation_model_id=432577&pr_number=313&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F313&signature=d90c2a8f3de03deb921dd45d034f84e7c8e62b869341ea9b3b74ba63419417c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->