### PR TITLE
Fix synced history retention

### DIFF
--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -661,6 +661,23 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
             Ok(())
         })?;
     }
+    if user_version < 22 {
+        log::info!("db: migrating schema {user_version} -> 22");
+        // History retention is device-local. Older sync builds logged every
+        // retention prune as a transcription delete, which let one device's
+        // shorter retention window erase history on its peers. Existing
+        // tombstones are retention deletes (there is no user-facing history
+        // delete action), so discard them and stop creating new ones.
+        run_migration(&mut conn, |conn| {
+            conn.execute_batch(
+                "DROP TRIGGER IF EXISTS trg_sync_transcriptions_del;
+                 DELETE FROM sync_log
+                  WHERE table_name = 'transcriptions' AND op = 'delete';
+                 PRAGMA user_version = 22;",
+            )?;
+            Ok(())
+        })?;
+    }
     // Early v20 development databases created sync_peers before receive and
     // send cursors were split. Their version marker is already 20, so the
     // migration above will not run again. Repair that partial v20 shape on
@@ -722,7 +739,9 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
 ///   thing on every paired device. Local integer ids stay the primary keys.
 /// - `sync_log` records one row per captured mutation (table, row uuid, op,
 ///   timestamp, originating device). Peers pull deltas by log position, so
-///   deletes propagate exactly and no tombstone rows pollute the main tables.
+///   content deletes propagate exactly and no tombstone rows pollute the main
+///   tables. Transcription history is append-only for sync: retention cleanup
+///   is local to each device and never becomes a delete op.
 /// - AFTER triggers on the syncable tables append to `sync_log`. The triggers
 ///   stay silent while `sync_state.applying` is 1 - that flag is how the sync
 ///   engine applies a remote change and records it in the log once (with the
@@ -1119,16 +1138,6 @@ CREATE TRIGGER IF NOT EXISTS trg_sync_transcriptions_ins AFTER INSERT ON transcr
   UPDATE transcriptions SET uuid = lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(6))) WHERE id = NEW.id AND uuid IS NULL;
   INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
   SELECT 'transcriptions', (SELECT uuid FROM transcriptions WHERE id = NEW.id), 'upsert',
