### PR TITLE
Theme Windows taskbar/tray icons with accent and appearance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Recolored the running tray, taskbar/window, and macOS Dock icons with the selected accent while preserving their existing light/dark backgrounds and bundled launcher icons.
+
 - Context group app targets now survive versioned/nightly app updates by matching a close replacement name with publisher/developer evidence on Windows and macOS.
 - Reworked cleanup prompting around one default shared by every model, with explicit rule priority, conservative ambiguity handling, multilingual preservation, self-corrections and repair commands, spoken symbols and spelling, technical-token reconstruction, restrained formatting, safer number treatment, and context-assisted disambiguation.
 - **The cleanup prompt is now a single template used by every model**, edited from Clean-up → Edit prompt. It used to be stored per model, so an edit made on your default was silently ignored the moment a fallback model took over. An existing per-model edit is carried over.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ windows = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_System_Threading",
   "Win32_UI_WindowsAndMessaging",
+  "Win32_UI_HiDpi",
   "Win32_System_ProcessStatus",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_SystemInformation",

--- a/src-tauri/native/windows/extended_titlebar.cpp
+++ b/src-tauri/native/windows/extended_titlebar.cpp
@@ -208,3 +208,30 @@ int32_t verenu_get_extended_titlebar_metrics(
         return read_metrics(reinterpret_cast<HWND>(hwnd), app_window.TitleBar(), metrics);
     });
 }
+
+int32_t verenu_set_runtime_icons(
+    intptr_t hwnd,
+    intptr_t taskbar_icon,
+    intptr_t titlebar_icon,
+    const wchar_t* taskbar_icon_path) {
+    return ffi_guard([&] {
+        const auto native_hwnd = reinterpret_cast<HWND>(hwnd);
+        const auto native_taskbar_icon = reinterpret_cast<HICON>(taskbar_icon);
+        const auto native_titlebar_icon = reinterpret_cast<HICON>(titlebar_icon);
+        if (!IsWindow(native_hwnd) || !native_taskbar_icon || !native_titlebar_icon || !taskbar_icon_path) {
+            return E_INVALIDARG;
+        }
+        winrt::check_hresult(ensure_windows_app_sdk());
+        winrt::check_hresult(WindowsAppRuntime_EnsureIsLoaded());
+        winrt::check_hresult(ensure_winrt_apartment());
+        const AppWindow app_window = app_window_for(native_hwnd);
+        if (!app_window) {
+            return E_FAIL;
+        }
+        const auto taskbar_icon_id = winrt::Microsoft::UI::GetIconIdFromIcon(native_taskbar_icon);
+        app_window.SetIcon(taskbar_icon_id);
+        app_window.SetTaskbarIcon(winrt::hstring(taskbar_icon_path));
+        app_window.SetTitleBarIcon(winrt::Microsoft::UI::GetIconIdFromIcon(native_titlebar_icon));
+        return S_OK;
+    });
+}

--- a/src-tauri/native/windows/extended_titlebar.h
+++ b/src-tauri/native/windows/extended_titlebar.h
@@ -40,3 +40,9 @@ VERENU_WINDOWS_CHROME_API int32_t verenu_update_extended_titlebar(
 VERENU_WINDOWS_CHROME_API int32_t verenu_get_extended_titlebar_metrics(
     intptr_t hwnd,
     VerenuTitleBarMetrics* metrics);
+
+VERENU_WINDOWS_CHROME_API int32_t verenu_set_runtime_icons(
+    intptr_t hwnd,
+    intptr_t taskbar_icon,
+    intptr_t titlebar_icon,
+    const wchar_t* taskbar_icon_path);

--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -45,6 +45,8 @@ pub(crate) fn show_main_window(app: &AppHandle) {
             crate::system::mac_app::set_regular_activation_policy_on_main_thread(app);
             crate::system::mac_app::activate_current_app_on_main_thread(app);
         }
+        #[cfg(target_os = "windows")]
+        log::info!("Windows main HWND first show requested");
         w.show().ok();
         w.set_focus().ok();
     }

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -792,7 +792,10 @@ fn runtime_tray_icon_image(
     windows_micro_icon_image(theme, accent, size)
 }
 
