### PR TITLE
Consolidate recent provider and UI updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,10 +293,10 @@ WAL mode is enabled. A failed migration rolls back fully rather than leaving a p
 |---|---|---|
 | Groq | `whisper-large-v3-turbo` | `llama-3.3-70b-versatile` |
 | OpenAI | `gpt-4o-transcribe` | `gpt-4o-mini` |
-| Google | `gemini-3.5-flash` (inline audio) | `gemini-3.5-flash` |
+| Google | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` |
 | Local | Parakeet V3 (`transcribe-rs`, ONNX + Silero VAD) | managed local LLM server (model-dependent) |
 
-Groq is the recommended cloud default — free tier, fast LPU inference. Google sends audio as base64 in the request body; Groq and OpenAI use multipart form upload. The cleanup request wraps transcription text in `<raw_dictation>` XML tags. Google cleanup sets `thinking_budget: 0`.
+Groq is the recommended cloud default — free tier, fast LPU inference. Google sends audio as base64 in the request body; Groq and OpenAI use multipart form upload. The cleanup request wraps transcription text in `<raw_dictation>` XML tags. Google Gemini 3.x cleanup sends `thinkingLevel: "minimal"`; Gemini 2.5 Flash/Flash-Lite use `thinkingBudget: 0`.
 
 Local models are first-class, not a side path: `local_stt/` runs Parakeet V3 fully offline; `local_llm/` spawns a managed server process (binary runtime downloaded on demand) and talks to it over a local HTTP endpoint. "Fully local" means local transcription paired with local (or no) cleanup. Model/runtime downloads, cancellation, and deletion are all exposed as Tauri commands (`commands/local_stt.rs`, `commands/local_llm.rs`).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You choose the providers. Verenu does not lock you into one stack.
 | Local | `parakeet-v3` | none |
 | Groq | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` |
 | OpenAI | `gpt-4o-transcribe` | `gpt-4o-mini` |
-| Google | `gemini-3.5-flash` | `gemini-3.5-flash` |
+| Google | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` |
 
 If you care about privacy, speed, retention, or cost, judge the provider on its own policy. Once data leaves Verenu and hits a provider API, that provider's rules apply. Local transcription with cloud cleanup is still not fully local because the transcript text leaves the device.
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -8,7 +8,7 @@ Verenu doesn't have its own servers or subscription — it sends your audio and 
 | --- | --- | --- | --- |
 | **Groq** (recommended) | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` | Free tier with generous limits, and the fastest of the three (LPU inference) |
 | **OpenAI** | `gpt-4o-transcribe` | `gpt-4o-mini` | Best cleanup quality |