-         CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
-         (SELECT uuid FROM sync_identity),
-         COALESCE((SELECT MAX(origin_seq) FROM sync_log
-                   WHERE origin = (SELECT uuid FROM sync_identity)), 0) + 1
-  WHERE (SELECT uuid FROM sync_identity) IS NOT NULL
-    AND (SELECT COALESCE(applying, 0) FROM sync_state) = 0;
-END;
-CREATE TRIGGER IF NOT EXISTS trg_sync_transcriptions_del AFTER DELETE ON transcriptions BEGIN
-  INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
-  SELECT 'transcriptions', OLD.uuid, 'delete',
          CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
          (SELECT uuid FROM sync_identity),
          COALESCE((SELECT MAX(origin_seq) FROM sync_log

--- a/src-tauri/src/data/db/tests.rs
+++ b/src-tauri/src/data/db/tests.rs
@@ -4,6 +4,32 @@ fn test_db() -> Db {
     open(":memory:").expect("test db")
 }
 
+#[test]
+fn retention_prune_does_not_create_transcription_delete_tombstones() {
+    let db = test_db();
+    insert_transcription_returning(&db, "old", "old", 1, 1_000, "test", None, None)
+        .expect("transcription");
+    {
+        let conn = lock_conn(&db).expect("lock");
+        conn.execute(
+            "UPDATE transcriptions SET created_at = datetime('now', '-30 days')",
+            [],
+        )
+        .expect("backdate transcription");
+    }
+
+    assert_eq!(prune_transcriptions_older_than(&db, 7).expect("prune"), 1);
+    let conn = lock_conn(&db).expect("lock");
+    let delete_logs: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sync_log WHERE table_name = 'transcriptions' AND op = 'delete'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("delete log count");
+    assert_eq!(delete_logs, 0);
+}
+
 fn temp_db_path(name: &str) -> std::path::PathBuf {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -285,7 +311,7 @@ fn open_self_heals_database_stuck_at_v2_with_legacy_dictionary() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .expect("version");
-    assert_eq!(version, 21);
+    assert_eq!(version, 22);
     drop(conn);
     drop(db);
     let _ = std::fs::remove_file(&path);

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -73,7 +73,6 @@ pub const SYNCABLE_SETTINGS: &[&str] = &[
     store::CONTEXTUAL_FORMATTING,
     store::CLEANUP_PROMPT_OVERRIDE,
     store::VERENU_SERVICE_CHECKS_ENABLED,
-    store::HISTORY_RETENTION,
 ];
 
 pub(crate) const UNRESOLVED_APP_PREFIX: &str = "?::";
@@ -549,10 +548,13 @@ fn api_call_payload(conn: &Connection, uuid: &str) -> Result<Option<serde_json::
     Ok(row.map(|row| serde_json::to_value(row).expect("serialize api call row")))
 }
 
-/// Resolves a collapsed log entry into a full wire op. A logged upsert whose
-/// row has since vanished resolves to a delete (the row was removed after the
-/// op was captured; the delete trigger's own entry will supersede this one).
+/// Resolves a collapsed log entry into a full wire op. History is append-only
+/// for sync purposes: retention pruning is device-local, so old transcription
+/// delete tombstones from pre-v22 databases must never be sent to peers.
 fn resolve_entry(conn: &Connection, entry: &sync_store::LogEntry) -> Result<Option<SyncOp>> {
+    if entry.table_name == "transcriptions" && entry.op == "delete" {
+        return Ok(None);
+    }
     let payload = match entry.table_name.as_str() {
         "dictionary" if entry.op == "upsert" => dictionary_payload(conn, &entry.row_uuid)?,
         "snippets" if entry.op == "upsert" => snippet_payload(conn, &entry.row_uuid)?,
@@ -1385,7 +1387,10 @@ fn normalize_domain(domain: &str) -> String {
 
 fn apply_transcription_op(conn: &Connection, op: &SyncOp) -> Result<Applied> {
     if op.is_delete() {
-        return apply_simple_delete(conn, op, "transcriptions", "transcriptions");
+        // Transcription deletion is retention cleanup, and retention is
+        // intentionally device-local. A peer must never erase a row merely
+        // because another device has a shorter local retention window.
+        return Ok(Applied::Skipped);
     }
     if let Some(stamp) = latest_stamp(conn, "transcriptions", &op.row_uuid)? {
         if !op.newer_than(&stamp) {

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -700,12 +700,51 @@ fn syncable_settings_exclude_device_local_keys() {
         crate::data::store::CLIPBOARD_PHRASE_ENABLED,
         crate::data::store::BETA_UPDATES_ENABLED,
         crate::data::store::LOCAL_MODEL_MEMORY_POLICY,
+        crate::data::store::HISTORY_RETENTION,
     ] {
         assert!(
             !SYNCABLE_SETTINGS.contains(&key),
             "{key} must stay device-local"
         );
     }
+}
+
+#[test]
+fn remote_transcription_deletes_do_not_erase_local_history() {
+    let db = test_db(&uuid("cccc"));
+    db::insert_transcription_returning(
+        &db,
+        "history text",
+        "history text",
+        2,
+        1_000,
+        "test",
+        None,
+        None,
+    )
+    .expect("transcription");
+    let transcription_uuid: String = {
+        let conn = db.lock().expect("lock");
+        conn.query_row("SELECT uuid FROM transcriptions LIMIT 1", [], |r| r.get(0))
+            .expect("uuid")
+    };
+
+    let op = super::protocol::SyncOp {
+        table: "transcriptions".to_string(),
+        row_uuid: transcription_uuid,
+        op: "delete".to_string(),
+        ts_ms: sync_store::now_ms() + 1,
+        origin: uuid("peer"),
+        origin_seq: 1,
+        payload: None,
+    };
+    let summary = {
+        let conn = db.lock().expect("lock");
+        engine::apply_ops(&conn, &[op]).expect("apply delete")
+    };
+    assert_eq!(summary.applied, 0);
+    let conn = db.lock().expect("lock");
+    assert_eq!(count(&conn, "SELECT COUNT(*) FROM transcriptions"), 1);
 }
 
 fn test_context_op(


### PR DESCRIPTION
Fix synced history retention

## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that stores dictated text locally.
> - Its history and Insights data are backed by the local SQLite database.
> - LAN sync was treating transcription retention cleanup like a user deletion.
> - A paired device with a shorter retention window could therefore erase older history on this device.
> - This pull request makes transcription history append-only across sync peers while keeping retention local.
> - The benefit is that one device's privacy setting cannot unexpectedly remove history from another device.

## What Changed

- Exclude the device-local history-retention setting from synced settings.
- Stop creating, sending, or applying transcription delete operations through sync.
- Migrate existing databases by removing stale transcription-delete tombstones.
- Add regression coverage for local pruning and incoming remote deletes.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml sync::tests` (23 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml retention_prune_does_not_create_transcription_delete_tombstones` (1 passed)
- `git diff --check` passed.
- `cargo fmt --check` remains blocked by pre-existing formatting differences across the `dev` branch; no formatter rewrite was applied.

## Risks

- Low migration risk: schema v22 drops only the transcription-delete trigger and old transcription delete log rows; content deletion sync behavior is unchanged.
- Existing rows are not restored by this code change. The affected device backup remains the recovery source for history already removed before the fix.

## Model Used

- OpenAI GPT-5.6-luna, high reasoning effort, with local code and database inspection.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (not run; backend-only change)
- [ ] `npm run lint` passes (not run; backend-only change)
- [ ] `npm run test:rust` passes (targeted Rust tests run instead)
- [ ] Smoke tests pass (not applicable; backend-only change)
- [x] Tests added or updated where applicable
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated in code comments and migration notes
- [x] Risks documented above
