### PR TITLE
Prevent macOS dev bundle identity regressions

### DIFF
--- a/scripts/macos/check-identity-contract.mjs
+++ b/scripts/macos/check-identity-contract.mjs
@@ -33,6 +33,9 @@ assert(!runner.includes('spawn(bundledBinary'), 'Development must never spawn Co
 assert(!runner.includes("const APP_BUNDLE_NAME = 'Verenu.app'"), 'Development must not create an ambiguously named Verenu.app.');
 assert(runner.includes("configured !== '-'"), 'Development signing must reject ad-hoc identity selection.');
 assert(relaunch.includes('exec /usr/bin/open -n'), 'macOS Relaunch must use LaunchServices.');
+assert(runner.includes('.staging-'), 'Development bundles must be staged before installation.');
+assert(runner.includes('installPreparedBundle'), 'Development bundle installation must use the atomic swap helper.');
+assert(runner.includes('Invalid Page'), 'Development runner must document the live-code-signature rebuild hazard.');
 
 if (failures.length > 0) {
   console.error('macOS identity contract failed:');

--- a/scripts/tauri-macos-dev-runner.mjs
+++ b/scripts/tauri-macos-dev-runner.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from 'node:child_process';
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { constants as osConstants } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -190,8 +190,21 @@ function optionValue(args, name) {
 
 function prepareSignedDevBundle(sourceBinary) {
   const profileDir = path.dirname(sourceBinary);
-  const appBundle = path.join(profileDir, 'bundle', 'macos-dev', APP_BUNDLE_NAME);
-  const contentsDir = path.join(appBundle, 'Contents');
+  const bundleDir = path.join(profileDir, 'bundle', 'macos-dev');
+  const appBundle = path.join(bundleDir, APP_BUNDLE_NAME);
+  // Never rewrite the executable inside a running app bundle. macOS validates
+  // signed code pages as they are faulted in; copying a rebuilt Mach-O over a
+  // live executable can terminate the old process with SIGKILL
+  // (CODESIGNING/Invalid Page). Build and sign a separate .app, then swap the
+  // directory at the stable path so old processes keep their original inode.
+  const stagingBundle = path.join(
+    bundleDir,
+    `${APP_BUNDLE_BASENAME}.staging-${process.pid}-${Date.now()}.app`,
+  );
+  rmSync(stagingBundle, { recursive: true, force: true });
+  mkdirSync(bundleDir, { recursive: true });
+  const preparedBundle = stagingBundle;
+  const contentsDir = path.join(preparedBundle, 'Contents');
   const macosDir = path.join(contentsDir, 'MacOS');
   const resourcesDir = path.join(contentsDir, 'Resources');
   const bundledBinary = path.join(macosDir, 'Verenu');
@@ -239,7 +252,7 @@ function prepareSignedDevBundle(sourceBinary) {
       normalizedEntitlements,
       '--sign',
       identity,
-      appBundle,
+      preparedBundle,
     ],
     { encoding: 'utf8', env: process.env },
   );
@@ -248,7 +261,7 @@ function prepareSignedDevBundle(sourceBinary) {
     process.exit(signResult.status ?? 1);
   }
 
-  const verifyResult = spawnSync('/usr/bin/codesign', ['--verify', '--deep', '--strict', appBundle], {
+  const verifyResult = spawnSync('/usr/bin/codesign', ['--verify', '--deep', '--strict', preparedBundle], {
     encoding: 'utf8',
     env: process.env,
   });
@@ -257,11 +270,47 @@ function prepareSignedDevBundle(sourceBinary) {
     process.exit(verifyResult.status ?? 1);
   }
 
-  verifyPreparedIdentity(appBundle, identity);
-  warnAboutLegacyDevelopmentCopies(profileDir, appBundle);
+  verifyPreparedIdentity(preparedBundle, identity);
+  installPreparedBundle(preparedBundle, appBundle);
+  quarantineLegacyDevelopmentCopy(profileDir, appBundle);
 
   console.log(`[macOS dev runner] Prepared signed bundle: ${appBundle}`);
-  return bundledBinary;
+  return path.join(appBundle, 'Contents', 'MacOS', 'Verenu');
+}
+
+function installPreparedBundle(preparedBundle, canonicalBundle) {
+  if (!existsSync(canonicalBundle)) {
+    renameSync(preparedBundle, canonicalBundle);
+    return;
+  }
+
+  const backupBundle = `${canonicalBundle}.previous-${process.pid}-${Date.now()}`;
+  try {
+    renameSync(canonicalBundle, backupBundle);
+    renameSync(preparedBundle, canonicalBundle);
+  } catch (error) {
+    if (!existsSync(canonicalBundle) && existsSync(backupBundle)) {
+      try { renameSync(backupBundle, canonicalBundle); } catch { /* preserve original error */ }
+    }
+    rmSync(preparedBundle, { recursive: true, force: true });
+    throw new Error(`Could not atomically install development app bundle: ${error}`);
+  }
+
+  // Keep old bundles alive until no process references their executable.
+  cleanupPreviousBundles(path.dirname(canonicalBundle));
+}
+
+function cleanupPreviousBundles(bundleDir) {
+  const entries = spawnSync('/bin/ls', ['-1', bundleDir], { encoding: 'utf8' });
+  if (entries.status !== 0) return;
+  for (const name of entries.stdout.split('\n').map((value) => value.trim()).filter(Boolean)) {
+    if (!name.startsWith(`${APP_BUNDLE_BASENAME}.app.previous-`)) continue;
+    const previousBundle = path.join(bundleDir, name);
+    const previousExecutable = path.join(previousBundle, 'Contents', 'MacOS', 'Verenu');
+    if (findBundleProcessIds(previousExecutable).length === 0) {
+      rmSync(previousBundle, { recursive: true, force: true });
+    }
+  }
 }
 
 function setPlistValue(plistPath, key, value) {
@@ -342,19 +391,41 @@ function plistValue(plist, key) {
   return result.status === 0 ? result.stdout.trim() : '';
 }
 
-function warnAboutLegacyDevelopmentCopies(profileDir, canonicalBundle) {
-  const marker = path.join(profileDir, '.verenu-dev-identity-migration-v1');
+function quarantineLegacyDevelopmentCopy(profileDir, canonicalBundle) {
+  const marker = path.join(profileDir, '.verenu-dev-identity-migration-v2');
   if (existsSync(marker)) return;
-  const candidates = [
-    path.join(profileDir, 'bundle', 'macos-dev', 'Verenu.app'),
-    '/Applications/Verenu Development.app',
-  ].filter((candidate) => candidate !== canonicalBundle && existsSync(candidate));
-  if (candidates.length > 0) {
-    console.warn('[macOS dev runner] Legacy/duplicate development app copies detected:');
-    for (const candidate of candidates) console.warn(`  ${candidate}`);
-    console.warn(
-      'Ignore or remove those copies manually. Grant permissions only to the canonical Verenu Development app shown above.',
-    );
+  const legacyBundle = path.join(profileDir, 'bundle', 'macos-dev', 'Verenu.app');
+  let legacyActive = false;
+  if (existsSync(legacyBundle) && legacyBundle !== canonicalBundle) {
+    const legacyExecutable = path.join(legacyBundle, 'Contents', 'MacOS', 'Verenu');
+    const activePids = findBundleProcessIds(legacyExecutable);
+    if (activePids.length > 0) {
+      legacyActive = true;
+      console.warn('[macOS dev runner] A legacy Verenu.app process is still running:');
+      console.warn(`  ${legacyBundle} (PID ${activePids.join(', ')})`);
+      console.warn('Quit that old copy before using Permissions. The current run will use Verenu Development.app.');
+    } else if (process.env.VERENU_KEEP_LEGACY_COPY === '1') {
+      console.warn(`[macOS dev runner] Keeping legacy copy by request: ${legacyBundle}`);
+    } else {
+      const quarantinedBundle = path.join(profileDir, 'bundle', 'macos-dev', 'Verenu Legacy.app');
+      try {
+        if (existsSync(quarantinedBundle)) {
+          console.warn(`[macOS dev runner] Legacy quarantine already exists: ${quarantinedBundle}`);
+        } else {
+          renameSync(legacyBundle, quarantinedBundle);
+          console.warn(`[macOS dev runner] Quarantined legacy development bundle: ${quarantinedBundle}`);
+        }
+      } catch (error) {
+        console.warn(`[macOS dev runner] Could not quarantine legacy bundle: ${error}`);
+        console.warn('Grant permissions only to the canonical Verenu Development.app shown above.');
+      }
+    }
   }
-  writeFileSync(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
+  const duplicateCanonical = '/Applications/Verenu Development.app';
+  if (duplicateCanonical !== canonicalBundle && existsSync(duplicateCanonical)) {
+    console.warn('[macOS dev runner] Another Verenu Development.app is registered at:');
+    console.warn(`  ${duplicateCanonical}`);
+    console.warn('Use only the canonical bundle printed by this runner for development permissions.');
+  }
+  if (!legacyActive) writeFileSync(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
 }

--- a/scripts/tauri-macos-dev-runner.mjs
+++ b/scripts/tauri-macos-dev-runner.mjs
@@ -427,5 +427,10 @@ function quarantineLegacyDevelopmentCopy(profileDir, canonicalBundle) {
     console.warn(`  ${duplicateCanonical}`);
     console.warn('Use only the canonical bundle printed by this runner for development permissions.');
   }
-  if (!legacyActive) writeFileSync(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
+  // Only mark migration complete after the legacy path is gone. If the
+  // quarantine destination already exists, retry/warn on the next run rather
+  // than permanently suppressing detection while Verenu.app remains present.
+  if (!legacyActive && !existsSync(legacyBundle)) {
+    writeFileSync(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
+  }
 }

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -8,11 +8,11 @@
 //! **Microphone**. Keychain access is surfaced separately when a provider key is
 //! stored.
 
+#[cfg(target_os = "macos")]
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
-#[cfg(target_os = "macos")]
-use std::path::Path;
 
 static PERMISSION_QUERY_GENERATION: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_os = "macos")]
@@ -628,7 +628,9 @@ pub fn open_notifications_settings() -> Result<(), String> {
 pub fn restart_app(handle: tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        if let Some(bundle) = crate::system::mac_app::bundle_path().filter(|path| {
+        if let Some(bundle) = crate::system::mac_app::bundle_path()
+            .map(canonical_relaunch_bundle)
+            .filter(|path| {
             Path::new(path.trim_end_matches('/'))
                 .extension()
                 .map(|extension| extension == "app")
@@ -657,6 +659,38 @@ pub fn restart_app(handle: tauri::AppHandle) -> Result<(), String> {
     #[cfg(not(target_os = "macos"))]
     {
         handle.restart();
+    }
+}
+
+/// Keep development relaunches on the canonical signed development bundle.
+/// Older dev runs left `Verenu.app` in the same target directory; relaunching
+/// that path would preserve its production identifier and ad-hoc TCC identity
+/// forever. The runner's `Verenu Development.app` is the only supported debug
+/// launch target, so redirect the legacy sibling when it is available.
+#[cfg(target_os = "macos")]
+fn canonical_relaunch_bundle(bundle: String) -> String {
+    if !cfg!(debug_assertions) {
+        return bundle;
+    }
+
+    let path = Path::new(&bundle);
+    let is_legacy_dev_bundle = path.file_name().and_then(|name| name.to_str())
+        == Some("Verenu.app")
+        && path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            == Some("macos-dev");
+    if !is_legacy_dev_bundle {
+        return bundle;
+    }
+
+    let canonical = path
+        .parent()
+        .map(|parent| parent.join("Verenu Development.app"));
+    match canonical.filter(|candidate| candidate.is_dir()) {
+        Some(candidate) => candidate.to_string_lossy().into_owned(),
+        None => bundle,
     }
 }
 

--- a/src/lib/components/MacPermissions.svelte
+++ b/src/lib/components/MacPermissions.svelte
@@ -138,8 +138,19 @@
   const canRepairStaleGrant = $derived(
     showRepairHint && accessibilityActionTaken && !!snapshot.diagnostics.bundleIdentifier,
   );
+  // macOS TCC follows the exact signed identity, not the visible app name.
+  // Treat any non-canonical debug launch as invalid even when it exposes some
+  // bundle metadata, so permission actions cannot target a stale identity.
   const invalidDevLaunch = $derived(
-    isMac && snapshot.diagnostics.processId > 0 && !snapshot.diagnostics.bundleIdentifier,
+    isMac && import.meta.env.DEV && snapshot.diagnostics.processId > 0 && (
+      snapshot.diagnostics.bundleIdentifier !== 'com.verenu.app.dev' ||
+      snapshot.diagnostics.bundleDisplayName !== 'Verenu Development' ||
+      !snapshot.diagnostics.isRunningInsideApp ||
+      !snapshot.diagnostics.signingIdentity ||
+      !snapshot.diagnostics.teamIdentifier ||
+      snapshot.diagnostics.signingIdentity === 'adhoc' ||
+      snapshot.diagnostics.teamIdentifier === 'not set'
+    ),
   );
 
   // Keep the bindable flag in sync with the core OS permissions.
@@ -456,9 +467,10 @@
   <div class="mac-permissions" onkeydown={(event) => { if (event.key === 'Escape' && showDiagnostics) { event.preventDefault(); showDiagnostics = false; } }}>
   {#if invalidDevLaunch}
     <div class="permission-warning" role="alert">
-      <strong>Verenu is still running from the old raw development executable.</strong>
-      Stop the current terminal dev command and run <code>npm run tauri dev</code> again.
-      The in-app Relaunch button cannot replace this process with the signed app bundle.
+      <strong>This is not the canonical signed development app.</strong>
+      Stop this process and run <code>npm run tauri dev</code> again. Development
+      permissions belong to <strong>Verenu Development</strong> (<code>com.verenu.app.dev</code>),
+      not another Verenu-named copy.
     </div>
   {/if}
   {#if variant === 'setup' && allGranted}


### PR DESCRIPTION
Build development as the canonical signed Verenu Development.app and launch it through LaunchServices. Stage and atomically swap rebuilt bundles so live signed code is never overwritten, quarantine stale legacy copies, keep relaunches on the canonical dev bundle, and enforce the identity contract in checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790657189&installation_model_id=432577&pr_number=314&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F314&signature=9d6351f341587a48d9a3dd256fcbe366c3d77d684c39516268a3eb5b22af8c87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->