### PR TITLE
Polish history metadata and copy interactions

### DIFF
--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -38,16 +38,31 @@
   $: filtersActive = search.trim().length > 0 || appFilter !== null;
   $: firstLabel = recents.length > 0 ? fmtDate(recents[0].created_at) : '';
 
-  function rowMeta(entry: Entry): string {
-    const parts: string[] = [];
-    if (entry.app_name) parts.push(formatAppLabel(entry.app_name));
+  function durationText(entry: Entry): string {
     if (
       typeof entry.duration_ms === 'number' &&
       Number.isFinite(entry.duration_ms) &&
       entry.duration_ms >= 0
     ) {
-      parts.push(fmtDuration(entry.duration_ms));
+      return fmtDuration(entry.duration_ms);
     }
+    return '';
+  }
+
+  const APP_LABEL_MAX_CHARS = 40;
+
+  function capAppLabel(appName: string): string {
+    const label = formatAppLabel(appName);
+    return label.length > APP_LABEL_MAX_CHARS
+      ? `${label.slice(0, APP_LABEL_MAX_CHARS - 1)}…`
+      : label;
+  }
+
+  function rowMeta(entry: Entry): string {
+    const parts: string[] = [];
+    if (entry.app_name) parts.push(formatAppLabel(entry.app_name));
+    const duration = durationText(entry);
+    if (duration) parts.push(duration);
     return parts.join(' · ');
   }
 
@@ -86,10 +101,33 @@
         delete cachedHeights[key];
       }
     }
+    for (const key of Object.keys(stackedMeta)) {
+      if (!keys.has(key)) {
+        delete stackedMeta[key];
+      }
+    }
   }
 
   const DEFAULT_HEADER_HEIGHT = 38;
   const DEFAULT_ROW_HEIGHT = 74;
+  let stackedMeta: Record<string, boolean> = {};
+
+  // Decide per row whether the left-column meta stack fits inside the row's
+  // existing height. Measured rather than compared against a tuned constant, so
+  // it stays correct when padding/font/spacing change. The left block is always
+  // in the DOM (absolutely positioned, invisible until hover) so it can be
+  // measured before we commit to a layout.
+  function measureStacked(node: HTMLElement, key: string) {
+    const metaEl = node.querySelector<HTMLElement>('.day-meta-left');
+    if (!metaEl) return;
+    // Skip while hovered: the below-variant grows the row on hover, which would
+    // otherwise flip the decision mid-interaction.
+    if (node.matches(':hover, :focus-within')) return;
+    const fits = metaEl.getBoundingClientRect().bottom <= node.getBoundingClientRect().bottom;
+    if (stackedMeta[key] !== fits) {
+      stackedMeta = { ...stackedMeta, [key]: fits };
+    }
+  }
 
   let container: HTMLElement | null = null;
   let listContainer: HTMLElement | null = null;
@@ -241,6 +279,7 @@
           cachedHeights[key] = height;
           changed = true;
         }
