### PR TITLE
Fix history row hover jitter feedback loop

### DIFF
--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -123,7 +123,8 @@
     // Skip while hovered: the below-variant grows the row on hover, which would
     // otherwise flip the decision mid-interaction.
     if (node.matches(':hover, :focus-within')) return;
-    const fits = metaEl.getBoundingClientRect().bottom <= node.getBoundingClientRect().bottom;
+    // 1px slack: sub-pixel layout differences must not flip the decision.
+    const fits = metaEl.getBoundingClientRect().bottom <= node.getBoundingClientRect().bottom + 1;
     if (stackedMeta[key] !== fits) {
       stackedMeta = { ...stackedMeta, [key]: fits };
     }
@@ -462,8 +463,11 @@
             </div>
             <div class="day-main">
               <div class="day-text">{item.entry.clean_text}</div>
-              {#if !stackedMeta[item.key] && rowMeta(item.entry)}
-                <div class="day-meta day-meta-below">{rowMeta(item.entry)}</div>
+              {#if rowMeta(item.entry)}
+                <!-- Always in the DOM: removing it changed the row height, which
+                     flipped the measured stacked/below decision, which put it
+                     back — a self-feeding hover jitter loop. -->
+                <div class="day-meta day-meta-below" aria-hidden={!!stackedMeta[item.key]}>{rowMeta(item.entry)}</div>
               {/if}
             </div>
             <button
@@ -650,8 +654,8 @@
       transform var(--ui-duration-fast) var(--ui-ease-out),
       max-height var(--ui-duration-fast) var(--ui-ease-out);
   }
-  .day-row:hover .day-meta-below,
-  .day-row:focus-within .day-meta-below {
+  .day-row:not(.meta-stacked):hover .day-meta-below,
+  .day-row:not(.meta-stacked):focus-within .day-meta-below {
     opacity: 1;
     max-height: 16px;
     transform: translateX(0);


### PR DESCRIPTION
## Problem
Some history rows on the Home page would rapidly jitter up/down by 1-2px while hovered.

## Cause
`.day-meta-below` was conditionally rendered based on `stackedMeta[key]`, but its presence changed the measured row height that `measureStacked` reads to compute `stackedMeta[key]` — removing it shrank the row (flips to "fits" → re-added), which grew the row again (flips to "doesn't fit" → removed), looping every ResizeObserver callback. Only borderline-height rows hit this, which is why it looked random.

## Fix
- Keep `.day-meta-below` always in the DOM (`aria-hidden` when stacked) so its own render no longer feeds the decision that controls it.
- Gate the hover expansion to `:not(.meta-stacked)` rows only.
- Add 1px slack to the fits comparison so sub-pixel geometry can't flip the decision.

## Testing
- `npm run check` — 0 errors, 0 warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790985218&installation_model_id=432577&pr_number=331&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F331&signature=dfc5efe5f37e1d41e540e7fa4cad77e4b0d457147dc0162becdf246243f39534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->