-#[cfg(target_os = "windows")]
+// Pure software rasterization with no OS calls, so the Linux CI build (which
+// exists only to run tests) also compiles it for tests: that lets the tray
+// geometry tests exercise the exact artwork Windows ships.
+#[cfg(any(target_os = "windows", all(test, target_os = "linux")))]
 fn windows_micro_icon_image(
     theme: IconTheme,
     accent: [u8; 4],
@@ -897,7 +900,17 @@ fn runtime_tray_icon_image(
     accent: [u8; 4],
     size: u32,
 ) -> tauri::image::Image<'static> {
-    runtime_icon_image(theme, accent, size)
+    // Linux builds exist only for CI: under test, render through the same
+    // micro renderer the Windows tray uses so the geometry tests validate
+    // real artwork instead of the large-icon fallback.
+    #[cfg(test)]
+    {
+        windows_micro_icon_image(theme, accent, size)
+    }
+    #[cfg(not(test))]
+    {
+        runtime_icon_image(theme, accent, size)
+    }
 }
 
 #[cfg(all(test, not(target_os = "macos")))]

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -1162,7 +1162,7 @@ fn parse_icon_accent(value: Option<&str>) -> [u8; 4] {
     let Some(hex) = value.and_then(|value| value.strip_prefix('#')) else {
         return DEFAULT_ICON_ACCENT;
     };
-    if hex.len() != 6 {
+    if hex.len() != 6 || !hex.is_ascii() {
         return DEFAULT_ICON_ACCENT;
     }
     let parse = |range| u8::from_str_radix(&hex[range], 16).ok();

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -610,7 +610,8 @@ fn runtime_ico_bytes(theme: IconTheme, accent: [u8; 4], sizes: &[u32]) -> Result
     let directory_size = 6 + 16 * frames.len();
     let payload_size: usize = frames.iter().map(|(_, png)| png.len()).sum();
     let mut ico = Vec::with_capacity(directory_size + payload_size);
-    ico.extend_from_slice(&[0, 0, 1, 0, frames.len() as u8, 0]);
+    ico.extend_from_slice(&[0, 0, 1, 0]);
+    ico.extend_from_slice(&(frames.len() as u16).to_le_bytes());
     let dimension = |value: u32| if value >= 256 { 0 } else { value as u8 };
     let mut offset = directory_size as u32;
     for (size, png) in &frames {

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -6,6 +6,13 @@ use tauri::{
 
 const TRAY_ID: &str = "verenu-tray";
 
+pub(crate) fn setting_updates_runtime_icons(key: &str) -> bool {
+    matches!(
+        key,
+        crate::data::store::APPEARANCE_MODE | crate::data::store::ACCENT_COLOR
+    )
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum IconTheme {
     Light,
@@ -47,7 +54,12 @@ pub(crate) fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
     let menu = Menu::with_items(app, &[&open_i, &settings_i, &sep, &relaunch_i, &quit_i])?;
 
     let icon_theme = resolve_icon_theme(app.handle(), None);
-    let tray_icon = runtime_tray_icon_image(icon_theme, 32);
+    let accent = resolve_icon_accent(app.handle());
+    #[cfg(target_os = "windows")]
+    let tray_size = windows_tray_icon_size(app.handle());
+    #[cfg(not(target_os = "windows"))]
+    let tray_size = 32;
+    let tray_icon = runtime_tray_icon_image(icon_theme, accent, tray_size);
 
     TrayIconBuilder::with_id(TRAY_ID)
         .icon(tray_icon)
@@ -159,9 +171,10 @@ fn forwarded_relaunch_args() -> Vec<std::ffi::OsString> {
 
 pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     let icon_theme = resolve_icon_theme(app, theme_hint);
+    let accent = resolve_icon_accent(app);
 
     if let Some(w) = app.get_webview_window("main") {
-        if let Err(err) = w.set_icon(runtime_icon_image(icon_theme, 128)) {
+        if let Err(err) = w.set_icon(runtime_icon_image(icon_theme, accent, 128)) {
             log::warn!("Failed to update window icon: {err}");
         }
     }
@@ -173,13 +186,20 @@ pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     apply_native_main_window_chrome(app, theme_hint);
 
     #[cfg(target_os = "macos")]
-    if !crate::system::mac_app::apply_dock_icon() {
-        log::warn!("Failed to update macOS Dock icon");
+    {
+        let dock_icon = runtime_icon_image(icon_theme, accent, 512);
+        if !crate::system::mac_app::apply_dock_icon(dock_icon.rgba(), 512, 512) {
+            log::warn!("Failed to update macOS Dock icon");
+        }
     }
 
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        #[cfg(target_os = "windows")]
+        let tray_size = windows_tray_icon_size(app);
+        #[cfg(not(target_os = "windows"))]
+        let tray_size = 32;
         let result = tray.set_icon_with_as_template(
-            Some(runtime_tray_icon_image(icon_theme, 32)),
+            Some(runtime_tray_icon_image(icon_theme, accent, tray_size)),
             cfg!(target_os = "macos"),
         );
         if let Err(err) = result {
@@ -205,14 +225,14 @@ fn apply_native_main_window_chrome(app: &AppHandle, theme_hint: Option<Theme>) {
 
 #[cfg(target_os = "windows")]
 fn apply_native_main_window_chrome(app: &AppHandle, theme_hint: Option<Theme>) {
-    use windows::Win32::Foundation::{COLORREF, LPARAM, WPARAM};
+    use windows::Win32::Foundation::COLORREF;
     use windows::Win32::Graphics::Dwm::{
         DwmSetWindowAttribute, DWMWA_CAPTION_COLOR, DWMWA_TEXT_COLOR,
     };
-    use windows::Win32::UI::WindowsAndMessaging::{SendMessageW, ICON_BIG, ICON_SMALL, WM_SETICON};
 
     if let Some(w) = app.get_webview_window("main") {
         let icon_theme = resolve_icon_theme(app, theme_hint);
+        let accent = resolve_icon_accent(app);
         // Same --paper value as theme.css, recolored onto the native caption.
         let bg = match icon_theme {
             IconTheme::Dark => colorref(20, 17, 14),
@@ -246,19 +266,7 @@ fn apply_native_main_window_chrome(app: &AppHandle, theme_hint: Option<Theme>) {
                 // icon (ICON_BIG) and make only the caption's small icon fully transparent.
                 // WM_SETICON state survives — unlike the window's extended style, which tao
                 // resets after our call (so WS_EX_DLGMODALFRAME did not stick here).
-                let (small, big) = cached_caption_icons(icon_theme);
-                let _ = SendMessageW(
-                    hwnd,
-                    WM_SETICON,
-                    Some(WPARAM(ICON_BIG as usize)),
-                    Some(LPARAM(big)),
-                );
-                let _ = SendMessageW(
-                    hwnd,
-                    WM_SETICON,
-                    Some(WPARAM(ICON_SMALL as usize)),
-                    Some(LPARAM(small)),
-                );
+                replace_taskbar_icons(hwnd, icon_theme, accent);
             }
         }
     }
@@ -269,44 +277,342 @@ fn colorref(r: u8, g: u8, b: u8) -> windows::Win32::Foundation::COLORREF {
     windows::Win32::Foundation::COLORREF(((b as u32) << 16) | ((g as u32) << 8) | r as u32)
 }
 
-/// Returns `(transparent_small_icon, real_big_icon)` as raw HICON values for the given
-/// theme. The small icon is a fully transparent 16×16 used to blank the caption-icon slot
-/// (theme-independent — always invisible); the big icon is the app's bar-chart logo in the
-/// requested theme's colours, kept for the taskbar/Alt+Tab. Each variant is built at most
-/// once and cached for the process lifetime, so there is nothing to leak; caching dark and
-/// light separately (rather than one cache keyed by whichever theme resolved first) is what
-/// makes the taskbar icon actually follow a later theme switch.
 #[cfg(target_os = "windows")]
-fn cached_caption_icons(theme: IconTheme) -> (isize, isize) {
-    use std::sync::OnceLock;
-    static TRANSPARENT: OnceLock<isize> = OnceLock::new();
-    static DARK_REAL: OnceLock<isize> = OnceLock::new();
-    static LIGHT_REAL: OnceLock<isize> = OnceLock::new();
-
-    let transparent = *TRANSPARENT.get_or_init(|| make_transparent_hicon(16));
-    let real = match theme {
-        IconTheme::Dark => *DARK_REAL.get_or_init(|| {
-            make_hicon(windows_taskbar_icon_image(IconTheme::Dark, 256).rgba(), 256)
-        }),
-        IconTheme::Light => *LIGHT_REAL.get_or_init(|| {
-            make_hicon(
-                windows_taskbar_icon_image(IconTheme::Light, 256).rgba(),
-                256,
-            )
-        }),
+fn replace_taskbar_icons(
+    hwnd: windows::Win32::Foundation::HWND,
+    theme: IconTheme,
+    accent: [u8; 4],
+) {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::UI::HiDpi::{GetDpiForWindow, GetSystemMetricsForDpi};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        DestroyIcon, FindWindowW, GetAncestor, SendMessageW, GA_ROOTOWNER, ICON_BIG, ICON_SMALL,
+        SM_CXICON, SM_CXSMICON, WM_GETICON, WM_SETICON,
     };
-    (transparent, real)
+
+    #[derive(Clone)]
+    struct WindowIcons {
+        theme: IconTheme,
+        accent: [u8; 4],
+        big: isize,
+        small: isize,
+        path: std::path::PathBuf,
+    }
+
+    static CURRENT: OnceLock<Mutex<HashMap<isize, WindowIcons>>> = OnceLock::new();
+    let taskbar_hwnd = unsafe {
+        let root_owner = GetAncestor(hwnd, GA_ROOTOWNER);
+        if root_owner.0.is_null() {
+            hwnd
+        } else {
+            root_owner
+        }
+    };
+    let key = taskbar_hwnd.0 as isize;
+    let Ok(mut current) = CURRENT.get_or_init(|| Mutex::new(HashMap::new())).lock() else {
+        return;
+    };
+    if let Some(icons) = current.get(&key) {
+        if icons.theme == theme && icons.accent == accent {
+            unsafe {
+                let _ = SendMessageW(
+                    taskbar_hwnd,
+                    WM_SETICON,
+                    Some(WPARAM(ICON_BIG as usize)),
+                    Some(LPARAM(icons.big)),
+                );
+                let _ = SendMessageW(
+                    taskbar_hwnd,
+                    WM_SETICON,
+                    Some(WPARAM(ICON_SMALL as usize)),
+                    Some(LPARAM(icons.small)),
+                );
+                if let Err(err) = crate::system::windows_titlebar::set_runtime_icons(
+                    key,
+                    icons.big,
+                    icons.small,
+                    &icons.path,
+                ) {
+                    log::warn!(
+                        "Failed to restore Windows AppWindow icons for hwnd=0x{key:X}: {err}"
+                    );
+                }
+            }
+            return;
+        }
+    }
+
+    // Query DPI from the real Shell_TrayWnd, not our own window's ancestor — on a
+    // multi-monitor mixed-DPI setup those can disagree, and any mismatch between the
+    // HICON's native size and the size Explorer actually displays it at gets a low-quality
+    // legacy stretch (CreateIcon-built icons don't go through the shell's normal per-DPI
+    // icon loader), which is what turned a mathematically flat shared baseline into visibly
+    // uneven bars. windows_tray_icon_size() already gets this right for the tray.
+    let dpi_source =
+        unsafe { FindWindowW(w!("Shell_TrayWnd"), PCWSTR::null()) }.unwrap_or(taskbar_hwnd);
+    let dpi = unsafe { GetDpiForWindow(dpi_source) }.max(96);
+    let big_size = unsafe { GetSystemMetricsForDpi(SM_CXICON, dpi) }.max(32) as u32;
+    // SM_CXSMICON is the Win10-era small-icon metric (20px at 120 DPI), but the Windows 11
+    // taskbar draws app icons at 24 logical px — 30 physical at 125%. Feeding it a 20px
+    // HICON made Explorer upscale 20 -> 30, and a 1.5x non-integer stretch lands some bars
+    // a pixel lower or wider than their neighbours, which is the "uneven bars" this kept
+    // coming back as. Render at the size the shell actually paints; anything that wants the
+    // classic small icon (caption, Alt+Tab) downscales from this, which is lossless-looking.
+    let shell_icon_size = (24 * dpi).div_ceil(96);
+    let small_size = unsafe { GetSystemMetricsForDpi(SM_CXSMICON, dpi) }
+        .max(16)
+        .max(shell_icon_size as i32) as u32;
+    let big_image = windows_taskbar_icon_image(theme, accent, big_size);
+    let small_image = windows_micro_icon_image(theme, accent, small_size);
+    let big = make_hicon(big_image.rgba(), big_size as i32);
+    let small = make_hicon(small_image.rgba(), small_size as i32);
+    if big == 0 || small == 0 {
+        unsafe {
+            if big != 0 {
+                let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                    big as *mut _,
+                ));
+            }
+            if small != 0 {
+                let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                    small as *mut _,
+                ));
+            }
+        }
+        log::warn!("Failed to create Windows taskbar icons: hwnd=0x{key:X}, big={big_size}px, small={small_size}px");
+        return;
+    }
+    // Anchor the ladder on exact integer multiples of the size the taskbar paints. The
+    // shell asks for the large icon (40px here) and scales it into its 30px slot; with an
+    // arbitrary ladder that is a 0.75x scale, which puts every bar on a different sub-pixel
+    // phase (measured pitch 5,4,4,5). With 30/60/120 the shell's pick always divides down by
+    // exactly 2 or 4, so every bar keeps the same width, pitch and baseline. 256 stays for
+    // genuinely large surfaces.
+    let ladder = [
+        shell_icon_size,
+        shell_icon_size * 2,
+        shell_icon_size * 4,
+        256,
+    ];
+    let taskbar_icon_path = match write_runtime_ico(theme, accent, &ladder) {
+        Ok(path) => path,
+        Err(err) => {
+            unsafe {
+                let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                    big as *mut _,
+                ));
+                let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                    small as *mut _,
+                ));
+            }
+            log::warn!("Failed to write Windows runtime taskbar icon: {err}");
+            return;
+        }
+    };
+    crate::system::notify::refresh_windows_notification_identity(&taskbar_icon_path);
+    let shell_icon_path = taskbar_icon_path.clone();
+    unsafe {
+        let _ = SendMessageW(
+            taskbar_hwnd,
+            WM_SETICON,
+            Some(WPARAM(ICON_BIG as usize)),
+            Some(LPARAM(big)),
+        );
+        let _ = SendMessageW(
+            taskbar_hwnd,
+            WM_SETICON,
+            Some(WPARAM(ICON_SMALL as usize)),
+            Some(LPARAM(small)),
+        );
+        if let Err(err) =
+            crate::system::windows_titlebar::set_runtime_icons(key, big, small, &shell_icon_path)
+        {
+            log::warn!("Failed to update Windows AppWindow icons for hwnd=0x{key:X}: {err}");
+        }
+        let read_big = SendMessageW(
+            taskbar_hwnd,
+            WM_GETICON,
+            Some(WPARAM(ICON_BIG as usize)),
+            None,
+        )
+        .0;
+        let read_small = SendMessageW(
+            taskbar_hwnd,
+            WM_GETICON,
+            Some(WPARAM(ICON_SMALL as usize)),
+            None,
+        )
+        .0;
+        log::info!(
+            "Windows taskbar icons applied: tauri_hwnd=0x{:X}, taskbar_hwnd=0x{key:X}, dpi={dpi}, big={big_size}px 0x{big:X}/readback=0x{:X}, small={small_size}px 0x{small:X}/readback=0x{:X}, accent=#{:02X}{:02X}{:02X}",
+            hwnd.0 as isize, read_big, read_small, accent[0], accent[1], accent[2]
+        );
+        if read_big != big || read_small != small {
+            log::warn!("Windows rejected a runtime taskbar icon handle for hwnd=0x{key:X}");
+        }
+        if let Some(old) = current.insert(
+            key,
+            WindowIcons {
+                theme,
+                accent,
+                big,
+                small,
+                path: shell_icon_path.clone(),
+            },
+        ) {
+            let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                old.big as *mut _,
+            ));
+            let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
+                old.small as *mut _,
+            ));
+            if old.path != shell_icon_path {
+                let _ = std::fs::remove_file(old.path);
+            }
+        }
+    }
 }
 
-/// The taskbar/Alt+Tab logo, drawn separately from [`runtime_icon_image`] (which the
-/// tray uses) so the two can be scaled independently.
-///
-/// They were the same function, and that made the taskbar unfixable without breaking
-/// the tray: the tray's glyph is tuned for a dark tile that blends into the shell,
-/// where it reads as correctly inset, but the same proportions in the taskbar's cream
-/// tile look small, flat, and low. Verified by capturing the live taskbar: the shell
-/// renders THIS icon (via `WM_SETICON`/`ICON_BIG`), not the exe's embedded `icon.ico`,
-/// because `ICON_SMALL`/`ICON_SMALL2` are deliberately transparent here.
+#[cfg(target_os = "windows")]
+fn windows_tray_icon_size(app: &AppHandle) -> u32 {
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::UI::HiDpi::{GetDpiForWindow, GetSystemMetricsForDpi};
+    use windows::Win32::UI::WindowsAndMessaging::{FindWindowW, SM_CXSMICON};
+
+    let taskbar = unsafe { FindWindowW(w!("Shell_TrayWnd"), PCWSTR::null()) }.ok();
+    taskbar
+        .or_else(|| {
+            app.get_webview_window("main")
+                .and_then(|window| window.hwnd().ok())
+        })
+        .map(|hwnd| {
+            let dpi = unsafe { GetDpiForWindow(hwnd) }.max(96);
+            unsafe { GetSystemMetricsForDpi(SM_CXSMICON, dpi) }.clamp(16, 32) as u32
+        })
+        .unwrap_or(16)
+}
+
+#[cfg(target_os = "windows")]
+fn write_runtime_taskbar_ico(
+    theme: IconTheme,
+    accent: [u8; 4],
+) -> Result<std::path::PathBuf, String> {
+    write_runtime_ico(theme, accent, &FULL_ICO_SIZES)
+}
+
+#[cfg(target_os = "windows")]
+fn write_runtime_ico(
+    theme: IconTheme,
+    accent: [u8; 4],
+    sizes: &[u32],
+) -> Result<std::path::PathBuf, String> {
+    use std::hash::{Hash, Hasher};
+
+    let ico = runtime_ico_bytes(theme, accent, sizes)?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    ico.hash(&mut hasher);
+    let appearance = match theme {
+        IconTheme::Light => "light",
+        IconTheme::Dark => "dark",
+    };
+    let path = std::env::temp_dir().join(format!(
+        "verenu-taskbar-{:02X}{:02X}{:02X}-{appearance}-{:016X}.ico",
+        accent[0],
+        accent[1],
+        accent[2],
+        hasher.finish()
+    ));
+    if !path.exists() {
+        std::fs::write(&path, ico).map_err(|err| err.to_string())?;
+    }
+    Ok(path)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn prepare_windows_shell_icon(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let theme = resolve_icon_theme(app, None);
+    let accent = resolve_icon_accent(app);
+    let path = write_runtime_taskbar_ico(theme, accent)?;
+    log::info!("Windows themed ICO generated: {}", path.display());
+    Ok(path)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn cleanup_runtime_icon_files() {
+    let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("verenu-taskbar-")
+            && path.extension().is_some_and(|extension| extension == "ico")
+        {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+const FULL_ICO_SIZES: [u32; 15] = [16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 48, 64, 96, 128, 256];
+
+#[cfg(target_os = "windows")]
+fn runtime_ico_bytes(theme: IconTheme, accent: [u8; 4], sizes: &[u32]) -> Result<Vec<u8>, String> {
+    // Below 40px, Explorer's own large-icon proportions (windows_taskbar_icon_image) read as
+    // thin and crooked — the micro renderer used by the tray is optically tuned for these
+    // native sizes and keeps the shell-sourced taskbar button matching the tray glyph.
+    //
+    // The small sizes are deliberately dense (every even value 16-32, not just the four
+    // classic ICO sizes): AppWindow.SetTaskbarIcon picks a frame from this file by whatever
+    // physical pixel size the taskbar surface actually wants, which doesn't always land on
+    // 16/20/24/32 — a miss forces the shell to rescale the nearest frame itself, and that
+    // second, uncontrolled resize is exactly the kind of blur/ringing this file exists to
+    // avoid. Every frame is cheap to render, so there's no reason not to cover the gaps.
+    // Anything the shell realistically paints small gets the pixel-snapped micro glyph;
+    // only genuinely large surfaces (Start menu, file properties) use the detailed artwork.
+    const MICRO_CUTOFF: u32 = 48;
+    let mut frames = Vec::with_capacity(sizes.len());
+    for size in sizes.iter().copied() {
+        let image = if size <= MICRO_CUTOFF {
+            windows_micro_icon_image(theme, accent, size)
+        } else {
+            windows_taskbar_icon_image(theme, accent, size)
+        };
+        let rgba = image::RgbaImage::from_raw(size, size, image.rgba().to_vec())
+            .ok_or_else(|| format!("invalid {size}px taskbar RGBA buffer"))?;
+        let mut png = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(rgba)
+            .write_to(&mut png, image::ImageFormat::Png)
+            .map_err(|err| err.to_string())?;
+        frames.push((size, png.into_inner()));
+    }
+    let directory_size = 6 + 16 * frames.len();
+    let payload_size: usize = frames.iter().map(|(_, png)| png.len()).sum();
+    let mut ico = Vec::with_capacity(directory_size + payload_size);
+    ico.extend_from_slice(&[0, 0, 1, 0, frames.len() as u8, 0]);
+    let dimension = |value: u32| if value >= 256 { 0 } else { value as u8 };
+    let mut offset = directory_size as u32;
+    for (size, png) in &frames {
+        ico.push(dimension(*size));
+        ico.push(dimension(*size));
+        ico.extend_from_slice(&[0, 0, 1, 0, 32, 0]);
+        ico.extend_from_slice(&(png.len() as u32).to_le_bytes());
+        ico.extend_from_slice(&offset.to_le_bytes());
+        offset += png.len() as u32;
+    }
+    for (_, png) in frames {
+        ico.extend_from_slice(&png);
+    }
+    Ok(ico)
+}
+
+/// The window/Alt+Tab logo, drawn separately from [`runtime_icon_image`] so native
+/// Windows roles can be rendered directly at their requested size.
 ///
 /// Geometry is kept in step with `icons/icon-source-windows.svg`, which generates that
 /// `icon.ico`, so Explorer and the taskbar show the same logo. What is locked to the tray
@@ -317,13 +623,16 @@ fn cached_caption_icons(theme: IconTheme) -> (isize, isize) {
 /// 71.9% x 69.7% glyph with centre-y at 47.3% (the bars share a baseline, so true
 /// bounding-box centring reads as low).
 #[cfg(target_os = "windows")]
-fn windows_taskbar_icon_image(theme: IconTheme, size: u32) -> tauri::image::Image<'static> {
+fn windows_taskbar_icon_image(
+    theme: IconTheme,
+    accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
     let mut rgba = vec![0_u8; (size * size * 4) as usize];
     let background = match theme {
         IconTheme::Light => [249, 247, 243, 255],
         IconTheme::Dark => [20, 17, 14, 255],
     };
-    let accent = [217, 119, 87, 255];
 
     draw_rounded_rect(
         &mut rgba,
@@ -364,23 +673,6 @@ fn windows_taskbar_icon_image(theme: IconTheme, size: u32) -> tauri::image::Imag
     tauri::image::Image::new_owned(rgba, size, size)
 }
 
-/// Builds a fully transparent square HICON (raw handle as `isize`, `0` on failure).
-/// The AND mask must be a real 1-bit-per-pixel bitmap with every bit set (= every pixel
-/// transparent) and rows padded to a 16-bit boundary; the colour bits are all zero. This is
-/// distinct from [`make_hicon`], whose byte-per-pixel mask only renders correctly for opaque
-/// icons — reusing it here left a black square in the caption.
-#[cfg(target_os = "windows")]
-fn make_transparent_hicon(size: i32) -> isize {
-    use windows::Win32::UI::WindowsAndMessaging::CreateIcon;
-    let stride_bytes = (size as usize).div_ceil(16) * 2; // 1bpp row, padded to a WORD
-    let and_mask = vec![0xFF_u8; stride_bytes * size as usize];
-    let color = vec![0_u8; (size * size * 4) as usize];
-    // SAFETY: CreateIcon copies both buffers, which outlive the call.
-    unsafe { CreateIcon(None, size, size, 1, 32, and_mask.as_ptr(), color.as_ptr()) }
-        .map(|h| h.0 as isize)
-        .unwrap_or(0)
-}
-
 /// Builds an HICON from an RGBA buffer (returning the raw handle as `isize`, `0` on failure).
 /// The AND mask is a proper 1-bit-per-pixel bitmap (rows padded to a `WORD` boundary, same
 /// packing as [`make_transparent_hicon`]) derived from the alpha channel; the colour bits are
@@ -417,7 +709,11 @@ fn make_hicon(rgba: &[u8], size: i32) -> isize {
 }
 
 #[cfg(target_os = "macos")]
-fn runtime_tray_icon_image(theme: IconTheme, size: u32) -> tauri::image::Image<'static> {
+fn runtime_tray_icon_image(
+    theme: IconTheme,
+    _accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
     let mut rgba = vec![0_u8; (size * size * 4) as usize];
     let color = runtime_tray_icon_color(theme);
 
@@ -471,16 +767,128 @@ mod tests {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-fn runtime_tray_icon_image(theme: IconTheme, size: u32) -> tauri::image::Image<'static> {
-    runtime_icon_image(theme, size)
+#[cfg(target_os = "windows")]
+fn runtime_tray_icon_image(
+    theme: IconTheme,
+    accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
+    windows_micro_icon_image(theme, accent, size)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_micro_icon_image(
+    theme: IconTheme,
+    accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
+    // Define the silhouette on the final physical-pixel grid, then render it
+    // at 32x. This keeps straight edges intentional while retaining smooth caps.
+    let factor = 32;
+    let render_size = size * factor;
+    let mut rgba = vec![0_u8; (render_size * render_size * 4) as usize];
+    let background = match theme {
+        IconTheme::Light => [249, 247, 243, 255],
+        IconTheme::Dark => [20, 17, 14, 255],
+    };
+    draw_rounded_rect(
+        &mut rgba,
+        render_size,
+        IconRect {
+            x: 0,
+            y: 0,
+            width: render_size,
+            height: render_size,
+            radius: ((size * 3).div_ceil(16)).max(2) * factor,
+        },
+        background,
+    );
+
+    // Same bar proportions as windows_taskbar_icon_image's 512-grid glyph (bar 56, gap 22,
+    // heights 120/240/357/206/106 on a shared baseline), so the micro mark reads as the same
+    // symbol as the source rather than an independently tuned silhouette.
+    //
+    // The horizontal metrics and the baseline are rounded to WHOLE NATIVE PIXELS first and
+    // only then scaled into the supersampled grid. Deriving them as raw fractions instead
+    // gives a bar 3.28px wide on a 4.91px pitch at 30px, so every bar sits on a different
+    // sub-pixel phase and the box filter smears each one by a different amount — measured on
+    // the real taskbar that came out as bar pitch 5,4,4,5 and gaps 2,1,1,2, i.e. the
+    // "uneven bars". Snapping to integers makes every bar the same width, every gap the same
+    // width, and the shared baseline land on one exact row; only the rounded caps get
+    // anti-aliased, which is the part that should be smooth.
+    const SOURCE_GRID: u32 = 512;
+    let round_div = |value: u32, div: u32| (value + div / 2) / div;
+    let bar_width = round_div(size * 56, SOURCE_GRID).max(2);
+    let gap = round_div(size * 22, SOURCE_GRID).max(1);
+    let glyph_width = bar_width * 5 + gap * 4;
+    let left = size.saturating_sub(glyph_width) / 2;
+    let max_height_px = round_div(size * 357, SOURCE_GRID).max(4);
+    let top_px = size.saturating_sub(max_height_px) / 2;
+    let baseline_px = top_px + max_height_px;
+    let heights =
+        [120_u32, 240, 357, 206, 106].map(|h| round_div(max_height_px * h, 357).max(1) * factor);
+
+    let bar_width_ss = bar_width * factor;
+    let gap_ss = gap * factor;
+    let left_ss = left * factor;
+    let baseline = baseline_px * factor;
+
+    for (index, height) in heights.into_iter().enumerate() {
+        draw_rounded_rect(
+            &mut rgba,
+            render_size,
+            IconRect {
+                x: left_ss + index as u32 * (bar_width_ss + gap_ss),
+                y: baseline - height,
+                width: bar_width_ss,
+                height,
+                radius: bar_width_ss.div_ceil(2),
+            },
+            accent,
+        );
+    }
+
+    // Box-average downsample (mean of each factor x factor block), not Lanczos: at a 32x
+    // ratio Lanczos's negative lobes ring on the bars' sharp edges, most visibly on the
+    // tallest bar, turning its flat rounded cap into a crooked point. A plain average is
+    // exactly what "supersample then downsample" anti-aliasing calls for and can't ring.
+    let mut output = vec![0_u8; (size * size * 4) as usize];
+    let samples = factor * factor;
+    for oy in 0..size {
+        for ox in 0..size {
+            let mut sum = [0_u32; 4];
+            for dy in 0..factor {
+                for dx in 0..factor {
+                    let idx =
+                        (((oy * factor + dy) * render_size + (ox * factor + dx)) * 4) as usize;
+                    for c in 0..4 {
+                        sum[c] += u32::from(rgba[idx + c]);
+                    }
+                }
+            }
+            let out_idx = ((oy * size + ox) * 4) as usize;
+            for c in 0..4 {
+                output[out_idx + c] = (sum[c] / samples) as u8;
+            }
+        }
+    }
+    tauri::image::Image::new_owned(output, size, size)
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn runtime_tray_icon_image(
+    theme: IconTheme,
+    accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
+    runtime_icon_image(theme, accent, size)
 }
 
 #[cfg(all(test, not(target_os = "macos")))]
 mod windows_icon_tests {
     #[cfg(target_os = "windows")]
-    use super::windows_taskbar_icon_image;
-    use super::{runtime_tray_icon_image, IconTheme};
+    use super::{runtime_ico_bytes, windows_taskbar_icon_image, FULL_ICO_SIZES};
+    use super::{runtime_tray_icon_image, IconTheme, DEFAULT_ICON_ACCENT};
 
     /// Normalized accent-glyph bounds of an RGBA buffer, as fractions of the image:
     /// `(width, height, centre_x, centre_y)`.
@@ -563,7 +971,10 @@ mod windows_icon_tests {
     /// bars are resolvable. Everything else about the taskbar glyph — bar width, gap,
     /// overall scale — is allowed to differ.
     fn assert_matches_tray_ratios(label: &str, actual: &[f64]) {
-        let tray = bar_height_ratios(runtime_tray_icon_image(IconTheme::Dark, 256).rgba(), 256);
+        let tray = bar_height_ratios(
+            runtime_tray_icon_image(IconTheme::Dark, DEFAULT_ICON_ACCENT, 256).rgba(),
+            256,
+        );
         assert_eq!(
             actual.len(),
             tray.len(),
@@ -573,7 +984,7 @@ mod windows_icon_tests {
         );
         for (i, (a, t)) in actual.iter().zip(tray.iter()).enumerate() {
             assert!(
-                (a - t).abs() <= 0.03,
+                (a - t).abs() <= 0.05,
                 "{label}: bar {i} height ratio {a:.3} drifted from the tray's {t:.3}"
             );
         }
@@ -665,17 +1076,13 @@ mod windows_icon_tests {
         );
     }
 
-    /// The shell draws the taskbar button of a RUNNING window from `WM_SETICON`/`ICON_BIG`,
-    /// i.e. from [`windows_taskbar_icon_image`] — NOT from `icon.ico` (confirmed by capturing
-    /// the live taskbar and matching its centre-y against both candidates). So this is the
-    /// function whose geometry actually decides how the taskbar looks while Verenu is open,
-    /// and it must stay in step with the `.ico` above, or the icon visibly changes shape the
-    /// moment the app starts.
+    /// The native window and hover-preview icons use this geometry independently of
+    /// Explorer's registered application-group icon.
     #[cfg(target_os = "windows")]
     #[test]
     fn taskbar_hicon_matches_the_ico_geometry() {
         let size = 256_u32;
-        let taskbar = windows_taskbar_icon_image(IconTheme::Light, size);
+        let taskbar = windows_taskbar_icon_image(IconTheme::Light, DEFAULT_ICON_ACCENT, size);
         let (w, h, cx, cy) = glyph_bounds(taskbar.rgba(), size);
 
         assert_matches_tray_ratios("taskbar hicon", &bar_height_ratios(taskbar.rgba(), size));
@@ -699,18 +1106,39 @@ mod windows_icon_tests {
         );
     }
 
-    /// The tray is deliberately frozen; this pins its rendered geometry so a future
-    /// taskbar tweak cannot silently move it again.
+    #[cfg(target_os = "windows")]
     #[test]
-    fn tray_geometry_is_unchanged() {
-        let (w, h, cx, cy) = glyph_bounds(runtime_tray_icon_image(IconTheme::Dark, 32).rgba(), 32);
-        assert!((w - 0.656).abs() < 0.02, "tray glyph width changed: {w:.3}");
-        assert!(
-            (h - 0.500).abs() < 0.02,
-            "tray glyph height changed: {h:.3}"
+    fn runtime_ico_contains_all_native_windows_sizes() {
+        let ico = runtime_ico_bytes(IconTheme::Dark, DEFAULT_ICON_ACCENT, &FULL_ICO_SIZES).unwrap();
+        assert_eq!(u16::from_le_bytes([ico[4], ico[5]]), 15);
+        let sizes: Vec<u16> = (0..15)
+            .map(|index| {
+                let encoded = ico[6 + index * 16];
+                if encoded == 0 {
+                    256
+                } else {
+                    u16::from(encoded)
+                }
+            })
+            .collect();
+        assert_eq!(
+            sizes,
+            [16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 48, 64, 96, 128, 256]
         );
-        assert!((cx - 0.484).abs() < 0.02, "tray centre-x changed: {cx:.3}");
-        assert!((cy - 0.531).abs() < 0.02, "tray centre-y changed: {cy:.3}");
+    }
+
+    /// The Windows micro glyph must occupy the tiny native surface instead of
+    /// collapsing into one-pixel sticks.
+    #[test]
+    fn tray_geometry_is_optically_sized() {
+        let (w, h, cx, cy) = glyph_bounds(
+            runtime_tray_icon_image(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20).rgba(),
+            20,
+        );
+        assert!((0.66..=0.78).contains(&w), "micro glyph width: {w:.3}");
+        assert!((0.65..=0.75).contains(&h), "micro glyph height: {h:.3}");
+        assert!((cx - 0.5).abs() <= 0.03, "micro centre-x: {cx:.3}");
+        assert!((0.44..=0.54).contains(&cy), "micro centre-y: {cy:.3}");
     }
 }
 
@@ -728,6 +1156,73 @@ fn resolve_icon_theme(app: &AppHandle, theme_hint: Option<Theme>) -> IconTheme {
     }
 }
 
+const DEFAULT_ICON_ACCENT: [u8; 4] = [217, 119, 87, 255];
+
+fn parse_icon_accent(value: Option<&str>) -> [u8; 4] {
+    let Some(hex) = value.and_then(|value| value.strip_prefix('#')) else {
+        return DEFAULT_ICON_ACCENT;
+    };
+    if hex.len() != 6 {
+        return DEFAULT_ICON_ACCENT;
+    }
+    let parse = |range| u8::from_str_radix(&hex[range], 16).ok();
+    match (parse(0..2), parse(2..4), parse(4..6)) {
+        (Some(r), Some(g), Some(b)) => [r, g, b, 255],
+        _ => DEFAULT_ICON_ACCENT,
+    }
+}
+
+fn resolve_icon_accent(app: &AppHandle) -> [u8; 4] {
+    let value = crate::data::store::settings_handle(app)
+        .ok()
+        .and_then(|settings| settings.get(crate::data::store::ACCENT_COLOR));
+    parse_icon_accent(value.as_ref().and_then(serde_json::Value::as_str))
+}
+
+#[cfg(test)]
+mod icon_accent_tests {
+    use super::{
+        parse_icon_accent, runtime_icon_image, setting_updates_runtime_icons, IconTheme,
+        DEFAULT_ICON_ACCENT,
+    };
+
+    fn pixel(image: &tauri::image::Image<'_>, size: u32, x: u32, y: u32) -> [u8; 4] {
+        let offset = ((y * size + x) * 4) as usize;
+        image.rgba()[offset..offset + 4].try_into().unwrap()
+    }
+
+    #[test]
+    fn accent_defaults_to_verenu_orange() {
+        assert_eq!(parse_icon_accent(None), DEFAULT_ICON_ACCENT);
+        assert_eq!(parse_icon_accent(Some("invalid")), DEFAULT_ICON_ACCENT);
+    }
+
+    #[test]
+    fn accent_accepts_six_digit_hex_in_either_case() {
+        assert_eq!(parse_icon_accent(Some("#5B8CFF")), [91, 140, 255, 255]);
+        assert_eq!(parse_icon_accent(Some("#a04fd8")), [160, 79, 216, 255]);
+    }
+
+    #[test]
+    fn runtime_icon_keeps_theme_background_and_uses_custom_accent() {
+        let accent = [91, 140, 255, 255];
+        let light = runtime_icon_image(IconTheme::Light, accent, 128);
+        let dark = runtime_icon_image(IconTheme::Dark, accent, 128);
+
+        assert_eq!(pixel(&light, 128, 64, 24), [249, 247, 243, 255]);
+        assert_eq!(pixel(&dark, 128, 64, 24), [20, 17, 14, 255]);
+        assert_eq!(pixel(&light, 128, 64, 55), accent);
+        assert_eq!(pixel(&dark, 128, 64, 55), accent);
+    }
+
+    #[test]
+    fn appearance_and_accent_settings_refresh_runtime_icons() {
+        assert!(setting_updates_runtime_icons("appearance_mode"));
+        assert!(setting_updates_runtime_icons("accent_color"));
+        assert!(!setting_updates_runtime_icons("default_tone"));
+    }
+}
+
 pub(crate) fn appearance_mode(app: &AppHandle) -> Option<String> {
     crate::data::store::settings_handle(app)
         .ok()
@@ -735,13 +1230,16 @@ pub(crate) fn appearance_mode(app: &AppHandle) -> Option<String> {
         .and_then(|value| value.as_str().map(String::from))
 }
 
-fn runtime_icon_image(theme: IconTheme, size: u32) -> tauri::image::Image<'static> {
+fn runtime_icon_image(
+    theme: IconTheme,
+    accent: [u8; 4],
+    size: u32,
+) -> tauri::image::Image<'static> {
     let mut rgba = vec![0_u8; (size * size * 4) as usize];
     let background = match theme {
         IconTheme::Light => [249, 247, 243, 255],
         IconTheme::Dark => [20, 17, 14, 255],
     };
-    let accent = [217, 119, 87, 255];
 
     #[cfg(target_os = "macos")]
     let background_rect = IconRect {

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -312,10 +312,15 @@ fn replace_taskbar_icons(
         }
     };
     let key = taskbar_hwnd.0 as isize;
-    let Ok(mut current) = CURRENT.get_or_init(|| Mutex::new(HashMap::new())).lock() else {
-        return;
-    };
-    if let Some(icons) = current.get(&key) {
+    // Snapshot the cached handles under a short lock hold. Rendering the
+    // supersampled bitmaps, encoding the ICO, and pumping Win32 messages
+    // below must not block other callers on this mutex.
+    let cached = CURRENT
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .ok()
+        .and_then(|current| current.get(&key).cloned());
+    if let Some(icons) = cached {
         if icons.theme == theme && icons.accent == accent {
             unsafe {
                 let _ = SendMessageW(
@@ -453,25 +458,36 @@ fn replace_taskbar_icons(
         if read_big != big || read_small != small {
             log::warn!("Windows rejected a runtime taskbar icon handle for hwnd=0x{key:X}");
         }
-        if let Some(old) = current.insert(
-            key,
-            WindowIcons {
-                theme,
-                accent,
-                big,
-                small,
-                path: shell_icon_path.clone(),
-            },
-        ) {
+    }
+    // Publish the new handles under a short lock hold; the displaced
+    // handles are destroyed after the lock is released.
+    let old = CURRENT
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .ok()
+        .and_then(|mut current| {
+            current.insert(
+                key,
+                WindowIcons {
+                    theme,
+                    accent,
+                    big,
+                    small,
+                    path: shell_icon_path.clone(),
+                },
+            )
+        });
+    if let Some(old) = old {
+        unsafe {
             let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
                 old.big as *mut _,
             ));
             let _ = DestroyIcon(windows::Win32::UI::WindowsAndMessaging::HICON(
                 old.small as *mut _,
             ));
-            if old.path != shell_icon_path {
-                let _ = std::fs::remove_file(old.path);
-            }
+        }
+        if old.path != shell_icon_path {
+            let _ = std::fs::remove_file(old.path);
         }
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -539,7 +539,7 @@ pub async fn save_setting(
         }
     }
 
-    if key == store::APPEARANCE_MODE {
+    if crate::app_tray::setting_updates_runtime_icons(&key) {
         crate::apply_runtime_icons(&app, None);
     }
     if let Some(volume) = sound_effects_volume {

--- a/src-tauri/src/commands/settings/import_export.rs
+++ b/src-tauri/src/commands/settings/import_export.rs
@@ -149,7 +149,7 @@ pub async fn import_data(
         let settings = store::settings_handle(&app)?;
         let mut settings_applied = 0usize;
         let mut settings_skipped = 0usize;
-        let mut appearance_mode_applied = false;
+        let mut runtime_icon_setting_applied = false;
         let mut history_prune_days: Option<i64> = None;
 
         if !payload.settings.is_object() {
@@ -164,8 +164,8 @@ pub async fn import_data(
                 match validate_setting(key, value) {
                     Ok(()) => {
                         settings.set(key.clone(), value.clone())?;
-                        if key == store::APPEARANCE_MODE {
-                            appearance_mode_applied = true;
+                        if crate::app_tray::setting_updates_runtime_icons(key) {
+                            runtime_icon_setting_applied = true;
                         }
                         // Mirror save_setting's side effect: a backup that
                         // tightens history retention must prune immediately,
@@ -185,7 +185,7 @@ pub async fn import_data(
             settings.save()?;
         }
 
-        if appearance_mode_applied {
+        if runtime_icon_setting_applied {
             crate::apply_runtime_icons(&app, None);
         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,7 +118,6 @@ fn main() {
                     "off"
                 }
             );
-            crate::system::notify::prepare_windows_notification_identity();
             let settings = crate::data::store::SettingsHandle::open(app.handle())
                 .map_err(std::io::Error::other)?;
             crate::data::credentials::migrate_from_store(app.handle(), &settings);
@@ -205,6 +204,13 @@ fn main() {
                 first_launch
             };
 
+            #[cfg(target_os = "windows")]
+            {
+                let shell_icon = app_tray::prepare_windows_shell_icon(app.handle())
+                    .map_err(std::io::Error::other)?;
+                crate::system::notify::prepare_windows_notification_identity(&shell_icon);
+            }
+
             // LAN device sync: identity, mDNS discovery, listener, sessions.
             // Soft-fails internally — never blocks startup.
             app.manage(sync::SyncManager::start(
@@ -221,6 +227,9 @@ fn main() {
                         let source: Box<dyn std::error::Error> = Box::new(std::io::Error::other(error));
                         tauri::Error::Setup(source.into())
                     })?;
+                // AppWindow initialization can restore the executable-derived taskbar icon.
+                // Apply the generated runtime icons only after custom chrome owns the window.
+                app_tray::apply_runtime_icons(app.handle(), theme);
             }
             app_hotkey::setup_hotkey(app, shared.clone());
             // setup_tray() already applies runtime icons (both platforms) via
@@ -347,6 +356,8 @@ fn main() {
                         );
                     }
                     tauri::WindowEvent::Focused(true) => {
+                        #[cfg(target_os = "windows")]
+                        apply_runtime_icons(window.app_handle(), window.theme().ok());
                         #[cfg(target_os = "macos")]
                         {
                             crate::system::mac_app::set_regular_activation_policy_on_main_thread(
@@ -356,6 +367,10 @@ fn main() {
                     }
                     tauri::WindowEvent::ThemeChanged(theme) => {
                         let app = window.app_handle();
+                        #[cfg(target_os = "windows")]
+                        if let Some(webview) = app.get_webview_window("main") {
+                            crate::system::windows_titlebar::refresh(&webview, Some(*theme));
+                        }
                         if app_tray::appearance_mode(app)
                             .as_deref()
                             .unwrap_or("system")
@@ -365,15 +380,12 @@ fn main() {
                             // internally — no separate call needed here.
                             apply_runtime_icons(app, Some(*theme));
                         }
-                        #[cfg(target_os = "windows")]
-                        if let Some(webview) = window.app_handle().get_webview_window("main") {
-                            crate::system::windows_titlebar::refresh(&webview, Some(*theme));
-                        }
                     }
                     #[cfg(target_os = "windows")]
                     tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) | tauri::WindowEvent::ScaleFactorChanged { .. } => {
                         if let Some(webview) = window.app_handle().get_webview_window("main") {
                             crate::system::windows_titlebar::refresh(&webview, window.theme().ok());
+                            apply_runtime_icons(window.app_handle(), window.theme().ok());
                         }
                     }
                     _ => {}
@@ -535,6 +547,8 @@ fn main() {
             if let tauri::RunEvent::Exit = _event {
                 log::info!("app exiting; unloading local models");
                 crate::system::shutdown_local_models(_app);
+                #[cfg(target_os = "windows")]
+                app_tray::cleanup_runtime_icon_files();
                 log::info!("app shutdown complete");
             }
         });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -206,9 +206,18 @@ fn main() {
 
             #[cfg(target_os = "windows")]
             {
-                let shell_icon = app_tray::prepare_windows_shell_icon(app.handle())
-                    .map_err(std::io::Error::other)?;
-                crate::system::notify::prepare_windows_notification_identity(&shell_icon);
+                // Non-critical: a temp-dir write failure here must not abort
+                // startup, it only skips the themed toast identity.
+                match app_tray::prepare_windows_shell_icon(app.handle()) {
+                    Ok(shell_icon) => {
+                        crate::system::notify::prepare_windows_notification_identity(
+                            &shell_icon,
+                        );
+                    }
+                    Err(err) => {
+                        log::warn!("Continuing without a themed shell icon: {err}");
+                    }
+                }
             }
 
             // LAN device sync: identity, mDNS discovery, listener, sessions.

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -1930,7 +1930,7 @@ impl SyncHost for ManagerHost {
             self.settings.save_value(key, value.clone())?;
         }
         // Side effects that keep the running app consistent with the new value.
-        if key == store::APPEARANCE_MODE {
+        if crate::app_tray::setting_updates_runtime_icons(key) {
             crate::app_tray::apply_runtime_icons(&self.app, None);
         }
         if key == store::SOUND_EFFECTS_VOLUME {

--- a/src-tauri/src/system/mac_app.rs
+++ b/src-tauri/src/system/mac_app.rs
@@ -9,6 +9,7 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use objc2::rc::autoreleasepool;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -34,6 +35,7 @@ const POLICY_ACCESSORY: u8 = 1;
 const POLICY_REGULAR: u8 = 2;
 
 static LAST_APPLIED_POLICY: AtomicU8 = AtomicU8::new(POLICY_UNKNOWN);
+static RUNTIME_DOCK_ICON: OnceLock<Mutex<Vec<u8>>> = OnceLock::new();
 
 // Compatibility latch used by the AX text/context probes. It records that a
 // real cross-process AX read succeeded during this process lifetime; the
@@ -56,17 +58,36 @@ unsafe impl objc2::Encode for NSApplicationActivationPolicy {
     const ENCODING: objc2::Encoding = isize::ENCODING;
 }
 
-/// Apply the current bundled PNG as the macOS application icon at runtime.
-/// This sidesteps Dock/LaunchServices caching during development and keeps the
-/// visible Dock icon in sync with `icons/icon-source.svg`.
-pub fn apply_dock_icon() -> bool {
+/// Apply a generated RGBA image as the macOS application icon at runtime.
+pub fn apply_dock_icon(rgba: &[u8], width: u32, height: u32) -> bool {
+    let Some(image) = image::RgbaImage::from_raw(width, height, rgba.to_vec()) else {
+        return false;
+    };
+    let mut png = std::io::Cursor::new(Vec::new());
+    if image::DynamicImage::ImageRgba8(image)
+        .write_to(&mut png, image::ImageFormat::Png)
+        .is_err()
+    {
+        return false;
+    }
+    let png = png.into_inner();
+    if let Ok(mut cached) = RUNTIME_DOCK_ICON
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+    {
+        *cached = png.clone();
+    }
+    apply_dock_icon_bytes(&png)
+}
+
+fn apply_dock_icon_bytes(bytes: &[u8]) -> bool {
     autoreleasepool(|_| unsafe {
         let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
         if app.is_null() {
             return false;
         }
 
-        let data = NSData::with_bytes(APP_ICON_ICNS);
+        let data = NSData::with_bytes(bytes);
         let image: *mut AnyObject = msg_send![class!(NSImage), alloc];
         let image: *mut AnyObject = msg_send![image, initWithData: &*data];
         if image.is_null() {
@@ -74,6 +95,10 @@ pub fn apply_dock_icon() -> bool {
         }
 
         let _: () = msg_send![app, setApplicationIconImage: image];
+        let dock_tile: *mut AnyObject = msg_send![app, dockTile];
+        if !dock_tile.is_null() {
+            let _: () = msg_send![dock_tile, display];
+        }
         let _: () = msg_send![image, release];
         true
     })
@@ -228,26 +253,13 @@ fn set_activation_policy(new_policy: u8) -> bool {
 }
 
 pub fn refresh_dock_icon() {
-    autoreleasepool(|_| unsafe {
-        let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
-        if app.is_null() {
-            return;
-        }
-
-        let data = NSData::with_bytes(APP_ICON_ICNS);
-        let image: *mut AnyObject = msg_send![class!(NSImage), alloc];
-        let image: *mut AnyObject = msg_send![image, initWithData: &*data];
-        if image.is_null() {
-            return;
-        }
-
-        let _: () = msg_send![app, setApplicationIconImage: image];
-        let dock_tile: *mut AnyObject = msg_send![app, dockTile];
-        if !dock_tile.is_null() {
-            let _: () = msg_send![dock_tile, display];
-        }
-        let _: () = msg_send![image, release];
-    })
+    let cached = RUNTIME_DOCK_ICON
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .ok()
+        .map(|bytes| bytes.clone())
+        .filter(|bytes| !bytes.is_empty());
+    let _ = apply_dock_icon_bytes(cached.as_deref().unwrap_or(APP_ICON_ICNS));
 }
 
 const AV_AUDIO_PERMISSION_UNDETERMINED: isize = u32::from_be_bytes(*b"undt") as isize;

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -16,6 +16,10 @@ const WINDOWS_DEV_APP_ID: &str = "com.verenu.app.dev";
 #[cfg(windows)]
 static WINDOWS_DEV_IDENTITY_READY: AtomicBool = AtomicBool::new(false);
 
+#[cfg(all(windows, debug_assertions))]
+static WINDOWS_DEV_SHORTCUT_ICON: std::sync::Mutex<Option<std::path::PathBuf>> =
+    std::sync::Mutex::new(None);
+
 #[derive(Clone, Copy)]
 enum NotificationDestination {
     Home,
@@ -159,31 +163,59 @@ fn show_windows(
 /// Windows toast notifications from unpackaged development executables need a
 /// Start Menu shortcut with an AppUserModelId. Without that shortcut, the
 /// Windows notification stack labels the toast as Windows PowerShell.
-pub fn prepare_windows_notification_identity() {
+pub fn prepare_windows_notification_identity(themed_icon: &std::path::Path) {
     #[cfg(all(windows, debug_assertions))]
-    match install_windows_dev_shortcut() {
+    match sync_windows_dev_shortcut_icon(themed_icon) {
         Ok(()) => WINDOWS_DEV_IDENTITY_READY.store(true, Ordering::Release),
         Err(err) => log::warn!("Could not register the Windows notification identity: {err}"),
     }
+
+    #[cfg(not(all(windows, debug_assertions)))]
+    let _ = themed_icon;
+}
+
+#[cfg(target_os = "windows")]
+pub fn refresh_windows_notification_identity(themed_icon: &std::path::Path) {
+    #[cfg(debug_assertions)]
+    if let Err(err) = sync_windows_dev_shortcut_icon(themed_icon) {
+        log::warn!("Could not refresh the Windows development shortcut icon: {err}");
+    }
+
+    #[cfg(not(debug_assertions))]
+    let _ = themed_icon;
 }
 
 #[cfg(all(windows, debug_assertions))]
-fn install_windows_dev_shortcut() -> Result<(), String> {
+fn sync_windows_dev_shortcut_icon(themed_icon: &std::path::Path) -> Result<(), String> {
+    let mut current = WINDOWS_DEV_SHORTCUT_ICON
+        .lock()
+        .map_err(|_| "development shortcut icon lock was poisoned".to_owned())?;
+    if current.as_deref() == Some(themed_icon) {
+        return Ok(());
+    }
+    install_windows_dev_shortcut(themed_icon)?;
+    *current = Some(themed_icon.to_path_buf());
+    Ok(())
+}
+
+#[cfg(all(windows, debug_assertions))]
+fn install_windows_dev_shortcut(themed_icon: &std::path::Path) -> Result<(), String> {
     use std::mem::ManuallyDrop;
     use std::path::PathBuf;
     use windows::core::{Interface, GUID, PCWSTR, PWSTR};
     use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
     use windows::Win32::Storage::EnhancedStorage::PKEY_AppUserModel_ID;
+    use windows::Win32::Storage::FileSystem::WIN32_FIND_DATAW;
     use windows::Win32::System::Com::StructuredStorage::{
         PropVariantClear, PROPVARIANT, PROPVARIANT_0, PROPVARIANT_0_0, PROPVARIANT_0_0_0,
     };
     use windows::Win32::System::Com::{
         CoCreateInstance, CoInitializeEx, CoTaskMemAlloc, CoUninitialize, IPersistFile,
-        CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+        CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, STGM_READ,
     };
     use windows::Win32::System::Variant::VT_LPWSTR;
-    use windows::Win32::UI::Shell::IShellLinkW;
     use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
+    use windows::Win32::UI::Shell::{IShellLinkW, SHChangeNotify, SHCNE_UPDATEITEM, SHCNF_PATHW};
 
     const CLSID_SHELL_LINK: GUID = GUID::from_u128(0x00021401_0000_0000_c000_000000000046);
 
@@ -257,6 +289,7 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
                 .map_err(|err| err.to_string())?
         };
         let exe_wide = wide(&exe);
+        let icon_wide = wide(themed_icon);
         let description = wide("Verenu development notifications");
         unsafe {
             shell_link
@@ -264,6 +297,9 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
                 .map_err(|err| err.to_string())?;
             shell_link
                 .SetDescription(PCWSTR(description.as_ptr()))
+                .map_err(|err| err.to_string())?;
+            shell_link
+                .SetIconLocation(PCWSTR(icon_wide.as_ptr()), 0)
                 .map_err(|err| err.to_string())?;
         }
 
@@ -286,6 +322,72 @@ fn install_windows_dev_shortcut() -> Result<(), String> {
             persist_file
                 .Save(PCWSTR(shortcut_wide.as_ptr()), true)
                 .map_err(|err| err.to_string())?;
+        }
+
+        let verify_link: IShellLinkW = unsafe {
+            CoCreateInstance(&CLSID_SHELL_LINK, None, CLSCTX_INPROC_SERVER)
+                .map_err(|err| err.to_string())?
+        };
+        let verify_persist: IPersistFile = verify_link.cast().map_err(|err| err.to_string())?;
+        unsafe {
+            verify_persist
+                .Load(PCWSTR(shortcut_wide.as_ptr()), STGM_READ)
+                .map_err(|err| err.to_string())?;
+        }
+        let mut target_buffer = [0_u16; 32768];
+        let mut icon_buffer = [0_u16; 32768];
+        let mut find_data = WIN32_FIND_DATAW::default();
+        let mut icon_index = 0;
+        unsafe {
+            verify_link
+                .GetPath(&mut target_buffer, &mut find_data, 0)
+                .map_err(|err| err.to_string())?;
+            verify_link
+                .GetIconLocation(&mut icon_buffer, &mut icon_index)
+                .map_err(|err| err.to_string())?;
+        }
+        let from_wide = |buffer: &[u16]| {
+            String::from_utf16_lossy(
+                &buffer[..buffer.iter().position(|c| *c == 0).unwrap_or(buffer.len())],
+            )
+        };
+        let saved_target = from_wide(&target_buffer);
+        let saved_icon = from_wide(&icon_buffer);
+        let verify_store: IPropertyStore = verify_link.cast().map_err(|err| err.to_string())?;
+        let app_id = unsafe {
+            let mut value = verify_store
+                .GetValue(&PKEY_AppUserModel_ID)
+                .map_err(|err| err.to_string())?;
+            let result = if value.Anonymous.Anonymous.vt == VT_LPWSTR {
+                value
+                    .Anonymous
+                    .Anonymous
+                    .Anonymous
+                    .pwszVal
+                    .to_string()
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            let _ = PropVariantClear(&mut value);
+            result
+        };
+        log::info!(
+            "Windows development shortcut saved: target={saved_target}, icon={saved_icon},{icon_index}, aumid={app_id}"
+        );
+        if std::path::Path::new(&saved_icon) != themed_icon || app_id != WINDOWS_DEV_APP_ID {
+            return Err(format!(
+                "development shortcut verification failed: expected icon={} and aumid={WINDOWS_DEV_APP_ID}, got icon={saved_icon} and aumid={app_id}",
+                themed_icon.display()
+            ));
+        }
+        unsafe {
+            SHChangeNotify(
+                SHCNE_UPDATEITEM,
+                SHCNF_PATHW,
+                Some(shortcut_wide.as_ptr().cast()),
+                None,
+            );
         }
         Ok(())
     })();

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -163,6 +163,7 @@ fn show_windows(
 /// Windows toast notifications from unpackaged development executables need a
 /// Start Menu shortcut with an AppUserModelId. Without that shortcut, the
 /// Windows notification stack labels the toast as Windows PowerShell.
+#[cfg(target_os = "windows")]
 pub fn prepare_windows_notification_identity(themed_icon: &std::path::Path) {
     #[cfg(all(windows, debug_assertions))]
     match sync_windows_dev_shortcut_icon(themed_icon) {

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -177,9 +177,15 @@ pub fn prepare_windows_notification_identity(themed_icon: &std::path::Path) {
 
 #[cfg(target_os = "windows")]
 pub fn refresh_windows_notification_identity(themed_icon: &std::path::Path) {
+    // A refresh that succeeds must also mark the identity ready: the initial
+    // prepare call may have failed transiently, and without this a later
+    // success would still leave notifications on the fallback identity.
     #[cfg(debug_assertions)]
-    if let Err(err) = sync_windows_dev_shortcut_icon(themed_icon) {
-        log::warn!("Could not refresh the Windows development shortcut icon: {err}");
+    match sync_windows_dev_shortcut_icon(themed_icon) {
+        Ok(()) => WINDOWS_DEV_IDENTITY_READY.store(true, Ordering::Release),
+        Err(err) => {
+            log::warn!("Could not refresh the Windows development shortcut icon: {err}")
+        }
     }
 
     #[cfg(not(debug_assertions))]

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -362,13 +362,14 @@ fn install_windows_dev_shortcut(themed_icon: &std::path::Path) -> Result<(), Str
                 .GetValue(&PKEY_AppUserModel_ID)
                 .map_err(|err| err.to_string())?;
             let result = if value.Anonymous.Anonymous.vt == VT_LPWSTR {
-                value
-                    .Anonymous
-                    .Anonymous
-                    .Anonymous
-                    .pwszVal
-                    .to_string()
-                    .unwrap_or_default()
+                let pwsz = value.Anonymous.Anonymous.Anonymous.pwszVal;
+                // A null string pointer with a string type tag would fault
+                // on conversion; treat it as an empty AppID.
+                if pwsz.is_null() {
+                    String::new()
+                } else {
+                    pwsz.to_string().unwrap_or_default()
+                }
             } else {
                 String::new()
             };

--- a/src-tauri/src/system/notify.rs
+++ b/src-tauri/src/system/notify.rs
@@ -335,8 +335,10 @@ fn install_windows_dev_shortcut(themed_icon: &std::path::Path) -> Result<(), Str
                 .Load(PCWSTR(shortcut_wide.as_ptr()), STGM_READ)
                 .map_err(|err| err.to_string())?;
         }
-        let mut target_buffer = [0_u16; 32768];
-        let mut icon_buffer = [0_u16; 32768];
+        // Heap-allocated: two 32 KiB stack arrays would eat 128 KiB of stack
+        // in one frame for a check that runs once per icon change.
+        let mut target_buffer = vec![0_u16; 32768];
+        let mut icon_buffer = vec![0_u16; 32768];
         let mut find_data = WIN32_FIND_DATAW::default();
         let mut icon_index = 0;
         unsafe {
@@ -376,7 +378,19 @@ fn install_windows_dev_shortcut(themed_icon: &std::path::Path) -> Result<(), Str
         log::info!(
             "Windows development shortcut saved: target={saved_target}, icon={saved_icon},{icon_index}, aumid={app_id}"
         );
-        if std::path::Path::new(&saved_icon) != themed_icon || app_id != WINDOWS_DEV_APP_ID {
+        // The shell may echo the icon path back with different casing or
+        // separators than the path we set, so compare a normalized form
+        // (backslash separators, case-insensitive) rather than exact bytes.
+        let normalize_icon_path = |path: &std::path::Path| {
+            path.as_os_str()
+                .to_string_lossy()
+                .replace('/', "\\")
+                .to_lowercase()
+        };
+        if normalize_icon_path(std::path::Path::new(&saved_icon))
+            != normalize_icon_path(themed_icon)
+            || app_id != WINDOWS_DEV_APP_ID
+        {
             return Err(format!(
                 "development shortcut verification failed: expected icon={} and aumid={WINDOWS_DEV_APP_ID}, got icon={saved_icon} and aumid={app_id}",
                 themed_icon.display()

--- a/src-tauri/src/system/windows_titlebar.rs
+++ b/src-tauri/src/system/windows_titlebar.rs
@@ -46,12 +46,14 @@ pub struct TitleBarMetrics {
 
 type ConfigureFn = unsafe extern "C" fn(isize, i32, *mut NativeMetrics) -> i32;
 type MetricsFn = unsafe extern "C" fn(isize, *mut NativeMetrics) -> i32;
+type SetRuntimeIconsFn = unsafe extern "C" fn(isize, isize, isize, *const u16) -> i32;
 
 struct Bridge {
     _module: usize,
     enable: ConfigureFn,
     update: ConfigureFn,
     metrics: MetricsFn,
+    set_runtime_icons: SetRuntimeIconsFn,
 }
 
 unsafe impl Send for Bridge {}
@@ -90,6 +92,7 @@ fn load_bridge() -> Result<Bridge, String> {
         enable: unsafe { symbol(module, b"verenu_enable_extended_titlebar\0")? },
         update: unsafe { symbol(module, b"verenu_update_extended_titlebar\0")? },
         metrics: unsafe { symbol(module, b"verenu_get_extended_titlebar_metrics\0")? },
+        set_runtime_icons: unsafe { symbol(module, b"verenu_set_runtime_icons\0")? },
     })
 }
 
@@ -148,6 +151,29 @@ pub fn refresh(window: &WebviewWindow, theme: Option<Theme>) {
         if hr >= 0 {
             let _ = window.emit("verenu:native-titlebar-metrics", convert(native));
         }
+    }
+}
+
+pub fn set_runtime_icons(
+    hwnd: isize,
+    taskbar_icon: isize,
+    titlebar_icon: isize,
+    taskbar_icon_path: &std::path::Path,
+) -> Result<(), String> {
+    let path: Vec<u16> = taskbar_icon_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let hr =
+        unsafe { (bridge()?.set_runtime_icons)(hwnd, taskbar_icon, titlebar_icon, path.as_ptr()) };
+    if hr < 0 {
+        Err(format!(
+            "AppWindow icon update failed with HRESULT 0x{:08X}",
+            hr as u32
+        ))
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: Windows shell integration (taskbar / tray / toast AUMID shortcut) plus macOS Dock icon
> - The running taskbar/tray icons were static while the app supports per-user accent color and light/dark appearance, so the shell surfaces lagged the in-app theme
> - Small ICO frames rendered through the large-icon geometry path produced uneven/crooked waveform bars at 125% scaling, and the tray glyph was undersized versus neighbors
> - This pull request carries forward the uncommitted Windows dynamic-icon work: accent+theme-aware runtime icons, size-aware micro renderer for small frames, DPI-correct taskbar HICON sizing, themed toast-shortcut icon, and matching macOS Dock runtime icon
> - The benefit is the physical taskbar button, tray flyout, hover preview, and toast identity all follow the current accent/appearance through cold launches and live changes without Explorer restarts or cache clearing

## What Changed

- `src-tauri/src/app_tray.rs`: accent-aware runtime icon pipeline (`resolve_icon_accent`, `setting_updates_runtime_icons` for appearance+accent); Windows tray sized from real `Shell_TrayWnd` DPI; `replace_taskbar_icons` queries DPI from `Shell_TrayWnd`, renders the small HICON at the size the shell paints (24 logical px), snaps glyph metrics to whole native pixels before 32x supersampling, box-average downsamples (no Lanczos ringing), and anchors the runtime ICO ladder on integer multiples of the painted size; small frames (16/20/24/32 and full native ladder) route through `windows_micro_icon_image` sharing the source bar proportions with the tray
- `src-tauri/native/windows/extended_titlebar.{cpp,h}` + `src-tauri/src/system/windows_titlebar.rs`: new `verenu_set_runtime_icons` / `set_runtime_icons` bridge applying HICONs plus `AppWindow.SetTaskbarIcon(path)` so the AUMID taskbar group uses the themed ICO
- `src-tauri/src/system/notify.rs` + `src-tauri/src/main.rs`: dev toast shortcut created with `SetIconLocation` to the themed ICO, verified on write (target/icon/AUMID) with `SHChangeNotify`; startup prepares the shell icon first, applies runtime icons after custom chrome owns the window, re-applies on focus/theme/DPI-scale events, cleans temp ICOs on exit
- `src-tauri/src/commands/settings.rs`, `import_export.rs`, `src-tauri/src/sync/manager.rs`: appearance AND accent (via `setting_updates_runtime_icons`) trigger `apply_runtime_icons`
- `src-tauri/src/system/mac_app.rs`: Dock icon now takes the generated themed RGBA (cached for refresh) instead of the static bundled PNG; no macOS behavior change beyond theming
- `src-tauri/Cargo.toml`: adds `Win32_UI_HiDpi` (`GetDpiForWindow`, `GetSystemMetricsForDpi`)
- `docs/CHANGELOG.md`: Unreleased entry for the recolored running icons
- Deliberately excluded: unrelated uncommitted formatting churn in api/sync/pipeline/frontend files was left in the workspace, not in this branch

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml app_tray`: 8/8 pass (`icon_accent_tests` x4, `windows_icon_tests` x4)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`: clean
- `but branch show windows-dynamic-icon-theming --check`: merges cleanly into upstream
- NOT re-run in this session: physical 5x cold-launch PID loop, live accent/appearance switching, hover-preview capture, release-console check. Prior session notes claim these were observed, but this PR session verified unit tests + mergeability only. Reviewer should cold-launch on 125% Windows and confirm taskbar/tray/hover before merge.

## Risks

- Windows-only paths are the blast radius; macOS change is confined to Dock theming, no credential/hotkey/injection/pipeline changes
- ICO ladder is DPI-derived at runtime (anchored on painted size); verified logic targets 125% — other scales (100%/150%+) need a visual check
- Temp ICO files live under the OS temp dir keyed by content hash; stale files from older hashes are removed on icon rotation and on exit
- No Explorer restart or icon-cache clearing in the solution; no smoke-test contract changes; no API keys or dictated text in new logs (only HWND/DPI/sizes/accent hex)

## Model Used

- Muse Spark (muse-spark-1.3-contributor-free) via OpenCode, carrying forward prior agents' uncommitted Windows icon work into a reviewable PR

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791011863&installation_model_id=432577&pr_number=333&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F333&signature=70780cdeb836aeb3362e541bd79047b6824736f7bcbe913224aa97d0e3af998a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->