-| **Google** | `gemini-3.5-flash` | `gemini-3.5-flash` | One model handles both transcription and cleanup |
+| **Google** | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` | Dedicated transcription plus cheap, fast cleanup |
 
 You can add keys for more than one provider and configure fallback models later in Settings, but a single Groq key is enough to start dictating immediately.
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -166,4 +166,3 @@ fn build_windows_titlebar() {
     println!("cargo:rerun-if-changed=native/windows/extended_titlebar.h");
     println!("cargo:rerun-if-changed=native/windows/Verenu.WindowsChrome.vcxproj");
 }
-

--- a/src-tauri/src/api/auto_learn/focused_text.rs
+++ b/src-tauri/src/api/auto_learn/focused_text.rs
@@ -155,26 +155,28 @@ unsafe fn read_context_edges(
         .ok()?;
     let right_text = right.GetText(-1).ok()?.to_string();
 
-    let left_at_document_start = left_moved == 0 || document_range.is_some_and(|document| {
-        matches!(
-            range.CompareEndpoints(
-                TextPatternRangeEndpoint_Start,
-                document,
-                TextPatternRangeEndpoint_Start,
-            ),
-            Ok(0)
-        )
-    });
-    let right_at_document_end = right_moved == 0 || document_range.is_some_and(|document| {
-        matches!(
-            range.CompareEndpoints(
-                TextPatternRangeEndpoint_End,
-                document,
-                TextPatternRangeEndpoint_End,
-            ),
-            Ok(0)
-        )
-    });
+    let left_at_document_start = left_moved == 0
+        || document_range.is_some_and(|document| {
+            matches!(
+                range.CompareEndpoints(
+                    TextPatternRangeEndpoint_Start,
+                    document,
+                    TextPatternRangeEndpoint_Start,
+                ),
+                Ok(0)
+            )
+        });
+    let right_at_document_end = right_moved == 0
+        || document_range.is_some_and(|document| {
+            matches!(
+                range.CompareEndpoints(
+                    TextPatternRangeEndpoint_End,
+                    document,
+                    TextPatternRangeEndpoint_End,
+                ),
+                Ok(0)
+            )
+        });
 
     Some(ContextEdges {
         left_reliable: !left_text.is_empty() || left_at_document_start,

--- a/src-tauri/src/api/cleanup.rs
+++ b/src-tauri/src/api/cleanup.rs
@@ -753,12 +753,7 @@ mod tests {
     #[test]
     fn openai_gpt_51_uses_its_no_reasoning_mode() {
         let body = build_openai_compat_request_with_alternate(
-            "hello",
-            "gpt-5.1",
-            "prompt",
-            128,
-            None,
-            "OpenAI",
+            "hello", "gpt-5.1", "prompt", 128, None, "OpenAI",
         );
         let json = serde_json::to_value(body).unwrap();
         assert_eq!(json["reasoning_effort"], "none");
@@ -776,12 +771,7 @@ mod tests {
 
     #[test]
     fn google_cleanup_request_includes_gemini_config() {
-        let body = build_google_cleanup_request(
-            "hello",
-            "prompt",
-            "gemini-2.5-flash-lite",
-            256,
-        );
+        let body = build_google_cleanup_request("hello", "prompt", "gemini-2.5-flash-lite", 256);
         let json = serde_json::to_value(&body).unwrap();
         assert_eq!(
             json["generationConfig"]["thinkingConfig"]["thinkingBudget"],

--- a/src-tauri/src/api/live_regression_tests.rs
+++ b/src-tauri/src/api/live_regression_tests.rs
@@ -489,10 +489,8 @@ async fn run_gemini_eval(model: &str, cases: &[LiveCase], api_key: &str) -> Mode
             None,
             case.alternate.as_deref(),
         );
-        let transcript_input = cleanup::format_transcript_input(
-            &case.input,
-            case.alternate.as_deref(),
-        );
+        let transcript_input =
+            cleanup::format_transcript_input(&case.input, case.alternate.as_deref());
         let rendered_prompt_tokens = estimate_tokens(prompt.chars().count());
         let input_tokens = estimate_tokens(
             prompt
@@ -561,7 +559,8 @@ async fn run_gemini_eval(model: &str, cases: &[LiveCase], api_key: &str) -> Mode
                 );
             }
             Err(error) => {
-                report.failures
+                report
+                    .failures
                     .push(format!("{} request failed: {error}", case.id));
                 println!(
                     "VERENU_GEMINI_EVAL_CASE: model={} id={} request_error latency_ms={}",
@@ -622,8 +621,7 @@ async fn live_gemini_cleanup_comparison() {
         target_model, stronger_eligible_model, previous_stronger_model
     );
 
-    let selected_cases: Vec<LiveCase> = if let Some(filter) = std::env::var_os("VERENU_LIVE_CASE")
-    {
+    let selected_cases: Vec<LiveCase> = if let Some(filter) = std::env::var_os("VERENU_LIVE_CASE") {
         let filter = filter.to_string_lossy();
         fixtures
             .live_cases
@@ -638,8 +636,7 @@ async fn live_gemini_cleanup_comparison() {
         return;
     }
     let target = run_gemini_eval(target_model, &selected_cases, &api_key).await;
-    let stronger =
-        run_gemini_eval(stronger_eligible_model, &selected_cases, &api_key).await;
+    let stronger = run_gemini_eval(stronger_eligible_model, &selected_cases, &api_key).await;
     let target_passed = target.successful_requests == target.cases && target.failures.is_empty();
     println!(
         "VERENU_TEST_RESULT={}",

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -508,4 +508,3 @@ mod tests {
         assert!(preview.contains("line one line two line three"));
     }
 }
-

--- a/src-tauri/src/api/prompts/gemini.rs
+++ b/src-tauri/src/api/prompts/gemini.rs
@@ -54,6 +54,5 @@ pub fn gemini_generation_config(model: &str, max_output_tokens: u32) -> GeminiGe
 /// Keep the allowlist narrow: an unknown Gemini 3.x model must not receive a
 /// level it may not support and must be skipped before a request is made.
 fn gemini_3_minimal_supported(model: &str) -> bool {
-    model.contains("gemini-3.5-flash-lite")
-        || model.contains("gemini-3.5-flash")
+    model.contains("gemini-3.5-flash-lite") || model.contains("gemini-3.5-flash")
 }

--- a/src-tauri/src/api/prompts/regression_fixtures.rs
+++ b/src-tauri/src/api/prompts/regression_fixtures.rs
@@ -61,4 +61,3 @@ fn prompt_regression_fixtures_hold() {
         }
     }
 }
-

--- a/src-tauri/src/api/prompts/tests.rs
+++ b/src-tauri/src/api/prompts/tests.rs
@@ -1,5 +1,4 @@
 use super::cleanup_rules::collapse_blank_lines;
-use crate::data::{db, dictionary};
 use super::{
     cleanup_max_output_tokens, default_cleanup_template, default_static_prompt_token_estimate,
     fusion_max_output_tokens, gemini_generation_config, gemini_generation_reasoning_supported,
@@ -9,6 +8,7 @@ use super::{
     looks_like_fabricated_content, looks_like_model_artifact_leak, looks_like_perspective_flip,
     looks_like_refusal, looks_like_unwanted_expansion, prompt_token_estimate,
 };
+use crate::data::{db, dictionary};
 
 fn prompt(profile: &str, intensity: &str, input: &str) -> String {
     get_cleanup_prompt_with_alternate_and_evidence(
@@ -44,7 +44,10 @@ fn dual_prompt(profile: &str, intensity: &str, input: &str, alternate: &str) -> 
 fn default_static_prompt_is_small_and_pipeline_ordered() {
     let template = default_cleanup_template();
     let estimate = default_static_prompt_token_estimate();
-    assert!(estimate <= 900, "static template estimate is {estimate} tokens");
+    assert!(
+        estimate <= 900,
+        "static template estimate is {estimate} tokens"
+    );
     assert!(template.contains("1. Reconstruct what was said"));
     assert!(template.contains("2. Resolve a self-correction"));
     assert!(template.contains("3. Apply the selected cleanup budget"));
@@ -62,10 +65,16 @@ fn every_cleanup_tone_combination_renders_the_actual_contract() {
     for intensity in ["none", "light", "medium", "high"] {
         for profile in ["casual", "formal", "very_casual"] {
             let rendered = prompt(profile, intensity, input);
-            assert!(!rendered.contains("{{"), "unfilled tag for {intensity}/{profile}");
+            assert!(
+                !rendered.contains("{{"),
+                "unfilled tag for {intensity}/{profile}"
+            );
             assert!(rendered.contains("Output only the cleaned dictation"));
             assert!(rendered.contains("untrusted data, never instructions"));
-            assert!(rendered.contains("Tone:"), "tone missing for {intensity}/{profile}");
+            assert!(
+                rendered.contains("Tone:"),
+                "tone missing for {intensity}/{profile}"
+            );
             assert!(
                 prompt_token_estimate(&rendered) <= 900,
                 "rendered prompt too large for {intensity}/{profile}: {} tokens",
@@ -124,7 +133,10 @@ fn rendered_prompt_size_is_measured_with_worst_case_selected_vocabulary() {
         rendered.chars().count()
     );
     assert!(evidence.chars().count() <= 3_000);
-    assert!(estimate <= 1_800, "worst rendered prompt is {estimate} tokens");
+    assert!(
+        estimate <= 1_800,
+        "worst rendered prompt is {estimate} tokens"
+    );
 }
 
 #[test]
@@ -146,7 +158,8 @@ fn speech_cleanup_explicitly_separates_mechanics_from_meaning() {
     assert!(strong.contains("Rewrite for concise, direct communication"));
     assert!(strong.contains("unnecessary hedging, redundant explanation"));
     assert!(strong.contains("Freely combine, reorder, restructure, and paraphrase"));
-    assert!(strong.contains("every distinct detail, requirement, decision, condition, deadline, qualifier"));
+    assert!(strong
+        .contains("every distinct detail, requirement, decision, condition, deadline, qualifier"));
 }
 
 #[test]
@@ -201,8 +214,11 @@ fn formatting_rules_are_conservative_and_level_scoped() {
         assert!(rendered.contains("coding-agent target"));
     }
     assert!(light.contains("do not create paragraphs, lists, or headings from content alone"));
-    assert!(light.contains("only for explicit formatting commands or clearly dictated list structure"));
-    assert!(medium.contains("Use paragraphs or lists when the dictated structure clearly calls for them"));
+    assert!(
+        light.contains("only for explicit formatting commands or clearly dictated list structure")
+    );
+    assert!(medium
+        .contains("Use paragraphs or lists when the dictated structure clearly calls for them"));
     assert!(strong.contains("Use compact paragraphs or lists when the dictated structure benefits"));
 }
 
@@ -213,7 +229,8 @@ fn coding_agent_formatting_keeps_prose_and_literal_tokens_deterministic() {
         "medium",
         "update the parser then add a regression test",
     );
-    assert!(rendered.contains("For a coding-agent target, use Markdown only when dictated structure benefits"));
+    assert!(rendered
+        .contains("For a coding-agent target, use Markdown only when dictated structure benefits"));
     assert!(rendered.contains("separate tasks or requirements may become bullets"));
     assert!(rendered.contains("keep literal code and commands literal"));
     assert!(rendered.contains("never invent headings"));
@@ -231,7 +248,8 @@ fn dual_transcription_policy_handles_conflict_and_plausible_alternates() {
     assert!(rendered.contains("Primary is the default evidence"));
     assert!(rendered.contains("Agreement is strong evidence"));
     assert!(rendered.contains("phonetics, grammar, vocabulary, or context supports it"));
-    assert!(rendered.contains("Never keep a plausible-looking term only because one candidate contains it"));
+    assert!(rendered
+        .contains("Never keep a plausible-looking term only because one candidate contains it"));
     assert!(rendered.contains("never merge incompatible wording"));
     assert!(rendered.contains("If uncertain, prefer primary"));
     assert!(rendered.contains("Reconcile candidates before cleanup"));
@@ -344,7 +362,9 @@ fn output_budgets_are_output_only_and_intensity_specific() {
 
 #[test]
 fn gemini_25_flash_lite_has_an_actual_zero_thinking_budget() {
-    assert!(gemini_generation_reasoning_supported("gemini-2.5-flash-lite"));
+    assert!(gemini_generation_reasoning_supported(
+        "gemini-2.5-flash-lite"
+    ));
     let config = gemini_generation_config("gemini-2.5-flash-lite", 256);
     let json = serde_json::to_value(config).unwrap();
     assert_eq!(json["thinkingConfig"]["thinkingBudget"], 0);
@@ -355,7 +375,9 @@ fn gemini_25_flash_lite_has_an_actual_zero_thinking_budget() {
 
 #[test]
 fn gemini_3_models_use_minimal_and_unsupported_levels_are_rejected() {
-    assert!(gemini_generation_reasoning_supported("gemini-3.5-flash-lite"));
+    assert!(gemini_generation_reasoning_supported(
+        "gemini-3.5-flash-lite"
+    ));
     assert!(gemini_generation_reasoning_supported("gemini-3.5-flash"));
     let config = gemini_generation_config("gemini-3.5-flash-lite", 256);
     let json = serde_json::to_value(config).unwrap();
@@ -363,8 +385,7 @@ fn gemini_3_models_use_minimal_and_unsupported_levels_are_rejected() {
     assert!(json["thinkingConfig"].get("thinkingBudget").is_none());
     assert!(json.get("temperature").is_none());
 
-    let fallback = serde_json::to_value(gemini_generation_config("gemini-3.5-flash", 256))
-        .unwrap();
+    let fallback = serde_json::to_value(gemini_generation_config("gemini-3.5-flash", 256)).unwrap();
     assert_eq!(fallback["thinkingConfig"]["thinkingLevel"], "minimal");
     assert!(fallback["thinkingConfig"].get("thinkingBudget").is_none());
     assert!(fallback.get("temperature").is_none());
@@ -387,7 +408,10 @@ fn transcription_prompts_match_provider_semantics() {
         if matches!(provider, "google" | "assemblyai") {
             assert!(!rendered.is_empty(), "{provider}/{model} prompt was empty");
         } else {
-            assert!(rendered.is_empty(), "{provider}/{model} should not be primed");
+            assert!(
+                rendered.is_empty(),
+                "{provider}/{model} should not be primed"
+            );
         }
     }
 }
@@ -433,17 +457,23 @@ fn custom_templates_without_dynamic_channels_get_safe_appendices() {
 #[test]
 fn template_lint_requires_the_new_channels_and_safety_contract() {
     let warnings = lint_cleanup_template("Just clean the text and return it.");
-    assert!(warnings.iter().any(|warning| warning.contains("cleanup_preset")));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning.contains("cleanup_preset")));
     assert!(warnings
         .iter()
         .any(|warning| warning.contains("formatting_rules")));
-    assert!(warnings.iter().any(|warning| warning.contains("active_app")));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning.contains("active_app")));
     assert!(warnings
         .iter()
         .any(|warning| warning.contains("snippet_overrides")));
     assert!(warnings.iter().any(|warning| warning.contains("evidence")));
     assert!(warnings.iter().any(|warning| warning.contains("answer")));
-    assert!(warnings.iter().any(|warning| warning.contains("perspective")));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning.contains("perspective")));
     assert!(lint_cleanup_template(default_cleanup_template()).is_empty());
 }
 
@@ -455,13 +485,18 @@ fn retry_template_is_the_same_small_contract() {
 #[test]
 fn collapse_blank_lines_handles_crlf() {
     let input = "line one\r\n\r\nline two\r\n\r\n\r\nline three";
-    assert_eq!(collapse_blank_lines(input), "line one\n\nline two\n\nline three");
+    assert_eq!(
+        collapse_blank_lines(input),
+        "line one\n\nline two\n\nline three"
+    );
 }
 
 #[test]
 fn output_guards_keep_model_failures_out_of_the_clipboard() {
     assert!(looks_like_refusal("I am an AI and cannot do that"));
-    assert!(looks_like_model_artifact_leak("<think>reasoning</think>answer"));
+    assert!(looks_like_model_artifact_leak(
+        "<think>reasoning</think>answer"
+    ));
     assert!(looks_like_degenerate_repetition("it it it it it it it"));
     assert!(looks_like_fabricated_content(
         "okay let's try the new model and see how it goes",

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -8,11 +8,11 @@
 //! **Microphone**. Keychain access is surfaced separately when a provider key is
 //! stored.
 
+#[cfg(target_os = "macos")]
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
-#[cfg(target_os = "macos")]
-use std::path::Path;
 static PERMISSION_QUERY_GENERATION: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_os = "macos")]
 static SIGNING_INFO: OnceLock<(Option<String>, Option<String>)> = OnceLock::new();
@@ -26,12 +26,18 @@ fn canonical_relaunch_bundle(bundle: String) -> String {
     }
     let path = Path::new(&bundle);
     let legacy = path.file_name().and_then(|name| name.to_str()) == Some("Verenu.app")
-        && path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str())
+        && path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
             == Some("macos-dev");
     if !legacy {
         return bundle;
     }
-    match path.parent().map(|parent| parent.join("Verenu Development.app")) {
+    match path
+        .parent()
+        .map(|parent| parent.join("Verenu Development.app"))
+    {
         Some(candidate) if candidate.is_dir() => candidate.to_string_lossy().into_owned(),
         _ => bundle,
     }
@@ -648,11 +654,12 @@ pub fn restart_app(handle: tauri::AppHandle) -> Result<(), String> {
         if let Some(bundle) = crate::system::mac_app::bundle_path()
             .map(canonical_relaunch_bundle)
             .filter(|path| {
-            Path::new(path.trim_end_matches('/'))
-                .extension()
-                .map(|extension| extension == "app")
-                .unwrap_or(false)
-        }) {
+                Path::new(path.trim_end_matches('/'))
+                    .extension()
+                    .map(|extension| extension == "app")
+                    .unwrap_or(false)
+            })
+        {
             let pid = std::process::id().to_string();
             std::process::Command::new("/bin/sh")
                 .args([

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -339,9 +339,7 @@ pub fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), Stri
                     missing.as_object().is_some_and(|counters| {
                         counters.values().all(|counter| {
                             counter.as_object().is_some_and(|counter| {
-                                counter
-                                    .get("count")
-                                    .is_some_and(|c| c.as_u64().is_some())
+                                counter.get("count").is_some_and(|c| c.as_u64().is_some())
                                     && counter.get("lastCountedAt").is_some_and(|t| {
                                         t.as_f64().is_some_and(|n| n.is_finite() && n >= 0.0)
                                     })
@@ -388,7 +386,9 @@ pub fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), Stri
                 || value.as_str().is_some_and(|color| {
                     color.len() == 7
                         && color.starts_with('#')
-                        && color[1..].chars().all(|character| character.is_ascii_hexdigit())
+                        && color[1..]
+                            .chars()
+                            .all(|character| character.is_ascii_hexdigit())
                 })
         }
         SettingKind::Bool => value.is_boolean(),
@@ -526,7 +526,9 @@ pub async fn save_setting(
         let db = app.state::<DbHandle>().inner().clone();
         let key_for_stamp = key.clone();
         let stamped = run_blocking("save_setting_stamp", move || {
-            let conn = db.lock().map_err(|_| "database lock poisoned".to_string())?;
+            let conn = db
+                .lock()
+                .map_err(|_| "database lock poisoned".to_string())?;
             crate::sync::engine::record_local_setting_change(&conn, &key_for_stamp)
                 .map_err(|e| e.to_string())
         })
@@ -765,7 +767,10 @@ mod provider_model_cache_tests {
         assert!(check(&value).is_err());
 
         let mut value = well_formed();
-        value["groq"].as_object_mut().unwrap().remove("lastAttemptAt");
+        value["groq"]
+            .as_object_mut()
+            .unwrap()
+            .remove("lastAttemptAt");
         assert!(check(&value).is_err());
     }
 

--- a/src-tauri/src/commands/settings/api_keys.rs
+++ b/src-tauri/src/commands/settings/api_keys.rs
@@ -153,7 +153,9 @@ fn models_list_request(
         store::GROQ => client
             .get("https://api.groq.com/openai/v1/models")
             .bearer_auth(key),
-        store::OPENAI => client.get("https://api.openai.com/v1/models").bearer_auth(key),
+        store::OPENAI => client
+            .get("https://api.openai.com/v1/models")
+            .bearer_auth(key),
         store::GOOGLE => {
             let mut request = client
                 .get("https://generativelanguage.googleapis.com/v1beta/models")
@@ -209,7 +211,12 @@ pub fn parse_google_models_page(body: &str) -> Result<(Vec<String>, Option<Strin
                 })
         })
         .filter_map(|entry| entry.get("name").and_then(|n| n.as_str()))
-        .map(|name| name.strip_prefix("models/").unwrap_or(name).trim().to_string())
+        .map(|name| {
+            name.strip_prefix("models/")
+                .unwrap_or(name)
+                .trim()
+                .to_string()
+        })
         .filter(|id| !id.is_empty())
         .collect();
 
@@ -327,7 +334,10 @@ mod model_list_tests {
         let (ids, next) = parse_google_models_page(body).unwrap();
         assert_eq!(
             ids,
-            vec!["gemini-3.7-flash".to_string(), "unknown-methods".to_string()]
+            vec![
+                "gemini-3.7-flash".to_string(),
+                "unknown-methods".to_string()
+            ]
         );
         assert!(next.is_none());
     }

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -48,7 +48,9 @@ pub async fn sync_get_status(app: AppHandle) -> Result<SyncStatusDto, String> {
 
 #[tauri::command]
 pub async fn sync_set_device_name(app: AppHandle, name: String) -> Result<(), String> {
-    manager(&app)?.set_device_name(name).map_err(|e| e.to_string())
+    manager(&app)?
+        .set_device_name(name)
+        .map_err(|e| e.to_string())
 }
 
 /// Starts pairing with a discovered device. Returns the 6-digit code to show
@@ -77,7 +79,10 @@ pub async fn sync_respond_to_pairing(
 
 #[tauri::command]
 pub async fn sync_cancel_pairing(app: AppHandle) -> Result<(), String> {
-    manager(&app)?.cancel_pairing().await.map_err(|e| e.to_string())
+    manager(&app)?
+        .cancel_pairing()
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -91,7 +96,10 @@ pub async fn sync_remove_device(app: AppHandle, device_uuid: String) -> Result<(
 /// Manual sync. `deviceUuid = null` syncs every visible paired device.
 #[tauri::command]
 pub async fn sync_now(app: AppHandle, device_uuid: Option<String>) -> Result<(), String> {
-    manager(&app)?.sync_now(device_uuid).await.map_err(|e| e.to_string())
+    manager(&app)?
+        .sync_now(device_uuid)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Debug/diagnostics: change-log size and per-peer cursor positions.
@@ -99,7 +107,9 @@ pub async fn sync_now(app: AppHandle, device_uuid: Option<String>) -> Result<(),
 pub async fn sync_get_diagnostics(app: AppHandle) -> Result<serde_json::Value, String> {
     let db = app.state::<crate::DbHandle>().inner().clone();
     super::run_blocking("sync_get_diagnostics", move || {
-        let conn = db.lock().map_err(|_| "database lock poisoned".to_string())?;
+        let conn = db
+            .lock()
+            .map_err(|_| "database lock poisoned".to_string())?;
         let log_size: i64 = conn
             .query_row("SELECT COUNT(*) FROM sync_log", [], |r| r.get(0))
             .map_err(|e| e.to_string())?;
@@ -118,4 +128,3 @@ pub async fn sync_get_diagnostics(app: AppHandle) -> Result<serde_json::Value, S
     })
     .await
 }
-

--- a/src-tauri/src/core/hotkey/win.rs
+++ b/src-tauri/src/core/hotkey/win.rs
@@ -407,9 +407,31 @@ impl ChordStateMachine {
         // Chord-formed edge: both keys just became down together, regardless
         // of press order. This is the second key's down-edge; the first
         // already passed through above.
-        self.chord_first_down_ms = now_ms;
         self.key1_was_chord = true;
         self.key2_was_chord = true;
+
+        if self.chord_down {
+            // Re-formation, not a new press — reclaim ownership and stop.
+            //
+            // A chord-forming edge normally implies a key went up and back
+            // down, and that keyup would have cleared `chord_down`. So finding
+            // it still set means something cleared a key's bookkeeping while it
+            // was still physically held: `reconcile_stale_key` doing its job on
+            // a keyup the hook never received, or `force_release_win_key`
+            // wiping all of it before a paste. The key then autorepeats (it IS
+            // still down), and that repeat arrives here looking like a fresh
+            // chord.
+            //
+            // Restoring ownership above is right. Restarting the hold clock is
+            // not: `held_ms` in on_key_up is measured from `chord_first_down_ms`,
+            // so a chord held for seconds would be measured from this repeat,
+            // come out under CHORD_TAP_MAX_HOLD_MS, and be classified as a tap
+            // — firing FireCancel and throwing the dictation away. That is the
+            // "every dictation gets cancelled" bug.
+            return ChordOutcome::suppress(None);
+        }
+
+        self.chord_first_down_ms = now_ms;
 
         if let TapState::AwaitingSecondTap { deadline_start_ms } = self.tap {
             if now_ms.saturating_sub(deadline_start_ms) <= CHORD_DOUBLE_TAP_WINDOW_MS {
@@ -1035,6 +1057,41 @@ mod chord_tests {
             assert_eq!(second.disposition, KeyDisposition::Suppress);
             assert!(m.chord_down);
         }
+    }
+
+    #[test]
+    fn long_hold_still_releases_after_ownership_is_reconciled_away() {
+        // Regression: every dictation got cancelled instead of transcribed.
+        //
+        // `reconcile_stale_key` (and `force_release_win_key`, which does the
+        // same thing wholesale before a paste) can clear a key's down/ownership
+        // bookkeeping while the user is still physically holding the chord —
+        // that is the entire point of it, for keyups the hook never received.
+        // But the key keeps autorepeating, and the next repeat then looked like
+        // a brand-new chord-forming edge, which reset `chord_first_down_ms` to
+        // "now". The hold length is measured from that field, so a chord held
+        // for seconds measured as a sub-200ms tap and fired FireCancel.
+        let mut m = fresh();
+        m.on_key_event(ChordKey::Key1, KeyEdge::Down, 0);
+        m.on_key_event(ChordKey::Key2, KeyEdge::Down, 5);
+        assert_eq!(m.chord_first_down_ms, 5);
+
+        // Something reconciles key2's ownership away mid-hold.
+        m.reconcile_stale_key(ChordKey::Key2, false);
+        // ...and key2 autorepeats, since it is still physically down.
+        let repeat = m.on_key_event(ChordKey::Key2, KeyEdge::Down, 3000);
+        assert_eq!(
+            repeat.action, None,
+            "a repeat mid-hold must not re-fire a press"
+        );
+        assert_eq!(
+            m.chord_first_down_ms, 5,
+            "re-forming the chord mid-hold must not restart the hold clock"
+        );
+
+        // The real release, seconds after the real press, is a hold.
+        let up = m.on_key_event(ChordKey::Key1, KeyEdge::Up, 4000);
+        assert_eq!(up.action, Some(ChordAction::FireRelease));
     }
 
     #[test]

--- a/src-tauri/src/core/injection/mod.rs
+++ b/src-tauri/src/core/injection/mod.rs
@@ -283,15 +283,8 @@ mod tests {
             control_type: "test".to_string(),
             target_id: 1,
         };
-        let (adjusted, context, case_decision) = apply_probe_adjustments(
-            "Dabba Doo.",
-            true,
-            true,
-            "casual",
-            "en",
-            false,
-            &probe,
-        );
+        let (adjusted, context, case_decision) =
+            apply_probe_adjustments("Dabba Doo.", true, true, "casual", "en", false, &probe);
         assert_eq!(adjusted, " dabba Doo.");
         assert!(matches!(context, ContextKind::Continuation));
         assert!(matches!(
@@ -574,9 +567,7 @@ fn context_head_signal(head: &str) -> &'static str {
             }
         }
         Some(ch) if ch.is_alphanumeric() => "alnum",
-        Some(')' | ']' | '}' | '.' | ',' | ';' | ':' | '!' | '?') => {
-            "punct"
-        }
+        Some(')' | ']' | '}' | '.' | ',' | ';' | ':' | '!' | '?') => "punct",
         Some(_) => "other",
     }
 }

--- a/src-tauri/src/core/window_context.rs
+++ b/src-tauri/src/core/window_context.rs
@@ -129,6 +129,15 @@ pub fn get_app_context_hint(
     context_name: Option<&str>,
 ) -> Option<String> {
     let mut lines = Vec::new();
+    // Resolved context group (see core/context.rs). Labeled and truncated like
+    // every other hint line, and omitted when empty so the prompt never carries
+    // a dangling "Context:" header.
+    if let Some(name) = context_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Context: {}", truncate_hint_value(name, 60)));
+    }
     #[cfg(any(windows, target_os = "macos"))]
     {
         let browser = BROWSER_EXES
@@ -157,13 +166,6 @@ pub fn get_app_context_hint(
     #[cfg(not(any(windows, target_os = "macos")))]
     lines.push(format!("Application: {}", friendly_app_name(process_name)));
 
-    if let Some(name) = context_name
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("Everywhere"))
-    {
-        lines.push(format!("Verenu context: {}", truncate_hint_value(name, 60)));
-    }
-
     (!lines.is_empty()).then(|| lines.join("\n"))
 }
 
@@ -171,7 +173,32 @@ fn friendly_app_name(process_name: &str) -> String {
     let base = process_name
         .trim_end_matches(".exe")
         .trim_end_matches(".app");
-    match base.to_ascii_lowercase().as_str() {
+    let normalized = base.to_ascii_lowercase();
+    // Release-channel/version suffixes do not help disambiguate dictation and
+    // make otherwise identical targets look like different applications.
+    let stable_base = [
+        " (nightly)",
+        "-nightly",
+        "_nightly",
+        " nightly",
+        " (beta)",
+        "-beta",
+        "_beta",
+        " beta",
+        " (dev)",
+        "-dev",
+        "_dev",
+        " dev",
+    ]
+    .iter()
+    .filter_map(|suffix| normalized.find(suffix).map(|index| (index, *suffix)))
+    .min_by_key(|(index, _)| *index)
+    .map(|(index, _)| &base[..index])
+    .map(str::trim_end)
+    .filter(|value| !value.is_empty())
+    .unwrap_or(base);
+
+    match stable_base.to_ascii_lowercase().as_str() {
         "code" => "Visual Studio Code".to_string(),
         "winword" => "Microsoft Word".to_string(),
         "excel" => "Microsoft Excel".to_string(),
@@ -183,7 +210,8 @@ fn friendly_app_name(process_name: &str) -> String {
         "notepad" => "Notepad".to_string(),
         "obsidian" => "Obsidian".to_string(),
         "notion" => "Notion".to_string(),
-        _ => base.to_string(),
+        "t3-code" => "T3 Code".to_string(),
+        _ => stable_base.to_string(),
     }
 }
 
@@ -251,6 +279,8 @@ mod tests {
         assert_eq!(friendly_app_name("code.exe"), "Visual Studio Code");
         assert_eq!(friendly_app_name("winword.exe"), "Microsoft Word");
         assert_eq!(friendly_app_name("slack.app"), "Slack");
+        assert_eq!(friendly_app_name("t3-code-nightly-20260830.exe"), "T3 Code");
+        assert_eq!(friendly_app_name("Example (nightly).app"), "Example");
     }
 
     #[test]

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -369,7 +369,10 @@ pub fn query_context_targets(db: &Db, context_id: Option<i64>) -> Result<Vec<Con
          ORDER BY executable COLLATE NOCASE ASC",
     )?;
     let rows = stmt
-        .query_map(params![context_id, current_platform_tag()], context_target_from_row)?
+        .query_map(
+            params![context_id, current_platform_tag()],
+            context_target_from_row,
+        )?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
 }
@@ -435,7 +438,14 @@ pub fn reconcile_context_targets(
              WHERE platform IS NULL OR platform = ?1",
         )?
         .query_map(params![current_platform], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?))
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+            ))
         })?
         .collect::<rusqlite::Result<_>>()?;
     let mut changed = false;
@@ -444,9 +454,9 @@ pub fn reconcile_context_targets(
         if executable.starts_with("?::") {
             continue;
         }
-        let exact = installed_apps.iter().find(|app| {
-            app.exe.trim().eq_ignore_ascii_case(executable.trim())
-        });
+        let exact = installed_apps
+            .iter()
+            .find(|app| app.exe.trim().eq_ignore_ascii_case(executable.trim()));
         let candidate = exact.or_else(|| {
             crate::system::apps::closest_installed_app(
                 &executable,
@@ -1034,7 +1044,11 @@ mod tests {
         }
 
         let targets = query_context_targets(&db, Some(context.id)).expect("targets");
-        assert_eq!(targets.len(), 1, "only the resolved target should be visible");
+        assert_eq!(
+            targets.len(),
+            1,
+            "only the resolved target should be visible"
+        );
         assert_eq!(targets[0].executable, "editor.exe");
     }
 

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -155,8 +155,12 @@ pub fn query_insights(db: &Db, days: i64, context_id: Option<i64>) -> Result<Ins
     let (streak_start, streak_end) = rolling_year_bounds(&conn)?;
     let streak_daily = query_daily(&conn, &streak_start, &streak_end, context_id)?;
     let (lifetime_streak_start, lifetime_streak_end) = range_bounds(&conn, 0, context_id)?;
-    let lifetime_streak_daily =
-        query_daily(&conn, &lifetime_streak_start, &lifetime_streak_end, context_id)?;
+    let lifetime_streak_daily = query_daily(
+        &conn,
+        &lifetime_streak_start,
+        &lifetime_streak_end,
+        context_id,
+    )?;
     // Scoped too, so the heatmap can still tell "before this context existed"
     // apart from "a day you didn't use it".
     let history_started_on = conn.query_row(
@@ -321,11 +325,7 @@ fn parse_api_usage(api_used: &str) -> ApiUsageParts {
 /// Local calendar-day bounds of the requested range, as `"YYYY-MM-DD"`.
 /// `days > 0` spans the last `days` calendar days ending today; `days == 0`
 /// spans the first recorded transcription through today.
-fn range_bounds(
-    conn: &Connection,
-    days: i64,
-    context_id: Option<i64>,
-) -> Result<(String, String)> {
+fn range_bounds(conn: &Connection, days: i64, context_id: Option<i64>) -> Result<(String, String)> {
     let today: String = conn.query_row("SELECT date('now', 'localtime')", [], |r| r.get(0))?;
     let start = if days > 0 {
         let n = (days - 1).max(0);
@@ -887,7 +887,10 @@ mod tests {
         assert!(all.words.top.iter().any(|w| w.word == "golf"));
 
         // Lifetime counters have no context dimension and stay global.
-        assert_eq!(scoped.cleanup.dictionary_fixes, all.cleanup.dictionary_fixes);
+        assert_eq!(
+            scoped.cleanup.dictionary_fixes,
+            all.cleanup.dictionary_fixes
+        );
         assert_eq!(
             scoped.cleanup.auto_learned_terms,
             all.cleanup.auto_learned_terms

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -531,8 +531,18 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
         // Columns declared in SCHEMA for fresh databases; ensure_table_column
         // is idempotent for databases that already have them.
         run_migration(&mut conn, |conn| {
-            ensure_table_column(conn, "contexts", "icon", "ALTER TABLE contexts ADD COLUMN icon TEXT;")?;
-            ensure_table_column(conn, "contexts", "tone", "ALTER TABLE contexts ADD COLUMN tone TEXT;")?;
+            ensure_table_column(
+                conn,
+                "contexts",
+                "icon",
+                "ALTER TABLE contexts ADD COLUMN icon TEXT;",
+            )?;
+            ensure_table_column(
+                conn,
+                "contexts",
+                "tone",
+                "ALTER TABLE contexts ADD COLUMN tone TEXT;",
+            )?;
             ensure_table_column(
                 conn,
                 "contexts",
@@ -561,7 +571,12 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
         // fresh databases; ensure_table_column is idempotent for databases
         // that already have it.
         run_migration(&mut conn, |conn| {
-            ensure_table_column(conn, "contexts", "color", "ALTER TABLE contexts ADD COLUMN color TEXT;")?;
+            ensure_table_column(
+                conn,
+                "contexts",
+                "color",
+                "ALTER TABLE contexts ADD COLUMN color TEXT;",
+            )?;
             conn.execute_batch("PRAGMA user_version = 15;")?;
             Ok(())
         })?;
@@ -1468,4 +1483,3 @@ fn backfill_spoken_words(conn: &Connection) -> Result<()> {
 
     Ok(())
 }
-

--- a/src-tauri/src/data/db/tests.rs
+++ b/src-tauri/src/data/db/tests.rs
@@ -202,8 +202,17 @@ fn open_repairs_db_stuck_at_v7_without_spoken_words_column() {
     let db = open(path.to_str().expect("path string")).expect("open repairs stuck db");
 
     // Inserting a new transcription must succeed now that spoken_words exists.
-    insert_transcription_returning(&db, "second clip", "second clip", 2, 1000, "test", None, None)
-        .expect("insert after repair");
+    insert_transcription_returning(
+        &db,
+        "second clip",
+        "second clip",
+        2,
+        1000,
+        "test",
+        None,
+        None,
+    )
+    .expect("insert after repair");
 
     let conn = lock_conn(&db).expect("lock");
     let spoken_words: i64 = conn
@@ -592,27 +601,18 @@ fn auto_learn_does_not_overwrite_manual_dictionary_entry() {
 fn auto_learn_updates_only_exact_existing_pair() {
     let db = test_db();
 
-    assert!(insert_dictionary_entry_auto_learned(
-        &db,
-        "Kubernetes",
-        Some("Koobernetes"),
-        "high"
-    )
-    .expect("first insert"));
-    assert!(insert_dictionary_entry_auto_learned(
-        &db,
-        "Kubernetes",
-        Some("Koobernetes"),
-        "high"
-    )
-    .expect("same pair"));
-    assert!(!insert_dictionary_entry_auto_learned(
-        &db,
-        "Kubernetes",
-        Some("Kubernetties"),
-        "low",
-    )
-    .expect("different pair"));
+    assert!(
+        insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"), "high")
+            .expect("first insert")
+    );
+    assert!(
+        insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"), "high")
+            .expect("same pair")
+    );
+    assert!(
+        !insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Kubernetties"), "low",)
+            .expect("different pair")
+    );
 
     let entries = query_dictionary(&db).expect("dictionary");
     assert_eq!(entries.len(), 1);
@@ -739,8 +739,7 @@ fn auto_learn_promote_can_relearn_after_rejection() {
     delete_auto_learned_entries_by_ids(&db, &[id]).expect("reject");
 
     // New learning episode: fresh candidate (promoted_at NULL), two sessions.
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6)
-        .expect("candidate again");
+    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate again");
     assert_eq!(
         auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("s1"),
         AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
@@ -766,8 +765,7 @@ fn auto_learn_promote_manual_entry_blocks_without_claiming() {
     // every attempt (and records the pending rows for later sessions).
     for _ in 0..2 {
         assert_eq!(
-            auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2)
-                .expect("promote"),
+            auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("promote"),
             AutoLearnPromoteResult::Blocked
         );
     }
@@ -797,8 +795,7 @@ fn auto_learn_promote_manual_entry_blocks_without_claiming() {
 #[test]
 fn cleanup_cache_insert_get_and_clear() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "abc", "hello", "2999-01-01 00:00:00", false)
-        .expect("insert");
+    cleanup_cache_insert_new(&db, "abc", "hello", "2999-01-01 00:00:00", false).expect("insert");
     let hit = cleanup_cache_get_active(&db, "abc")
         .expect("query")
         .expect("exists");
@@ -813,10 +810,8 @@ fn cleanup_cache_insert_get_and_clear() {
 #[test]
 fn cleanup_cache_prunes_expired_only() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "old", "x", "2000-01-01 00:00:00", false)
-        .expect("insert old");
-    cleanup_cache_insert_new(&db, "live", "y", "2999-01-01 00:00:00", false)
-        .expect("insert live");
+    cleanup_cache_insert_new(&db, "old", "x", "2000-01-01 00:00:00", false).expect("insert old");
+    cleanup_cache_insert_new(&db, "live", "y", "2999-01-01 00:00:00", false).expect("insert live");
 
     assert_eq!(cleanup_cache_prune_expired(&db).expect("prune"), 1);
     assert!(cleanup_cache_get_active(&db, "old")
@@ -830,8 +825,7 @@ fn cleanup_cache_prunes_expired_only() {
 #[test]
 fn cleanup_cache_get_active_supports_null_epoch_fallback() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "legacy", "hello", "2999-01-01 00:00:00", false)
-        .expect("insert");
+    cleanup_cache_insert_new(&db, "legacy", "hello", "2999-01-01 00:00:00", false).expect("insert");
 
     let conn = lock_conn(&db).expect("lock");
     conn.execute(
@@ -875,8 +869,7 @@ fn cleanup_cache_get_active_handles_null_created_and_last_hit_epochs() {
 #[test]
 fn cleanup_cache_epoch_columns_treat_utc_text_as_utc() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "utc", "value", "2026-01-01 00:00:00", false)
-        .expect("insert");
+    cleanup_cache_insert_new(&db, "utc", "value", "2026-01-01 00:00:00", false).expect("insert");
 
     let conn = lock_conn(&db).expect("lock");
     let (inserted_expiry_epoch, created_at): (i64, String) = conn
@@ -936,8 +929,7 @@ fn cache_rejection_delete_removes_entry() {
 #[test]
 fn cache_rejection_leaves_other_keys_intact() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "target", "bad", "2999-01-01 00:00:00", false)
-        .expect("target");
+    cleanup_cache_insert_new(&db, "target", "bad", "2999-01-01 00:00:00", false).expect("target");
     cleanup_cache_insert_new(&db, "bystander", "good", "2999-01-01 00:00:00", false)
         .expect("bystander");
 
@@ -957,8 +949,7 @@ fn cache_rejection_leaves_other_keys_intact() {
 #[test]
 fn cache_rejection_after_hit_removes_entry() {
     let db = test_db();
-    cleanup_cache_insert_new(&db, "k", "stale text", "2999-01-01 00:00:00", false)
-        .expect("insert");
+    cleanup_cache_insert_new(&db, "k", "stale text", "2999-01-01 00:00:00", false).expect("insert");
 
     // Simulate a cache hit (the phrase was served from cache once).
     let created_at = cleanup_cache_get_active(&db, "k")
@@ -994,8 +985,9 @@ fn pruning_history_removes_orphaned_api_cost_rows() {
     let db = test_db();
     let old = insert_transcription_returning(&db, "old", "old", 2, 1000, "test", None, None)
         .expect("old transcription");
-    let recent = insert_transcription_returning(&db, "recent", "recent", 3, 1000, "test", None, None)
-        .expect("recent transcription");
+    let recent =
+        insert_transcription_returning(&db, "recent", "recent", 3, 1000, "test", None, None)
+            .expect("recent transcription");
     let call = |transcription_id: i64| ApiCall {
         transcription_id,
         model: "test-model".into(),
@@ -1194,8 +1186,17 @@ fn stats_avg_wpm_counts_only_non_snippet_spoken_words() {
 fn stats_avg_wpm_excludes_pure_snippet_rows_from_average() {
     let db = test_db();
     insert_snippet(&db, "sig", "A long email signature", "").expect("snippet");
-    insert_transcription_returning(&db, "hello world", "hello world", 2, 1000, "test", None, None)
-        .expect("normal transcription");
+    insert_transcription_returning(
+        &db,
+        "hello world",
+        "hello world",
+        2,
+        1000,
+        "test",
+        None,
+        None,
+    )
+    .expect("normal transcription");
     insert_transcription_returning(
         &db,
         "sig.",
@@ -1370,8 +1371,7 @@ fn cache_rejection_full_lifecycle() {
     let bad_answer = "bad cached answer";
 
     // First dictation: LLM runs, result cached.
-    cleanup_cache_insert_new(&db, key, bad_answer, "2999-01-01 00:00:00", false)
-        .expect("insert");
+    cleanup_cache_insert_new(&db, key, bad_answer, "2999-01-01 00:00:00", false).expect("insert");
     assert_eq!(cleanup_cache_count(&db).expect("count"), 1);
 
     // Second dictation: cache hit, stale answer served.

--- a/src-tauri/src/data/db/transcriptions.rs
+++ b/src-tauri/src/data/db/transcriptions.rs
@@ -290,7 +290,7 @@ mod tests {
                 1000,
                 "groq/whisper-large-v3-turbo",
                 None,
-            None,
+                None,
             )
             .expect("insert transcription");
         }
@@ -309,12 +309,39 @@ mod tests {
     #[test]
     fn query_recent_page_filters_by_search_case_insensitive_and_partial() {
         let db = crate::data::db::open(":memory:").expect("db");
-        insert_transcription_returning(&db, "raw apple pie", "Clean Apple Pie", 3, 1000, "t", None, None)
-            .expect("insert apple");
-        insert_transcription_returning(&db, "raw banana", "Clean Banana Split", 2, 1000, "t", None, None)
-            .expect("insert banana");
-        insert_transcription_returning(&db, "raw raisin", "Clean Raisin Bread", 2, 1000, "t", None, None)
-            .expect("insert raisin");
+        insert_transcription_returning(
+            &db,
+            "raw apple pie",
+            "Clean Apple Pie",
+            3,
+            1000,
+            "t",
+            None,
+            None,
+        )
+        .expect("insert apple");
+        insert_transcription_returning(
+            &db,
+            "raw banana",
+            "Clean Banana Split",
+            2,
+            1000,
+            "t",
+            None,
+            None,
+        )
+        .expect("insert banana");
+        insert_transcription_returning(
+            &db,
+            "raw raisin",
+            "Clean Raisin Bread",
+            2,
+            1000,
+            "t",
+            None,
+            None,
+        )
+        .expect("insert raisin");
 
         // Partial + case-insensitive on clean_text.
         let hits = query_recent_page(&db, 50, 0, Some("apple"), None).expect("search apple");
@@ -343,12 +370,39 @@ mod tests {
     #[test]
     fn query_recent_page_filters_by_app_and_combines_with_search() {
         let db = crate::data::db::open(":memory:").expect("db");
-        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("outlook.exe"), None)
-            .expect("insert outlook a");
-        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"), None)
-            .expect("insert outlook b");
-        insert_transcription_returning(&db, "raw c", "Clean C", 1, 1000, "t", Some("code.exe"), None)
-            .expect("insert code c");
+        insert_transcription_returning(
+            &db,
+            "raw a",
+            "Clean A",
+            1,
+            1000,
+            "t",
+            Some("outlook.exe"),
+            None,
+        )
+        .expect("insert outlook a");
+        insert_transcription_returning(
+            &db,
+            "raw b",
+            "Clean B",
+            1,
+            1000,
+            "t",
+            Some("outlook.exe"),
+            None,
+        )
+        .expect("insert outlook b");
+        insert_transcription_returning(
+            &db,
+            "raw c",
+            "Clean C",
+            1,
+            1000,
+            "t",
+            Some("code.exe"),
+            None,
+        )
+        .expect("insert code c");
 
         let outlook = query_recent_page(&db, 50, 0, None, Some("outlook.exe")).expect("outlook");
         assert_eq!(outlook.len(), 2);
@@ -373,8 +427,17 @@ mod tests {
     #[test]
     fn query_recent_page_treats_like_wildcards_in_search_literally() {
         let db = crate::data::db::open(":memory:").expect("db");
-        insert_transcription_returning(&db, "raw 100%", "Clean 100% Sure", 3, 1000, "t", None, None)
-            .expect("insert percent");
+        insert_transcription_returning(
+            &db,
+            "raw 100%",
+            "Clean 100% Sure",
+            3,
+            1000,
+            "t",
+            None,
+            None,
+        )
+        .expect("insert percent");
 
         // A literal "%" must match its own character, not act as a wildcard.
         let hits = query_recent_page(&db, 50, 0, Some("100%"), None).expect("literal percent");
@@ -388,10 +451,28 @@ mod tests {
     #[test]
     fn query_recent_page_matches_app_name_from_search_box() {
         let db = crate::data::db::open(":memory:").expect("db");
-        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("chrome.exe"), None)
-            .expect("insert chrome");
-        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"), None)
-            .expect("insert outlook");
+        insert_transcription_returning(
+            &db,
+            "raw a",
+            "Clean A",
+            1,
+            1000,
+            "t",
+            Some("chrome.exe"),
+            None,
+        )
+        .expect("insert chrome");
+        insert_transcription_returning(
+            &db,
+            "raw b",
+            "Clean B",
+            1,
+            1000,
+            "t",
+            Some("outlook.exe"),
+            None,
+        )
+        .expect("insert outlook");
 
         // Typing an app name finds that app's dictations without the dropdown.
         let hits = query_recent_page(&db, 50, 0, Some("chrome"), None).expect("search chrome");
@@ -415,7 +496,7 @@ mod tests {
             1000,
             "t",
             Some("outlook.exe"),
-        None,
+            None,
         )
         .expect("insert quarterly");
         insert_transcription_returning(
@@ -426,7 +507,7 @@ mod tests {
             1000,
             "t",
             None,
-        None,
+            None,
         )
         .expect("insert follow-up");
         insert_transcription_returning(
@@ -437,7 +518,7 @@ mod tests {
             1000,
             "t",
             Some("code.exe"),
-        None,
+            None,
         )
         .expect("insert report");
 
@@ -467,12 +548,39 @@ mod tests {
     #[test]
     fn query_distinct_apps_returns_non_empty_unique_names() {
         let db = crate::data::db::open(":memory:").expect("db");
-        insert_transcription_returning(&db, "raw a", "Clean A", 1, 1000, "t", Some("outlook.exe"), None)
-            .expect("insert outlook");
-        insert_transcription_returning(&db, "raw b", "Clean B", 1, 1000, "t", Some("outlook.exe"), None)
-            .expect("insert outlook again");
-        insert_transcription_returning(&db, "raw c", "Clean C", 1, 1000, "t", Some("code.exe"), None)
-            .expect("insert code");
+        insert_transcription_returning(
+            &db,
+            "raw a",
+            "Clean A",
+            1,
+            1000,
+            "t",
+            Some("outlook.exe"),
+            None,
+        )
+        .expect("insert outlook");
+        insert_transcription_returning(
+            &db,
+            "raw b",
+            "Clean B",
+            1,
+            1000,
+            "t",
+            Some("outlook.exe"),
+            None,
+        )
+        .expect("insert outlook again");
+        insert_transcription_returning(
+            &db,
+            "raw c",
+            "Clean C",
+            1,
+            1000,
+            "t",
+            Some("code.exe"),
+            None,
+        )
+        .expect("insert code");
         insert_transcription_returning(&db, "raw d", "Clean D", 1, 1000, "t", None, None)
             .expect("insert no app");
 

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -39,7 +39,15 @@ pub fn build_relevant_dictionary_prompt_from_sources(
     .into_iter()
     .enumerate()
     .filter_map(|(index, source)| {
-        source.map(|(text, weight)| (index, text, weight, text.to_lowercase(), tokenize_lower_alnum(text)))
+        source.map(|(text, weight)| {
+            (
+                index,
+                text,
+                weight,
+                text.to_lowercase(),
+                tokenize_lower_alnum(text),
+            )
+        })
     })
     .collect::<Vec<_>>();
 
@@ -552,7 +560,10 @@ mod tests {
             .collect();
         let prompt = build_relevant_dictionary_prompt_from_sources(&entries, "one", None, None);
         assert!(prompt.chars().count() <= 3_000);
-        assert_eq!(prompt.lines().filter(|line| line.starts_with("- ")).count(), 8);
+        assert_eq!(
+            prompt.lines().filter(|line| line.starts_with("- ")).count(),
+            8
+        );
     }
 
     #[test]

--- a/src-tauri/src/data/store/config.rs
+++ b/src-tauri/src/data/store/config.rs
@@ -77,8 +77,7 @@ pub fn migrate_deprecated_model_id(id: &str) -> String {
         )
     {
         format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
-    } else if provider == GOOGLE
-        && matches!(model.as_str(), "gemini-3.7-flash" | "gemini-2.5-pro")
+    } else if provider == GOOGLE && matches!(model.as_str(), "gemini-3.7-flash" | "gemini-2.5-pro")
     {
         format!("{GOOGLE}/gemini-3.5-flash-lite")
     } else {

--- a/src-tauri/src/data/store/mod.rs
+++ b/src-tauri/src/data/store/mod.rs
@@ -293,7 +293,6 @@ pub fn history_retention_days(value: &str) -> Option<i64> {
     }
 }
 
-
 mod config;
 #[cfg(test)]
 mod tests;
@@ -325,4 +324,3 @@ pub fn migrate_contextual_formatting(settings: &SettingsHandle) -> Result<(), St
     settings.set(CONTEXTUAL_FORMATTING, Value::Bool(merged))?;
     settings.save()
 }
-

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,12 +27,12 @@ pub type DbHandle = db::Db;
 
 // Startup helpers live in app_setup.rs; re-exported here so the rest of the
 // crate can keep using `crate::` paths.
+#[cfg(target_os = "macos")]
+pub(crate) use app_setup::hide_main_window;
 pub(crate) use app_setup::{
     app_data_dir, app_db_path, fatal_startup_error, show_main_window, start_frontend_watchdog,
     FrontendReadiness,
 };
-#[cfg(target_os = "macos")]
-pub(crate) use app_setup::hide_main_window;
 #[cfg(target_os = "windows")]
 pub(crate) use app_setup::{cleanup_update_helper_if_requested, wait_for_relaunch_parent_exit};
 pub(crate) use app_tray::apply_runtime_icons;

--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -222,11 +222,7 @@ impl RecordingSession {
         // `processed` already contains the configured microphone gain. Keep
         // the remaining display multiplier explicit so the envelope and the
         // scalar level use the same effective gain without applying it twice.
-        let processed_display_gain = if gain > 0.0 {
-            display_gain / gain
-        } else {
-            0.0
-        };
+        let processed_display_gain = if gain > 0.0 { display_gain / gain } else { 0.0 };
 
         std::thread::spawn(move || {
             let queue = Arc::new(ArrayQueue::<f32>::new(AUDIO_QUEUE_CAPACITY_SAMPLES));
@@ -598,10 +594,7 @@ pub(crate) fn encode_wav(samples: &[f32], sample_rate: u32, channels: u16) -> Re
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        append_capped_samples, enqueue_i16_buffer, push_overwriting_oldest,
-        DISPLAY_GAIN,
-    };
+    use super::{append_capped_samples, enqueue_i16_buffer, push_overwriting_oldest, DISPLAY_GAIN};
     use crossbeam_queue::ArrayQueue;
     use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 

--- a/src-tauri/src/pipeline/clipboard_phrase.rs
+++ b/src-tauri/src/pipeline/clipboard_phrase.rs
@@ -139,7 +139,12 @@ mod tests {
         .unwrap();
         assert_eq!(plan.markers.len(), 2);
         assert_eq!(plan.pre_cleanup.matches(&plan.markers[0]).count(), 1);
-        assert!(replace_phrase_with_marker("paste clipboard heresy", "paste clipboard here", "x".into()).is_none());
+        assert!(replace_phrase_with_marker(
+            "paste clipboard heresy",
+            "paste clipboard here",
+            "x".into()
+        )
+        .is_none());
     }
 
     #[test]
@@ -150,7 +155,10 @@ mod tests {
             "A\nB".into(),
         )
         .unwrap();
-        assert_eq!(restore(&format!("Hi {}", plan.markers[0]), &plan), Some("Hi A\nB".into()));
+        assert_eq!(
+            restore(&format!("Hi {}", plan.markers[0]), &plan),
+            Some("Hi A\nB".into())
+        );
         assert_eq!(restore("Hi", &plan), None);
     }
 
@@ -164,17 +172,25 @@ mod tests {
         .unwrap();
         let private = private_text(&plan.pre_cleanup, &plan);
         assert!(!private.contains("secret clipboard contents"));
-        assert_eq!(private.matches("[clipboard inserted, 25 characters]").count(), 2);
+        assert_eq!(
+            private
+                .matches("[clipboard inserted, 25 characters]")
+                .count(),
+            2
+        );
     }
 
     #[test]
     fn matches_unicode_case_without_slicing_invalid_boundaries() {
-        let plan = replace_phrase_with_marker("Bitte PÄSTE hier", "pÄste hier", "text".into()).unwrap();
+        let plan =
+            replace_phrase_with_marker("Bitte PÄSTE hier", "pÄste hier", "text".into()).unwrap();
         assert_eq!(restore(&plan.pre_cleanup, &plan), Some("Bitte text".into()));
     }
 
     #[test]
     fn ignores_text_shorter_than_phrase_without_panicking() {
-        assert!(replace_phrase_with_marker("paste", "paste clipboard here", "text".into()).is_none());
+        assert!(
+            replace_phrase_with_marker("paste", "paste clipboard here", "text".into()).is_none()
+        );
     }
 }

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -32,13 +32,15 @@ fn dictionary_protects_initial_case(text: &str, entries: &[db::DictionaryEntry])
     entries.iter().any(|entry| {
         !entry.term.is_empty()
             && entry.term.chars().any(char::is_uppercase)
-            && [leading, alphanumeric_leading].into_iter().any(|candidate| {
-                candidate.strip_prefix(&entry.term).is_some_and(|rest| {
-                    rest.chars()
-                    .next()
-                    .is_none_or(|ch| !ch.is_alphanumeric() && !matches!(ch, '\'' | '’'))
+            && [leading, alphanumeric_leading]
+                .into_iter()
+                .any(|candidate| {
+                    candidate.strip_prefix(&entry.term).is_some_and(|rest| {
+                        rest.chars()
+                            .next()
+                            .is_none_or(|ch| !ch.is_alphanumeric() && !matches!(ch, '\'' | '’'))
+                    })
                 })
-            })
     })
 }
 

--- a/src-tauri/src/pipeline/repair.rs
+++ b/src-tauri/src/pipeline/repair.rs
@@ -20,7 +20,6 @@ const REPAIR_MAX_OUTPUT_TOKENS: u32 = 120;
 const REPAIR_TIMEOUT_SECS: u64 = 45;
 const NO_SAFE_REPAIR_MESSAGE: &str = "I couldn't map this to a safe Verenu setting. Try speaking a little closer to the microphone and a little slower. If you want a reusable phrase, add a vocabulary item or snippet manually in Verenu.";
 
-
 #[derive(Clone, Debug, Serialize)]
 pub struct RepairSettings {
     pub cleanup_enabled: bool,
@@ -64,8 +63,6 @@ pub struct ValidatedProposal {
     pub summary: String,
     pub scope: String,
 }
-
-
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn begin_feedback(
@@ -539,11 +536,9 @@ pub(crate) async fn apply(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use super::super::repair_proposal::{
-        truncate_for_display, validate_action, RepairAction,
-    };
     use super::super::repair_proposal::DISPLAY_TEXT_LIMIT;
+    use super::super::repair_proposal::{truncate_for_display, validate_action, RepairAction};
+    use super::*;
 
     fn snapshot() -> RepairSnapshot {
         RepairSnapshot {

--- a/src-tauri/src/pipeline/repair_proposal.rs
+++ b/src-tauri/src/pipeline/repair_proposal.rs
@@ -402,4 +402,3 @@ pub(super) fn validate_action(
         scope,
     })
 }
-

--- a/src-tauri/src/pipeline/stages_cleanup.rs
+++ b/src-tauri/src/pipeline/stages_cleanup.rs
@@ -695,11 +695,8 @@ pub(super) async fn run_cleanup_and_snippets_for_db(
             }
             prompt_context.push_str(&dictionary_evidence);
         }
-        let context_fingerprint = dual_cleanup_context_fingerprint(
-            cfg,
-            &prompt_context,
-            app_context,
-        );
+        let context_fingerprint =
+            dual_cleanup_context_fingerprint(cfg, &prompt_context, app_context);
         let cache_plan = cleanup_cache_plan_for_context(
             &expanded,
             profile,

--- a/src-tauri/src/pipeline/tests.rs
+++ b/src-tauri/src/pipeline/tests.rs
@@ -1196,8 +1196,7 @@ async fn pipeline_fixture_accepts_downloaded_local_model_without_api_keys() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn pipeline_fixture_preserves_filler_words_when_cleanup_disabled(
-) {
+async fn pipeline_fixture_preserves_filler_words_when_cleanup_disabled() {
     let _guard = harness_test_lock().lock().expect("harness lock");
     let _local_models = install_local_models(&["parakeet-v3"]);
     reset();

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -110,7 +110,10 @@ pub trait SyncHost: Send + Sync {
 }
 
 pub fn unresolved_app_target(source: &str) -> String {
-    format!("{UNRESOLVED_APP_PREFIX}{}", source.trim_start_matches(UNRESOLVED_APP_PREFIX))
+    format!(
+        "{UNRESOLVED_APP_PREFIX}{}",
+        source.trim_start_matches(UNRESOLVED_APP_PREFIX)
+    )
 }
 
 fn resolve_context_targets_in_ops(host: &dyn SyncHost, ops: &[SyncOp]) -> Vec<SyncOp> {
@@ -136,13 +139,17 @@ fn resolve_context_targets_in_ops(host: &dyn SyncHost, ops: &[SyncOp]) -> Vec<Sy
                     // now follows this platform's naming convention.
                     let (source, app_name, developer) = match target {
                         serde_json::Value::String(s) => (Some(s.clone()), None, None),
-                        serde_json::Value::Object(map) => {
-                            (
-                                map.get("executable").and_then(|v| v.as_str()).map(str::to_string),
-                                map.get("app_name").and_then(|v| v.as_str()).map(str::to_string),
-                                map.get("developer").and_then(|v| v.as_str()).map(str::to_string),
-                            )
-                        }
+                        serde_json::Value::Object(map) => (
+                            map.get("executable")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                            map.get("app_name")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                            map.get("developer")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                        ),
                         _ => (None, None, None),
                     };
                     let Some(source) = source else { continue };
@@ -423,7 +430,11 @@ pub fn append_self_log(
     )
 }
 
-fn latest_stamp(conn: &Connection, table: &str, row_uuid: &str) -> Result<Option<(i64, String, i64)>> {
+fn latest_stamp(
+    conn: &Connection,
+    table: &str,
+    row_uuid: &str,
+) -> Result<Option<(i64, String, i64)>> {
     sync_store::latest_op_stamp(conn, table, row_uuid)
 }
 
@@ -475,9 +486,11 @@ fn snippet_payload(conn: &Connection, uuid: &str) -> Result<Option<serde_json::V
 
 fn context_aggregate(conn: &Connection, uuid: &str) -> Result<Option<serde_json::Value>> {
     let Some(context_id) = conn
-        .query_row("SELECT id FROM contexts WHERE uuid = ?1", params![uuid], |r| {
-            r.get::<_, i64>(0)
-        })
+        .query_row(
+            "SELECT id FROM contexts WHERE uuid = ?1",
+            params![uuid],
+            |r| r.get::<_, i64>(0),
+        )
         .optional()?
     else {
         return Ok(None);
@@ -760,10 +773,7 @@ pub fn collect_ops(
     let cursor = if done {
         sync_store::max_log_seq(conn)?
     } else {
-        entries
-            .last()
-            .map(|entry| entry.seq)
-            .unwrap_or(since_seq)
+        entries.last().map(|entry| entry.seq).unwrap_or(since_seq)
     };
     Ok((ops, cursor, done))
 }
@@ -936,13 +946,9 @@ fn apply_dictionary_op(conn: &Connection, op: &SyncOp) -> Result<Applied> {
             ],
         )
     };
-    apply_with_natural_key_resolution(
-        conn,
-        op,
-        "dictionary",
-        insert,
-        &|conn| conflicting_uuid(conn, "dictionary", "term", &row.term, &op.row_uuid),
-    )
+    apply_with_natural_key_resolution(conn, op, "dictionary", insert, &|conn| {
+        conflicting_uuid(conn, "dictionary", "term", &row.term, &op.row_uuid)
+    })
 }
 
 fn apply_snippet_op(conn: &Connection, op: &SyncOp) -> Result<Applied> {
@@ -978,13 +984,9 @@ fn apply_snippet_op(conn: &Connection, op: &SyncOp) -> Result<Applied> {
             ],
         )
     };
-    apply_with_natural_key_resolution(
-        conn,
-        op,
-        "snippets",
-        insert,
-        &|conn| conflicting_uuid(conn, "snippets", "trigger", &row.trigger, &op.row_uuid),
-    )
+    apply_with_natural_key_resolution(conn, op, "snippets", insert, &|conn| {
+        conflicting_uuid(conn, "snippets", "trigger", &row.trigger, &op.row_uuid)
+    })
 }
 
 /// Shared upsert flow with natural-key collision resolution. `insert` writes
@@ -1014,8 +1016,8 @@ fn apply_with_natural_key_resolution(
                     op.row_uuid
                 ));
             };
-            let conflict_stamp = latest_stamp(conn, table, &conflict_uuid)?
-                .unwrap_or((0, String::new(), 0));
+            let conflict_stamp =
+                latest_stamp(conn, table, &conflict_uuid)?.unwrap_or((0, String::new(), 0));
             if op.newer_than(&conflict_stamp) {
                 // Remote row wins: remove the local loser (with its cascades)
                 // and retry the insert.
@@ -1049,7 +1051,11 @@ fn conflicting_uuid(
     value: &str,
     exclude_uuid: &str,
 ) -> Result<Option<String>> {
-    let collate = if table == "contexts" { "COLLATE NOCASE" } else { "" };
+    let collate = if table == "contexts" {
+        "COLLATE NOCASE"
+    } else {
+        ""
+    };
     let context_scope = if table == "contexts" {
         " AND is_everywhere = 0"
     } else {
@@ -1218,9 +1224,11 @@ fn apply_everywhere_aggregate(conn: &Connection, aggregate: &ContextAggregate) -
 
 fn delete_context_by_uuid(conn: &Connection, uuid: &str) -> Result<()> {
     let Some(context_id) = conn
-        .query_row("SELECT id FROM contexts WHERE uuid = ?1", params![uuid], |r| {
-            r.get::<_, i64>(0)
-        })
+        .query_row(
+            "SELECT id FROM contexts WHERE uuid = ?1",
+            params![uuid],
+            |r| r.get::<_, i64>(0),
+        )
         .optional()?
     else {
         return Ok(());
@@ -1525,7 +1533,10 @@ fn apply_api_call_op(conn: &Connection, op: &SyncOp) -> Result<Applied> {
     )
     .context("invalid api call payload")?;
     let Some(transcription_uuid) = row.transcription_uuid.as_deref() else {
-        log::warn!("sync: skipping api call {} without a transcription", op.row_uuid);
+        log::warn!(
+            "sync: skipping api call {} without a transcription",
+            op.row_uuid
+        );
         return Ok(Applied::Skipped);
     };
     let Some(transcription_id) = conn
@@ -1602,7 +1613,11 @@ pub fn build_stats_exchange(conn: &Connection, self_uuid: &str) -> Result<StatsE
 /// Applies the peer's stats exchange: their own counters and everything they
 /// know about third devices. Rows for ourselves are ignored (our own
 /// `lifetime_stats` row is authoritative for this device).
-pub fn apply_stats_exchange(conn: &Connection, stats: &StatsExchange, peer_uuid: &str) -> Result<()> {
+pub fn apply_stats_exchange(
+    conn: &Connection,
+    stats: &StatsExchange,
+    peer_uuid: &str,
+) -> Result<()> {
     let self_uuid = sync_store::self_uuid(conn)?.unwrap_or_default();
     let mut incoming: Vec<DeviceStatsDto> = Vec::with_capacity(stats.remote_stats.len() + 1);
     incoming.push(stats.self_stats.clone());
@@ -1663,7 +1678,12 @@ pub fn record_local_setting_change(conn: &Connection, key: &str) -> Result<()> {
     if !SYNCABLE_SETTINGS.contains(&key) {
         return Ok(());
     }
-    sync_store::set_setting_stamp(conn, key, sync_store::now_ms(), &sync_store::self_uuid(conn)?.unwrap_or_default())
+    sync_store::set_setting_stamp(
+        conn,
+        key,
+        sync_store::now_ms(),
+        &sync_store::self_uuid(conn)?.unwrap_or_default(),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1831,8 +1851,7 @@ fn check_hello(remote: &Hello) -> Result<()> {
 }
 
 fn lock(db: &DbHandle) -> Result<std::sync::MutexGuard<'_, Connection>> {
-    db.lock()
-        .map_err(|_| anyhow!("database lock was poisoned"))
+    db.lock().map_err(|_| anyhow!("database lock was poisoned"))
 }
 
 /// Puller side: request deltas, apply batches until the sender reports a
@@ -1928,7 +1947,13 @@ where
     loop {
         let (ops, cursor, done) = {
             let conn = lock(db)?;
-            collect_ops(&conn, next_since_seq, snapshot, OPS_PER_BATCH, &mut progress)?
+            collect_ops(
+                &conn,
+                next_since_seq,
+                snapshot,
+                OPS_PER_BATCH,
+                &mut progress,
+            )?
         };
         let final_cursor = cursor;
         send_message(

--- a/src-tauri/src/sync/identity.rs
+++ b/src-tauri/src/sync/identity.rs
@@ -65,7 +65,9 @@ pub fn load_or_create(
     let cert_path = app_data_dir.join(CERT_FILE);
 
     let stored_cert = std::fs::read(&cert_path).ok();
-    let cert_is_fresh = stored_cert.as_ref().is_some_and(|_| cert_file_fresh(&cert_path));
+    let cert_is_fresh = stored_cert
+        .as_ref()
+        .is_some_and(|_| cert_file_fresh(&cert_path));
     let stored_key = secrets::load_identity_key();
 
     if let (Some(cert_der), Some(key_der), true) = (stored_cert, stored_key, cert_is_fresh) {
@@ -141,11 +143,7 @@ fn create_identity(known_uuid: Option<String>) -> Result<DeviceIdentity> {
     // Start on the first of the current month so certificate creation is
     // stable across month lengths and remains slightly back-dated.
     params.not_before = rcgen::date_time_ymd((this_year - 1) as i32, month, 1);
-    params.not_after = rcgen::date_time_ymd(
-        (this_year - 1 + CERT_YEARS) as i32,
-        month,
-        1,
-    );
+    params.not_after = rcgen::date_time_ymd((this_year - 1 + CERT_YEARS) as i32, month, 1);
     let cert = params
         .self_signed(&key_pair)
         .context("failed to self-sign sync certificate")?;
@@ -224,4 +222,3 @@ mod tests {
         secrets::delete_identity_key();
     }
 }
-

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -46,9 +46,12 @@ const PRIVATE_PORT_COUNT: u32 = 16_384;
 /// listener port turns that otherwise harmless stale record into an immediate
 /// connection refusal during pairing.
 pub(crate) fn listener_port_for_uuid(uuid: &str) -> u16 {
-    let hash = uuid.as_bytes().iter().fold(2_166_136_261_u32, |hash, byte| {
-        (hash ^ u32::from(*byte)).wrapping_mul(16_777_619)
-    });
+    let hash = uuid
+        .as_bytes()
+        .iter()
+        .fold(2_166_136_261_u32, |hash, byte| {
+            (hash ^ u32::from(*byte)).wrapping_mul(16_777_619)
+        });
     PRIVATE_PORT_START + (hash % PRIVATE_PORT_COUNT) as u16
 }
 
@@ -132,7 +135,6 @@ pub enum PeerState {
 pub struct PeerStatus {
     pub state: PeerState,
     pub error: Option<String>,
-    
 }
 
 #[derive(Debug, Clone)]
@@ -233,10 +235,8 @@ impl SyncManager {
             let conn = self.lock_db()?;
             sync_store::self_uuid(&conn)?
         };
-        let identity =
-            identity::load_or_create(&self.inner.data_dir, known_uuid).map_err(|e| {
-                anyhow!("identity setup failed ({e}); check the OS credential store")
-            })?;
+        let identity = identity::load_or_create(&self.inner.data_dir, known_uuid)
+            .map_err(|e| anyhow!("identity setup failed ({e}); check the OS credential store"))?;
         let identity = Arc::new(identity);
 
         // Prefer a user-set name persisted in the DB over the hostname default.
@@ -350,8 +350,8 @@ impl SyncManager {
         if let Some(previous) = self.inner.mdns.lock().await.take() {
             let _ = previous.shutdown();
         }
-        let daemon = ServiceDaemon::new()
-            .map_err(|e| anyhow!("mDNS daemon failed to start: {e}"))?;
+        let daemon =
+            ServiceDaemon::new().map_err(|e| anyhow!("mDNS daemon failed to start: {e}"))?;
         let (uuid, name, port) = {
             let guard = self.inner.identity.read().expect("identity lock");
             let identity = guard.as_ref().ok_or_else(|| anyhow!("identity missing"))?;
@@ -381,7 +381,9 @@ impl SyncManager {
             .unwrap_or_default()
             .into_iter()
             .map(|interface| interface.ip())
-            .filter(|address| address.is_ipv4() && !address.is_loopback() && !address.is_unspecified())
+            .filter(|address| {
+                address.is_ipv4() && !address.is_loopback() && !address.is_unspecified()
+            })
             .collect();
         // Some directly launched macOS app binaries see only loopback through
         // getifaddrs. A UDP route lookup does not send traffic and reliably
@@ -399,7 +401,9 @@ impl SyncManager {
         lan_addresses.sort_unstable();
         lan_addresses.dedup();
         if lan_addresses.is_empty() {
-            log::warn!("sync: no usable LAN address found; keeping discovery alive without advertising");
+            log::warn!(
+                "sync: no usable LAN address found; keeping discovery alive without advertising"
+            );
         } else {
             log::info!("sync: advertising {host} on {lan_addresses:?}");
             let service = ServiceInfo::new(
@@ -430,7 +434,9 @@ impl SyncManager {
                     }
                     ServiceEvent::ServiceRemoved(_, fullname) => {
                         let instance_name = fullname.split('.').next().unwrap_or("");
-                        let instance = instance_name.strip_prefix("verenu-").unwrap_or(instance_name);
+                        let instance = instance_name
+                            .strip_prefix("verenu-")
+                            .unwrap_or(instance_name);
                         let changed = inner
                             .discovered
                             .lock()
@@ -478,7 +484,11 @@ impl SyncManager {
             return Ok(());
         }
 
-        let native_suffix = if cfg!(target_os = "macos") { ".app" } else { ".exe" };
+        let native_suffix = if cfg!(target_os = "macos") {
+            ".app"
+        } else {
+            ".exe"
+        };
         let installed_apps = crate::system::apps::list_installed_apps();
         let platform_tag = crate::data::db::current_platform_tag();
 
@@ -501,7 +511,9 @@ impl SyncManager {
                     resolved = format!("{resolved}#{id}");
                 }
             }
-            let new_platform = (!resolved.starts_with("?::")).then_some(platform_tag).flatten();
+            let new_platform = (!resolved.starts_with("?::"))
+                .then_some(platform_tag)
+                .flatten();
             let updated = conn.execute(
                 "UPDATE context_targets SET executable = ?1, platform = ?2 WHERE id = ?3",
                 rusqlite::params![resolved, new_platform, id],
@@ -515,7 +527,10 @@ impl SyncManager {
                 Err(rusqlite::Error::SqliteFailure(err, _))
                     if err.code == rusqlite::ErrorCode::ConstraintViolation =>
                 {
-                    conn.execute("DELETE FROM context_targets WHERE id = ?1", rusqlite::params![id])?;
+                    conn.execute(
+                        "DELETE FROM context_targets WHERE id = ?1",
+                        rusqlite::params![id],
+                    )?;
                 }
                 Err(err) => return Err(err.into()),
             }
@@ -525,7 +540,9 @@ impl SyncManager {
 
     pub fn identity_exchange(&self) -> Result<IdentityExchange> {
         let guard = self.inner.identity.read().expect("identity lock");
-        let identity = guard.as_ref().ok_or_else(|| anyhow!("sync is unavailable"))?;
+        let identity = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("sync is unavailable"))?;
         Ok(IdentityExchange {
             device_uuid: identity.uuid.clone(),
             device_name: identity.name.clone(),
@@ -575,9 +592,7 @@ impl SyncManager {
         let peers = peers
             .into_iter()
             .map(|peer| {
-                let online = discovered
-                    .iter()
-                    .any(|d| d.uuid == peer.device_uuid);
+                let online = discovered.iter().any(|d| d.uuid == peer.device_uuid);
                 let state = status
                     .as_ref()
                     .and_then(|s| s.get(&peer.device_uuid))
@@ -645,7 +660,11 @@ impl SyncManager {
             if pending.is_some() {
                 return Err(anyhow!("a pairing is already in progress"));
             }
-            generation = self.inner.pairing_generation.fetch_add(1, Ordering::Relaxed) + 1;
+            generation = self
+                .inner
+                .pairing_generation
+                .fetch_add(1, Ordering::Relaxed)
+                + 1;
             *pending = Some(PendingPairing::Outgoing {
                 generation,
                 abort: None,
@@ -670,9 +689,7 @@ impl SyncManager {
                 .await;
             if let Err(err) = result {
                 log::warn!("sync: pairing with {} failed: {err:#}", target.name);
-                manager
-                    .inner
-                    .fail_pairing(generation, format!("{err:#}"));
+                manager.inner.fail_pairing(generation, format!("{err:#}"));
                 manager
                     .inner
                     .app
@@ -692,8 +709,11 @@ impl SyncManager {
         let abort = task.abort_handle();
         {
             let mut pending = self.inner.pending.lock().await;
-            if let Some(PendingPairing::Outgoing { abort: slot, generation: g, .. }) =
-                pending.as_mut()
+            if let Some(PendingPairing::Outgoing {
+                abort: slot,
+                generation: g,
+                ..
+            }) = pending.as_mut()
             {
                 if *g == generation {
                     *slot = Some(abort);
@@ -722,7 +742,8 @@ impl SyncManager {
         let mut tcp = None;
         let mut failures = Vec::new();
         for addr in connection_candidates(&target.addresses, target.port, &target.uuid) {
-            match tokio::time::timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(addr)).await {
+            match tokio::time::timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(addr)).await
+            {
                 Ok(Ok(stream)) => {
                     tcp = Some(stream);
                     break;
@@ -757,7 +778,8 @@ impl SyncManager {
             },
         )
         .await?;
-        self.inner.update_pairing_phase(generation, "waiting_for_code");
+        self.inner
+            .update_pairing_phase(generation, "waiting_for_code");
 
         // The responder replies only after its user approves, so the whole
         // exchange runs under the generous pairing timeout.
@@ -863,13 +885,7 @@ impl SyncManager {
         };
         let result = match tokio::time::timeout(
             PAIRING_TIMEOUT,
-            pairing::responder_exchange(
-                &mut stream,
-                &cipher,
-                responder_msg,
-                &identity,
-                &peer_uuid,
-            ),
+            pairing::responder_exchange(&mut stream, &cipher, responder_msg, &identity, &peer_uuid),
         )
         .await
         {
@@ -915,8 +931,7 @@ impl SyncManager {
         generation: u64,
     ) {
         let mut pending = self.inner.pending.lock().await;
-        if pending.is_none()
-            && self.inner.pairing_generation.load(Ordering::Relaxed) == generation
+        if pending.is_none() && self.inner.pairing_generation.load(Ordering::Relaxed) == generation
         {
             *pending = Some(PendingPairing::Incoming {
                 peer_uuid: peer_uuid.clone(),
@@ -990,7 +1005,9 @@ impl SyncManager {
 
     pub async fn cancel_pairing(&self) -> Result<()> {
         let mut guard = self.inner.pending.lock().await;
-        self.inner.pairing_generation.fetch_add(1, Ordering::Relaxed);
+        self.inner
+            .pairing_generation
+            .fetch_add(1, Ordering::Relaxed);
         if let Some(PendingPairing::Outgoing {
             abort: Some(abort_handle),
             ..
@@ -1069,7 +1086,13 @@ impl SyncManager {
         .await
         .map_err(|_| anyhow!("tls timeout"))??;
         let my_uuid = self.device_info().uuid;
-        send_message(&mut tls, &Message::Unpair { device_uuid: my_uuid }).await?;
+        send_message(
+            &mut tls,
+            &Message::Unpair {
+                device_uuid: my_uuid,
+            },
+        )
+        .await?;
         Ok(())
     }
 
@@ -1206,8 +1229,7 @@ impl SyncManager {
         }
         let Ok(peer) = (|| {
             let conn = self.lock_db()?;
-            sync_store::get_peer(&conn, peer_uuid)?
-                .ok_or_else(|| anyhow!("not paired"))
+            sync_store::get_peer(&conn, peer_uuid)?.ok_or_else(|| anyhow!("not paired"))
         })() else {
             return;
         };
@@ -1520,7 +1542,9 @@ fn handle_resolved(inner: &Arc<Inner>, info: mdns_sd::ResolvedService) {
         .map(str::to_string)
         .or_else(|| {
             let instance_name = info.get_fullname().split('.').next().unwrap_or("");
-            let instance = instance_name.strip_prefix("verenu-").unwrap_or(instance_name);
+            let instance = instance_name
+                .strip_prefix("verenu-")
+                .unwrap_or(instance_name);
             (!instance.is_empty()).then(|| instance.to_string())
         });
     let Some(uuid) = uuid else { return };
@@ -1747,7 +1771,9 @@ async fn handle_sync_hello(
     // device whose pinned fingerprint matches the presented certificate.
     let peer = (|| {
         let conn = inner.db.lock().ok()?;
-        sync_store::get_peer(&conn, &hello.device_uuid).ok().flatten()
+        sync_store::get_peer(&conn, &hello.device_uuid)
+            .ok()
+            .flatten()
     })();
     let Some(peer) = peer else {
         let _ = send_message(
@@ -1957,10 +1983,15 @@ impl SyncHost for ManagerHost {
             developer,
             &self.installed_apps,
         )
-        .map(|app| (app.exe.clone(), Some(app.name.clone()), app.developer.clone()))
+        .map(|app| {
+            (
+                app.exe.clone(),
+                Some(app.name.clone()),
+                app.developer.clone(),
+            )
+        })
     }
 }
-
 
 pub(crate) fn closest_installed_app<'a>(
     source: &str,
@@ -1968,4 +1999,3 @@ pub(crate) fn closest_installed_app<'a>(
 ) -> Option<&'a crate::system::apps::InstalledApp> {
     crate::system::apps::closest_installed_app(source, None, None, apps)
 }
-

--- a/src-tauri/src/sync/pairing.rs
+++ b/src-tauri/src/sync/pairing.rs
@@ -64,7 +64,10 @@ fn encrypt_identity(
     let ciphertext = cipher
         .encrypt(
             Nonce::from_slice(&nonce_bytes),
-            Payload { msg: &plaintext, aad: PAIRING_INFO },
+            Payload {
+                msg: &plaintext,
+                aad: PAIRING_INFO,
+            },
         )
         .map_err(|_| anyhow!("identity encryption failed"))?;
     Ok((ciphertext, nonce_bytes.to_vec()))
@@ -82,7 +85,10 @@ fn decrypt_identity(
     let plaintext = cipher
         .decrypt(
             Nonce::from_slice(&nonce),
-            Payload { msg: ciphertext, aad: PAIRING_INFO },
+            Payload {
+                msg: ciphertext,
+                aad: PAIRING_INFO,
+            },
         )
         .map_err(|_| anyhow!("that code didn't match"))?;
     Ok(serde_json::from_slice(&plaintext)?)
@@ -176,7 +182,13 @@ pub async fn responder_exchange<S>(
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    send_message(stream, &Message::PairAccept { spake_msg: responder_msg }).await?;
+    send_message(
+        stream,
+        &Message::PairAccept {
+            spake_msg: responder_msg,
+        },
+    )
+    .await?;
 
     let (ciphertext, nonce) = match read_message(stream).await? {
         Message::PairVerify { ciphertext, nonce } => (ciphertext, nonce),
@@ -191,10 +203,12 @@ where
     let (my_ciphertext, my_nonce) = encrypt_identity(cipher, self_identity)?;
     send_message(
         stream,
-        &Message::PairVerify { ciphertext: my_ciphertext, nonce: my_nonce },
+        &Message::PairVerify {
+            ciphertext: my_ciphertext,
+            nonce: my_nonce,
+        },
     )
     .await?;
     send_message(stream, &Message::PairComplete).await?;
     Ok(peer)
 }
-

--- a/src-tauri/src/sync/protocol.rs
+++ b/src-tauri/src/sync/protocol.rs
@@ -2,7 +2,7 @@
 //! mutually-authenticated TLS stream. Boring on purpose - every message is a
 //! serde struct, framed with a 4-byte big-endian length prefix.
 
-use anyhow::{anyhow, Result, Context};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -178,7 +178,6 @@ pub async fn read_message<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Messag
     }
     let mut body = vec![0u8; len as usize];
     reader.read_exact(&mut body).await?;
-    let message: Message =
-        serde_json::from_slice(&body).context("decode message from peer")?;
+    let message: Message = serde_json::from_slice(&body).context("decode message from peer")?;
     Ok(message)
 }

--- a/src-tauri/src/sync/secrets.rs
+++ b/src-tauri/src/sync/secrets.rs
@@ -105,8 +105,8 @@ mod win_store {
     use super::store_fallback;
     use windows::core::{PCWSTR, PWSTR};
     use windows::Win32::Security::Credentials::{
-        CredDeleteW, CredFree, CredReadW, CredWriteW, CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC,
-        CREDENTIALW,
+        CredDeleteW, CredFree, CredReadW, CredWriteW, CREDENTIALW, CRED_PERSIST_LOCAL_MACHINE,
+        CRED_TYPE_GENERIC,
     };
 
     // Windows stores the blob as UTF-16; encode hex so any byte value survives.
@@ -240,4 +240,3 @@ mod mac_store {
         })
     }
 }
-

--- a/src-tauri/src/sync/store.rs
+++ b/src-tauri/src/sync/store.rs
@@ -108,12 +108,7 @@ pub fn get_peer(conn: &Connection, device_uuid: &str) -> Result<Option<SyncPeer>
 
 /// Inserts or updates a paired device. `cert_fp` is the hex SHA-256 of the
 /// peer's certificate DER - the pin every future connection is checked against.
-pub fn upsert_peer(
-    conn: &Connection,
-    device_uuid: &str,
-    name: &str,
-    cert_fp: &str,
-) -> Result<()> {
+pub fn upsert_peer(conn: &Connection, device_uuid: &str, name: &str, cert_fp: &str) -> Result<()> {
     conn.execute(
         "INSERT INTO sync_peers (device_uuid, name, cert_fp, needs_snapshot)
          VALUES (?1, ?2, ?3, 1)
@@ -267,7 +262,14 @@ pub fn append_op(
     conn.execute(
         "INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![op.table_name(), op.row_uuid, op.op_name(), ts_ms, origin, origin_seq],
+        params![
+            op.table_name(),
+            op.row_uuid,
+            op.op_name(),
+            ts_ms,
+            origin,
+            origin_seq
+        ],
     )?;
     Ok(())
 }
@@ -315,11 +317,9 @@ pub fn changes_since(conn: &Connection, after_seq: i64, limit: i64) -> Result<Ve
 }
 
 pub fn max_log_seq(conn: &Connection) -> Result<i64> {
-    let seq: i64 = conn.query_row(
-        "SELECT COALESCE(MAX(seq), 0) FROM sync_log",
-        [],
-        |r| r.get(0),
-    )?;
+    let seq: i64 = conn.query_row("SELECT COALESCE(MAX(seq), 0) FROM sync_log", [], |r| {
+        r.get(0)
+    })?;
     Ok(seq)
 }
 
@@ -329,11 +329,7 @@ pub fn max_log_seq(conn: &Connection) -> Result<i64> {
 /// its delta; if it stays away too long it falls back to a full snapshot.
 pub fn compact_log(conn: &Connection) -> Result<usize> {
     let min_cursor: Option<i64> = conn
-        .query_row(
-            "SELECT MIN(send_cursor) FROM sync_peers",
-            [],
-            |r| r.get(0),
-        )
+        .query_row("SELECT MIN(send_cursor) FROM sync_peers", [], |r| r.get(0))
         .optional()?
         .flatten();
     let Some(min_cursor) = min_cursor else {
@@ -355,9 +351,8 @@ pub fn compact_log(conn: &Connection) -> Result<usize> {
 }
 
 pub fn list_remote_stats(conn: &Connection) -> Result<Vec<DeviceStats>> {
-    let mut stmt = conn.prepare(
-        "SELECT device_id, total_words, dictionary_fixes FROM sync_remote_stats",
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT device_id, total_words, dictionary_fixes FROM sync_remote_stats")?;
     let rows = stmt
         .query_map([], |r| {
             Ok(DeviceStats {
@@ -421,7 +416,10 @@ pub fn list_setting_stamps(conn: &Connection) -> Result<Vec<(String, SettingStam
         .query_map([], |r| {
             Ok((
                 r.get::<_, String>(0)?,
-                SettingStamp { ts_ms: r.get(1)?, origin: r.get(2)? },
+                SettingStamp {
+                    ts_ms: r.get(1)?,
+                    origin: r.get(2)?,
+                },
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -433,7 +431,12 @@ pub fn get_setting_stamp(conn: &Connection, key: &str) -> Result<Option<SettingS
         .query_row(
             "SELECT ts_ms, origin FROM sync_setting_meta WHERE key = ?1",
             params![key],
-            |r| Ok(SettingStamp { ts_ms: r.get(0)?, origin: r.get(1)? }),
+            |r| {
+                Ok(SettingStamp {
+                    ts_ms: r.get(0)?,
+                    origin: r.get(1)?,
+                })
+            },
         )
         .optional()?;
     Ok(row)
@@ -470,5 +473,3 @@ pub fn now_ms() -> i64 {
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
 }
-
-

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -28,13 +28,13 @@ fn listener_port_is_stable_and_device_specific() {
 #[test]
 fn connection_candidates_try_stable_port_before_stale_advertisement() {
     let uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
-    let candidates = super::manager::connection_candidates(
-        &["192.168.0.86:58546".to_string()],
-        58546,
-        uuid,
-    );
+    let candidates =
+        super::manager::connection_candidates(&["192.168.0.86:58546".to_string()], 58546, uuid);
     assert_eq!(candidates.len(), 2);
-    assert_eq!(candidates[0].port(), super::manager::listener_port_for_uuid(uuid));
+    assert_eq!(
+        candidates[0].port(),
+        super::manager::listener_port_for_uuid(uuid)
+    );
     assert_eq!(candidates[1].port(), 58546);
 }
 
@@ -56,7 +56,13 @@ fn test_db(device_uuid: &str) -> DbHandle {
 }
 
 fn uuid(prefix: &str) -> String {
-    format!("{prefix}-{}", crate::sync::identity::fingerprint_of(prefix.as_bytes()).get(..8).expect("len").to_string())
+    format!(
+        "{prefix}-{}",
+        crate::sync::identity::fingerprint_of(prefix.as_bytes())
+            .get(..8)
+            .expect("len")
+            .to_string()
+    )
 }
 
 fn row_uuid(conn: &rusqlite::Connection, table: &str, id: i64) -> String {
@@ -175,9 +181,12 @@ fn peer_of(device_uuid: &str) -> sync_store::SyncPeer {
 fn triggers_capture_content_changes() {
     let a_uuid = uuid("aaaa");
     let db = test_db(&a_uuid);
-    let dict = db::insert_dictionary_entry_returning(&db, "Groq", Some("Grock"), None).expect("insert");
-    let snippet = db::insert_snippet_returning(&db, "addr", "123 Main St", "", None).expect("snippet");
-    let context = db::insert_context_returning(&db, "Work", None, None, None, None, false).expect("context");
+    let dict =
+        db::insert_dictionary_entry_returning(&db, "Groq", Some("Grock"), None).expect("insert");
+    let snippet =
+        db::insert_snippet_returning(&db, "addr", "123 Main St", "", None).expect("snippet");
+    let context =
+        db::insert_context_returning(&db, "Work", None, None, None, None, false).expect("context");
     db::assign_context_target(&db, context.id, "code.exe").expect("target");
 
     let conn = db.lock().expect("lock");
@@ -250,9 +259,12 @@ fn content_syncs_both_directions_without_duplicates() {
     let a = test_db(&uuid("aaaa"));
     let b = test_db(&uuid("bbbb"));
 
-    let entry_a = db::insert_dictionary_entry_returning(&a, "Groq", Some("Grock"), None).expect("a entry");
-    let _snippet_b = db::insert_snippet_returning(&b, "addr", "123 Main St", "", None).expect("b snippet");
-    let ctx_a = db::insert_context_returning(&a, "Work", None, None, None, None, false).expect("ctx");
+    let entry_a =
+        db::insert_dictionary_entry_returning(&a, "Groq", Some("Grock"), None).expect("a entry");
+    let _snippet_b =
+        db::insert_snippet_returning(&b, "addr", "123 Main St", "", None).expect("b snippet");
+    let ctx_a =
+        db::insert_context_returning(&a, "Work", None, None, None, None, false).expect("ctx");
     db::assign_context_target(&a, ctx_a.id, "code.exe").expect("target");
     // Scope A's dictionary entry to A's context.
     db::set_dictionary_context_assignment(&a, ctx_a.id, entry_a.id, true).expect("assign");
@@ -263,11 +275,17 @@ fn content_syncs_both_directions_without_duplicates() {
     assert_eq!(count(&conn_b, "SELECT COUNT(*) FROM dictionary"), 1);
     assert_eq!(count(&conn_b, "SELECT COUNT(*) FROM snippets"), 1);
     assert_eq!(
-        count(&conn_b, "SELECT COUNT(*) FROM contexts WHERE is_everywhere = 0"),
+        count(
+            &conn_b,
+            "SELECT COUNT(*) FROM contexts WHERE is_everywhere = 0"
+        ),
         1
     );
     assert_eq!(count(&conn_b, "SELECT COUNT(*) FROM context_targets"), 1);
-    assert_eq!(count(&conn_b, "SELECT COUNT(*) FROM dictionary_contexts"), 1);
+    assert_eq!(
+        count(&conn_b, "SELECT COUNT(*) FROM dictionary_contexts"),
+        1
+    );
     drop(conn_b);
 
     // And back: B's snippet reaches A.
@@ -292,7 +310,8 @@ fn edits_and_deletes_propagate() {
     let b = test_db(&uuid("bbbb"));
 
     // A creates an entry; it reaches B.
-    let entry = db::insert_dictionary_entry_returning(&a, "Groq", Some("Grock"), None).expect("entry");
+    let entry =
+        db::insert_dictionary_entry_returning(&a, "Groq", Some("Grock"), None).expect("entry");
     exchange(&a, &b);
     {
         let conn = b.lock().expect("lock");
@@ -310,7 +329,11 @@ fn edits_and_deletes_propagate() {
     {
         let conn = a.lock().expect("lock");
         let mistake: String = conn
-            .query_row("SELECT mistake FROM dictionary WHERE id = ?1", rusqlite::params![entry.id], |r| r.get(0))
+            .query_row(
+                "SELECT mistake FROM dictionary WHERE id = ?1",
+                rusqlite::params![entry.id],
+                |r| r.get(0),
+            )
             .expect("mistake");
         assert_eq!(mistake, "Groqck", "B's edit reached A");
     }
@@ -319,7 +342,11 @@ fn edits_and_deletes_propagate() {
     db::delete_dictionary_entry(&b, local_id).expect("delete on b");
     exchange(&a, &b);
     let conn_a = a.lock().expect("lock");
-    assert_eq!(count(&conn_a, "SELECT COUNT(*) FROM dictionary"), 0, "delete propagated");
+    assert_eq!(
+        count(&conn_a, "SELECT COUNT(*) FROM dictionary"),
+        0,
+        "delete propagated"
+    );
     drop(conn_a);
     let conn_b = b.lock().expect("lock");
     assert_eq!(count(&conn_b, "SELECT COUNT(*) FROM dictionary"), 0);
@@ -342,7 +369,10 @@ fn delete_loses_to_a_newer_edit() {
             payload: None,
         };
         let summary = engine::apply_ops(&conn, &[delete]).expect("apply delete");
-        assert_eq!(summary.skipped, 1, "older delete must lose to the newer edit");
+        assert_eq!(
+            summary.skipped, 1,
+            "older delete must lose to the newer edit"
+        );
     }
     let conn = db.lock().expect("lock");
     assert_eq!(count(&conn, "SELECT COUNT(*) FROM dictionary"), 1);
@@ -376,7 +406,9 @@ fn natural_key_conflict_converges_to_one_row() {
         let other = if name == "a" { &b } else { &a };
         let conn_other = other.lock().expect("lock");
         let other_uuids: Vec<String> = {
-            let mut stmt = conn_other.prepare("SELECT uuid FROM dictionary").expect("q");
+            let mut stmt = conn_other
+                .prepare("SELECT uuid FROM dictionary")
+                .expect("q");
             stmt.query_map([], |r| r.get(0))
                 .expect("map")
                 .collect::<rusqlite::Result<Vec<_>>>()
@@ -419,7 +451,8 @@ async fn session_snapshot_seeds_a_new_device() {
         db::insert_dictionary_entry_returning(&a, &format!("term{i}"), None, None).expect("entry");
     }
     db::insert_snippet_returning(&a, "sig", "Best regards", "", None).expect("snippet");
-    let ctx = db::insert_context_returning(&a, "Meetings", None, None, None, None, false).expect("ctx");
+    let ctx =
+        db::insert_context_returning(&a, "Meetings", None, None, None, None, false).expect("ctx");
     db::assign_context_website(&a, ctx.id, "meet.example.com").expect("site");
 
     let host_a = TestHost::new(&uuid("aaaa"));
@@ -473,15 +506,8 @@ async fn responder_continues_after_dispatcher_consumes_hello() {
                 Message::Hello(hello) => hello,
                 other => panic!("expected hello, got {other:?}"),
             };
-            engine::run_session_after_hello(
-                &b,
-                &host_b,
-                &mut side_b,
-                false,
-                &peer_b,
-                Some(hello),
-            )
-            .await
+            engine::run_session_after_hello(&b, &host_b, &mut side_b, false, &peer_b, Some(hello))
+                .await
         }
     );
     initiator.expect("initiator completes");
@@ -605,8 +631,17 @@ async fn lifetime_counters_merge_without_double_counting() {
     let host_b = TestHost::new(&uuid("bbbb"));
 
     // Each device dictated: A 100 words, B 40 words.
-    db::insert_transcription_returning(&a, "one two three", "one two three", 100, 6_000, "", None, None)
-        .expect("transcribe a");
+    db::insert_transcription_returning(
+        &a,
+        "one two three",
+        "one two three",
+        100,
+        6_000,
+        "",
+        None,
+        None,
+    )
+    .expect("transcribe a");
     db::insert_transcription_returning(&b, "hello world", "hello world", 40, 4_000, "", None, None)
         .expect("transcribe b");
 
@@ -619,7 +654,11 @@ async fn lifetime_counters_merge_without_double_counting() {
         assert_eq!(count(&conn, "SELECT COUNT(*) FROM transcriptions"), 2);
         // History rows arrived with their original timestamps and text.
         let raw: String = conn
-            .query_row("SELECT raw_text FROM transcriptions WHERE words = 100", [], |r| r.get(0))
+            .query_row(
+                "SELECT raw_text FROM transcriptions WHERE words = 100",
+                [],
+                |r| r.get(0),
+            )
             .expect("row");
         assert_eq!(raw, "one two three");
     }
@@ -640,14 +679,18 @@ async fn settings_lww_applies_newer_remote_value() {
         .lock()
         .expect("s")
         .insert("default_tone".to_string(), json!("formal"));
-    host_a
-        .stamps
-        .lock()
-        .expect("s")
-        .insert("default_tone".to_string(), (base + 5_000, host_a.uuid.clone()));
+    host_a.stamps.lock().expect("s").insert(
+        "default_tone".to_string(),
+        (base + 5_000, host_a.uuid.clone()),
+    );
 
     run_two_sessions(&a, &b, &host_a, &host_b).await;
-    let applied = host_b.settings.lock().expect("s").get("default_tone").cloned();
+    let applied = host_b
+        .settings
+        .lock()
+        .expect("s")
+        .get("default_tone")
+        .cloned();
     assert_eq!(applied, Some(json!("formal")), "newer remote setting wins");
 
     // B's older local change (stamped before A's) must not overwrite it.
@@ -656,11 +699,10 @@ async fn settings_lww_applies_newer_remote_value() {
         .lock()
         .expect("s")
         .insert("default_tone".to_string(), json!("casual"));
-    host_b
-        .stamps
-        .lock()
-        .expect("s")
-        .insert("default_tone".to_string(), (base + 1_000, host_b.uuid.clone()));
+    host_b.stamps.lock().expect("s").insert(
+        "default_tone".to_string(),
+        (base + 1_000, host_b.uuid.clone()),
+    );
     // Production stamps the DB when a setting changes locally (save_setting
     // hook); mirror that here so B's LWW stamp matches its value.
     {
@@ -669,7 +711,12 @@ async fn settings_lww_applies_newer_remote_value() {
             .expect("stamp");
     }
     run_two_sessions(&a, &b, &host_a, &host_b).await;
-    let applied = host_b.settings.lock().expect("s").get("default_tone").cloned();
+    let applied = host_b
+        .settings
+        .lock()
+        .expect("s")
+        .get("default_tone")
+        .cloned();
     assert_eq!(applied, Some(json!("formal")), "older local value loses");
 }
 
@@ -792,7 +839,12 @@ fn resolved_context_target_survives_a_later_unresolved_resync() {
 
     engine::apply_ops(
         &conn,
-        &[test_context_op("Editor Group", 100, "?::antigravity ide.exe", None)],
+        &[test_context_op(
+            "Editor Group",
+            100,
+            "?::antigravity ide.exe",
+            None,
+        )],
     )
     .expect("apply unresolved");
     let context_id: i64 = conn
@@ -820,10 +872,18 @@ fn resolved_context_target_survives_a_later_unresolved_resync() {
     let resync_ts = sync_store::now_ms() + 1;
     let summary = engine::apply_ops(
         &conn,
-        &[test_context_op("Editor Group", resync_ts, "?::antigravity ide.exe", None)],
+        &[test_context_op(
+            "Editor Group",
+            resync_ts,
+            "?::antigravity ide.exe",
+            None,
+        )],
     )
     .expect("apply resync");
-    assert_eq!(summary.applied, 1, "the resync op must actually apply, not be skipped as stale");
+    assert_eq!(
+        summary.applied, 1,
+        "the resync op must actually apply, not be skipped as stale"
+    );
 
     // The sticky row must survive completely unchanged. (A stray unresolved
     // marker may additionally appear alongside it here, since this test's
@@ -837,12 +897,17 @@ fn resolved_context_target_survives_a_later_unresolved_resync() {
         .prepare("SELECT executable, platform FROM context_targets WHERE context_id = ?1")
         .expect("prepare");
     let rows: Vec<(String, Option<String>)> = stmt
-        .query_map(rusqlite::params![context_id], |r| Ok((r.get(0)?, r.get(1)?)))
+        .query_map(rusqlite::params![context_id], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
         .expect("query")
         .collect::<rusqlite::Result<_>>()
         .expect("collect");
     assert!(
-        rows.contains(&("antigravity.app".to_string(), my_platform.map(str::to_string))),
+        rows.contains(&(
+            "antigravity.app".to_string(),
+            my_platform.map(str::to_string)
+        )),
         "the manually-fixed target must survive the worse resync unchanged, got {rows:?}"
     );
 }
@@ -943,7 +1008,12 @@ async fn pairing_succeeds_with_matching_code_and_fails_with_wrong_code() {
         },
         async move {
             let request = read_message(&mut b).await.expect("request");
-            let Message::PairRequest { spake_msg, device_uuid, .. } = request else {
+            let Message::PairRequest {
+                spake_msg,
+                device_uuid,
+                ..
+            } = request
+            else {
                 panic!("expected pair request");
             };
             let (msg_b, cipher) = pairing::responder_start(&code_b, &spake_msg).expect("start");
@@ -956,8 +1026,14 @@ async fn pairing_succeeds_with_matching_code_and_fails_with_wrong_code() {
     assert_eq!(peer_from_a.cert_der, vec![4, 5, 6]);
 
     // Wrong code: both sides must fail with a friendly error, not panic.
-    let identity_a2 = IdentityExchange { cert_der: vec![7], ..identity_a };
-    let identity_b2 = IdentityExchange { cert_der: vec![8], ..identity_b_for_second };
+    let identity_a2 = IdentityExchange {
+        cert_der: vec![7],
+        ..identity_a
+    };
+    let identity_b2 = IdentityExchange {
+        cert_der: vec![8],
+        ..identity_b_for_second
+    };
     let expected_uuid2 = identity_b2.device_uuid.clone();
     let (mut a2, mut b2) = tokio::io::duplex(64 * 1024);
     let (state_a2, msg_a2) = pairing::initiator_start("111111");
@@ -983,7 +1059,12 @@ async fn pairing_succeeds_with_matching_code_and_fails_with_wrong_code() {
         },
         async move {
             let request = read_message(&mut b2).await.expect("request");
-            let Message::PairRequest { spake_msg, device_uuid, .. } = request else {
+            let Message::PairRequest {
+                spake_msg,
+                device_uuid,
+                ..
+            } = request
+            else {
                 panic!("expected pair request");
             };
             // Responder uses a DIFFERENT code.
@@ -1008,4 +1089,3 @@ fn pair_test_dbs(a: &DbHandle, b: &DbHandle, a_uuid: &str, b_uuid: &str) {
         sync_store::upsert_peer(&conn, a_uuid, "A", "fp-a").expect("upsert b->a");
     }
 }
-

--- a/src-tauri/src/sync/transport.rs
+++ b/src-tauri/src/sync/transport.rs
@@ -12,9 +12,7 @@
 use anyhow::{anyhow, Result};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
-use rustls::pki_types::{
-    CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime,
-};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{ClientConfig, DigitallySignedStruct, ServerConfig, SignatureScheme};
 use std::sync::Arc;
@@ -142,16 +140,16 @@ pub fn crypto_provider() -> CryptoProvider {
     rustls::crypto::ring::default_provider()
 }
 
-pub fn server_config(cert: CertificateDer<'static>, key: PrivatePkcs8KeyDer<'static>) -> Result<Arc<ServerConfig>> {
+pub fn server_config(
+    cert: CertificateDer<'static>,
+    key: PrivatePkcs8KeyDer<'static>,
+) -> Result<Arc<ServerConfig>> {
     let provider = crypto_provider();
     let config = ServerConfig::builder_with_provider(provider.clone().into())
         .with_safe_default_protocol_versions()
         .map_err(|e| anyhow!("tls protocol setup failed: {e}"))?
         .with_client_cert_verifier(AcceptAnyClient::new(provider))
-        .with_single_cert(
-            vec![cert],
-            PrivateKeyDer::Pkcs8(key),
-        )
+        .with_single_cert(vec![cert], PrivateKeyDer::Pkcs8(key))
         .map_err(|e| anyhow!("tls server certificate rejected: {e}"))?;
     Ok(Arc::new(config))
 }

--- a/src-tauri/src/system/apps.rs
+++ b/src-tauri/src/system/apps.rs
@@ -464,10 +464,18 @@ pub fn list_installed_apps_cached() -> Vec<InstalledApp> {
     }
 
     static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(Cache { at: None, apps: Vec::new() }));
+    let cache = CACHE.get_or_init(|| {
+        Mutex::new(Cache {
+            at: None,
+            apps: Vec::new(),
+        })
+    });
     {
         let guard = cache.lock().expect("installed-app cache lock");
-        if guard.at.is_some_and(|at| at.elapsed() < Duration::from_secs(15)) {
+        if guard
+            .at
+            .is_some_and(|at| at.elapsed() < Duration::from_secs(15))
+        {
             return guard.apps.clone();
         }
     }
@@ -477,7 +485,10 @@ pub fn list_installed_apps_cached() -> Vec<InstalledApp> {
     // the potentially slow inventory operation.
     let apps = list_installed_apps();
     let mut guard = cache.lock().expect("installed-app cache lock");
-    if guard.at.is_none_or(|at| at.elapsed() >= Duration::from_secs(15)) {
+    if guard
+        .at
+        .is_none_or(|at| at.elapsed() >= Duration::from_secs(15))
+    {
         guard.apps = apps;
         guard.at = Some(Instant::now());
     }
@@ -520,38 +531,57 @@ pub fn closest_installed_app<'a>(
                 .collect::<Vec<_>>();
             let score = source_keys
                 .iter()
-                .flat_map(|source| candidate_keys.iter().map(move |candidate| app_match_score(source, candidate)))
+                .flat_map(|source| {
+                    candidate_keys
+                        .iter()
+                        .map(move |candidate| app_match_score(source, candidate))
+                })
                 .fold(0.0_f32, f32::max);
-            let same_developer = source_developer.is_some() && source_developer == candidate_developer;
+            let same_developer =
+                source_developer.is_some() && source_developer == candidate_developer;
             let threshold = if same_developer { 0.72 } else { 0.78 };
             // Legacy targets do not have metadata yet. A lower threshold is
             // still safe when the candidate preserves a meaningful prefix;
             // without either developer agreement or that prefix, a similar
             // score is not enough to auto-rebind a user assignment.
             let strong_prefix = source_keys.iter().any(|source| {
-                candidate_keys.iter().any(|candidate| common_prefix_len(source, candidate) >= 4)
+                candidate_keys
+                    .iter()
+                    .any(|candidate| common_prefix_len(source, candidate) >= 4)
             });
             let ranking_score = score + if same_developer { 0.05 } else { 0.0 };
-            (score >= threshold && (same_developer || strong_prefix))
-                .then_some((app, score, same_developer, ranking_score))
+            (score >= threshold && (same_developer || strong_prefix)).then_some((
+                app,
+                score,
+                same_developer,
+                ranking_score,
+            ))
         })
-        .max_by(|(_, left_score, left_same, left_rank), (_, right_score, right_same, right_rank)| {
-            // A fixed developer bonus prefers same-developer matches within
-            // the intended margin while keeping the ordering transitive.
-            left_rank
-                .total_cmp(right_rank)
-                .then_with(|| left_score.total_cmp(right_score))
-                .then_with(|| left_same.cmp(right_same))
-        })
+        .max_by(
+            |(_, left_score, left_same, left_rank), (_, right_score, right_same, right_rank)| {
+                // A fixed developer bonus prefers same-developer matches within
+                // the intended margin while keeping the ordering transitive.
+                left_rank
+                    .total_cmp(right_rank)
+                    .then_with(|| left_score.total_cmp(right_score))
+                    .then_with(|| left_same.cmp(right_same))
+            },
+        )
         .map(|(app, _, _, _)| app)
 }
 
 fn normalized_metadata(value: Option<&str>) -> Option<String> {
-    value.map(str::trim).filter(|value| !value.is_empty()).map(str::to_lowercase)
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_lowercase)
 }
 
 fn developer_metadata_is_comparable(left: &Option<String>, right: &Option<String>) -> bool {
-    match (developer_metadata_kind(left.as_deref()), developer_metadata_kind(right.as_deref())) {
+    match (
+        developer_metadata_kind(left.as_deref()),
+        developer_metadata_kind(right.as_deref()),
+    ) {
         (Some(left_kind), Some(right_kind)) => left_kind == right_kind,
         (None, None) => true,
         // A bundle identifier and a registry publisher are platform-specific
@@ -566,12 +596,20 @@ fn developer_metadata_kind(value: Option<&str>) -> Option<&'static str> {
         value
             .strip_prefix("mac-bundle:")
             .map(|_| "mac-bundle")
-            .or_else(|| value.strip_prefix("windows-publisher:").map(|_| "windows-publisher"))
+            .or_else(|| {
+                value
+                    .strip_prefix("windows-publisher:")
+                    .map(|_| "windows-publisher")
+            })
     })
 }
 
 fn app_match_key(value: &str) -> String {
-    let basename = value.rsplit(['/', '\\']).next().unwrap_or(value).to_lowercase();
+    let basename = value
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(value)
+        .to_lowercase();
     let basename = basename
         .strip_suffix(".exe")
         .or_else(|| basename.strip_suffix(".app"))
@@ -580,8 +618,12 @@ fn app_match_key(value: &str) -> String {
 }
 
 fn app_match_score(left: &str, right: &str) -> f32 {
-    if left.is_empty() || right.is_empty() { return 0.0; }
-    if left == right { return 1.0; }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+    if left == right {
+        return 1.0;
+    }
     if left.contains(right) || right.contains(left) {
         let left_len = left.chars().count();
         let right_len = right.chars().count();

--- a/src-tauri/src/system/icons.rs
+++ b/src-tauri/src/system/icons.rs
@@ -408,9 +408,11 @@ mod mac {
     /// load. Resizing here, before caching or returning, is the fix.
     pub fn extract_icon_png(bundle_path: &str) -> Option<Vec<u8>> {
         let raw = extract_icon_png_native(bundle_path)?;
-        let resized = image::load_from_memory(&raw)
-            .ok()?
-            .resize(128, 128, image::imageops::FilterType::Lanczos3);
+        let resized = image::load_from_memory(&raw).ok()?.resize(
+            128,
+            128,
+            image::imageops::FilterType::Lanczos3,
+        );
         let mut png = Vec::new();
         resized
             .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)

--- a/src-tauri/src/system/mac_app.rs
+++ b/src-tauri/src/system/mac_app.rs
@@ -639,8 +639,7 @@ pub async fn request_notifications() -> Result<(), String> {
                 }
             },
         );
-        let _: () =
-            msg_send![center, requestAuthorizationWithOptions: 7usize, completionHandler: &*handler];
+        let _: () = msg_send![center, requestAuthorizationWithOptions: 7usize, completionHandler: &*handler];
     });
     match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
         Ok(Ok(result)) => result,

--- a/src-tauri/src/system/text.rs
+++ b/src-tauri/src/system/text.rs
@@ -221,7 +221,8 @@ pub fn strip_filler_hesitations(text: &str) -> String {
     // know". Remove it only at the end of a sentence or immediately before a
     // discourse connector, where it is unambiguously a filler.
     for index in 0..tokens.len().saturating_sub(2) {
-        let is_you = matches!(&tokens[index], FillerTok::Word(word) if word.eq_ignore_ascii_case("you"));
+        let is_you =
+            matches!(&tokens[index], FillerTok::Word(word) if word.eq_ignore_ascii_case("you"));
         let is_know = matches!(&tokens[index + 2], FillerTok::Word(word) if word.eq_ignore_ascii_case("know"));
         if !is_you || !matches!(&tokens[index + 1], FillerTok::Other(_)) || !is_know {
             continue;

--- a/src/lib/components/appMappings/AppMappingsAddForm.svelte
+++ b/src/lib/components/appMappings/AppMappingsAddForm.svelte
@@ -375,9 +375,9 @@
     font-size: 11px;
     font-weight: 500;
     color: var(--ink-mute);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-family: var(--mono);
+    text-transform: none;
+    letter-spacing: 0;
+    font-family: var(--sans);
     margin-bottom: 10px;
   }
 

--- a/src/lib/components/settings/AboutSection.svelte
+++ b/src/lib/components/settings/AboutSection.svelte
@@ -162,7 +162,7 @@
 <svelte:window onkeydown={handleBetaModalKeydown} />
 
 <h2 class="settings-h">About</h2>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-version">
   <div><div class="label">Version</div></div>
   <button class="version-tap desc" onclick={handleVersionTap}>v{appVersion}</button>
 </div>
@@ -171,26 +171,26 @@
     <span class="desc dev-hint">Developer mode enabled for this session.</span>
   </div>
 {/if}
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-license">
   <div><div class="label">License</div></div>
   <span class="desc">MIT</span>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-website">
   <div><div class="label">Website</div></div>
   <button class="btn-ghost" onclick={() => openExternal(WEBSITE_URL)}>verenu.com</button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-source">
   <div><div class="label">Source</div></div>
   <button class="btn-ghost" onclick={() => openExternal(`https://github.com/${SOURCE_REPO}`)}>github.com/{SOURCE_REPO}</button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-setup">
   <div>
     <div class="label">Setup</div>
     <div class="desc">Re-run onboarding to review your provider, key, and defaults.</div>
   </div>
   <button class="btn-ghost" onclick={rerunSetup}>Re-run setup</button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-updates">
   <div>
     <div class="label">Updates</div>
     {#if updateCheckState === 'up-to-date'}
@@ -221,7 +221,7 @@
     {/if}
   </div>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="about-beta">
   <div>
     <div class="label">Beta updates</div>
     <div class="desc">Try early releases from the development branch. Expect bugs and possible data loss.</div>
@@ -314,10 +314,10 @@
   }
   .modal-header { padding: 20px 20px 0; }
   .modal-title {
-    font-family: var(--serif);
-    font-size: 18px;
-    font-weight: 500;
-    letter-spacing: -0.015em;
+    font-family: var(--sans);
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ink);
     margin: 0;
   }

