### PR TITLE
Fix Insights layout on narrow windows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 - Context group websites are now checked for DNS existence before being saved, so a typo can't silently create a website target that will never match anything.
 - Added a subtle pop-in animation when adding an app or website to a context group, without replaying it for the rest of the list when switching between context groups.
 - Added `docs/CONTEXTS.md` and marked App Mappings, Dictionary, and Snippets as legacy pages across the docs.
+- Fixed the Insights page stacking its summary tiles too early on narrow windows, stranding the gauge in a half-empty row — the hero band, heatmap rail, and vocabulary sections now adapt to the available column width and stay side by side down to the minimum window size.
 
 ## 0.15.1 beta - Audio & Polish
 

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -269,13 +269,25 @@
     margin-inline: auto;
     padding: var(--page-pad-y) var(--page-pad-x) 36px;
     min-width: 0;
+    /* The sidebar eats ~220px of viewport width, so viewport media queries
+       fire far too late for this column. Query the column itself instead —
+       same pattern as the settings-panel container in Settings.svelte. */
+    container-type: inline-size;
+    container-name: insights;
   }
 
   .head {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 16px;
+    gap: 12px 16px;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  .head > div:first-child {
+    flex: 1 1 240px;
+    min-width: 0;
   }
 
   .page-h {
@@ -296,6 +308,13 @@
     gap: 8px;
     flex-wrap: wrap;
     justify-content: flex-end;
+    min-width: 0;
+    flex: 0 1 auto;
+  }
+
+  .head-filters > :global(*) {
+    min-width: 0;
+    max-width: 100%;
   }
 
   /* Match the app-mappings / tone dropdowns rather than the default pill radius. */
@@ -340,7 +359,8 @@
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
-    gap: 12px;
+    gap: 8px 12px;
+    flex-wrap: wrap;
     padding-bottom: 8px;
     margin-bottom: 14px;
     border-bottom: 1px solid var(--line);
@@ -415,8 +435,15 @@
     max-width: 380px;
   }
 
