### PR TITLE
Preserve context group targets across app updates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Context group app targets now survive versioned/nightly app updates by matching a close replacement name with publisher/developer evidence on Windows and macOS.
 - Reworked cleanup prompting around one default shared by every model, with explicit rule priority, conservative ambiguity handling, multilingual preservation, self-corrections and repair commands, spoken symbols and spelling, technical-token reconstruction, restrained formatting, safer number treatment, and context-assisted disambiguation.
 - **The cleanup prompt is now a single template used by every model**, edited from Clean-up → Edit prompt. It used to be stored per model, so an edit made on your default was silently ignored the moment a fallback model took over. An existing per-model edit is carried over.
 - Fixed Gemini 3 requests failing with `Thinking level MINIMAL is not supported for this model` — affected both cleanup and transcription on newer Gemini 3 flash models, which accept `low` but not `minimal`.

--- a/src-tauri/src/commands/contexts.rs
+++ b/src-tauri/src/commands/contexts.rs
@@ -126,6 +126,8 @@ pub async fn get_context_targets(
 ) -> Result<Vec<db::ContextTarget>, String> {
     let db = db_state(&app);
     run_blocking("get_context_targets", move || {
+        let installed_apps = crate::system::apps::list_installed_apps();
+        db::reconcile_context_targets(&db, &installed_apps).map_err(|e| e.to_string())?;
         db::query_context_targets(&db, context_id).map_err(|e| e.to_string())
     })
     .await
@@ -136,10 +138,19 @@ pub async fn assign_context_target(
     app: AppHandle,
     context_id: i64,
     executable: String,
+    app_name: Option<String>,
+    developer: Option<String>,
 ) -> Result<db::ContextTarget, String> {
     let db = db_state(&app);
     run_blocking("assign_context_target", move || {
-        db::assign_context_target(&db, context_id, &executable).map_err(|e| e.to_string())
+        db::assign_context_target_with_metadata(
+            &db,
+            context_id,
+            &executable,
+            app_name.as_deref(),
+            developer.as_deref(),
+        )
+        .map_err(|e| e.to_string())
     })
     .await
 }

--- a/src-tauri/src/core/context.rs
+++ b/src-tauri/src/core/context.rs
@@ -5,6 +5,11 @@ use anyhow::Result;
 use crate::data::db::{self, Context, Db};
 
 pub fn resolve_context(db: &Db, executable: &str, domain: Option<&str>) -> Result<Context> {
+    // App bundles/installers commonly replace their executable name on every
+    // update. Refresh a target lazily on the dictation path so users do not
+    // need to reopen the Contexts screen after a nightly release changes.
+    let installed_apps = crate::system::apps::list_installed_apps_cached();
+    db::reconcile_context_targets(db, &installed_apps)?;
     db::resolve_context_for_target(db, executable, domain)
 }
 

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -440,7 +440,7 @@ pub fn reconcile_context_targets(
         .collect::<rusqlite::Result<_>>()?;
     let mut changed = false;
 
-    for (id, context_id, executable, app_name, developer, platform) in rows {
+    for (id, _context_id, executable, app_name, developer, platform) in rows {
         if executable.starts_with("?::") {
             continue;
         }
@@ -459,12 +459,12 @@ pub fn reconcile_context_targets(
         if exact.is_none() && candidate.exe.eq_ignore_ascii_case(&executable) {
             continue;
         }
-        let owned_elsewhere: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM context_targets WHERE executable = ?1 AND id <> ?2 AND context_id <> ?3)",
-            params![candidate.exe, id, context_id],
+        let already_owned: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM context_targets WHERE executable = ?1 AND id <> ?2)",
+            params![candidate.exe, id],
             |row| row.get(0),
         )?;
-        if owned_elsewhere {
+        if already_owned {
             continue;
         }
         let next_executable = if exact.is_some() {

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -459,19 +459,19 @@ pub fn reconcile_context_targets(
         if exact.is_none() && candidate.exe.eq_ignore_ascii_case(&executable) {
             continue;
         }
-        let already_owned: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM context_targets WHERE executable = ?1 AND id <> ?2)",
-            params![candidate.exe, id],
-            |row| row.get(0),
-        )?;
-        if already_owned {
-            continue;
-        }
         let next_executable = if exact.is_some() {
             executable.clone()
         } else {
             candidate.exe.trim().to_lowercase()
         };
+        let already_owned: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM context_targets WHERE executable = ?1 AND id <> ?2)",
+            params![next_executable, id],
+            |row| row.get(0),
+        )?;
+        if already_owned {
+            continue;
+        }
         let next_app_name = normalize_optional_trimmed(Some(candidate.name.as_str()));
         let next_developer = normalize_optional_trimmed(candidate.developer.as_deref());
         let next_platform = platform.clone().or(current_platform.map(str::to_string));

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -46,6 +46,15 @@ pub struct ContextTarget {
     pub created_at: String,
 }
 
+type ContextTargetRow = (
+    i64,
+    i64,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
 /// Tag applied to a target assigned on this device, so a synced-in target
 /// from another OS (e.g. a Windows `.exe` name landing in a Mac's database)
 /// can be hidden from this device's UI without being deleted — going back to
@@ -419,7 +428,7 @@ pub fn reconcile_context_targets(
 ) -> Result<bool> {
     let conn = lock_conn(db)?;
     let current_platform = current_platform_tag();
-    let rows: Vec<(i64, i64, String, Option<String>, Option<String>, Option<String>)> = conn
+    let rows: Vec<ContextTargetRow> = conn
         .prepare(
             "SELECT id, context_id, executable, app_name, developer, platform
              FROM context_targets

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -35,6 +35,10 @@ pub struct ContextTarget {
     pub id: i64,
     pub context_id: i64,
     pub executable: String,
+    /// The app identity captured when this target was assigned. These fields
+    /// let a target survive versioned/nightly app identifiers changing.
+    pub app_name: Option<String>,
+    pub developer: Option<String>,
     /// `"windows"` / `"macos"`, or `None` for rows assigned before this field
     /// existed (or synced from an unrecognized platform) — those stay visible
     /// on every device rather than disappearing.
@@ -328,8 +332,10 @@ fn context_target_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextT
         id: row.get(0)?,
         context_id: row.get(1)?,
         executable: row.get(2)?,
-        platform: row.get(3)?,
-        created_at: row.get(4)?,
+        app_name: row.get(3)?,
+        developer: row.get(4)?,
+        platform: row.get(5)?,
+        created_at: row.get(6)?,
     })
 }
 
@@ -346,7 +352,7 @@ fn context_target_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextT
 pub fn query_context_targets(db: &Db, context_id: Option<i64>) -> Result<Vec<ContextTarget>> {
     let conn = lock_conn(db)?;
     let mut stmt = conn.prepare(
-        "SELECT id, context_id, executable, platform, created_at
+        "SELECT id, context_id, executable, app_name, developer, platform, created_at
          FROM context_targets
          WHERE (?1 IS NULL OR context_id = ?1)
            AND (?2 IS NULL OR platform IS NULL OR platform = ?2)
@@ -359,8 +365,21 @@ pub fn query_context_targets(db: &Db, context_id: Option<i64>) -> Result<Vec<Con
     Ok(rows)
 }
 
+#[cfg(test)]
 pub fn assign_context_target(db: &Db, context_id: i64, executable: &str) -> Result<ContextTarget> {
+    assign_context_target_with_metadata(db, context_id, executable, None, None)
+}
+
+pub fn assign_context_target_with_metadata(
+    db: &Db,
+    context_id: i64,
+    executable: &str,
+    app_name: Option<&str>,
+    developer: Option<&str>,
+) -> Result<ContextTarget> {
     let normalized_executable = normalize_executable(executable)?;
+    let normalized_app_name = normalize_optional_trimmed(app_name);
+    let normalized_developer = normalize_optional_trimmed(developer);
     let mut conn = lock_conn(db)?;
     let context = query_context_conn(&conn, context_id)?;
     if context.is_everywhere {
@@ -369,18 +388,106 @@ pub fn assign_context_target(db: &Db, context_id: i64, executable: &str) -> Resu
 
     let tx = conn.transaction()?;
     tx.execute(
-        "INSERT INTO context_targets (context_id, executable, platform) VALUES (?1, ?2, ?3)
-         ON CONFLICT(executable) DO UPDATE SET context_id = excluded.context_id, platform = excluded.platform",
-        params![context_id, normalized_executable, current_platform_tag()],
+        "INSERT INTO context_targets (context_id, executable, app_name, developer, platform) VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(executable) DO UPDATE SET context_id = excluded.context_id, app_name = excluded.app_name, developer = excluded.developer, platform = excluded.platform",
+        params![
+            context_id,
+            normalized_executable,
+            normalized_app_name,
+            normalized_developer,
+            current_platform_tag()
+        ],
     )?;
     let target = tx.query_row(
-        "SELECT id, context_id, executable, platform, created_at
+        "SELECT id, context_id, executable, app_name, developer, platform, created_at
          FROM context_targets WHERE executable = ?1",
         params![normalized_executable],
         context_target_from_row,
     )?;
     tx.commit()?;
     Ok(target)
+}
+
+/// Rebinds a target whose old executable disappeared to a strong local app
+/// candidate. Exact executable matches refresh metadata; replacements require
+/// a close name and reject known developer mismatches. The unique executable
+/// constraint is respected: a candidate already owned by another context is
+/// left alone rather than silently stealing that assignment.
+pub fn reconcile_context_targets(
+    db: &Db,
+    installed_apps: &[crate::system::apps::InstalledApp],
+) -> Result<bool> {
+    let conn = lock_conn(db)?;
+    let current_platform = current_platform_tag();
+    let rows: Vec<(i64, i64, String, Option<String>, Option<String>, Option<String>)> = conn
+        .prepare(
+            "SELECT id, context_id, executable, app_name, developer, platform
+             FROM context_targets
+             WHERE platform IS NULL OR platform = ?1",
+        )?
+        .query_map(params![current_platform], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?))
+        })?
+        .collect::<rusqlite::Result<_>>()?;
+    let mut changed = false;
+
+    for (id, context_id, executable, app_name, developer, platform) in rows {
+        if executable.starts_with("?::") {
+            continue;
+        }
+        let exact = installed_apps.iter().find(|app| {
+            app.exe.trim().eq_ignore_ascii_case(executable.trim())
+        });
+        let candidate = exact.or_else(|| {
+            crate::system::apps::closest_installed_app(
+                &executable,
+                app_name.as_deref(),
+                developer.as_deref(),
+                installed_apps,
+            )
+        });
+        let Some(candidate) = candidate else { continue };
+        if exact.is_none() && candidate.exe.eq_ignore_ascii_case(&executable) {
+            continue;
+        }
+        let owned_elsewhere: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM context_targets WHERE executable = ?1 AND id <> ?2 AND context_id <> ?3)",
+            params![candidate.exe, id, context_id],
+            |row| row.get(0),
+        )?;
+        if owned_elsewhere {
+            continue;
+        }
+        let next_executable = if exact.is_some() {
+            executable.clone()
+        } else {
+            candidate.exe.trim().to_lowercase()
+        };
+        let next_app_name = normalize_optional_trimmed(Some(candidate.name.as_str()));
+        let next_developer = normalize_optional_trimmed(candidate.developer.as_deref());
+        let next_platform = platform.clone().or(current_platform.map(str::to_string));
+        if next_executable == executable
+            && next_app_name == app_name
+            && next_developer == developer
+            && next_platform == platform
+        {
+            continue;
+        }
+        let updated = conn.execute(
+            "UPDATE context_targets
+             SET executable = ?1, app_name = ?2, developer = ?3, platform = ?4
+             WHERE id = ?5",
+            params![
+                next_executable,
+                next_app_name,
+                next_developer,
+                next_platform,
+                id
+            ],
+        )?;
+        changed |= updated > 0;
+    }
+    Ok(changed)
 }
 
 pub fn remove_context_target(db: &Db, context_id: i64, executable: &str) -> Result<()> {
@@ -786,6 +893,55 @@ mod tests {
                 .id,
             EVERYWHERE_CONTEXT_ID
         );
+    }
+
+    #[test]
+    fn stale_target_rebinds_to_close_replacement_with_same_developer() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Coding", None, None, None, None, false)
+            .expect("context");
+        assign_context_target_with_metadata(
+            &db,
+            context.id,
+            "t3-code-nightly-20260830.exe",
+            Some("T3 Code (nightly) 0.0.37-nightly.20260830"),
+            Some("T3 Tools"),
+        )
+        .expect("target");
+
+        let apps = vec![crate::system::apps::InstalledApp {
+            name: "T3 Code (nightly) 0.0.38-nightly.20260901".to_string(),
+            exe: "t3-code-nightly-20260901.exe".to_string(),
+            developer: Some("T3 Tools".to_string()),
+        }];
+        assert!(reconcile_context_targets(&db, &apps).expect("reconcile"));
+        let targets = query_context_targets(&db, Some(context.id)).expect("targets");
+        assert_eq!(targets[0].executable, "t3-code-nightly-20260901.exe");
+        assert_eq!(targets[0].developer.as_deref(), Some("T3 Tools"));
+    }
+
+    #[test]
+    fn stale_target_rejects_close_name_from_different_developer() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Coding", None, None, None, None, false)
+            .expect("context");
+        assign_context_target_with_metadata(
+            &db,
+            context.id,
+            "t3-code-nightly-old.exe",
+            Some("T3 Code nightly"),
+            Some("T3 Tools"),
+        )
+        .expect("target");
+
+        let apps = vec![crate::system::apps::InstalledApp {
+            name: "T3 Code nightly".to_string(),
+            exe: "t3-code-nightly-new.exe".to_string(),
+            developer: Some("Unrelated Tools".to_string()),
+        }];
+        assert!(!reconcile_context_targets(&db, &apps).expect("reconcile"));
+        let targets = query_context_targets(&db, Some(context.id)).expect("targets");
+        assert_eq!(targets[0].executable, "t3-code-nightly-old.exe");
     }
 
     #[test]

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -66,6 +66,8 @@ CREATE TABLE IF NOT EXISTS context_targets (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
   context_id   INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
   executable   TEXT NOT NULL COLLATE NOCASE UNIQUE,
+  app_name     TEXT,
+  developer    TEXT,
   platform     TEXT,
   created_at   DATETIME NOT NULL DEFAULT (datetime('now'))
 );