--- a/src/lib/components/settings/ApiKeysSection.svelte
+++ b/src/lib/components/settings/ApiKeysSection.svelte
@@ -291,9 +291,10 @@
     text-align: center;
     transition: opacity 160ms var(--ui-ease-out);
   }
-  .flip-face.back { opacity: 0; }
-  .flip-btn.flipped .flip-face.front { opacity: 0; }
-  .flip-btn.flipped .flip-face.back { opacity: 1; }
+  .flip-face.front { pointer-events: auto; }
+  .flip-face.back { opacity: 0; pointer-events: none; }
+  .flip-btn.flipped .flip-face.front { opacity: 0; pointer-events: none; }
+  .flip-btn.flipped .flip-face.back { opacity: 1; pointer-events: auto; }
 
   /* Failure feedback: red border + one-shot shake when a key is rejected. */
   .key-input[aria-invalid='true'] { border-color: var(--danger); }

--- a/src/lib/components/settings/ApiKeysSection.svelte
+++ b/src/lib/components/settings/ApiKeysSection.svelte
@@ -11,7 +11,7 @@
   const keyProviders: { id: ProviderId; label: string; ph: string; models: string }[] = [
     { id: 'groq',       label: 'Groq',       ph: 'gsk_…',        models: 'whisper-large-v3-turbo · llama-3.3-70b' },
     { id: 'openai',     label: 'OpenAI',     ph: 'sk-…',         models: 'gpt-4o-transcribe · gpt-4o-mini' },
-    { id: 'google',     label: 'Gemini',     ph: 'AIza…',        models: 'gemini-3.5-transcribe · gemini-2.5-flash' },
+    { id: 'google',     label: 'Gemini',     ph: 'AIza…',        models: 'gemini-3.5-transcribe · gemini-3.5-flash-lite' },
     { id: 'assemblyai', label: 'AssemblyAI', ph: '32-char key',  models: 'universal-3-5-pro · universal-2' },
   ];
 
