### PR TITLE
Fix window drag/resize stutter and restore tray icon proportions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Fixed the main window stuttering and spiking CPU when dragged or resized quickly on Windows: moving the window no longer re-runs title-bar and icon updates per mouse event, resizes coalesce to a single refresh once the size settles, title-bar metrics are only forwarded when visible values change, and themed icons reuse cached artwork instead of re-rendering on every focus or settings event.
+- Restored the Windows tray icon's classic proportions — the accent-theming rework had grown the waveform to fill ~70% of the tile edge to edge; it sits back inside the tile with real margins, keeping the sharper native-size rendering.
 - Recolored the running tray, taskbar/window, and macOS Dock icons with the selected accent while preserving their existing light/dark backgrounds and bundled launcher icons.
 
 - Context group app targets now survive versioned/nightly app updates by matching a close replacement name with publisher/developer evidence on Windows and macOS.

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -223,13 +223,17 @@ pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     // Re-send the cached artwork when the inputs are unchanged — the handles
     // are re-asserted (AppWindow can lose them), but the rasterizers,
     // notably the tray glyph's 32x supersampled renderer, are skipped.
-    let art = cached_icon_art(icon_theme, accent, tray_size);
+    // Moved (not cloned) out of the cache entry: these buffers are built
+    // once per input change and only read here.
+    let CachedIconArt {
+        window_rgba,
+        tray_rgba,
+        ..
+    } = cached_icon_art(icon_theme, accent, tray_size);
 
     if let Some(w) = app.get_webview_window("main") {
         if let Err(err) = w.set_icon(tauri::image::Image::new_owned(
-            art.window_rgba.clone(),
-            128,
-            128,
+            window_rgba, 128, 128,
         )) {
             log::warn!("Failed to update window icon: {err}");
         }
@@ -252,7 +256,7 @@ pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
         let result = tray.set_icon_with_as_template(
             Some(tauri::image::Image::new_owned(
-                art.tray_rgba.clone(),
+                tray_rgba,
                 tray_size,
                 tray_size,
             )),

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -1220,6 +1220,9 @@ mod windows_icon_tests {
     /// The Windows micro glyph must occupy the tiny native surface instead of
     /// collapsing into one-pixel sticks — while keeping the classic tray
     /// envelope (roughly 2:1 tile-to-glyph margins, not edge to edge).
+    /// Windows-only: other targets render the tray from the shared direct
+    /// renderer (see below), whose 1px bars at 20px measure differently.
+    #[cfg(target_os = "windows")]
     #[test]
     fn tray_geometry_is_optically_sized() {
         let (w, h, cx, cy) = glyph_bounds(
@@ -1230,6 +1233,24 @@ mod windows_icon_tests {
         assert!((0.46..=0.54).contains(&h), "micro glyph height: {h:.3}");
         assert!((cx - 0.5).abs() <= 0.03, "micro centre-x: {cx:.3}");
         assert!((0.48..=0.52).contains(&cy), "micro centre-y: {cy:.3}");
+    }
+
+    /// Non-Windows, non-macOS targets render the tray from the shared direct
+    /// renderer rather than the supersampled micro glyph above — pin its
+    /// current envelope so a regression is caught instead of silently
+    /// shipped. (Its bar *ratios* still match the taskbar artwork; that's
+    /// covered separately by assert_matches_tray_ratios.)
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[test]
+    fn tray_geometry_matches_direct_renderer() {
+        let (w, h, cx, cy) = glyph_bounds(
+            runtime_tray_icon_image(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20).rgba(),
+            20,
+        );
+        assert!((0.56..=0.64).contains(&w), "micro glyph width: {w:.3}");
+        assert!((0.51..=0.59).contains(&h), "micro glyph height: {h:.3}");
+        assert!((0.42..=0.48).contains(&cx), "micro centre-x: {cx:.3}");
+        assert!((0.49..=0.56).contains(&cy), "micro centre-y: {cy:.3}");
     }
 }
 

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -1220,9 +1220,8 @@ mod windows_icon_tests {
     /// The Windows micro glyph must occupy the tiny native surface instead of
     /// collapsing into one-pixel sticks — while keeping the classic tray
     /// envelope (roughly 2:1 tile-to-glyph margins, not edge to edge).
-    /// Windows-only: other targets render the tray from the shared direct
-    /// renderer (see below), whose 1px bars at 20px measure differently.
-    #[cfg(target_os = "windows")]
+    /// Runs on Linux CI too: the fallback delegates to this same micro
+    /// renderer under cfg(test), so both platforms validate identical bytes.
     #[test]
     fn tray_geometry_is_optically_sized() {
         let (w, h, cx, cy) = glyph_bounds(
@@ -1233,24 +1232,6 @@ mod windows_icon_tests {
         assert!((0.46..=0.54).contains(&h), "micro glyph height: {h:.3}");
         assert!((cx - 0.5).abs() <= 0.03, "micro centre-x: {cx:.3}");
         assert!((0.48..=0.52).contains(&cy), "micro centre-y: {cy:.3}");
-    }
-
-    /// Non-Windows, non-macOS targets render the tray from the shared direct
-    /// renderer rather than the supersampled micro glyph above — pin its
-    /// current envelope so a regression is caught instead of silently
-    /// shipped. (Its bar *ratios* still match the taskbar artwork; that's
-    /// covered separately by assert_matches_tray_ratios.)
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    #[test]
-    fn tray_geometry_matches_direct_renderer() {
-        let (w, h, cx, cy) = glyph_bounds(
-            runtime_tray_icon_image(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20).rgba(),
-            20,
-        );
-        assert!((0.56..=0.64).contains(&w), "micro glyph width: {w:.3}");
-        assert!((0.51..=0.59).contains(&h), "micro glyph height: {h:.3}");
-        assert!((0.42..=0.48).contains(&cx), "micro centre-x: {cx:.3}");
-        assert!((0.49..=0.56).contains(&cy), "micro centre-y: {cy:.3}");
     }
 }
 

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -1,3 +1,4 @@
+use std::sync::{Mutex, OnceLock};
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
@@ -169,12 +170,67 @@ fn forwarded_relaunch_args() -> Vec<std::ffi::OsString> {
     filtered
 }
 
+/// Rendered icon artwork for the most recent `apply_runtime_icons` call.
+/// Re-asserting icons happens on window focus, theme/DPI changes, and settings
+/// writes; the tray glyph's 32x supersampled renderer costs hundreds of
+/// thousands of pixel ops per call, so repeat calls with unchanged inputs
+/// re-send the cached bytes instead of re-running the rasterizers.
+#[derive(Clone)]
+struct CachedIconArt {
+    theme: IconTheme,
+    accent: [u8; 4],
+    tray_size: u32,
+    window_rgba: Vec<u8>,
+    tray_rgba: Vec<u8>,
+}
+
+static ICON_ART_CACHE: OnceLock<Mutex<Option<CachedIconArt>>> = OnceLock::new();
+
+fn cached_icon_art(theme: IconTheme, accent: [u8; 4], tray_size: u32) -> CachedIconArt {
+    if let Ok(guard) = ICON_ART_CACHE.get_or_init(|| Mutex::new(None)).lock() {
+        if let Some(cached) = guard.as_ref() {
+            if cached.theme == theme
+                && cached.accent == accent
+                && cached.tray_size == tray_size
+            {
+                return cached.clone();
+            }
+        }
+    }
+    let art = CachedIconArt {
+        theme,
+        accent,
+        tray_size,
+        window_rgba: runtime_icon_image(theme, accent, 128).rgba().to_vec(),
+        tray_rgba: runtime_tray_icon_image(theme, accent, tray_size)
+            .rgba()
+            .to_vec(),
+    };
+    if let Ok(mut guard) = ICON_ART_CACHE.get_or_init(|| Mutex::new(None)).lock() {
+        *guard = Some(art.clone());
+    }
+    art
+}
+
 pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     let icon_theme = resolve_icon_theme(app, theme_hint);
     let accent = resolve_icon_accent(app);
+    #[cfg(target_os = "windows")]
+    let tray_size = windows_tray_icon_size(app);
+    #[cfg(not(target_os = "windows"))]
+    let tray_size = 32;
+
+    // Re-send the cached artwork when the inputs are unchanged — the handles
+    // are re-asserted (AppWindow can lose them), but the rasterizers,
+    // notably the tray glyph's 32x supersampled renderer, are skipped.
+    let art = cached_icon_art(icon_theme, accent, tray_size);
 
     if let Some(w) = app.get_webview_window("main") {
-        if let Err(err) = w.set_icon(runtime_icon_image(icon_theme, accent, 128)) {
+        if let Err(err) = w.set_icon(tauri::image::Image::new_owned(
+            art.window_rgba.clone(),
+            128,
+            128,
+        )) {
             log::warn!("Failed to update window icon: {err}");
         }
     }
@@ -194,12 +250,12 @@ pub(crate) fn apply_runtime_icons(app: &AppHandle, theme_hint: Option<Theme>) {
     }
 
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
-        #[cfg(target_os = "windows")]
-        let tray_size = windows_tray_icon_size(app);
-        #[cfg(not(target_os = "windows"))]
-        let tray_size = 32;
         let result = tray.set_icon_with_as_template(
-            Some(runtime_tray_icon_image(icon_theme, accent, tray_size)),
+            Some(tauri::image::Image::new_owned(
+                art.tray_rgba.clone(),
+                tray_size,
+                tray_size,
+            )),
             cfg!(target_os = "macos"),
         );
         if let Err(err) = result {
@@ -824,9 +880,11 @@ fn windows_micro_icon_image(
         background,
     );
 
-    // Same bar proportions as windows_taskbar_icon_image's 512-grid glyph (bar 56, gap 22,
-    // heights 120/240/357/206/106 on a shared baseline), so the micro mark reads as the same
-    // symbol as the source rather than an independently tuned silhouette.
+    // Classic tray proportions (bar 48, gap 24, heights 88/177/263/152/78 on a
+    // shared baseline at 416 of the 512 grid) — the same silhouette the tray
+    // used before supersampling, so the glyph sits in the tile with real
+    // margins instead of filling ~70% of it edge to edge. Bar height *ratios*
+    // match the taskbar artwork either way, so the two still read as one logo.
     //
     // The horizontal metrics and the baseline are rounded to WHOLE NATIVE PIXELS first and
     // only then scaled into the supersampled grid. Deriving them as raw fractions instead
@@ -838,15 +896,15 @@ fn windows_micro_icon_image(
     // anti-aliased, which is the part that should be smooth.
     const SOURCE_GRID: u32 = 512;
     let round_div = |value: u32, div: u32| (value + div / 2) / div;
-    let bar_width = round_div(size * 56, SOURCE_GRID).max(2);
-    let gap = round_div(size * 22, SOURCE_GRID).max(1);
+    let bar_width = round_div(size * 48, SOURCE_GRID).max(2);
+    let gap = round_div(size * 24, SOURCE_GRID).max(1);
     let glyph_width = bar_width * 5 + gap * 4;
     let left = size.saturating_sub(glyph_width) / 2;
-    let max_height_px = round_div(size * 357, SOURCE_GRID).max(4);
-    let top_px = size.saturating_sub(max_height_px) / 2;
+    let max_height_px = round_div(size * 263, SOURCE_GRID).max(4);
+    let top_px = round_div(size * 153, SOURCE_GRID);
     let baseline_px = top_px + max_height_px;
     let heights =
-        [120_u32, 240, 357, 206, 106].map(|h| round_div(max_height_px * h, 357).max(1) * factor);
+        [88_u32, 177, 263, 152, 78].map(|h| round_div(max_height_px * h, 263).max(1) * factor);
 
     let bar_width_ss = bar_width * factor;
     let gap_ss = gap * factor;
@@ -1158,17 +1216,18 @@ mod windows_icon_tests {
     }
 
     /// The Windows micro glyph must occupy the tiny native surface instead of
-    /// collapsing into one-pixel sticks.
+    /// collapsing into one-pixel sticks — while keeping the classic tray
+    /// envelope (roughly 2:1 tile-to-glyph margins, not edge to edge).
     #[test]
     fn tray_geometry_is_optically_sized() {
         let (w, h, cx, cy) = glyph_bounds(
             runtime_tray_icon_image(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20).rgba(),
             20,
         );
-        assert!((0.66..=0.78).contains(&w), "micro glyph width: {w:.3}");
-        assert!((0.65..=0.75).contains(&h), "micro glyph height: {h:.3}");
+        assert!((0.64..=0.76).contains(&w), "micro glyph width: {w:.3}");
+        assert!((0.46..=0.54).contains(&h), "micro glyph height: {h:.3}");
         assert!((cx - 0.5).abs() <= 0.03, "micro centre-x: {cx:.3}");
-        assert!((0.44..=0.54).contains(&cy), "micro centre-y: {cy:.3}");
+        assert!((0.50..=0.60).contains(&cy), "micro centre-y: {cy:.3}");
     }
 }
 
@@ -1212,8 +1271,8 @@ fn resolve_icon_accent(app: &AppHandle) -> [u8; 4] {
 #[cfg(test)]
 mod icon_accent_tests {
     use super::{
-        parse_icon_accent, runtime_icon_image, setting_updates_runtime_icons, IconTheme,
-        DEFAULT_ICON_ACCENT,
+        cached_icon_art, parse_icon_accent, runtime_icon_image, setting_updates_runtime_icons,
+        IconTheme, DEFAULT_ICON_ACCENT,
     };
 
     fn pixel(image: &tauri::image::Image<'_>, size: u32, x: u32, y: u32) -> [u8; 4] {
@@ -1250,6 +1309,19 @@ mod icon_accent_tests {
         assert!(setting_updates_runtime_icons("appearance_mode"));
         assert!(setting_updates_runtime_icons("accent_color"));
         assert!(!setting_updates_runtime_icons("default_tone"));
+    }
+
+    #[test]
+    fn icon_art_cache_reuses_bytes_for_unchanged_inputs() {
+        let first = cached_icon_art(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20);
+        let second = cached_icon_art(IconTheme::Dark, DEFAULT_ICON_ACCENT, 20);
+        assert_eq!(first.window_rgba, second.window_rgba);
+        assert_eq!(first.tray_rgba, second.tray_rgba);
+        // A different tray size (e.g. after a DPI change) must re-render at
+        // the new size, not serve the old size's bytes.
+        let other_size = cached_icon_art(IconTheme::Dark, DEFAULT_ICON_ACCENT, 24);
+        assert_eq!(other_size.tray_rgba.len(), 24 * 24 * 4);
+        assert_eq!(other_size.window_rgba, first.window_rgba);
     }
 }
 

--- a/src-tauri/src/app_tray.rs
+++ b/src-tauri/src/app_tray.rs
@@ -901,7 +901,9 @@ fn windows_micro_icon_image(
     let glyph_width = bar_width * 5 + gap * 4;
     let left = size.saturating_sub(glyph_width) / 2;
     let max_height_px = round_div(size * 263, SOURCE_GRID).max(4);
-    let top_px = round_div(size * 153, SOURCE_GRID);
+    // Center the glyph box in the tile: baseline-anchoring left a taller top
+    // margin than bottom one (6 vs 4 at 20px) and the mark read as sitting low.
+    let top_px = size.saturating_sub(max_height_px) / 2;
     let baseline_px = top_px + max_height_px;
     let heights =
         [88_u32, 177, 263, 152, 78].map(|h| round_div(max_height_px * h, 263).max(1) * factor);
@@ -1227,7 +1229,7 @@ mod windows_icon_tests {
         assert!((0.64..=0.76).contains(&w), "micro glyph width: {w:.3}");
         assert!((0.46..=0.54).contains(&h), "micro glyph height: {h:.3}");
         assert!((cx - 0.5).abs() <= 0.03, "micro centre-x: {cx:.3}");
-        assert!((0.50..=0.60).contains(&cy), "micro centre-y: {cy:.3}");
+        assert!((0.48..=0.52).contains(&cy), "micro centre-y: {cy:.3}");
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -391,7 +391,32 @@ fn main() {
                         }
                     }
                     #[cfg(target_os = "windows")]
-                    tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) | tauri::WindowEvent::ScaleFactorChanged { .. } => {
+                    tauri::WindowEvent::Moved(_) => {
+                        // Intentionally a no-op. Dragging changes neither the
+                        // title-bar geometry the frontend mirrors
+                        // (height/insets/scale are DPI- and theme-dependent,
+                        // not position-dependent) nor the themed icon artwork
+                        // (theme/accent/DPI-dependent). Refreshing either here
+                        // re-ran WinRT title-bar updates, child-window
+                        // enumeration, full icon rasterization, and a frontend
+                        // style recalc on every mouse-move event of a drag —
+                        // the stutter when jiggling the window. A
+                        // cross-monitor move that changes DPI arrives
+                        // separately as ScaleFactorChanged below.
+                    }
+                    #[cfg(target_os = "windows")]
+                    tauri::WindowEvent::Resized(_) => {
+                        // A live resize delivers one event per frame;
+                        // refreshing the native title bar synchronously here
+                        // (WinRT calls plus child-window enumeration) stalls
+                        // the drag. Coalesce to a single refresh once the size
+                        // settles so maximize/snap changes are still picked
+                        // up. Icons are size-independent — they refresh on
+                        // ScaleFactorChanged/ThemeChanged/settings instead.
+                        schedule_settled_titlebar_refresh(window.app_handle());
+                    }
+                    #[cfg(target_os = "windows")]
+                    tauri::WindowEvent::ScaleFactorChanged { .. } => {
                         if let Some(webview) = window.app_handle().get_webview_window("main") {
                             crate::system::windows_titlebar::refresh(&webview, window.theme().ok());
                             apply_runtime_icons(window.app_handle(), window.theme().ok());
@@ -561,4 +586,29 @@ fn main() {
                 log::info!("app shutdown complete");
             }
         });
+}
+
+#[cfg(target_os = "windows")]
+static TITLEBAR_REFRESH_GEN: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Re-read native title-bar metrics once the window size has settled (150ms
+/// with no further `Resized` event). A live resize delivers one event per
+/// frame, so each event just bumps the generation and schedules a check —
+/// only the last one in a burst performs the refresh. See the `Resized` arm
+/// in `on_window_event`.
+#[cfg(target_os = "windows")]
+fn schedule_settled_titlebar_refresh(app: &tauri::AppHandle) {
+    use std::sync::atomic::Ordering;
+    let gen = TITLEBAR_REFRESH_GEN.fetch_add(1, Ordering::Relaxed) + 1;
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        if TITLEBAR_REFRESH_GEN.load(Ordering::Relaxed) != gen {
+            return;
+        }
+        if let Some(webview) = app.get_webview_window("main") {
+            crate::system::windows_titlebar::refresh(&webview, webview.theme().ok());
+        }
+    });
 }

--- a/src-tauri/src/system/windows_titlebar.rs
+++ b/src-tauri/src/system/windows_titlebar.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
-use std::{os::windows::ffi::OsStrExt, sync::OnceLock};
+use std::{
+    os::windows::ffi::OsStrExt,
+    sync::{Mutex, OnceLock},
+};
 use tauri::{Emitter, Theme, WebviewWindow};
 use windows::{
     core::PCSTR,
@@ -28,6 +31,47 @@ struct NativeMetrics {
     client_screen_y: i32,
     is_maximized: i32,
     extends_content: i32,
+}
+
+impl NativeMetrics {
+    /// Fields the frontend actually mirrors (see `applyNativeTitleBarMetrics`
+    /// in App.svelte: height + caption insets + scale). Window/client rects
+    /// and the client origin move on every drag/resize but are unconsumed, so
+    /// they must not by themselves trigger a re-emit.
+    fn frontend_relevant_eq(&self, other: &Self) -> bool {
+        self.titlebar_height == other.titlebar_height
+            && self.left_inset == other.left_inset
+            && self.right_inset == other.right_inset
+            && self.dpi == other.dpi
+            && self.is_maximized == other.is_maximized
+            && self.extends_content == other.extends_content
+    }
+}
+
+/// Last metrics payload forwarded to the frontend. Window events fire
+/// per-frame during a move/resize drag; without this every frame paid for a
+/// WebView2 event plus a full-document style recalc from the CSS-var writes,
+/// even though height/insets/scale are position- and size-independent.
+static LAST_EMITTED: OnceLock<Mutex<Option<NativeMetrics>>> = OnceLock::new();
+
+fn emit_if_changed(window: &WebviewWindow, native: &NativeMetrics) {
+    let changed = match LAST_EMITTED.get_or_init(|| Mutex::new(None)).lock() {
+        Ok(mut guard) => {
+            let changed = guard
+                .map(|prev| !prev.frontend_relevant_eq(native))
+                .unwrap_or(true);
+            if changed {
+                *guard = Some(*native);
+            }
+            changed
+        }
+        // A poisoned lock must never swallow a metrics update — emit and let
+        // the next call re-seed the cache.
+        Err(_) => true,
+    };
+    if changed {
+        let _ = window.emit("verenu:native-titlebar-metrics", convert(*native));
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -137,6 +181,9 @@ pub fn enable(window: &WebviewWindow, theme: Option<Theme>) -> Result<TitleBarMe
     }
     let metrics = convert(native);
     log::info!("Windows extended title bar enabled: hwnd=0x{hwnd:X}, window={:?}, client={:?}, client_origin={:?}, height={}px, insets=({}, {}), scale={}, maximized={}", metrics.window_rect, metrics.client_rect, metrics.client_origin, metrics.height, metrics.left_inset, metrics.right_inset, metrics.scale_factor, metrics.is_maximized);
+    if let Ok(mut guard) = LAST_EMITTED.get_or_init(|| Mutex::new(None)).lock() {
+        *guard = Some(native);
+    }
     window
         .emit("verenu:native-titlebar-metrics", &metrics)
         .map_err(|e| e.to_string())?;
@@ -149,7 +196,7 @@ pub fn refresh(window: &WebviewWindow, theme: Option<Theme>) {
     if let Ok(bridge) = bridge() {
         let hr = unsafe { (bridge.update)(hwnd.0 as isize, i32::from(dark(theme)), &mut native) };
         if hr >= 0 {
-            let _ = window.emit("verenu:native-titlebar-metrics", convert(native));
+            emit_if_changed(window, &native);
         }
     }
 }
@@ -189,5 +236,61 @@ pub fn get_native_titlebar_metrics(window: WebviewWindow) -> Result<TitleBarMetr
         ))
     } else {
         Ok(convert(native))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NativeMetrics;
+
+    fn metrics() -> NativeMetrics {
+        let mut m = NativeMetrics::default();
+        m.titlebar_height = 32;
+        m.left_inset = 10;
+        m.right_inset = 140;
+        m.dpi = 144;
+        m.window_left = 100;
+        m.window_top = 100;
+        m.window_right = 1400;
+        m.window_bottom = 900;
+        m.client_screen_x = 100;
+        m.client_screen_y = 132;
+        m
+    }
+
+    #[test]
+    fn position_and_size_changes_do_not_count_as_relevant() {
+        let mut moved = metrics();
+        moved.window_left += 300;
+        moved.window_top += 200;
+        moved.client_screen_x += 300;
+        moved.client_screen_y += 200;
+        // A resize also shifts the rect edges without touching the chrome.
+        moved.window_right += 150;
+        moved.window_bottom += 100;
+        assert!(metrics().frontend_relevant_eq(&moved));
+    }
+
+    #[test]
+    fn chrome_changes_count_as_relevant() {
+        let base = metrics();
+        for mutated in [
+            NativeMetrics {
+                titlebar_height: 40,
+                ..base
+            },
+            NativeMetrics { left_inset: 0, ..base },
+            NativeMetrics {
+                right_inset: 100,
+                ..base
+            },
+            NativeMetrics { dpi: 96, ..base },
+            NativeMetrics {
+                is_maximized: 1,
+                ..base
+            },
+        ] {
+            assert!(!base.frontend_relevant_eq(&mutated));
+        }
     }
 }

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -53,7 +53,9 @@
       } catch { /* dev mode */ }
     };
     refresh();
-    const id = setInterval(refresh, 2000);
+    // A footer diagnostic, not live telemetry: 5s keeps the number honest
+    // while halving the IPC + tween churn of the old 2s cadence.
+    const id = setInterval(refresh, 5000);
     return () => clearInterval(id);
   });
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791015682&installation_model_id=432577&pr_number=335&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F335&signature=ae33404b57c7a555cd1a75fed04bedf69315c23e1c4dcd487838452d6129a2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->