@@ -675,6 +677,25 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
                   WHERE table_name = 'transcriptions' AND op = 'delete';
                  PRAGMA user_version = 22;",
             )?;
+            Ok(())
+        })?;
+    }
+    if user_version < 23 {
+        log::info!("db: migrating schema {user_version} -> 23");
+        run_migration(&mut conn, |conn| {
+            ensure_table_column(
+                conn,
+                "context_targets",
+                "app_name",
+                "ALTER TABLE context_targets ADD COLUMN app_name TEXT;",
+            )?;
+            ensure_table_column(
+                conn,
+                "context_targets",
+                "developer",
+                "ALTER TABLE context_targets ADD COLUMN developer TEXT;",
+            )?;
+            conn.execute_batch("PRAGMA user_version = 23;")?;
             Ok(())
         })?;
     }

--- a/src-tauri/src/data/db/tests.rs
+++ b/src-tauri/src/data/db/tests.rs
@@ -311,7 +311,7 @@ fn open_self_heals_database_stuck_at_v2_with_legacy_dictionary() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .expect("version");
-    assert_eq!(version, 22);
+    assert_eq!(version, 23);
     drop(conn);
     drop(db);
     let _ = std::fs::remove_file(&path);

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -93,6 +93,20 @@ pub trait SyncHost: Send + Sync {
     fn resolve_app_target(&self, source: &str) -> Option<String> {
         Some(source.to_string())
     }
+    fn resolve_app_target_with_metadata(
+        &self,
+        source: &str,
+        app_name: Option<&str>,
+        developer: Option<&str>,
+    ) -> Option<(String, Option<String>, Option<String>)> {
+        self.resolve_app_target(source).map(|resolved| {
+            (
+                resolved,
+                app_name.map(str::to_string),
+                developer.map(str::to_string),
+            )
+        })
+    }
 }
 
 pub fn unresolved_app_target(source: &str) -> String {
@@ -115,28 +129,47 @@ fn resolve_context_targets_in_ops(host: &dyn SyncHost, ops: &[SyncOp]) -> Vec<Sy
                 for target in targets {
                     // Wire shape is either a bare string (a peer on an older
                     // build, or a legacy pre-platform-tag row) or a
-                    // `{executable, platform}` object. Either way, rewrite
+                    // `{executable, platform, app_name, developer}` object. Either way, rewrite
                     // `executable` to this device's own app identifier (or the
                     // `?::` unresolved marker) and stamp `platform` with this
                     // device's OS once resolved, since the rewritten string
                     // now follows this platform's naming convention.
-                    let source = match target {
-                        serde_json::Value::String(s) => Some(s.clone()),
+                    let (source, app_name, developer) = match target {
+                        serde_json::Value::String(s) => (Some(s.clone()), None, None),
                         serde_json::Value::Object(map) => {
-                            map.get("executable").and_then(|v| v.as_str()).map(str::to_string)
+                            (
+                                map.get("executable").and_then(|v| v.as_str()).map(str::to_string),
+                                map.get("app_name").and_then(|v| v.as_str()).map(str::to_string),
+                                map.get("developer").and_then(|v| v.as_str()).map(str::to_string),
+                            )
                         }
-                        _ => None,
+                        _ => (None, None, None),
                     };
                     let Some(source) = source else { continue };
-                    let resolved = host
-                        .resolve_app_target(&source)
-                        .unwrap_or_else(|| unresolved_app_target(&source));
+                    let (resolved, resolved_name, resolved_developer) = host
+                        .resolve_app_target_with_metadata(
+                            &source,
+                            app_name.as_deref(),
+                            developer.as_deref(),
+                        )
+                        .unwrap_or_else(|| {
+                            (
+                                unresolved_app_target(&source),
+                                app_name.clone(),
+                                developer.clone(),
+                            )
+                        });
                     let platform = if resolved.starts_with(UNRESOLVED_APP_PREFIX) {
                         None
                     } else {
                         db::current_platform_tag()
                     };
-                    *target = serde_json::json!({ "executable": resolved, "platform": platform });
+                    *target = serde_json::json!({
+                        "executable": resolved,
+                        "platform": platform,
+                        "app_name": resolved_name,
+                        "developer": resolved_developer,
+                    });
                 }
             }
             op
@@ -190,6 +223,10 @@ pub enum TargetEntry {
         executable: String,
         #[serde(default)]
         platform: Option<String>,
+        #[serde(default)]
+        app_name: Option<String>,
+        #[serde(default)]
+        developer: Option<String>,
     },
 }
 