+        measureStacked(node, key);
       }
     }
     if (changed) {
@@ -252,6 +291,7 @@
   function measureItem(node: HTMLElement, key: string) {
     nodeKeys.set(node, key);
     sharedObserver.observe(node);
+    measureStacked(node, key);
 
     return {
       update(newKey: string) {
@@ -263,6 +303,7 @@
           updateLayout();
           updateVirtualList();
         }
+        measureStacked(node, newKey);
       },
       destroy() {
         sharedObserver.unobserve(node);
@@ -389,12 +430,24 @@
             {item.label}
           </div>
         {:else if item.type === 'row'}
-          <div use:measureItem={item.key} class="day-row" class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
-            <div class="day-time">{fmtTime(item.entry.created_at)}</div>
+          <div use:measureItem={item.key} class="day-row" class:meta-stacked={stackedMeta[item.key]} class:first-in-table={(index === 0 && !hasBanner) || flatItems[index - 1]?.type === 'header'}>
+            <div class="day-time">
+              {fmtTime(item.entry.created_at)}
+              {#if rowMeta(item.entry)}
+                <div class="day-meta day-meta-left" aria-hidden={!stackedMeta[item.key]}>
+                  {#if item.entry.app_name}
+                    <div class="day-meta-app">{capAppLabel(item.entry.app_name)}</div>
+                  {/if}
+                  {#if durationText(item.entry)}
+                    <div class="day-meta-line">{durationText(item.entry)}</div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
             <div class="day-main">
               <div class="day-text">{item.entry.clean_text}</div>
-              {#if rowMeta(item.entry)}
-                <div class="day-meta">{rowMeta(item.entry)}</div>
+              {#if !stackedMeta[item.key] && rowMeta(item.entry)}
+                <div class="day-meta day-meta-below">{rowMeta(item.entry)}</div>
               {/if}
             </div>
             <button
@@ -450,16 +503,15 @@
 
   .day-row {
     display: grid;
-    grid-template-columns: 84px 1fr auto;
+    grid-template-columns: 84px 1fr 18px;
     align-items: start;
     padding: 11px 4px;
     border-bottom: 1px solid var(--line);
     gap: 14px;
     cursor: default;
+    box-sizing: border-box;
   }
   .day-row:hover { background: var(--control-hover); }
-  .day-row:not(:hover) .copy-btn:not(:focus-visible) { opacity: 0.25; }
-  .day-row:hover .copy-btn { opacity: 0.9; }
 
   .copy-btn {
     all: unset;
@@ -471,14 +523,20 @@
     height: 18px;
     border-radius: 4px;
     color: var(--ink-mute);
-    opacity: 0.25;
-    transition: color 0.12s, opacity 0.12s;
+    opacity: 0;
+    transform: translateX(8px);
+    transition: opacity 0.16s var(--ui-ease-out, ease), transform 0.16s var(--ui-ease-out, ease), color 0.12s;
     flex-shrink: 0;
     margin-top: 2px;
   }
-  .copy-btn:hover { opacity: 0.9; }
-  .copy-btn:focus-visible {
+  .day-row:hover .copy-btn,
+  .copy-btn:focus-visible,
+  .copy-btn.copied {
     opacity: 0.9;
+    transform: translateX(0);
+  }
+  .copy-btn:hover { color: var(--ink-strong); }
+  .copy-btn:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
@@ -486,6 +544,7 @@
   .copy-btn svg { width: 10px; height: 10px; }
 
   .day-time {
+    position: relative;
     font-family: var(--mono);
     font-size: 11px;
     color: var(--ink-mute);
@@ -510,26 +569,73 @@
   }
 
   .day-meta {
+    /* Explicit: the left variant lives inside .day-time, which is mono/500 with
+       tabular numerals — without this it wouldn't match the underneath variant. */
+    font-family: var(--sans);
+    font-weight: 400;
+    font-variant-numeric: normal;
     font-size: 10.5px;
     color: var(--ink-faint);
     letter-spacing: 0.01em;
-    min-width: 0;
+    opacity: 0;
+  }
+
+  .day-meta-line {
+    max-width: 84px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    opacity: 0;
+  }
+
+  .day-meta-app {
+    max-width: 84px;
+    overflow-wrap: break-word;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  /* Row is already tall enough (multi-line text) — stack in the left column,
+     no extra height ever needed, so it never shifts the page. */
+  .day-meta-left {
+    position: absolute;
+    top: 20px;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    transform: translateX(-8px);
+    transition:
+      opacity var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-fast) var(--ui-ease-out);
+  }
+  .day-row.meta-stacked:hover .day-meta-left,
+  .day-row.meta-stacked:focus-within .day-meta-left {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  /* Row is short (one-line text) — no room on the left without growing the
+     row, so put it underneath instead; only this variant needs to grow. */
+  .day-meta-below {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     max-height: 0;
-    transform: translateY(-2px);
+    transform: translateX(-8px);
     transition:
       opacity var(--ui-duration-fast) var(--ui-ease-out),
       transform var(--ui-duration-fast) var(--ui-ease-out),
       max-height var(--ui-duration-fast) var(--ui-ease-out);
   }
-  .day-row:hover .day-meta,
-  .day-row:focus-within .day-meta {
+  .day-row:hover .day-meta-below,
+  .day-row:focus-within .day-meta-below {
     opacity: 1;
     max-height: 16px;
-    transform: translateY(0);
+    transform: translateX(0);
   }
 
   .error-msg {

--- a/tests/integration/playwright-test-history-filter-dev.cjs
+++ b/tests/integration/playwright-test-history-filter-dev.cjs
@@ -92,10 +92,10 @@ const historyMockWrap = function () {
 
     if (false) {
     // Row metadata: app label + compact duration under the text.
-    const metaFirst = await page.locator('.day-meta').first().innerText();
+    const metaFirst = await page.locator('.day-meta-left').first().innerText();
     if (!/Outlook · \d+s/.test(metaFirst)) errors.push(`row meta wrong: "${metaFirst}"`);
     // Row with no app but a duration still shows just the duration.
-    const metaNoApp = await page.locator('.day-row:has-text("Draft a response to the vendor") .day-meta').innerText();
+    const metaNoApp = await page.locator('.day-row:has-text("Draft a response to the vendor") .day-meta-left').innerText();
     if (metaNoApp !== '5s') errors.push(`no-app row meta wrong: "${metaNoApp}"`);
     if ((await page.locator('.day-row').count()) !== 6) errors.push('all history rows should render unfiltered');
     }
@@ -141,9 +141,9 @@ const historyMockWrap = function () {
     await page.waitForTimeout(500);
     if ((await page.locator('.day-row').count()) !== 6) errors.push('resetting to All apps must restore all rows');
     if ((await page.locator('.empty-state').count()) !== 0) errors.push('empty state must disappear after resetting to All apps');
-    const metaFirst = await page.locator('.day-meta').first().innerText();
+    const metaFirst = await page.locator('.day-meta-left').first().innerText();
     if (!/Outlook/.test(metaFirst) || !/\d+s/.test(metaFirst)) errors.push(`row meta wrong: "${metaFirst}"`);
-    const metaNoApp = await page.locator('.day-row:has-text("Draft a response to the vendor") .day-meta').innerText();
+    const metaNoApp = await page.locator('.day-row:has-text("Draft a response to the vendor") .day-meta-left').innerText();
     if (metaNoApp !== '5s') errors.push(`no-app row meta wrong: "${metaNoApp}"`);
 
     // The explicit clear action enters with a horizontal transition and resets


### PR DESCRIPTION
## Summary

- Reveal the copy control on row hover while keeping its grid column fixed.
- Choose per-row metadata placement from measured available height.
- Stack app and duration metadata in the left column for tall rows; reveal it on hover without layout shift.
- Keep short-row metadata underneath with capped app labels and a small hover-only height expansion.

## Verification

- `npm run check`
- `npm run test:unit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790824672&installation_model_id=432577&pr_number=319&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F319&signature=d1155dc5145bf3ad47434a309496b210b888ebcdba118ab51d7227cb967f63c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->