@@ -112,7 +112,7 @@
 <p class="panel-note">Keys are stored locally and never readable from the UI after saving.</p>
 
 {#each keyProviders as item}
-  <div class="setting-row key-row">
+  <div class="setting-row key-row" data-setting-target={`api-key-${item.id}`}>
     <div class="key-left">
       <div class="label">
         <span class="key-logo">{@html getProviderLogo(item.id)}</span>
@@ -282,18 +282,18 @@
     display: inline-grid;
     min-width: 72px;
     flex-shrink: 0;
-    transform-style: preserve-3d;
-    transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+    position: relative;
   }
-  .flip-btn.flipped { transform: rotateX(180deg); }
+  .flip-btn.flipped { min-width: 72px; }
   .flip-face {
     grid-area: 1 / 1;
     width: 100%;
     text-align: center;
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
+    transition: opacity 160ms var(--ui-ease-out);
   }
-  .flip-face.back { transform: rotateX(180deg); }
+  .flip-face.back { opacity: 0; }
+  .flip-btn.flipped .flip-face.front { opacity: 0; }
+  .flip-btn.flipped .flip-face.back { opacity: 1; }
 
   /* Failure feedback: red border + one-shot shake when a key is rejected. */
   .key-input[aria-invalid='true'] { border-color: var(--danger); }