@@ -205,6 +242,20 @@ impl TargetEntry {
         match self {
             TargetEntry::Legacy(_) => None,
             TargetEntry::Tagged { platform, .. } => platform.as_deref(),
+        }
+    }
+
+    fn app_name(&self) -> Option<&str> {
+        match self {
+            TargetEntry::Legacy(_) => None,
+            TargetEntry::Tagged { app_name, .. } => app_name.as_deref(),
+        }
+    }
+
+    fn developer(&self) -> Option<&str> {
+        match self {
+            TargetEntry::Legacy(_) => None,
+            TargetEntry::Tagged { developer, .. } => developer.as_deref(),
         }
     }
 }
@@ -463,13 +514,16 @@ fn context_aggregate(conn: &Connection, uuid: &str) -> Result<Option<serde_json:
         None => return Ok(None),
     };
     let mut stmt = conn.prepare(
-        "SELECT executable, platform FROM context_targets WHERE context_id = ?1 ORDER BY executable",
+        "SELECT executable, platform, app_name, developer
+         FROM context_targets WHERE context_id = ?1 ORDER BY executable",
     )?;
     aggregate.targets = stmt
         .query_map(params![context_id], |r| {
             Ok(TargetEntry::Tagged {
                 executable: r.get(0)?,
                 platform: r.get(1)?,
+                app_name: r.get(2)?,
+                developer: r.get(3)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -1221,9 +1275,18 @@ fn reconcile_context_children(
             continue;
         }
         conn.execute(
-            "INSERT INTO context_targets (context_id, executable, platform) VALUES (?1, ?2, ?3)
-             ON CONFLICT(executable) DO UPDATE SET context_id = excluded.context_id, platform = excluded.platform",
-            params![context_id, normalized, entry.platform()],
+            "INSERT INTO context_targets (context_id, executable, app_name, developer, platform)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(executable) DO UPDATE SET context_id = excluded.context_id,
+                 app_name = excluded.app_name, developer = excluded.developer,
+                 platform = excluded.platform",
+            params![
+                context_id,
+                normalized,
+                entry.app_name(),
+                entry.developer(),
+                entry.platform()
+            ],
         )?;
     }
     let target_executables: Vec<String> = aggregate

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -1944,6 +1944,21 @@ impl SyncHost for ManagerHost {
     fn resolve_app_target(&self, source: &str) -> Option<String> {
         closest_installed_app(source, &self.installed_apps).map(|app| app.exe.clone())
     }
+
+    fn resolve_app_target_with_metadata(
+        &self,
+        source: &str,
+        app_name: Option<&str>,
+        developer: Option<&str>,
+    ) -> Option<(String, Option<String>, Option<String>)> {
+        crate::system::apps::closest_installed_app(
+            source,
+            app_name,
+            developer,
+            &self.installed_apps,
+        )
+        .map(|app| (app.exe.clone(), Some(app.name.clone()), app.developer.clone()))
+    }
 }
 
 
@@ -1951,65 +1966,6 @@ pub(crate) fn closest_installed_app<'a>(
     source: &str,
     apps: &'a [crate::system::apps::InstalledApp],
 ) -> Option<&'a crate::system::apps::InstalledApp> {
-    let source = source.trim_start_matches("?::");
-    let source_key = app_match_key(source);
-    if source_key.len() < 3 {
-        return None;
-    }
-    apps.iter()
-        .filter_map(|app| {
-            let score = [app_match_key(&app.exe), app_match_key(&app.name)]
-                .into_iter()
-                .map(|candidate| app_match_score(&source_key, &candidate))
-                .fold(0.0_f32, f32::max);
-            (score >= 0.72).then_some((app, score))
-        })
-        .max_by(|(_, left), (_, right)| left.total_cmp(right))
-        .map(|(app, _)| app)
-}
-
-fn app_match_key(value: &str) -> String {
-    let basename = value
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(value);
-    let basename = basename.to_lowercase();
-    let basename = basename
-        .strip_suffix(".exe")
-        .or_else(|| basename.strip_suffix(".app"))
-        .unwrap_or(basename.as_str());
-    basename
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .collect::<String>()
-}
-
-fn app_match_score(left: &str, right: &str) -> f32 {
-    if left.is_empty() || right.is_empty() {
-        return 0.0;
-    }
-    if left == right {
-        return 1.0;
-    }
-    if left.contains(right) || right.contains(left) {
-        return left.len().min(right.len()) as f32 / left.len().max(right.len()) as f32;
-    }
-    let distance = levenshtein(left.as_bytes(), right.as_bytes());
-    1.0 - distance as f32 / left.len().max(right.len()) as f32
-}
-
-fn levenshtein(left: &[u8], right: &[u8]) -> usize {
-    let mut previous: Vec<usize> = (0..=right.len()).collect();
-    let mut current = vec![0; right.len() + 1];
-    for (i, &left_byte) in left.iter().enumerate() {
-        current[0] = i + 1;
-        for (j, &right_byte) in right.iter().enumerate() {
-            current[j + 1] = (previous[j + 1] + 1)
-                .min(current[j] + 1)
-                .min(previous[j] + usize::from(left_byte != right_byte));
-        }
-        std::mem::swap(&mut previous, &mut current);
-    }
-    previous[right.len()]
+    crate::system::apps::closest_installed_app(source, None, None, apps)
 }
 

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -854,10 +854,12 @@ fn context_app_matching_uses_local_name_and_rejects_weak_matches() {
         InstalledApp {
             name: "Visual Studio Code".to_string(),
             exe: "code.exe".to_string(),
+            developer: None,
         },
         InstalledApp {
             name: "Google Chrome".to_string(),
             exe: "chrome.exe".to_string(),
+            developer: None,
         },
     ];
     let matched = super::manager::closest_installed_app("Visual Studio Code.app", &apps)

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -431,36 +431,23 @@ fn nonempty_metadata(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-/// Returns a stable publisher/team hint where macOS exposes one. Team IDs are
-/// the best signal for signed apps and remain stable across bundle/version
-/// changes. Unsigned apps fall back to their bundle identifier, when present.
+/// Returns a stable bundle identity where macOS exposes one. Bundle identifiers
+/// are available without spawning a process and normally remain stable across
+/// bundle/version changes, making them a useful developer signal here.
 #[cfg(target_os = "macos")]
 fn mac_app_developer(path: &std::path::Path) -> Option<String> {
-    use std::process::Command;
+    use core_foundation::bundle::CFBundle;
+    use core_foundation::string::CFString;
+    use core_foundation::url::CFURL;
 
-    let signed = Command::new("/usr/bin/codesign")
-        .args(["-dv", "--verbose=4"])
-        .arg(path)
-        .output()
-        .ok()?;
-    let diagnostic = String::from_utf8_lossy(&signed.stderr);
-    if let Some(team) = diagnostic
-        .lines()
-        .find_map(|line| line.strip_prefix("TeamIdentifier="))
-        .and_then(nonempty_metadata)
-    {
-        return Some(team);
-    }
-
-    // `plutil` handles both XML and binary Info.plist files without adding a
-    // plist parser dependency to the desktop binary.
-    let plist = path.join("Contents/Info.plist");
-    let output = Command::new("/usr/bin/plutil")
-        .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-"])
-        .arg(plist)
-        .output()
-        .ok()?;
-    nonempty_metadata(&String::from_utf8_lossy(&output.stdout))
+    let url = CFURL::from_path(path, true)?;
+    let bundle = CFBundle::new(url)?;
+    let key = CFString::from_static_string("CFBundleIdentifier");
+    bundle
+        .info_dictionary()
+        .find(key)
+        .and_then(|value| value.downcast::<CFString>())
+        .and_then(|value| nonempty_metadata(&value.to_string()))
 }
 
 /// A cached inventory for the dictation path. Registry/bundle enumeration is
@@ -553,7 +540,7 @@ fn app_match_key(value: &str) -> String {
         .strip_suffix(".exe")
         .or_else(|| basename.strip_suffix(".app"))
         .unwrap_or(basename.as_str());
-    basename.chars().filter(|ch| ch.is_ascii_alphanumeric()).collect()
+    basename.chars().filter(|ch| ch.is_alphanumeric()).collect()
 }
 
 fn app_match_score(left: &str, right: &str) -> f32 {

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -529,23 +529,19 @@ pub fn closest_installed_app<'a>(
             let strong_prefix = source_keys.iter().any(|source| {
                 candidate_keys.iter().any(|candidate| common_prefix_len(source, candidate) >= 4)
             });
+            let ranking_score = score + if same_developer { 0.05 } else { 0.0 };
             (score >= threshold && (same_developer || strong_prefix))
-                .then_some((app, score, same_developer))
+                .then_some((app, score, same_developer, ranking_score))
         })
-        .max_by(|(_, left_score, left_same), (_, right_score, right_same)| {
-            // Prefer developer-confirmed matches within a small score margin;
-            // otherwise the strongest name match wins.
-            if (left_score - right_score).abs() < 0.05 {
-                left_same
-                    .cmp(right_same)
-                    .then_with(|| left_score.total_cmp(right_score))
-            } else {
-                left_score
-                    .total_cmp(right_score)
-                    .then_with(|| left_same.cmp(right_same))
-            }
+        .max_by(|(_, left_score, left_same, left_rank), (_, right_score, right_same, right_rank)| {
+            // A fixed developer bonus prefers same-developer matches within
+            // the intended margin while keeping the ordering transitive.
+            left_rank
+                .total_cmp(right_rank)
+                .then_with(|| left_score.total_cmp(right_score))
+                .then_with(|| left_same.cmp(right_same))
         })
-        .map(|(app, _, _)| app)
+        .map(|(app, _, _, _)| app)
 }
 
 fn normalized_metadata(value: Option<&str>) -> Option<String> {

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -478,7 +478,7 @@ pub fn list_installed_apps_cached() -> Vec<InstalledApp> {
     static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(Cache { at: None, apps: Vec::new() }));
     let mut guard = cache.lock().expect("installed-app cache lock");
-    if guard.at.map_or(true, |at| at.elapsed() >= Duration::from_secs(15)) {
+    if guard.at.is_none_or(|at| at.elapsed() >= Duration::from_secs(15)) {
         guard.apps = list_installed_apps();
         guard.at = Some(Instant::now());
     }

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -522,10 +522,17 @@ pub fn closest_installed_app<'a>(
                 .then_some((app, score, same_developer))
         })
         .max_by(|(_, left_score, left_same), (_, right_score, right_same)| {
-            // Prefer developer-confirmed matches when scores are close.
-            left_score
-                .total_cmp(right_score)
-                .then_with(|| left_same.cmp(right_same))
+            // Prefer developer-confirmed matches within a small score margin;
+            // otherwise the strongest name match wins.
+            if (left_score - right_score).abs() < 0.05 {
+                left_same
+                    .cmp(right_same)
+                    .then_with(|| left_score.total_cmp(right_score))
+            } else {
+                left_score
+                    .total_cmp(right_score)
+                    .then_with(|| left_same.cmp(right_same))
+            }
         })
         .map(|(app, _, _)| app)
 }

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 pub struct InstalledApp {
     pub name: String,
     pub exe: String,
+    /// Publisher/team identity when the platform exposes one. It is kept
+    /// optional because running processes and some unsigned apps do not have
+    /// one.
+    #[serde(default)]
+    pub developer: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -56,7 +61,11 @@ pub fn list_installed_apps() -> Vec<InstalledApp> {
                 };
                 let name = stem.to_string();
                 let exe = format!("{}.app", name.to_lowercase());
-                apps.push(InstalledApp { name, exe });
+                apps.push(InstalledApp {
+                    name,
+                    exe,
+                    developer: mac_app_developer(&path),
+                });
             }
         }
 
