### PR TITLE
Make the paste failure pill clickable

### DIFF
--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -350,6 +350,7 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     let has_clickable_buttons = matches!(
         state,
         "cancelled"
+            | "paste_failed"
             | "copied"
             | "repair_input"
             | "repair_recording"

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -782,6 +782,7 @@
         state = incoming;
         void setPillInteractive(
           incoming === 'cancelled' ||
+          incoming === 'paste_failed' ||
           incoming === 'copied' ||
           incoming === 'repair_input' ||
           incoming === 'repair_recording' ||


### PR DESCRIPTION
The Not pasted pill renders Copy and Dismiss buttons, but the native window remained click-through because paste_failed was missing from both interactive-state allowlists.

Add paste_failed to the backend and frontend pointer-event gates.

Verification: npm run check; cargo check --manifest-path src-tauri/Cargo.toml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790827919&installation_model_id=432577&pr_number=322&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F322&signature=83179dfa1e137d0807a2ce198e2c56cbdce174e777a0555eee0285ea12bcbd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->