### PR TITLE
Fix browser context pill resolution

### DIFF
--- a/src-tauri/src/core/browser_probe.rs
+++ b/src-tauri/src/core/browser_probe.rs
@@ -1,6 +1,6 @@
 //! Best-effort browser address-bar domain read, used to pick a Context by
 //! website when dictating into a browser tab. Only ever called when the
-//! foreground process is a known browser (`window_context::is_browser_exe`).
+//! captured process is a known browser (`window_context::is_browser_exe`).
 //! Any failure, timeout, or missing permission returns `None` and the caller
 //! falls back to exe-only context resolution — this must never block or
 //! error the dictation pipeline.
@@ -40,8 +40,6 @@ mod win {
         CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationTreeWalker,
         IUIAutomationValuePattern, UIA_EditControlTypeId, UIA_ValuePatternId,
     };
-    use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
-
     const BUDGET: Duration = Duration::from_millis(150);
     const MAX_DEPTH: u32 = 8;
     const MAX_VISITED: u32 = 400;
@@ -71,15 +69,15 @@ mod win {
         }
     }
 
-    /// Reads the foreground browser window's address bar text via UI
-    /// Automation. Tries the Chromium `addressEditBox` AutomationId first
-    /// (fast, exact), then falls back to the first Edit control found in a
-    /// depth/time-bounded tree walk (covers Firefox and other engines).
-    pub fn read_address_bar_text() -> Option<String> {
+    /// Reads a browser window's address bar text via UI Automation. Chromium's
+    /// exact `addressEditBox` is preferred even when it appears after a page
+    /// input in the tree; the generic Edit fallback is only used when no exact
+    /// address bar was found (for Firefox and other engines).
+    pub fn read_address_bar_text(window_id: usize) -> Option<String> {
         let _com = ComGuard::init();
         let automation: IUIAutomation =
             unsafe { CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER).ok()? };
-        let hwnd = unsafe { GetForegroundWindow() };
+        let hwnd = HWND(window_id as *mut core::ffi::c_void);
         if hwnd.0.is_null() {
             return None;
         }
@@ -91,7 +89,15 @@ mod win {
             visited: 0,
         };
 
-        find_address_bar(&walker, &root, 0, &mut budget)
+        let mut result = AddressBarSearch::default();
+        find_address_bar(&walker, &root, 0, &mut budget, &mut result);
+        result.exact.or(result.fallback)
+    }
+
+    #[derive(Default)]
+    struct AddressBarSearch {
+        exact: Option<String>,
+        fallback: Option<String>,
     }
 
     fn find_address_bar(
@@ -99,9 +105,10 @@ mod win {
         element: &IUIAutomationElement,
         depth: u32,
         budget: &mut Budget,
-    ) -> Option<String> {
+        result: &mut AddressBarSearch,
+    ) {
         if depth > MAX_DEPTH || budget.exhausted() {
-            return None;
+            return;
         }
         budget.visited += 1;
 
@@ -111,49 +118,36 @@ mod win {
         let control_type = unsafe { element.CurrentControlType() }.ok();
         let is_edit = control_type.map(|v| v.0) == Some(UIA_EditControlTypeId.0);
 
-        if is_edit && automation_id == "addressEditBox" {
+        // Do not require the control type here. The automation id is the
+        // browser-owned identifier and remains the strongest signal if the
+        // browser changes how it exposes the value pattern.
+        if automation_id.eq_ignore_ascii_case("addressEditBox") {
             if let Some(text) = read_value(element) {
-                return Some(text);
+                result.exact = Some(text);
+                return;
             }
         }
 
-        // Recurse into children first (depth-first), remembering the first
-        // plain Edit control as a fallback if no exact address bar is found.
-        let mut fallback: Option<String> = None;
+        if is_edit && result.fallback.is_none() {
+            result.fallback = read_value(element);
+        }
+
         if let Ok(child) = unsafe { walker.GetFirstChildElement(element) } {
             let mut current = Some(child);
             while let Some(node) = current {
-                if budget.exhausted() {
+                if budget.exhausted() || result.exact.is_some() {
                     break;
                 }
-                if let Some(text) = find_address_bar(walker, &node, depth + 1, budget) {
-                    return Some(text);
-                }
-                if fallback.is_none() && is_edit_control(&node) {
-                    fallback = read_value(&node);
-                }
+                find_address_bar(walker, &node, depth + 1, budget, result);
                 current = unsafe { walker.GetNextSiblingElement(&node) }.ok();
             }
         }
-
-        if is_edit && fallback.is_none() {
-            fallback = read_value(element);
-        }
-        fallback
-    }
-
-    fn is_edit_control(element: &IUIAutomationElement) -> bool {
-        unsafe { element.CurrentControlType() }
-            .map(|v| v.0)
-            .ok()
-            == Some(UIA_EditControlTypeId.0)
     }
 
     fn read_value(element: &IUIAutomationElement) -> Option<String> {
-        let pattern = unsafe {
-            element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId)
-        }
-        .ok()?;
+        let pattern =
+            unsafe { element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId) }
+                .ok()?;
         let value = unsafe { pattern.CurrentValue() }.ok()?.to_string();
         if value.trim().is_empty() {
             None
@@ -169,26 +163,26 @@ mod mac {
     /// existing AX shim in `system/macos_ax_text_marker.m` to read the known
     /// per-browser address-bar identifiers). Returns `None` so website
     /// matching silently falls back to exe-only resolution on macOS for now.
-    pub fn read_address_bar_text() -> Option<String> {
+    pub fn read_address_bar_text(_window_id: usize) -> Option<String> {
         None
     }
 }
 
-#[cfg(windows)]
-use win::read_address_bar_text as platform_read_address_bar_text;
 #[cfg(target_os = "macos")]
 use mac::read_address_bar_text as platform_read_address_bar_text;
+#[cfg(windows)]
+use win::read_address_bar_text as platform_read_address_bar_text;
 #[cfg(not(any(windows, target_os = "macos")))]
-fn platform_read_address_bar_text() -> Option<String> {
+fn platform_read_address_bar_text(_window_id: usize) -> Option<String> {
     None
 }
 
-/// Reads the active browser's address bar and returns just the domain, e.g.
-/// "mail.google.com". Caller must confirm the foreground process is a
+/// Reads a browser window's address bar and returns just the domain, e.g.
+/// "mail.google.com". Caller must confirm the captured process is a
 /// browser (`window_context::is_browser_exe`) before calling this — it does
 /// not check that itself, since the OS-level read is comparatively costly.
-pub fn read_active_browser_domain() -> Option<String> {
-    let raw = platform_read_address_bar_text()?;
+pub fn read_browser_domain_for_window(window_id: usize) -> Option<String> {
+    let raw = platform_read_address_bar_text(window_id)?;
     extract_domain(&raw)
 }
 
@@ -206,7 +200,10 @@ mod tests {
 
     #[test]
     fn extracts_domain_from_bare_host() {
-        assert_eq!(extract_domain("Example.com"), Some("example.com".to_string()));
+        assert_eq!(
+            extract_domain("Example.com"),
+            Some("example.com".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -270,7 +270,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // for any other window. Best-effort: a probe failure just means the
     // context resolves by exe alone, same as before this feature existed.
     let browser_domain = if window_context::is_browser_exe(&process_name) {
-        browser_probe::read_active_browser_domain()
+        browser_probe::read_browser_domain_for_window(target.id)
     } else {
         None
     };

--- a/src-tauri/src/pipeline/stages_style.rs
+++ b/src-tauri/src/pipeline/stages_style.rs
@@ -46,9 +46,7 @@ pub(super) fn apply_app_style_overrides(
         .and_then(|c| c.tone.as_deref())
         .map(str::trim)
         .filter(|t| !t.is_empty());
-    let mapping_profile = mapping
-        .map(|m| m.profile.trim())
-        .filter(|p| !p.is_empty());
+    let mapping_profile = mapping.map(|m| m.profile.trim()).filter(|p| !p.is_empty());
     context_tone
         .or(mapping_profile)
         .map(str::to_owned)
@@ -64,10 +62,9 @@ pub(super) fn apply_app_style_overrides(
 ///
 /// The hwnd→process-name read can come up empty (elevated target processes,
 /// race between capture and start), so the process name falls back to the
-/// live foreground window; an unresolved context just leaves the chip hidden
-/// until processing resolves one. Without this early emit the label only ever
-/// appeared once processing began, which made it useless right when it
-/// matters.
+/// live foreground window. Browser domains are read from the captured target
+/// too, making website-only groups available before recording begins; an
+/// unresolved context remains hidden until processing resolves one.
 pub(super) fn emit_context_for_window(app: &AppHandle, hwnd: usize) {
     let process_name = if hwnd != 0 {
         window_context::get_process_name_for_hwnd(hwnd)
@@ -76,11 +73,18 @@ pub(super) fn emit_context_for_window(app: &AppHandle, hwnd: usize) {
     }
     .or_else(window_context::get_active_process_name)
     .unwrap_or_default();
-    // Exe-only context lookup (no address-bar probe here — this runs on the
-    // recording-start path and must stay fast; the real pipeline resolves
-    // the domain-refined context and re-emits it).
+    // Read the domain from the captured browser window as well as the exe.
+    // This keeps website-only context groups accurate on the recording pill;
+    // the bounded UIA probe remains best-effort and falls back to exe lookup.
+    let browser_domain = if window_context::is_browser_exe(&process_name) {
+        crate::core::browser_probe::read_browser_domain_for_window(hwnd)
+    } else {
+        None
+    };
     let db_handle = app.state::<crate::DbHandle>().inner().clone();
-    if let Ok(context) = crate::core::context::resolve_context(&db_handle, &process_name, None) {
+    if let Ok(context) =
+        crate::core::context::resolve_context(&db_handle, &process_name, browser_domain.as_deref())
+    {
         crate::pipeline::pill::queue_pill_context(&context.name);
     }
 }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold, audio capture, transcription, cleanup, and text injection.
> - This change targets the pipeline context resolver and the floating dictation pill.
> - Website-only context groups were shown as Everywhere during recording because recording-start resolution skipped the browser-tab domain probe.
> - Chrome's UI Automation walk could also return a page edit field before Chrome's address bar.
> - This pull request resolves the captured browser window's domain at recording start and prefers Chrome's exact address-bar control.
> - The benefit is an accurate context-group label while dictation is in progress, including Chrome tabs such as chatgpt.com.

## What Changed

- Resolve browser website targets from the captured target window at recording start.
- Use the captured target window again during processing instead of the current foreground window.
- Search for Chrome's exact addressEditBox before falling back to a generic edit control.

## Verification

- `npm run check` passes.
- Focused Rust tests pass for browser-domain extraction and website-context precedence.
- Manual scenario: start dictation in a Chrome tab assigned to a context group and confirm the group label appears above the pill immediately.

## Risks

- Low risk. The browser probe remains bounded and best-effort; failures retain the existing executable-based fallback.
- The probe now uses the captured window handle, so a focus change during transcription cannot change the selected context.

## Model Used

- OpenAI GPT-5.6, Codex harness, high-reasoning tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes
- [x] Tests added or updated where applicable: existing focused tests pass
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790825483&installation_model_id=432577&pr_number=320&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F320&signature=a32adac489764b59c4d42e43d7b2f51193dbf19178ce81971e2f941e19629ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->