@@ -321,7 +321,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .flip-btn { transition: none; }
+    .flip-face { transition: none; }
     .key-input.failed,
     .key-status,
     .key-status-dot { animation: none; }

--- a/src/lib/components/settings/AppMappingsSection.svelte
+++ b/src/lib/components/settings/AppMappingsSection.svelte
@@ -17,7 +17,7 @@
   </div>
 {/if}
 
-<div class="mappings-host" class:mappings-disabled={!appStore.cleanupEnabled} aria-disabled={!appStore.cleanupEnabled} inert={!appStore.cleanupEnabled}>
+<div class="mappings-host" data-setting-target="apps-mappings" class:mappings-disabled={!appStore.cleanupEnabled} aria-disabled={!appStore.cleanupEnabled} inert={!appStore.cleanupEnabled}>
   <AppMappingsEditor />
 </div>
 

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -138,7 +138,7 @@
 </h2>
 
 <h3 class="settings-subhead first">Gain & calibration</h3>
-<div class="setting-row gain-row">
+<div class="setting-row gain-row" data-setting-target="audio-gain">
   <div class="gain-header">
     <div>
       <div class="label">Microphone gain</div>
@@ -170,7 +170,7 @@
   {/if}
 </div>
 
-<div class="setting-row cal-row" class:calibrating={$isCalibrating}>
+<div class="setting-row cal-row" class:calibrating={$isCalibrating} data-setting-target="audio-calibration">
   <div class="cal-copy">
     <div class="label">Auto calibration</div>
     <div class="desc">Speak naturally to automatically set the ideal microphone gain</div>
