### PR TITLE
Fix Insights WPM label spacing

### DIFF
--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -236,6 +236,10 @@
     text-align: center;
   }
 
+  .tile-gauge .tile-label {
+    margin-top: 13px;
+  }
+
   .gauge {
     width: 100%;
     max-width: 150px;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that captures speech, transcribes it, cleans it up, and injects the result into the focused app.
> - The Insights subsystem presents local usage, speed, streak, vocabulary, and cost information.
> - The WPM gauge label sat farther from its value than the surrounding hero content warranted.
> - This is a small visual alignment issue in the gauge tile, separate from the Insights data query and retention behavior.
> - This pull request adds a scoped margin adjustment to the WPM label.
> - The benefit is a tighter, more deliberate relationship between the WPM value and its label.

## What Changed

- Moved the WPM gauge label down 4px with a gauge-specific rule, leaving the other hero labels unchanged.

## Verification

- npm run check passed with 0 Svelte errors and warnings.
- cargo test --manifest-path src-tauri/Cargo.toml insights passed: 19 tests.
- Checked the live Insights preview in the collaborative browser and confirmed the computed label margin is 13px.

## Risks

- Low risk. This is a scoped CSS-only change with no data, IPC, or shared control behavior changes.

> Checked docs/ROADMAP.md; this bug fix does not duplicate planned work.

## Model Used

- OpenAI GPT-5.6 (Codex), repository inspection, tool use, and live preview verification.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked docs/ROADMAP.md
- [x] npm run check passes
- [ ] npm run lint passes
- [ ] npm run test:rust passes
- [ ] Smoke tests pass
- [x] Tests verified where applicable
- [ ] UI changes include attached before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] No version bump
- [x] Relevant documentation updated where applicable
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790981402&installation_model_id=432577&pr_number=330&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F330&signature=77b00c0b3731f6d0b186f1906141f521114c0cdf7a48e230172b89e06bb208d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->