@@ -357,7 +366,13 @@ fn scan_uninstall(root: windows::Win32::System::Registry::HKEY, path: &str) -> V
                 if let (Some(name), Some(icon)) = (display_name, display_icon) {
                     if let Some(exe) = parse_exe_from_icon(&icon) {
                         let name = friendly_app_name(&exe, &name);
-                        apps.push(InstalledApp { name, exe });
+                        let publisher = reg_read_string(hsubkey, "Publisher")
+                            .and_then(|value| nonempty_metadata(&value));
+                        apps.push(InstalledApp {
+                            name,
+                            exe,
+                            developer: publisher,
+                        });
                     }
                 }
                 let _ = RegCloseKey(hsubkey).ok();
@@ -389,7 +404,11 @@ fn get_running_processes() -> Vec<InstalledApp> {
                     if !exe.is_empty() && exe != "system idle process" && !exe.starts_with('[') {
                         let name =
                             friendly_app_name(&exe, exe.strip_suffix(".exe").unwrap_or(&exe));
-                        let app = InstalledApp { name, exe };
+                        let app = InstalledApp {
+                            name,
+                            exe,
+                            developer: None,
+                        };
                         if is_user_facing_app(&app) {
                             apps.push(app);
                         }
@@ -405,4 +424,166 @@ fn get_running_processes() -> Vec<InstalledApp> {
     apps.sort_by(|a, b| a.exe.cmp(&b.exe));
     apps.dedup_by(|a, b| a.exe == b.exe);
     apps
+}
+
+fn nonempty_metadata(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Returns a stable publisher/team hint where macOS exposes one. Team IDs are
+/// the best signal for signed apps and remain stable across bundle/version
+/// changes. Unsigned apps fall back to their bundle identifier, when present.
+#[cfg(target_os = "macos")]
+fn mac_app_developer(path: &std::path::Path) -> Option<String> {
+    use std::process::Command;
+
+    let signed = Command::new("/usr/bin/codesign")
+        .args(["-dv", "--verbose=4"])
+        .arg(path)
+        .output()
+        .ok()?;
+    let diagnostic = String::from_utf8_lossy(&signed.stderr);
+    if let Some(team) = diagnostic
+        .lines()
+        .find_map(|line| line.strip_prefix("TeamIdentifier="))
+        .and_then(nonempty_metadata)
+    {
+        return Some(team);
+    }
+
+    // `plutil` handles both XML and binary Info.plist files without adding a
+    // plist parser dependency to the desktop binary.
+    let plist = path.join("Contents/Info.plist");
+    let output = Command::new("/usr/bin/plutil")
+        .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-"])
+        .arg(plist)
+        .output()
+        .ok()?;
+    nonempty_metadata(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// A cached inventory for the dictation path. Registry/bundle enumeration is
+/// appropriate for the settings UI, but should not happen on every hotkey
+/// release. A short TTL still notices nightly-app replacements promptly.
+pub fn list_installed_apps_cached() -> Vec<InstalledApp> {
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    struct Cache {
+        at: Option<Instant>,
+        apps: Vec<InstalledApp>,
+    }
+
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(Cache { at: None, apps: Vec::new() }));
+    let mut guard = cache.lock().expect("installed-app cache lock");
+    if guard.at.map_or(true, |at| at.elapsed() >= Duration::from_secs(15)) {
+        guard.apps = list_installed_apps();
+        guard.at = Some(Instant::now());
+    }
+    guard.apps.clone()
+}
+
+/// Finds a replacement for a target whose executable/name no longer exists.
+/// Exact app identity is preferred, a known developer may lower the name
+/// threshold, and a conflicting known developer is never accepted.
+pub fn closest_installed_app<'a>(
+    source_executable: &str,
+    source_name: Option<&str>,
+    source_developer: Option<&str>,
+    apps: &'a [InstalledApp],
+) -> Option<&'a InstalledApp> {
+    let source_executable = source_executable.trim_start_matches("?::");
+    let source_keys = [source_executable, source_name.unwrap_or("")]
+        .into_iter()
+        .map(app_match_key)
+        .filter(|key| key.len() >= 3)
+        .collect::<Vec<_>>();
+    if source_keys.is_empty() {
+        return None;
+    }
+    let source_developer = normalized_metadata(source_developer);
+    apps.iter()
+        .filter_map(|app| {
+            let candidate_developer = normalized_metadata(app.developer.as_deref());
+            if source_developer.is_some()
+                && candidate_developer.is_some()
+                && source_developer != candidate_developer
+            {
+                return None;
+            }
+            let candidate_keys = [app.exe.as_str(), app.name.as_str()]
+                .into_iter()
+                .map(app_match_key)
+                .filter(|key| !key.is_empty())
+                .collect::<Vec<_>>();
+            let score = source_keys
+                .iter()
+                .flat_map(|source| candidate_keys.iter().map(move |candidate| app_match_score(source, candidate)))
+                .fold(0.0_f32, f32::max);
+            let same_developer = source_developer.is_some() && source_developer == candidate_developer;
+            let threshold = if same_developer { 0.72 } else { 0.78 };
+            // Legacy targets do not have metadata yet. A lower threshold is
+            // still safe when the candidate preserves a meaningful prefix;
+            // without either developer agreement or that prefix, a similar
+            // score is not enough to auto-rebind a user assignment.
+            let strong_prefix = source_keys.iter().any(|source| {
+                candidate_keys.iter().any(|candidate| common_prefix_len(source, candidate) >= 4)
+            });
+            (score >= threshold && (same_developer || strong_prefix))
+                .then_some((app, score, same_developer))
+        })
+        .max_by(|(_, left_score, left_same), (_, right_score, right_same)| {
+            // Prefer developer-confirmed matches when scores are close.
+            left_score
+                .total_cmp(right_score)
+                .then_with(|| left_same.cmp(right_same))
+        })
+        .map(|(app, _, _)| app)
+}
+
+fn normalized_metadata(value: Option<&str>) -> Option<String> {
+    value.map(str::trim).filter(|value| !value.is_empty()).map(str::to_lowercase)
+}
+
+fn app_match_key(value: &str) -> String {
+    let basename = value.rsplit(['/', '\\']).next().unwrap_or(value).to_lowercase();
+    let basename = basename
+        .strip_suffix(".exe")
+        .or_else(|| basename.strip_suffix(".app"))
+        .unwrap_or(basename.as_str());
+    basename.chars().filter(|ch| ch.is_ascii_alphanumeric()).collect()
+}
+
+fn app_match_score(left: &str, right: &str) -> f32 {
+    if left.is_empty() || right.is_empty() { return 0.0; }
+    if left == right { return 1.0; }
+    if left.contains(right) || right.contains(left) {
+        return left.len().min(right.len()) as f32 / left.len().max(right.len()) as f32;
+    }
+    let distance = levenshtein(left.as_bytes(), right.as_bytes());
+    1.0 - distance as f32 / left.len().max(right.len()) as f32
+}
+
+fn common_prefix_len(left: &str, right: &str) -> usize {
+    left.chars()
+        .zip(right.chars())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn levenshtein(left: &[u8], right: &[u8]) -> usize {
+    let mut previous: Vec<usize> = (0..=right.len()).collect();
+    let mut current = vec![0; right.len() + 1];
+    for (i, &left_byte) in left.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, &right_byte) in right.iter().enumerate() {
+            current[j + 1] = (previous[j + 1] + 1)
+                .min(current[j] + 1)
+                .min(previous[j] + usize::from(left_byte != right_byte));
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[right.len()]
 }

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -464,9 +464,20 @@ pub fn list_installed_apps_cached() -> Vec<InstalledApp> {
 
     static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(Cache { at: None, apps: Vec::new() }));
+    {
+        let guard = cache.lock().expect("installed-app cache lock");
+        if guard.at.is_some_and(|at| at.elapsed() < Duration::from_secs(15)) {
+            return guard.apps.clone();
+        }
+    }
+
+    // Do not hold the mutex while walking the registry/bundle directories.
+    // Multiple callers may refresh concurrently, but none will block behind
+    // the potentially slow inventory operation.
+    let apps = list_installed_apps();
     let mut guard = cache.lock().expect("installed-app cache lock");
     if guard.at.is_none_or(|at| at.elapsed() >= Duration::from_secs(15)) {
-        guard.apps = list_installed_apps();
+        guard.apps = apps;
         guard.at = Some(Instant::now());
     }
     guard.apps.clone()
@@ -554,10 +565,14 @@ fn app_match_score(left: &str, right: &str) -> f32 {
     if left.is_empty() || right.is_empty() { return 0.0; }
     if left == right { return 1.0; }
     if left.contains(right) || right.contains(left) {
-        return left.len().min(right.len()) as f32 / left.len().max(right.len()) as f32;
+        let left_len = left.chars().count();
+        let right_len = right.chars().count();
+        return left_len.min(right_len) as f32 / left_len.max(right_len) as f32;
     }
-    let distance = levenshtein(left.as_bytes(), right.as_bytes());
-    1.0 - distance as f32 / left.len().max(right.len()) as f32
+    let left_chars = left.chars().collect::<Vec<_>>();
+    let right_chars = right.chars().collect::<Vec<_>>();
+    let distance = levenshtein(&left_chars, &right_chars);
+    1.0 - distance as f32 / left_chars.len().max(right_chars.len()) as f32
 }
 
 fn common_prefix_len(left: &str, right: &str) -> usize {
@@ -567,15 +582,15 @@ fn common_prefix_len(left: &str, right: &str) -> usize {
         .count()
 }
 
-fn levenshtein(left: &[u8], right: &[u8]) -> usize {
+fn levenshtein(left: &[char], right: &[char]) -> usize {
     let mut previous: Vec<usize> = (0..=right.len()).collect();
     let mut current = vec![0; right.len() + 1];
-    for (i, &left_byte) in left.iter().enumerate() {
+    for (i, &left_char) in left.iter().enumerate() {
         current[0] = i + 1;
-        for (j, &right_byte) in right.iter().enumerate() {
+        for (j, &right_char) in right.iter().enumerate() {
             current[j + 1] = (previous[j + 1] + 1)
                 .min(current[j] + 1)
-                .min(previous[j] + usize::from(left_byte != right_byte));
+                .min(previous[j] + usize::from(left_char != right_char));
         }
         std::mem::swap(&mut previous, &mut current);
     }

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -371,7 +371,7 @@ fn scan_uninstall(root: windows::Win32::System::Registry::HKEY, path: &str) -> V
                         apps.push(InstalledApp {
                             name,
                             exe,
-                            developer: publisher,
+                            developer: publisher.map(|value| format!("windows-publisher:{value}")),
                         });
                     }
                 }
@@ -448,6 +448,7 @@ fn mac_app_developer(path: &std::path::Path) -> Option<String> {
         .find(key)
         .and_then(|value| value.downcast::<CFString>())
         .and_then(|value| nonempty_metadata(&value.to_string()))
+        .map(|value| format!("mac-bundle:{value}"))
 }
 
 /// A cached inventory for the dictation path. Registry/bundle enumeration is
@@ -507,6 +508,7 @@ pub fn closest_installed_app<'a>(
             let candidate_developer = normalized_metadata(app.developer.as_deref());
             if source_developer.is_some()
                 && candidate_developer.is_some()
+                && developer_metadata_is_comparable(&source_developer, &candidate_developer)
                 && source_developer != candidate_developer
             {
                 return None;
@@ -546,6 +548,26 @@ pub fn closest_installed_app<'a>(
 
 fn normalized_metadata(value: Option<&str>) -> Option<String> {
     value.map(str::trim).filter(|value| !value.is_empty()).map(str::to_lowercase)
+}
+
+fn developer_metadata_is_comparable(left: &Option<String>, right: &Option<String>) -> bool {
+    match (developer_metadata_kind(left.as_deref()), developer_metadata_kind(right.as_deref())) {
+        (Some(left_kind), Some(right_kind)) => left_kind == right_kind,
+        (None, None) => true,
+        // A bundle identifier and a registry publisher are platform-specific
+        // identities. Do not treat their differing formats as proof of a
+        // developer mismatch when resolving a cross-platform synced target.
+        _ => false,
+    }
+}
+
+fn developer_metadata_kind(value: Option<&str>) -> Option<&'static str> {
+    value.and_then(|value| {
+        value
+            .strip_prefix("mac-bundle:")
+            .map(|_| "mac-bundle")
+            .or_else(|| value.strip_prefix("windows-publisher:").map(|_| "windows-publisher"))
+    })
 }
 
 fn app_match_key(value: &str) -> String {

--- a/src/lib/appMappings.ts
+++ b/src/lib/appMappings.ts
@@ -1,6 +1,7 @@
 export interface InstalledApp {
   name: string;
   exe: string;
+  developer?: string | null;
 }
 
 export interface AppMapping {

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -48,6 +48,9 @@ export interface ContextTarget {
   id: number;
   context_id: number;
   executable: string;
+  app_name: string | null;
+  developer: string | null;
+  platform: string | null;
   created_at: string;
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1300,7 +1300,9 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
         id: nextDevId(rows),
         context_id: contextId,
         executable,
-        app_name: typeof args?.appName === 'string' ? args.appName : null,
+        app_name: typeof (args?.appName ?? args?.app_name) === 'string'
+          ? String(args?.appName ?? args?.app_name)
+          : null,
         developer: typeof args?.developer === 'string' ? args.developer : null,
         platform: null,
         created_at: now,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -49,6 +49,8 @@ type DevContextTarget = {
   id: number;
   context_id: number;
   executable: string;
+  app_name?: string | null;
+  developer?: string | null;
   platform: string | null;
   created_at: string;
 };
@@ -1294,7 +1296,15 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       if (!readDevContexts().some((context) => context.id === contextId)) throw new Error(`Context ${contextId} was not found`);
       const now = devNow();
       const rows = readDevContextTargets().filter((target) => target.executable !== executable);
-      const target: DevContextTarget = { id: nextDevId(rows), context_id: contextId, executable, platform: null, created_at: now };
+      const target: DevContextTarget = {
+        id: nextDevId(rows),
+        context_id: contextId,
+        executable,
+        app_name: typeof args?.appName === 'string' ? args.appName : null,
+        developer: typeof args?.developer === 'string' ? args.developer : null,
+        platform: null,
+        created_at: now,
+      };
       writeDevList(DEV_CONTEXT_TARGETS_KEY, [...rows, target]);
       return target as T;
     }
@@ -1391,10 +1401,10 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
     case 'get_recent_logs':
     case 'get_installed_apps':
       return [
-        { name: 'Google Chrome', exe: 'chrome.exe' },
-        { name: 'Visual Studio Code', exe: 'code.exe' },
-        { name: 'Discord', exe: 'discord.exe' },
-        { name: 'Windows Terminal', exe: 'wt.exe' },
+        { name: 'Google Chrome', exe: 'chrome.exe', developer: 'Google LLC' },
+        { name: 'Visual Studio Code', exe: 'code.exe', developer: 'Microsoft Corporation' },
+        { name: 'Discord', exe: 'discord.exe', developer: 'Discord Inc.' },
+        { name: 'Windows Terminal', exe: 'wt.exe', developer: 'Microsoft Corporation' },
       ] as T;
     case 'get_stats':
       return { total_words: 0, avg_wpm: 0, day_streak: 0 } as T;

--- a/src/lib/views/Contexts.svelte
+++ b/src/lib/views/Contexts.svelte
@@ -253,6 +253,7 @@
       installedApps = (nextApps ?? []).map((app) => ({
         name: cleanAppName(app.name || app.exe),
         exe: normalizeExe(app.exe),
+        developer: app.developer ?? null,
       }));
       if (contextsStore.error) contextErrorMessage = contextsStore.error;
       await loadContextItems(selectedContextId);
@@ -710,6 +711,8 @@
           const target = await invoke<ContextTarget>('assign_context_target', {
             contextId: created.id,
             executable: app.exe,
+            appName: app.name,
+            developer: app.developer ?? null,
           });
           // Read the live store array each iteration: a captured snapshot
           // would drop targets assigned by earlier iterations of this loop.
@@ -799,6 +802,8 @@
       const target = await invoke<ContextTarget>('assign_context_target', {
         contextId: selectedContext.id,
         executable: app.exe,
+        appName: app.name,
+        developer: app.developer ?? null,
       });
       contextsStore.targets = [...targets.filter((item) => normalizeExe(item.executable) !== normalizeExe(app.exe)), target];
       markRecentlyAdded(normalizeExe(app.exe));
@@ -817,12 +822,12 @@
     }
   }
 
-  function appLabel(executable: string) {
+  function appLabel(executable: string, target?: ContextTarget) {
     if (executable.startsWith('?::')) {
-      return `${cleanAppName(executable.slice(3))} (not found)`;
+      return cleanAppName(target?.app_name || executable.slice(3));
     }
     const app = installedApps.find((item) => normalizeExe(item.exe) === normalizeExe(executable));
-    return cleanAppName(app?.name || executable);
+    return cleanAppName(app?.name || target?.app_name || executable);
   }
 
   function closeWebsitePicker() {
@@ -1033,9 +1038,9 @@
                 animate:flip={{ duration: motionMs(220), easing: expoOut }}
                 in:fly={{ y: motionPx(MOTION_PX.nudge), duration: recentlyAddedChips.has(normalizeExe(target.executable)) ? motionMs(220) : 0, easing: expoOut }}
               >
-                <AppIcon exe={target.executable} label={appLabel(target.executable)} size={16} />
-                {appLabel(target.executable)}
-                <button type="button" aria-label={`Remove ${appLabel(target.executable)}`} onclick={() => removeApp(target)}>
+                <AppIcon exe={target.executable} label={appLabel(target.executable, target)} size={16} />
+                {appLabel(target.executable, target)}
+                <button type="button" aria-label={`Remove ${appLabel(target.executable, target)}`} onclick={() => removeApp(target)}>
                   <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
                 </button>
               </span>


### PR DESCRIPTION
## Summary
- Persist app name and developer metadata for context-group app targets.
- Reconcile versioned or replaced app executables using close-name matching plus publisher/developer evidence.
- Keep the recovery path active on Windows and macOS, including sync and dictation resolution.

## Verification
- npm run check
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790825608&installation_model_id=432577&pr_number=321&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F321&signature=6e0bc827259f8a496f07409afe56f50aeedaf4a6138b0f79a27424c903b5e733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->