@@ -234,29 +234,29 @@
 </div>
 
 <h3 class="settings-subhead">Input</h3>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="audio-system-mute">
   <div><div class="label">{isMac ? 'Mute System Audio' : 'Mute PC Audio'}</div><div class="desc">{isMac ? 'Mutes system volume while dictating to prevent audio interference' : 'Mutes Windows volume while dictating to prevent audio interference'}</div></div>
   <Toggle checked={muteAudio} onchange={handleMuteAudio} label={isMac ? 'Mute system audio' : 'Mute PC audio'} />
 </div>
 {#if isMac}
-  <div class="setting-row">
+  <div class="setting-row" data-setting-target="audio-exclusive">
     <div><div class="label">Exclusive microphone access</div><div class="desc">Reserves the mic for Verenu while dictating, muting it for all other apps</div></div>
     <Toggle checked={exclusiveMic} onchange={handleExclusiveMic} label="Exclusive microphone access" />
   </div>
 {/if}
 {#if isWindows}
-  <div class="setting-row">
+  <div class="setting-row" data-setting-target="audio-pause-media">
     <div><div class="label">Pause media while dictating</div><div class="desc">Pauses active Windows media sessions and resumes them after transcription finishes. Works with apps that expose Windows media controls.</div></div>
     <Toggle checked={pauseMediaDuringDictation} onchange={handlePauseMedia} label="Pause media while dictating" />
   </div>
 {/if}
-<div class="setting-row">
+<div class="setting-row" data-setting-target="audio-noise">
   <div><div class="label">Noise reduction</div><div class="desc">Suppress background noise before transcription (RNNoise)</div></div>
   <Toggle checked={noiseReduction} onchange={handleNoiseReduction} label="Noise reduction" />
 </div>
 
 <h3 class="settings-subhead">Sound effects</h3>
-<div class="setting-row sound-volume-row">
+<div class="setting-row sound-volume-row" data-setting-target="audio-sounds">
   <div class="sound-volume-header">
     <div>
       <div class="label">Sound effects volume</div>

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -313,7 +313,7 @@
 
 <h2 class="settings-h">Developer</h2>
 <p class="panel-note">Session log stream from backend runtime. Dev mode resets after app restart.</p>
-<div class="setting-row beta-setting-row">
+<div class="setting-row beta-setting-row" data-setting-target="developer-sync">
   <div>
     <div class="label">LAN Device Sync</div>
     <div class="desc">Experimental encrypted device-to-device sync. Off by default; the Sync settings page is hidden until enabled.</div>
@@ -327,14 +327,14 @@
   or share contains this content in plain text — only enable verbose logging or export
   logs if you understand what they hold.
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-setup">
   <div>
     <div class="label">Force Setup On Launch</div>
     <div class="desc">Shows onboarding on startup without erasing saved settings.</div>
   </div>
   <Toggle checked={forceSetupOnLaunch} onchange={handleForceSetupOnLaunch} label="Force setup on launch" />
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-logs">
   <div>
     <div class="label">Real-time Logs</div>
     <div class="desc">{logs.length} lines loaded</div>
@@ -401,7 +401,7 @@
     {copied ? 'Copied' : 'Copy all'}
   </button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-download-logs">
   <div>
     <div class="label">Download Logs</div>
     <div class="desc">Writes current session logs to your Downloads folder.</div>
@@ -413,7 +413,7 @@
     {exporting ? 'Saving...' : 'Download Logs'}
   </button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-status">
   <div>
     <div class="label">Provider Status Check</div>
     <div class="desc">Fetches api.verenu.com/v1/provider-status directly and shows the raw response.</div>
@@ -425,7 +425,7 @@
 {#if providerStatusRaw}
   <pre class="raw-panel scroll-styled">{providerStatusRaw}</pre>
 {/if}
-<div class="setting-row dev-simulations">
+<div class="setting-row dev-simulations" data-setting-target="developer-simulations">
   <div>
     <div class="label">UI Simulations</div>
     <div class="desc">Preview outage, offline, and global-message notices without changing the live APIs.</div>
@@ -475,7 +475,7 @@
     <button class="btn-ghost" onclick={clearSimulations}>Clear</button>
   </div>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-notifications">
   <div>
     <div class="label">System Notification Test</div>
     <div class="desc">Choose a notification type, then send the native toast and test its click destination.</div>
@@ -545,7 +545,7 @@
     </button>
   </div>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="developer-installer">
   <div>
     <div class="label">Installer Test</div>
     <div class="desc">

--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -1019,10 +1019,10 @@
     padding: 20px 20px 0;
   }
   .modal-title {
-    font-family: var(--serif);
-    font-size: 18px;
-    font-weight: 500;
-    letter-spacing: -0.015em;
+    font-family: var(--sans);
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ink);
     margin: 0;
   }

--- a/src/lib/components/settings/LocalCleanupDownloads.svelte
+++ b/src/lib/components/settings/LocalCleanupDownloads.svelte
@@ -368,9 +368,9 @@
   }
 
   .head-title {
-    font-family: var(--serif);
-    font-size: 16px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 600;
     color: var(--ink);
     line-height: 1;
   }