-  @media (max-width: 900px) {
-    .head { flex-direction: column; }
+  /* Container query, not viewport: the rail + sidebar decide how wide this
+     column actually is. Below ~560px the title and both dropdowns stack and
+     left-align instead of squeezing into one row. */
+  @container insights (max-width: 560px) {
+    .head { flex-direction: column; align-items: stretch; }
+    .head-filters { justify-content: flex-start; }
+    .page-sub { max-width: none; }
+    .context-picker { max-width: 100%; }
+    .range-picker { max-width: 100%; }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -61,6 +61,7 @@
       <DonutChart {segments} primaryLabel={fmtUsd(summary.total)} secondaryLabel="total" />
     {/if}
 
+    <div class="cost-scroll scroll-styled">
     <table class="cost-table">
       <thead>
         <tr>
@@ -68,7 +69,7 @@
           <th scope="col" class="num">Total usage</th>
           <th scope="col" class="num avg-usage">Average usage</th>
           <th scope="col" class="num">Est. cost</th>
-          <th scope="col" class="num">Avg. cost</th>
+          <th scope="col" class="num avg-cost">Avg. cost</th>
           <th scope="col" class="num">Share</th>
         </tr>
       </thead>
@@ -82,12 +83,13 @@
             <td class="num">{usageLabel(row)}</td>
             <td class="num avg-usage">{averageUsageLabel(row)}</td>
             <td class="num">{fmtUsd(row.cost)}</td>
-            <td class="num">{averageCostLabel(row)}</td>
+            <td class="num avg-cost">{averageCostLabel(row)}</td>
             <td class="num">{row.cost === null ? '—' : `${(row.share * 100).toFixed(1)}%`}</td>
           </tr>
         {/each}
       </tbody>
     </table>
+    </div>
 
     {#if summary.hasUnpriced}
       <p class="foot">Models shown as — have no published rate on file, so they are missing from the total.</p>
@@ -98,10 +100,16 @@
 <style>
   /* .card / .card-head / .card-h / .card-sub are owned by Insights.svelte. */
 
+  .cost-scroll {
+    margin-top: 16px;
+    overflow-x: auto;
+    min-width: 0;
+  }
+
   .cost-table {
     width: 100%;
+    min-width: 520px;
     border-collapse: collapse;
-    margin-top: 16px;
     font-size: 11.5px;
     table-layout: fixed;
   }
@@ -141,9 +149,18 @@
     color: var(--ink-mute);
   }
 
-  @media (max-width: 760px) {
-    .cost-table { table-layout: auto; }
+  /* Container query against the insights column (owned by Insights.svelte).
+     Hiding one pair of columns buys room first; the scroll container is the
+     safety net if the window goes narrower still. */
+  @container insights (max-width: 560px) {
+    .cost-table { table-layout: auto; min-width: 0; }
     .avg-usage { display: none; }
+  }
+
+  @container insights (max-width: 420px) {
+    .avg-cost { display: none; }
+    .cost-table th:first-child { width: auto; }
+    .model { overflow-wrap: anywhere; }
   }
 
   .foot {

--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -196,6 +196,8 @@
   .readout {
     text-align: right;
     white-space: nowrap;
+    min-width: 0;
+    flex-shrink: 1;
   }
   .readout-num {
     display: block;
@@ -223,10 +225,21 @@
   .axis {
     display: flex;
     justify-content: space-between;
+    gap: 8px;
     font-size: 10.5px;
     color: var(--ink-mute);
     margin-top: 2px;
+    min-width: 0;
   }
+
+  .axis span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .axis span:last-child { text-align: right; }
 
   rect { transition: fill var(--ui-duration-fast) var(--ui-ease-out), y var(--ui-duration-base) var(--ui-ease-out), height var(--ui-duration-base) var(--ui-ease-out); }
 

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -168,6 +168,13 @@
     align-items: baseline;
     gap: 10px;
     flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  .tile-relative .tile-head {
+    /* Reserve room for the absolutely-positioned delta pill so a large
+       "303.0k" reading never slides underneath it on narrow columns. */
+    padding-right: 92px;
   }
 
   .big {
@@ -238,7 +245,7 @@
 
   .gauge {
     width: 100%;
-    max-width: 150px;
+    max-width: min(150px, 100%);
     height: auto;
     display: block;
   }
@@ -292,21 +299,59 @@
     margin-left: auto;
   }
 
-  @media (max-width: 900px) {
-    .hero { grid-template-columns: 1fr; }
+  /* Container queries against the insights column (owned by Insights.svelte):
+     viewport queries fired too late because the sidebar consumes ~220px.
+     The band stays 3-up as long as possible — stacking early is what left a
+     150px gauge stranded in a full-width row with empty space beside it. */
+  @container insights (max-width: 680px) {
+    /* Compact 3-up: tighter gutters and a smaller gauge/number so all three
+       tiles still fit side by side instead of stacking. */
+    .hero { gap: 14px; }
+    .tile + .tile { padding-left: 14px; }
+    .tile-relative .tile-head { padding-right: 84px; }
+    .delta { font-size: 10px; padding: 2px 7px; }
+    .big { font-size: 24px; }
+    .big small { font-size: 15px; }
+    .gauge { max-width: min(120px, 100%); }
+    .gauge-value { font-size: 20px; }
+    .tile-note { font-size: 11.5px; }
+    .stat-num { font-size: 14px; }
+    .stat-label { font-size: 10.5px; }
+  }
+
+  @container insights (max-width: 500px) {
+    .hero { grid-template-columns: 1fr; gap: 0; }
     /* Stacked, the vertical rules become horizontal ones — same trick
        StatsCard uses when its row collapses. */
     .tile + .tile {
       border-left: 0;
       padding-left: 0;
       border-top: 1px solid var(--line);
-      padding-top: clamp(18px, 3vw, 32px);
+      padding-top: 18px;
+      margin-top: 18px;
     }
-    /* Stacked, the gauge lines up with the other two rather than floating
-       centred in its own row. */
+    /* Stacked, the gauge goes horizontal — dial on the left, labels on the
+       right — so the row reads as one full-width fact instead of a small
+       centred dial with empty space beside it. */
     .tile-gauge {
-      align-items: flex-start;
+      display: grid;
+      grid-template-columns: 110px minmax(0, 1fr);
+      column-gap: 14px;
+      align-items: center;
       text-align: left;
     }
+    .tile-gauge .gauge {
+      grid-row: span 2;
+      max-width: 110px;
+    }
+    .tile-gauge .tile-label { margin-top: 0; }
+    .tile-gauge .tile-note { margin-top: 4px; }
+  }
+
+  /* Very narrow: the delta pill joins the flow instead of floating over the
+     hero number it would otherwise collide with. */
+  @container insights (max-width: 380px) {
+    .tile-relative .tile-head { padding-right: 0; }
+    .delta { position: static; align-self: flex-start; margin-bottom: 8px; }
   }
 </style>

--- a/src/lib/views/insights/HourStrip.svelte
+++ b/src/lib/views/insights/HourStrip.svelte
@@ -119,9 +119,24 @@
   .axis {
     display: flex;
     justify-content: space-between;
+    gap: 6px;
     font-size: 10.5px;
     color: var(--ink-mute);
     margin-top: 6px;
+    min-width: 0;
+  }
+
+  .axis span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @container insights (max-width: 420px) {
+    .strip { gap: 2px; }
+    .axis span:nth-child(2),
+    .axis span:nth-child(4) { display: none; }
   }
 
   .foot {

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -98,11 +98,26 @@
 
   onMount(() => {
     if (!gridHost) return;
-    const update = () => { availableWidth = gridHost?.clientWidth ?? 640; };
+    // A window drag can deliver several ResizeObserver notifications before
+    // the next frame; writing Svelte state in each one would run the whole
+    // reactive pass (and any DOM patch) multiple times per frame. Coalesce
+    // into a single update per animation frame instead.
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      if (gridHost) availableWidth = gridHost.clientWidth;
+    };
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(update);
+    };
     update();
-    const observer = new ResizeObserver(update);
+    const observer = new ResizeObserver(schedule);
     observer.observe(gridHost);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
   });
 
   /* One label per month the grid spans, positioned above that month's first
@@ -447,8 +462,12 @@
   .legend-label-more { margin-left: 3px; }
   .legend-gap { width: 10px; }
 
-  /* Stacked, the rail's vertical rule becomes a horizontal one. */
-  @media (max-width: 900px) {
+  /* Stacked, the rail's vertical rule becomes a horizontal one.
+     Container query against the insights column (owned by Insights.svelte):
+     viewport queries fired too late because the sidebar consumes ~220px.
+     Kept at 540px so calendar + rail stay side by side through the same
+     widths where the hero band stays 3-up. */
+  @container insights (max-width: 540px) {
     .heat-layout { flex-direction: column; }
     .heat-side {
       flex: 1 1 auto;

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -271,7 +271,11 @@
     color: var(--ink-mute);
   }
 
-  @media (max-width: 860px) {
+  @container insights (max-width: 500px) {
     .split { grid-template-columns: 1fr; gap: 20px; }
+  }
+
+  @container insights (max-width: 400px) {
+    .figures { grid-template-columns: minmax(0, 1fr); gap: 12px; }
   }
 </style>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Insights is the read-only UI subsystem for local analytics (Svelte 5 + Tailwind, computed from local SQLite history, nothing leaves the machine)
> - At the 900px min window width the sidebar consumes ~220px of viewport, so viewport media queries fired too late: the hero band stacked early and stranded the 150px gauge alone in a full-width row with dead space beside it
> - This pull request switches the page to container queries against the Insights column itself, so sections stay side by side with compact sizing and only stack when truly tiny
> - The benefit is a narrow-window Insights page with no stranded whitespace, no number/pill overlap, and one less per-frame Svelte update during window drags

## What Changed

- `Insights.svelte`: `.content-inner` is now a named `insights` inline-size container (same pattern as the `settings-panel` container); header and shared `card-head` rows wrap; head stacking moved to a 560px container query
- `HeroStats.svelte`: 3-up hero band holds down to a 500px column, with a compact 500–680px mode (tighter gutters, smaller gauge/numbers/delta); below 500px it stacks with a horizontal gauge (dial left, labels right); delta pill drops into flow below 380px so it can't overlap the hero number
- `StreakHeatmap.svelte` / `WordStats.svelte`: rail/split stacking moved to container queries (540px/500px) so they stay side by side through the same widths where the hero stays 3-up
- `CostBreakdown.svelte`: table wrapped in a horizontal scroll container; average-usage / average-cost columns hide progressively at 560px / 420px instead of crushing
- `DailyChart.svelte` / `HourStrip.svelte`: axis labels truncate with ellipsis; hour axis hides alternate labels below 420px
- `StreakHeatmap.svelte`: ResizeObserver batches to one Svelte update per animation frame during window drags (same values out, fewer reactive passes)
- `docs/CHANGELOG.md`: Unreleased entry

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npx vitest run src/lib/views/insights` — 2 passed
- `npm run build` — succeeds; verified the compiled CSS contains `container: insights/inline-size` plus all 10 `@container insights` queries
- A/B perf repro (identical heavy DOM, container queries vs equivalent viewport media queries, 71 real viewport resizes with forced layout each): 95ms vs 94ms total — no measurable resize cost from container queries
- Manual check for reviewer: drag the main window to the 900px minimum width and open Insights — the hero band stays 3-up side by side; shrink further (devtools device width) to see the horizontal-gauge stacked mode. After-screenshots from a local run welcome — I verified via compiled-CSS inspection plus a static repro, not a live app screenshot.

## Risks

- Low risk: CSS-only except one behavior-preserving ResizeObserver batching change. No smoke-test selectors touched, no backend/data/migration changes.
- Container queries need Chromium 105+; the evergreen WebView2 runtime is far newer, and the build compiles them through cleanly.
- The in-flight typography-restyling session has overlapping uncommitted hunks in these same files (serif→sans, de-uppercased labels). I deliberately excluded every one of those hunks — verified zero `font-family` add/remove lines in this diff — so this PR neither absorbs nor clobbers that work. Whoever lands second may see adjacent-line context shifts, but no direct conflicts are expected.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- Muse Spark (muse-spark-1.3, Meta) via OpenCode, with tool use (file search/read/edit, shell for type-check/build/tests, local Playwright A/B perf measurement)

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) — frontend `check` passes; Rust Clippy could not link because `Verenu.WindowsChrome.dll` was locked by the running dev app (unrelated to this CSS-only change)
- [ ] `npm run test:rust` passes — not run (no Rust changes; same file-lock environment issue)
- [ ] Smoke tests pass — not run locally; leaving to PR CI (fast profile)
- [x] Tests added or updated where applicable — no new tests needed (CSS-only); existing insights unit tests pass
- [ ] UI changes include before/after screenshots — before-state shown in the issue screenshots; after-screenshots pending a local run (see Verification)
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together — no version bump
- [x] Relevant documentation updated to reflect changes — CHANGELOG Unreleased entry added
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791012030&installation_model_id=432577&pr_number=334&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F334&signature=a691af46da9a5cc378b42b745a3f66135f65345f6daeaef2d461c11698ae9653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->