### PR TITLE
Fix hotkey recovery and history banner layout

### DIFF
--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -321,6 +321,28 @@ impl ChordStateMachine {
     fn mark_key_passed_through(&mut self, key: ChordKey) {
         *self.key_passed_through_mut(key) = true;
     }
+    /// Corrects stale ownership bookkeeping against live OS key state. A
+    /// keyup can occasionally never reach this hook (e.g. swallowed by
+    /// another low-level hook, or eaten by the OS's own Start-menu handling
+    /// of a bare Win press) which leaves `key_down` stuck true forever —
+    /// after that, the next lone press of the *other* key looks like a
+    /// chord-forming edge and fires dictation off a single key. Called with
+    /// the live `GetAsyncKeyState` read for the *other* key (never the one
+    /// whose edge is currently being processed — its own down/up handling
+    /// already reconciles itself).
+    fn reconcile_stale_key(&mut self, key: ChordKey, os_held: bool) {
+        if os_held || !*self.key_down_mut(key) {
+            return;
+        }
+        *self.key_down_mut(key) = false;
+        *self.key_passed_through_mut(key) = false;
+        self.set_key_was_chord(key, false);
+        if !self.key1_down && !self.key2_down {
+            self.chord_down = false;
+            self.handless_from_chord = false;
+        }
+    }
+
     fn key_was_chord(&self, key: ChordKey) -> bool {
         match key {
             ChordKey::Key1 => self.key1_was_chord,
@@ -796,9 +818,19 @@ unsafe extern "system" fn hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -
             let edge = if is_down { KeyEdge::Down } else { KeyEdge::Up };
             let now = GetTickCount64();
 
+            // Live OS truth for whichever key this event is NOT about — never
+            // the key whose own edge we're processing, since its bookkeeping
+            // is about to be updated by on_key_event itself.
+            let (other_key, other_os_held) = if key == ChordKey::Key1 {
+                (ChordKey::Key2, unsafe { modifier_held(k2) })
+            } else {
+                (ChordKey::Key1, unsafe { modifier_held(k1) })
+            };
+
             let (outcome, key1_was_passed_through, key2_was_passed_through) =
                 CHORD_MACHINE.with(|m| {
                     let mut machine = m.borrow_mut();
+                    machine.reconcile_stale_key(other_key, other_os_held);
                     let key1_was_passed_through =
                         key == ChordKey::Key2 && machine.key1_passed_through;
                     let key2_was_passed_through =
@@ -1193,6 +1225,30 @@ mod chord_tests {
         let up = m.on_space_event(KeyEdge::Up);
         assert_eq!(down.disposition, KeyDisposition::Passthrough);
         assert_eq!(up.disposition, KeyDisposition::Passthrough);
+    }
+
+    #[test]
+    fn stale_key_bookkeeping_does_not_fire_on_lone_press() {
+        let mut m = fresh();
+        // Simulate a missed keyup: key1 (e.g. Ctrl) is marked down internally
+        // but the OS no longer reports it held.
+        m.on_key_event(ChordKey::Key1, KeyEdge::Down, 0);
+        m.reconcile_stale_key(ChordKey::Key1, false);
+        assert!(!m.key1_down);
+        // A lone press of key2 must not look like a chord-forming edge.
+        let outcome = m.on_key_event(ChordKey::Key2, KeyEdge::Down, 100);
+        assert_eq!(outcome.action, None);
+        assert_eq!(outcome.disposition, KeyDisposition::Passthrough);
+    }
+
+    #[test]
+    fn reconcile_leaves_genuinely_held_key_untouched() {
+        let mut m = fresh();
+        m.on_key_event(ChordKey::Key1, KeyEdge::Down, 0);
+        m.reconcile_stale_key(ChordKey::Key1, true);
+        assert!(m.key1_down);
+        let outcome = m.on_key_event(ChordKey::Key2, KeyEdge::Down, 10);
+        assert_eq!(outcome.action, Some(ChordAction::FirePress));
     }
 
     #[test]

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -369,10 +369,10 @@
   }
 
   .page-h {
-    font-family: var(--serif);
-    font-size: 26px;
-    font-weight: 500;
-    letter-spacing: -0.02em;
+    font-family: var(--sans);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
     margin: 0 0 4px;
     line-height: 1.1;
     color: var(--ink);

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -352,12 +352,19 @@
     <div class="day-table">
       {#if cancelledEntry}
         <div
-          class="day-row"
+          class="day-row banner-row"
           transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(cancelledEntry.created_at)}</div>
           <div class="day-text error-msg">You cancelled a recording — pick it back up?</div>
           <div class="row-actions">
+            <button
+              class="retry-btn"
+              onclick={onContinueCancelled}
+              disabled={resumingCancelled}
+            >
+              {resumingCancelled ? '…' : 'Continue'}
+            </button>
             <button
               class="dismiss-btn"
               onclick={onDismissCancelled}
@@ -369,19 +376,12 @@
                 <path d="M6 6l12 12M6 18 18 6"/>
               </svg>
             </button>
-            <button
-              class="retry-btn"
-              onclick={onContinueCancelled}
-              disabled={resumingCancelled}
-            >
-              {resumingCancelled ? '…' : 'Continue'}
-            </button>
           </div>
         </div>
       {/if}
       {#if failedEntry}
         <div
-          class="day-row"
+          class="day-row banner-row"
           transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(failedEntry.created_at)}</div>
@@ -489,9 +489,10 @@
   }
 
   .day-head {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 14px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 13px;
+    font-weight: 500;
     color: var(--ink-soft);
     margin: 4px 4px 10px;
   }
@@ -512,6 +513,10 @@
     box-sizing: border-box;
   }
   .day-row:hover { background: var(--control-hover); }
+
+  /* Banner rows put a wider action cluster (Retry, or Discard+Continue) in the
+     third column, which is normally sized just for the 18px copy-btn. */
+  .day-row.banner-row { grid-template-columns: 84px 1fr auto; }
 
   .copy-btn {
     all: unset;
@@ -706,9 +711,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;


### PR DESCRIPTION
> - Verenu is a Windows and macOS AI dictation app: hold the hotkey, capture audio, transcribe, clean up, and inject text.
> - This change touches the Windows hotkey state machine and the homepage history UI.
> - A missed modifier key-up could leave chord bookkeeping stale, causing a lone Ctrl or Win press to trigger dictation.
> - History recovery banners used a narrow copy-button grid column, allowing Continue/Discard controls to overflow the card.
> - The homepage history list also needed its existing interaction and layout fixes packaged together for review.
> - This pull request reconciles stale modifier state against live OS state and gives recovery banners an auto-sized action column.
> - The benefit is safer dictation activation and recovery controls that remain inside the homepage card.

## What Changed

- Reconcile the non-event chord key with GetAsyncKeyState before processing each Windows chord event; add regression coverage for stale and genuinely held keys.
- Add an auto-sized grid column to cancelled/failed history banners and keep Continue before the dismiss action.
- Preserve the current homepage/history typography adjustments included with this work.

## Verification

- cargo test --manifest-path src-tauri/Cargo.toml chord_tests ? 18 passed.
- npm run check ? blocked in the shared dirty worktree by an unrelated src/lib/pillVisualizer.test.ts import of missing perceptualLevel; no pill visualizer files are part of this PR.
- Whitespace validation passed for the committed diff.
- UI screenshot/manual verification: not run in this environment.

## Risks

Low. The hotkey change only clears internally stale ownership when the live OS state says the other modifier is no longer held. The UI change is limited to history recovery-banner grid sizing and ordering.

## Model Used

- OpenAI Codex, GPT-5.6, extended reasoning and tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked docs/ROADMAP.md ? this is a bug-fix/UI-reliability change and does not duplicate planned feature work
- [ ] npm run check passes (blocked by unrelated dirty-worktree error described above)
- [ ] npm run lint passes
- [x] Targeted Rust chord tests pass
- [ ] Smoke tests pass
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (not applicable)
- [x] Relevant documentation updated to reflect changes (not required for this bug fix)
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790930238&installation_model_id=432577&pr_number=328&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F328&signature=9f70041529ea4907eea306dbabceda858a0407ea0c0fea10f844a50bc0a81fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