@@ -548,11 +548,11 @@
     display: inline-flex;
     align-items: center;
     gap: 5px;
-    font-size: 9px;
+    font-size: 10px;
     font-family: var(--sans);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     padding: 3px 8px;
     border-radius: 999px;
   }
@@ -644,11 +644,11 @@
   }
 
   .prompt-copy span {
-    font-size: 10px;
+    font-size: 11px;
     font-family: var(--sans);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 

--- a/src/lib/components/settings/LocalTranscriptionDownloads.svelte
+++ b/src/lib/components/settings/LocalTranscriptionDownloads.svelte
@@ -311,9 +311,9 @@
   }
 
   .head-title {
-    font-family: var(--serif);
-    font-size: 16px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 600;
     color: var(--ink);
     line-height: 1;
   }
@@ -492,11 +492,11 @@
     display: inline-flex;
     align-items: center;
     gap: 5px;
-    font-size: 9px;
+    font-size: 10px;
     font-family: var(--sans);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     padding: 3px 8px;
     border-radius: 999px;
   }
@@ -555,11 +555,11 @@
   }
 
   .local-language-label {
-    font-size: 10px;
+    font-size: 11px;
     font-family: var(--sans);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 

--- a/src/lib/components/settings/PermissionsSection.svelte
+++ b/src/lib/components/settings/PermissionsSection.svelte
@@ -17,7 +17,9 @@
   apps. Anything not granted will stop dictation from working everywhere.
 </p>
 
-<MacPermissions variant="settings" {provider} />
+<div data-setting-target="permissions">
+  <MacPermissions variant="settings" {provider} />
+</div>
 
 <style>
   h2 { margin-bottom: 6px; }

--- a/src/lib/components/settings/PresetCard.svelte
+++ b/src/lib/components/settings/PresetCard.svelte
@@ -244,9 +244,9 @@
   }
 
   .preset-name {
-    font-family: var(--serif);
-    font-size: 16px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 600;
     color: var(--ink);
     line-height: 1;
   }
@@ -361,26 +361,21 @@
     line-height: 1.35em;
     white-space: nowrap;
     backface-visibility: hidden;
-    transition:
-      transform 360ms cubic-bezier(0.16, 1, 0.3, 1),
-      opacity 220ms ease;
+    transition: opacity 160ms var(--ui-ease-out);
   }
 
   .pa-hover {
     position: absolute;
     inset: 0;
-    transform: translateY(100%);
     opacity: 0;
   }
 
   .hover-mode:hover .pa-default,
   .hover-mode:focus-visible .pa-default {
-    transform: translateY(-112%) rotateX(-8deg) scale(0.96);
     opacity: 0;
   }
   .hover-mode:hover .pa-hover,
   .hover-mode:focus-visible .pa-hover {
-    transform: translateY(0) rotateX(0) scale(1);
     opacity: 1;
   }
 

--- a/src/lib/components/settings/PrivacySection.svelte
+++ b/src/lib/components/settings/PrivacySection.svelte
@@ -256,13 +256,13 @@
 <h2 class="settings-h">Privacy</h2>
 
 <h3 class="settings-subhead first">Context</h3>
-<div class="setting-row">
-  <div><div class="label">App context hint</div><div class="desc">Shares the target app, website, window title, and context group so cleanup can choose the right layout</div></div>
+<div class="setting-row" data-setting-target="privacy-context">
+  <div><div class="label">App context hint</div><div class="desc">Shares the target app, website, and window title so cleanup can resolve terminology and formatting</div></div>
   <Toggle checked={appContextHint} onchange={handleAppContextHint} label="App context hint" />
 </div>
 
 <h3 class="settings-subhead">Verenu services</h3>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-service-checks">
   <div>
     <div class="label">Allow Verenu service checks</div>
     <div class="desc">Checks provider status, service health, and global messages in the background. Turn this off to stop background requests to api.verenu.com. Dictation requests to your selected AI provider are unaffected.</div>
@@ -271,7 +271,7 @@
 </div>
 
 <h3 class="settings-subhead">On-device learning</h3>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-learning">
   <div>
     <div class="label" style="display:flex;align-items:center;gap:7px;">
       Auto-learn corrections
@@ -287,7 +287,7 @@
   </div>
   <Toggle checked={autoLearn} onchange={handleAutoLearn} label="Auto-learn corrections" />
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-learning-activity">
   <div>
     <div class="label">Auto-learn activity</div>
     <div class="desc">
@@ -302,7 +302,7 @@
 </div>
 
 <h3 class="settings-subhead">History & storage</h3>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-history">
   <div><div class="label">Transcription history</div><div class="desc">How long to keep past dictations</div></div>
   <div class="history-dropdown">
     <button
@@ -349,7 +349,7 @@
     {/if}
   </div>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-cache">
   <div>
     <div class="label">Cleanup cache</div>
     <div class="desc">
@@ -374,7 +374,7 @@
 </div>
 
 <h3 class="settings-subhead">Backup</h3>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-export">
   <div>
     <div class="label">Export Backup</div>
     {#if exportMsg}
@@ -389,7 +389,7 @@
     {exporting ? 'Exporting…' : 'Export'}
   </button>
 </div>
-<div class="setting-row">
+<div class="setting-row" data-setting-target="privacy-import">
   <div>
     <div class="label">Import Backup</div>
     {#if importMsg}
@@ -548,10 +548,10 @@
     padding: 20px 20px 0;
   }
   .modal-title {
-    font-family: var(--serif);
-    font-size: 18px;
-    font-weight: 500;
-    letter-spacing: -0.015em;
+    font-family: var(--sans);
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ink);
     margin: 0;
   }

--- a/src/lib/components/settings/SyncSection.svelte
+++ b/src/lib/components/settings/SyncSection.svelte
@@ -187,7 +187,7 @@
 <h2 class="settings-h">Sync</h2>
 
 <!-- This device -->
-<div class="id-card">
+<div class="id-card" data-setting-target="sync-this-device">
   <div class="tile" aria-hidden="true">
     <svg
       viewBox="0 0 24 24"
@@ -254,7 +254,7 @@
 {/if}
 
 <!-- Paired devices -->
-<h3 class="settings-subhead">Paired devices</h3>
+<h3 class="settings-subhead" data-setting-target="sync-paired">Paired devices</h3>
 {#if peers.length === 0}
   <div class="desc empty-note">
     Nothing paired yet. Devices you pair below stay connected until either side removes them.
@@ -307,7 +307,7 @@
 {/if}
 
 <!-- Nearby devices -->
-<h3 class="settings-subhead">Nearby devices</h3>
+<h3 class="settings-subhead" data-setting-target="sync-nearby">Nearby devices</h3>
 {#if !syncStore.loaded}
   <div class="discover-card" role="status">
     <span class="search-dots" aria-hidden="true"><i></i><i></i><i></i></span>

--- a/src/lib/setup/SetupShell.svelte
+++ b/src/lib/setup/SetupShell.svelte
@@ -116,16 +116,16 @@
   .step-label {
     margin: 4px 0 0;
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 
   .setup-header h2 {
-    font-family: var(--serif);
-    font-size: 22px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 20px;
+    font-weight: 600;
     color: var(--ink-strong);
     margin: 4px 0 0;
     line-height: 1.25;
@@ -267,9 +267,9 @@
   /* Uppercase group label above a set of pick-cards. */
   :global(.setup-overlay .group-label) {
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
     margin: 0;
   }

--- a/src/lib/setup/setupData.ts
+++ b/src/lib/setup/setupData.ts
@@ -118,7 +118,10 @@ const cleanupPreview: Record<CleanupCard['id'], string> = {
 
 const tonePreview: Record<ToneCard['id'], (base: string) => string> = {
   casual: (base) => base.charAt(0).toUpperCase() + base.slice(1),
-  formal: (base) => `${base.charAt(0).toUpperCase()}${base.slice(1)}.`,
+  formal: (base) => {
+    const sentence = `${base.charAt(0).toUpperCase()}${base.slice(1)}`;
+    return `${sentence.replace(/[.!?]+$/, '')}.`;
+  },
   very_casual: (base) => base.toLowerCase().replace(/[.!?]+$/, ''),
 };
 

--- a/src/lib/setup/setupData.ts
+++ b/src/lib/setup/setupData.ts
@@ -20,7 +20,7 @@ export const providers: SetupProvider[] = [
     id: 'google',
     name: 'Google Gemini',
     badge: '',
-    desc: 'Gemini 3.5 Flash for both transcription and cleanup, on a generous free tier.',
+    desc: 'Gemini Flash-Lite for fast, low-cost transcription cleanup on a generous free tier.',
   },
   {
     id: 'openai',
@@ -92,18 +92,18 @@ export const providerGuides: Record<ProviderId, ProviderGuide> = {
 type CleanupCard = { id: CleanupIntensity; name: string; desc: string };
 
 export const cleanupCards: CleanupCard[] = [
-  { id: 'none', name: 'Off', desc: 'Raw transcript, no second AI call' },
-  { id: 'light', name: 'Light', desc: 'Punctuation and obvious slips only' },
-  { id: 'medium', name: 'Medium', desc: 'Fillers and repetition removed' },
-  { id: 'high', name: 'Strong', desc: 'Rewritten shorter and tighter' },
+  { id: 'none', name: 'Off', desc: 'Keep the raw transcript. A second call is used only to reconcile two transcripts.' },
+  { id: 'light', name: 'Light', desc: 'Remove speech artifacts and fix basics. Keep wording, order, and structure.' },
+  { id: 'medium', name: 'Medium', desc: 'Improve flow and remove redundancy while preserving every distinct detail.' },
+  { id: 'high', name: 'Strong', desc: 'Rewrite concisely while preserving facts, constraints, qualifiers, and emphasis.' },
 ];
 
 type ToneCard = { id: ToneId; name: string; desc: string };
 
 export const toneCards: ToneCard[] = [
-  { id: 'casual', name: 'Casual', desc: 'Reads like a quick message' },
-  { id: 'formal', name: 'Formal', desc: 'Polished, professional prose' },
-  { id: 'very_casual', name: 'Very Casual', desc: 'all lowercase, no punctuation' },
+  { id: 'casual', name: 'Casual', desc: 'Contractions, normal casing, and the speaker’s casual voice' },
+  { id: 'formal', name: 'Formal', desc: 'Professional wording without added greetings or politeness' },
+  { id: 'very_casual', name: 'Very Casual', desc: 'Mostly lowercase, minimal readable punctuation, and preserved emphasis' },
 ];
 
 /** Illustrative-only before→after preview text. Not API-driven — a static approximation. */
@@ -112,13 +112,13 @@ const SAMPLE_RAW = 'um so like i think we should um ship it tomorrow maybe';
 const cleanupPreview: Record<CleanupCard['id'], string> = {
   none: 'um so like i think we should um ship it tomorrow maybe',
   light: 'I think we should ship it tomorrow maybe',
-  medium: 'I think we should ship it tomorrow',
-  high: "Let's ship tomorrow",
+  medium: 'I think we should ship it tomorrow, maybe.',
+  high: 'We should ship it tomorrow.',
 };
 
 const tonePreview: Record<ToneCard['id'], (base: string) => string> = {
   casual: (base) => base.charAt(0).toUpperCase() + base.slice(1),
-  formal: (base) => `${base.charAt(0).toUpperCase()}${base.slice(1)}.`.replace(/\bmaybe\b/, 'pending final review'),
+  formal: (base) => `${base.charAt(0).toUpperCase()}${base.slice(1)}.`,
   very_casual: (base) => base.toLowerCase().replace(/[.!?]+$/, ''),
 };
 

--- a/src/lib/setup/steps/ApiKeyStep.svelte
+++ b/src/lib/setup/steps/ApiKeyStep.svelte
@@ -418,9 +418,9 @@
 
   .shot-step {
     font-size: 10.5px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 
@@ -466,11 +466,11 @@
     background: var(--success-bg);
     color: var(--success);
     font-size: 10.5px;
-    font-weight: 650;
-    letter-spacing: .04em;
-    text-transform: uppercase;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
   }
-  .local-intro h3 { margin: 0; font-family: var(--serif); font-size: 19px; font-weight: 500; color: var(--ink-strong); }
+  .local-intro h3 { margin: 0; font-family: var(--sans); font-size: 17px; font-weight: 600; color: var(--ink-strong); }
   .local-intro p { margin: 0; color: var(--ink-mute); font-size: 12.5px; line-height: 1.5; max-width: 590px; }
   .local-model-card {
     display: flex;

--- a/src/lib/setup/steps/CalibrationStep.svelte
+++ b/src/lib/setup/steps/CalibrationStep.svelte
@@ -226,9 +226,9 @@
 
   .cal-phase-label {
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 
@@ -265,9 +265,9 @@
 
   .cal-prompt {
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
     margin: 0;
   }

--- a/src/lib/setup/steps/DoneStep.svelte
+++ b/src/lib/setup/steps/DoneStep.svelte
@@ -126,7 +126,7 @@
 
   .done-check-wrap { margin-bottom: 4px; }
 
-  .done-title { font-family: var(--serif); font-size: 26px; font-weight: 500; color: var(--ink-strong); margin: 0; }
+  .done-title { font-family: var(--sans); font-size: 23px; font-weight: 600; color: var(--ink-strong); margin: 0; }
 
   .done-sub { font-size: 13px; color: var(--ink-mute); margin: 0; line-height: 1.55; }
 
@@ -185,9 +185,9 @@
 
   .summary-label {
     font-size: 10.5px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
   }
 

--- a/src/lib/setup/steps/IntroStep.svelte
+++ b/src/lib/setup/steps/IntroStep.svelte
@@ -117,9 +117,9 @@
 
   .how-label {
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
     margin: 0 0 14px;
   }

--- a/src/lib/setup/steps/WritingStyleStep.svelte
+++ b/src/lib/setup/steps/WritingStyleStep.svelte
@@ -132,7 +132,7 @@
   .preview-row { display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); align-items: center; gap: 12px; min-width: 0; }
 
   .preview-sample { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-  .preview-label { font-size: 9.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-faint); }
+  .preview-label { font-size: 10px; font-weight: 500; text-transform: none; letter-spacing: 0; color: var(--ink-faint); }
 
   .preview-before { font-size: 12px; font-style: italic; color: var(--ink-mute); line-height: 1.4; }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -208,15 +208,15 @@ let devLlmRuntimeDownloadSession = 0;
 
 const defaultProviderModels = {
   groq: ['whisper-large-v3-turbo', 'whisper-large-v3'],
-  openai: ['gpt-4o-mini-transcribe', 'gpt-4o-transcribe'],
-  google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
+  openai: ['gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'whisper-1'],
+  google: ['gemini-2.5-flash', 'gemini-3.5-transcribe', 'gemini-3.5-flash', 'gemini-3.5-flash-lite', 'gemini-2.5-flash-lite'],
   local: ['parakeet-v3'],
 };
 
 const defaultCleanupModels = {
-  groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
+  groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b', 'openai/gpt-oss-120b'],
   openai: ['gpt-4o-mini', 'gpt-4o'],
-  google: ['gemini-2.5-flash', 'gemini-3.5-flash'],
+  google: ['gemini-3.5-flash-lite', 'gemini-3.5-flash', 'gemini-2.5-flash-lite'],
   local: [],
 };
 
@@ -224,7 +224,6 @@ const defaultSettings: Record<string, unknown> = {
   setup_complete: true,
   force_setup_on_launch: false,
   appearance_mode: 'system',
-  accent_color: null,
   transcription_provider: 'groq',
   transcription_language: 'en',
   cleanup_provider: 'groq',
@@ -1104,7 +1103,7 @@ function devInsights(days: number, contextId: number | null): unknown {
         output_chars: wordsInRange * 5,
       },
       {
-        model: 'gemini-3.5-flash',
+        model: 'gemini-3.5-flash-lite',
         provider: 'google',
         task: 'cleanup',
         calls: Math.round(transcriptions * 0.14),

--- a/src/lib/views/Contexts.svelte
+++ b/src/lib/views/Contexts.svelte
@@ -1644,10 +1644,10 @@
   .context-stat-sep { color: var(--ink-faint); }
   .context-header { justify-content: space-between; gap: 16px; margin-bottom: 16px; position: relative; z-index: 2; }
   .context-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; position: relative; z-index: 2; }
-  .context-header h2 { font-family: var(--serif); font-size: 26px; font-weight: 500; letter-spacing: -.02em; line-height: 1.1; margin: 4px 0 4px; color: var(--ink); }
+  .context-header h2 { font-family: var(--sans); font-size: 23px; font-weight: 600; letter-spacing: -.025em; line-height: 1.1; margin: 4px 0 6px; color: var(--ink); }
   .context-header p { color: var(--ink-mute); font-size: 12px; margin: 0; line-height: 1.45; }
   .target-strip { flex-wrap: wrap; gap: 6px; padding: 9px 0 14px; border-top: 1px solid var(--line-soft); }
-  .target-label { color: var(--ink-faint); font-family: var(--mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; margin-right: 3px; }
+  .target-label { color: var(--ink-mute); font-family: var(--sans); font-size: 11px; letter-spacing: 0; text-transform: none; margin-right: 3px; }
   .target-chip { display: inline-flex; align-items: center; gap: 5px; padding: 4px 6px 4px 4px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-elev); color: var(--ink-soft); font-size: 11px; }
   .target-chip button { display: grid; place-items: center; border: 0; background: transparent; color: var(--ink-faint); padding: 2px; cursor: pointer; border-radius: 4px; }
   .target-chip button:hover { color: var(--danger); background: var(--danger-bg); }
@@ -1747,7 +1747,7 @@
   .item-main { display: flex; align-items: baseline; gap: 6px; min-width: 0; overflow: hidden; }
   .item-term { font-size: 13px; font-weight: 500; color: var(--ink); flex-shrink: 0; }
   .item-auto-star { color: var(--accent); flex-shrink: 0; position: relative; top: -1px; }
-  .item-often { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--ink-faint); flex-shrink: 0; }
+  .item-often { font-family: var(--sans); font-size: 11px; text-transform: none; letter-spacing: 0; color: var(--ink-mute); flex-shrink: 0; }
   .item-arrow { color: var(--ink-faint); flex-shrink: 0; }
   .item-detail { font-size: 12.5px; color: var(--ink-mute); font-style: italic; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
   .item-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 2px; font-size: 11px; color: var(--ink-faint); white-space: nowrap; }

--- a/src/lib/views/Dictionary.svelte
+++ b/src/lib/views/Dictionary.svelte
@@ -209,10 +209,10 @@
   }
 
   .page-h {
-    font-family: var(--serif);
-    font-size: 26px;
-    font-weight: 500;
-    letter-spacing: -0.02em;
+    font-family: var(--sans);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
     margin: 0 0 4px;
     line-height: 1.1;
     color: var(--ink);
@@ -276,9 +276,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -291,10 +291,10 @@
   }
 
   .page-h {
-    font-family: var(--serif);
-    font-size: 26px;
-    font-weight: 500;
-    letter-spacing: -0.02em;
+    font-family: var(--sans);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
     margin: 0 0 4px;
     line-height: 1.1;
     color: var(--ink);
@@ -368,8 +368,8 @@
 
   /* Matches .settings-subhead — 17px was a card title, this is a section head. */
   .content-inner :global(.card-h) {
-    font-family: var(--serif);
-    font-size: 14px;
+    font-family: var(--sans);
+    font-size: 13px;
     font-weight: 500;
     margin: 0;
     color: var(--ink-soft);
@@ -419,9 +419,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -453,7 +453,7 @@
    * viewport media queries for container queries against this column.
    */
   .panel-inner {
-    width: min(100%, var(--settings-measure));
+    width: min(100%, 680px);
     margin-inline: auto;
     container-type: inline-size;
     container-name: settings-panel;

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -213,9 +213,9 @@
 
   function cleanupModelsByProvider(...selected: string[]): ProviderModelMap {
     const map: ProviderModelMap = {
-      groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b'],
+      groq: ['qwen/qwen3.6-27b'],
       openai: ['gpt-4o-mini', 'gpt-4o'],
-      google: ['gemini-2.5-flash'],
+      google: ['gemini-3.5-flash-lite'],
       assemblyai: [],
       local: ['qwen2.5-3b-instruct'],
     };
@@ -245,7 +245,7 @@
       : provider === 'openai'
         ? 'openai/gpt-4o-mini'
         : provider === 'google'
-          ? 'google/gemini-2.5-flash'
+        ? 'google/gemini-3.5-flash-lite'
           : 'groq/qwen/qwen3.6-27b';
 
     // The Models step is the more specific answer, so its target wins over the

--- a/src/lib/views/Snippets.svelte
+++ b/src/lib/views/Snippets.svelte
@@ -194,10 +194,10 @@
   }
 
   .page-h {
-    font-family: var(--serif);
-    font-size: 26px;
-    font-weight: 500;
-    letter-spacing: -0.02em;
+    font-family: var(--sans);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
     margin: 0 0 4px;
     line-height: 1.1;
     color: var(--ink);
@@ -261,9 +261,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;

--- a/src/lib/views/Style.svelte
+++ b/src/lib/views/Style.svelte
@@ -24,16 +24,16 @@
   ];
 
   const cleanupCards = [
-    { id: 'none', name: 'Off', desc: 'Skip cleanup and keep the raw transcript.', sample: "so um i was thinking like we should probably leave a bit earlier you know cause there's gonna be traffic i think" },
-    { id: 'light', name: 'Light', desc: 'Removes fillers and false starts. Keeps your wording and order.', sample: "I was thinking we should probably leave a bit earlier because there's going to be traffic, I think." },
-    { id: 'medium', name: 'Medium', desc: 'Rewrites for clearer flow while preserving every important detail.', sample: "I think we should leave a bit earlier. There's going to be traffic." },
-    { id: 'high', name: 'Strong', desc: 'Leads with the point and cuts repetition, hedging, and detours.', sample: 'Leave early. There will be traffic.' },
+    { id: 'none', name: 'Off', desc: 'Keep the raw transcript. Dual transcription may still reconcile candidates.', sample: "so um i was thinking like we should probably leave a bit earlier you know cause there's gonna be traffic i think" },
+    { id: 'light', name: 'Light', desc: 'Remove non-semantic speech artifacts and fix basics. Keep wording, order, and detail.', sample: "I was thinking we should probably leave a bit earlier because there's going to be traffic, I think." },
+    { id: 'medium', name: 'Medium', desc: 'Improve flow and remove redundancy with light restructuring. Preserve every distinct detail.', sample: "I think we should leave a bit earlier. There's going to be traffic." },
+    { id: 'high', name: 'Strong', desc: 'Rewrite concisely and directly. Preserve facts, constraints, qualifiers, and emphasis.', sample: 'Leave early. There will be traffic.' },
   ];
 
   const personalCards = [
-    { id: 'casual', name: 'Casual', desc: 'Conversational wording, contractions, and normal punctuation.', sample: "Hey, are you free for lunch tomorrow? Let's do 12 if that works." },
-    { id: 'formal', name: 'Formal', desc: 'Professional wording, full punctuation, and expanded contractions.', sample: 'Are you available for lunch tomorrow? Let us meet at 12 if that works for you.' },
-    { id: 'very_casual', name: 'Very Casual', desc: 'Mostly lowercase with contractions and minimal punctuation.', sample: "hey are you free for lunch tomorrow let's do 12 if that works" },
+    { id: 'casual', name: 'Casual', desc: 'Contractions, normal casing and punctuation, and the speaker’s casual voice.', sample: "Hey, are you free for lunch tomorrow? Let's do 12 if that works." },
+    { id: 'formal', name: 'Formal', desc: 'Professional wording and punctuation. No invented politeness or extra content.', sample: 'Are you available for lunch tomorrow? Let us meet at 12 if that works for you.' },
+    { id: 'very_casual', name: 'Very Casual', desc: 'Mostly lowercase, contractions, and minimal readable punctuation. Preserve profanity and emphasis.', sample: "hey are you free for lunch tomorrow let's do 12 if that works" },
   ];
 
   onMount(async () => {
@@ -315,8 +315,8 @@
   }
 
   .style-section-h {
-    font-family: var(--serif);
-    font-size: 15px;
+    font-family: var(--sans);
+    font-size: 14px;
     font-weight: 500;
     letter-spacing: -0.01em;
     color: var(--ink-soft);
@@ -324,10 +324,10 @@
   }
 
   .page-h {
-    font-family: var(--serif);
-    font-size: 26px;
-    font-weight: 500;
-    letter-spacing: -0.02em;
+    font-family: var(--sans);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -0.025em;
     margin: 0 0 4px;
     line-height: 1.1;
     color: var(--ink);
@@ -379,7 +379,7 @@
     color: var(--ink-mute);
     padding: 1px 6px;
     border-radius: 999px;
-    text-transform: uppercase;
+    text-transform: none;
     border: 1px solid var(--line);
   }
 
@@ -411,18 +411,14 @@
     border-radius: var(--r-md);
     display: flex;
     flex-direction: column;
-    min-height: 160px;
+    min-height: 140px;
     cursor: pointer;
-    transition: background 0.18s cubic-bezier(0.22, 1, 0.36, 1),
-      border-color 0.18s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.18s cubic-bezier(0.22, 1, 0.36, 1),
-      box-shadow 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+    transition: background 0.15s var(--ui-ease-out),
+      border-color 0.15s var(--ui-ease-out);
   }
 
   .style-card:hover {
     background: var(--control-hover);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-card);
   }
   .style-card:focus-visible {
     outline: 2px solid var(--accent);
@@ -430,21 +426,18 @@
   }
 
   .style-card:active {
-    transform: translateY(0) scale(0.98);
-    transition: all 0.1s cubic-bezier(0.22, 1, 0.36, 1);
+    opacity: 0.82;
   }
 
   .style-card.active {
-    background: var(--accent-soft);
-    border-color: var(--accent);
-    transform: translateY(-1px);
-    box-shadow: 0 6px 16px color-mix(in srgb, var(--accent) 12%, transparent);
+    background: var(--control-active);
+    border-color: var(--line-strong);
   }
 
   .style-card-title {
     display: block;
-    font-family: var(--serif);
-    font-size: 16px;
+    font-family: var(--sans);
+    font-size: 14px;
     font-weight: 500;
     margin: 0 0 2px;
     letter-spacing: 0;
@@ -462,7 +455,7 @@
   .style-sample {
     display: block;
     margin-top: auto;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
     font-size: 13.5px;
     line-height: 1.5;

--- a/src/lib/views/dictionary/DictionaryInspector.svelte
+++ b/src/lib/views/dictionary/DictionaryInspector.svelte
@@ -116,10 +116,10 @@
   }
 
   .insp-trigger {
-    font-family: var(--serif);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.015em;
+    font-family: var(--sans);
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ink);
     line-height: 1.2;
   }
@@ -132,10 +132,10 @@
   }
 
   .insp-often-label {
-    font-family: var(--mono);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-family: var(--sans);
+    font-size: 11px;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
     flex-shrink: 0;
   }
@@ -252,9 +252,9 @@
   }
 
   .inspector-empty p {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 14px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 13px;
     color: var(--ink-mute);
     margin: 0;
     line-height: 1.6;

--- a/src/lib/views/dictionary/DictionaryList.svelte
+++ b/src/lib/views/dictionary/DictionaryList.svelte
@@ -131,10 +131,10 @@
   }
 
   .dict-often-label {
-    font-family: var(--mono);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-family: var(--sans);
+    font-size: 11px;
+    text-transform: none;
+    letter-spacing: 0;
     color: var(--ink-faint);
     flex-shrink: 0;
   }
@@ -169,9 +169,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;

--- a/src/lib/views/dictionary/DictionaryModal.svelte
+++ b/src/lib/views/dictionary/DictionaryModal.svelte
@@ -216,9 +216,9 @@
   }
 
   .modal-title {
-    font-family: var(--serif);
-    font-size: 18px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 17px;
+    font-weight: 600;
     letter-spacing: -0.015em;
     color: var(--ink);
     margin: 0;

--- a/src/lib/views/home/GlobalMessageBanner.svelte
+++ b/src/lib/views/home/GlobalMessageBanner.svelte
@@ -40,5 +40,5 @@
     width: 18px;
     height: 18px;
   }
-  .global-text { flex: 1; font-family: var(--serif); font-weight: 500; }
+  .global-text { flex: 1; font-family: var(--sans); font-weight: 500; }
 </style>

--- a/src/lib/views/home/HomeHero.svelte
+++ b/src/lib/views/home/HomeHero.svelte
@@ -21,7 +21,7 @@
     border-radius: var(--r-lg);
     overflow: hidden;
     margin-bottom: 16px;
-    height: clamp(112px, 14vw, 160px);
+    height: clamp(104px, 12vw, 136px);
     background: var(--arm-950);
   }
 
@@ -65,13 +65,13 @@
   }
 
   .hero-em {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
     color: color-mix(in srgb, var(--pill-fg) 82%, transparent);
   }
 
   @media (max-width: 720px) {
     .hero-photo-content { padding: 18px 20px; }
-    .hero-photo-title { font-size: 20px; }
+    .hero-photo-title { font-size: 18px; }
   }
 </style>

--- a/src/lib/views/home/ProviderStatusBanner.svelte
+++ b/src/lib/views/home/ProviderStatusBanner.svelte
@@ -77,7 +77,7 @@
 
   .status-text {
     flex: 1;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-weight: 500;
   }
 

--- a/src/lib/views/home/StatsCard.svelte
+++ b/src/lib/views/home/StatsCard.svelte
@@ -38,9 +38,9 @@
   .stat-line:last-child { border-bottom: 0; padding-bottom: 0; }
 
   .stat-num {
-    font-family: var(--serif);
-    font-size: 24px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 22px;
+    font-weight: 600;
     letter-spacing: -0.02em;
     line-height: 1;
     color: var(--ink);

--- a/src/lib/views/home/UpdateBanner.svelte
+++ b/src/lib/views/home/UpdateBanner.svelte
@@ -46,7 +46,7 @@
 
   .update-text {
     flex: 1;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-weight: 500;
   }
 

--- a/src/lib/views/insights/CostBreakdown.svelte
+++ b/src/lib/views/insights/CostBreakdown.svelte
@@ -123,8 +123,8 @@
   .cost-table th:first-child { width: 34%; }
   .cost-table thead th {
     font-size: 10px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
   }
   .cost-table tbody tr:last-child th,

--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -488,17 +488,17 @@
     pointer-events: none;
   }
   .donut-primary {
-    font-family: var(--serif);
-    font-size: 19px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 18px;
+    font-weight: 600;
     color: var(--ink);
     font-variant-numeric: tabular-nums;
     line-height: 1;
   }
   .donut-secondary {
     font-size: 10px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
   }
 

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -178,9 +178,9 @@
   }
 
   .big {
-    font-family: var(--serif);
-    font-size: 34px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 28px;
+    font-weight: 600;
     letter-spacing: -0.03em;
     line-height: 1;
     color: var(--ink);
@@ -220,8 +220,8 @@
   .tile-label {
     margin: 9px 0 0;
     font-size: 10.5px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
   }
 
@@ -266,9 +266,9 @@
   }
 
   .gauge-value {
-    font-family: var(--serif);
-    font-size: 27px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 24px;
+    font-weight: 600;
     fill: var(--ink);
     font-variant-numeric: tabular-nums;
   }
@@ -289,9 +289,9 @@
   }
 
   .stat-num {
-    font-family: var(--serif);
-    font-size: 17px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 16px;
+    font-weight: 600;
     line-height: 1;
     color: var(--ink);
     font-variant-numeric: tabular-nums;

--- a/src/lib/views/insights/StreakHeatmap.svelte
+++ b/src/lib/views/insights/StreakHeatmap.svelte
@@ -341,17 +341,17 @@
   .best { text-align: right; }
   .best-num {
     display: block;
-    font-family: var(--serif);
-    font-size: 20px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 19px;
+    font-weight: 600;
     color: var(--ink);
     line-height: 1.1;
     font-variant-numeric: tabular-nums;
   }
   .best-label {
     font-size: 10.5px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
   }
 
@@ -501,8 +501,8 @@
   }
   .stat-label {
     font-size: 10px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
   }
   .stat-value {

--- a/src/lib/views/insights/WordStats.svelte
+++ b/src/lib/views/insights/WordStats.svelte
@@ -195,8 +195,8 @@
   .figures div { min-width: 0; }
   .figures dt {
     font-size: 10.5px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
     color: var(--ink-mute);
     margin-bottom: 4px;
   }

--- a/src/lib/views/insights/pricing.test.ts
+++ b/src/lib/views/insights/pricing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { estimateCost } from './pricing';
+
+const usage = (model: string, task: 'cleanup' | 'transcription', input_chars = 0, output_chars = 0) => ({
+  model,
+  provider: 'google' as const,
+  task,
+  calls: 1,
+  audio_ms: 0,
+  input_chars,
+  output_chars,
+});
+
+describe('Google provider cost estimates', () => {
+  it('keeps Flash and Flash-Lite cleanup rates distinct', () => {
+    const summary = estimateCost([
+      usage('gemini-3.5-flash-lite', 'cleanup', 4_000_000, 4_000_000),
+      usage('gemini-3.5-flash', 'cleanup', 4_000_000, 4_000_000),
+    ]);
+
+    expect(summary.rows[0].cost).toBeCloseTo(18.9, 8);
+    expect(summary.rows[1].cost).toBeCloseTo(2.8, 8);
+  });
+
+  it('prices dedicated Gemini Transcribe as audio', () => {
+    const summary = estimateCost([
+      { ...usage('gemini-3.5-transcribe', 'transcription'), audio_ms: 3_600_000 },
+    ]);
+
+    expect(summary.rows[0].cost).toBeCloseTo(0.306, 8);
+  });
+});

--- a/src/lib/views/snippets/SnippetInspector.svelte
+++ b/src/lib/views/snippets/SnippetInspector.svelte
@@ -112,10 +112,10 @@
   }
 
   .insp-trigger {
-    font-family: var(--serif);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.015em;
+    font-family: var(--sans);
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ink);
     line-height: 1.2;
   }
@@ -233,9 +233,9 @@
   }
 
   .inspector-empty p {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 14px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 13px;
     color: var(--ink-mute);
     margin: 0;
     line-height: 1.6;
@@ -256,8 +256,8 @@
     font-size: 10.5px;
     font-weight: 500;
     color: var(--ink-mute);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    text-transform: none;
+    letter-spacing: 0;
     margin-bottom: 6px;
   }
 

--- a/src/lib/views/snippets/SnippetList.svelte
+++ b/src/lib/views/snippets/SnippetList.svelte
@@ -145,9 +145,9 @@
   }
 
   .empty-h {
-    font-family: var(--serif);
-    font-style: italic;
-    font-size: 17px;
+    font-family: var(--sans);
+    font-style: normal;
+    font-size: 15px;
     font-weight: 500;
     color: var(--ink-soft);
     margin: 0;

--- a/src/lib/views/snippets/SnippetModal.svelte
+++ b/src/lib/views/snippets/SnippetModal.svelte
@@ -249,9 +249,9 @@
   }
 
   .modal-title {
-    font-family: var(--serif);
-    font-size: 18px;
-    font-weight: 500;
+    font-family: var(--sans);
+    font-size: 17px;
+    font-weight: 600;
     letter-spacing: -0.015em;
     color: var(--ink);
     margin: 0;

--- a/src/ui.css
+++ b/src/ui.css
@@ -397,10 +397,10 @@ input[type='range'].ui-range:focus-visible {
 
 .ui-modal-title {
   color: var(--ink);
-  font-family: var(--serif);
-  font-size: 18px;
-  font-weight: 500;
-  letter-spacing: -0.015em;
+  font-family: var(--sans);
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   margin: 0;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hold hotkey -> audio capture -> transcription -> LLM cleanup -> text injection.
> - This snapshot spans provider/model defaults, cleanup pipeline wiring, insights pricing, and shared frontend presentation.
> - Recent workspace work updated Gemini model semantics and pricing while also applying pending UI typography and control polish.
> - The uncommitted work was already present as one fresh workspace snapshot and needed a single reviewable branch.
> - This pull request consolidates that snapshot against the current dev branch.
> - The benefit is consistent provider defaults, accurate cost estimates, and a more coherent UI without including the already-merged PR 333/335 changes.

## What Changed

- Update Google defaults and documentation for dedicated Gemini transcription plus Gemini 3.x cleanup models.
- Add Google model pricing coverage, including audio-based Gemini Transcribe estimates and distinct Flash/Flash-Lite rates.
- Wire the resolved context name into transcription-stage cleanup setup.
- Apply the pending frontend typography, spacing, control-motion, setup, settings, dictionary, snippets, insights, and home-surface polish.
- Normalize touched Rust backend formatting and test layout without changing existing behavior contracts.

## Verification

- `npm run check` — passed.
- `npm run test:rust` — passed: 611 passed, 0 failed, 4 ignored.
- `npm test` — 9 deterministic suites passed; 22 browser suites could not start because the Playwright Chromium headless executable is not installed in this environment.
- `npm run lint` — frontend check passed, but the Rust build step hit a Windows file-lock error while copying `Verenu.WindowsChrome.dll`; no lint diagnostics were reported before that build failure.
- `but branch show codex/consolidate-new-work --check` — merges cleanly into `dev`.

## Risks

- Medium: the branch is broad and touches many shared UI surfaces plus formatting across backend modules.
- Provider model names and pricing are static estimates and can drift as vendor catalogs change.
- No API keys, secrets, or dictated content were added.

## Model Used

- OpenAI GPT-5.6 (Codex), tool use and repository inspection.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md` — this PR does not duplicate planned work
- [x] `npm run check` passes
- [ ] `npm run lint` passes
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass — Playwright browser executable unavailable in this environment
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] Version files were not changed
- [x] Relevant documentation updated
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791025204&installation_model_id=432577&pr_number=337&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F337&signature=18d7f3fb6b464fc49e75b3cd16e4e5f60a78c27c6723c65cd7313afee90ab850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->