### PR TITLE
Replace the Insights pace dial with a tick-scale meter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Replaced the Insights speaking-pace dial with a tick-scale meter that matches the rest of the page: the tile is now left-aligned on the same baseline grid as its two neighbours, quarter marks make the scale readable at a glance, the scale ceiling grows to always clear your personal best, and the best itself is marked on the scale instead of only being named underneath.
 - Fixed the main window stuttering and spiking CPU when dragged or resized quickly on Windows: moving the window no longer re-runs title-bar and icon updates per mouse event, resizes coalesce to a single refresh once the size settles, title-bar metrics are only forwarded when visible values change, and themed icons reuse cached artwork instead of re-rendering on every focus or settings event.
 - Restored the Windows tray icon's classic proportions — the accent-theming rework had grown the waveform to fill ~70% of the tile edge to edge; it sits back inside the tile with real margins, keeping the sharper native-size rendering.
 - Recolored the running tray, taskbar/window, and macOS Dock icons with the selected accent while preserving their existing light/dark backgrounds and bundled launcher icons.

--- a/src/lib/views/insights/HeroStats.svelte
+++ b/src/lib/views/insights/HeroStats.svelte
@@ -3,7 +3,15 @@
   import { tweened } from 'svelte/motion';
   import { expoOut } from 'svelte/easing';
   import { motionMs } from '../../motion';
-  import { fmtCompact, fmtNumber, bookEquivalent, pctDelta } from './helpers';
+  import {
+    fmtCompact,
+    fmtNumber,
+    bookEquivalent,
+    pctDelta,
+    paceScale,
+    paceTickOffset,
+    PACE_TICKS,
+  } from './helpers';
   import AnimatedNumber from './AnimatedNumber.svelte';
   import type { InsightsPayload } from './types';
 
@@ -14,14 +22,20 @@
   // the page is filtered. Say so rather than letting them read as scoped.
   const scoped = $derived(data.context_id !== null);
 
-  /* Gauge spans 0–200 wpm. The average speaking pace (~100 wpm) sits dead
-     centre, so most readings land mid-arc with room on both sides for
-     unusually slow or fast talkers. */
-  const GAUGE_MAX = 200;
-  const GAUGE_MID = 100;
-  const ARC_LENGTH = Math.PI * 52; // r=52 semicircle
+  /* The pace meter is a ruler, not a dial: same flat, hairline vocabulary as
+     the bars elsewhere on this page, and it leaves the tile left-aligned on
+     the same baseline grid as its two neighbours.
 
-  // Tweened so the arc — and everything derived from it — glides to a new
+     Scale runs 0 → a round ceiling that always clears the personal best, so
+     the best marker never pins itself to the last tick and read as "maxed". */
+  const TICKS = PACE_TICKS;
+  const tickIndices = Array.from({ length: TICKS }, (_, i) => i);
+  // Measured so ticks can be pinned to whole pixels; see paceTickOffset().
+  let rulerW = $state(0);
+  const scale = $derived(paceScale(data.totals.best_wpm));
+  const scaleMax = $derived(scale.max);
+
+  // Tweened so the meter — and everything derived from it — glides to a new
   // reading instead of snapping when a fresh dictation lands.
   const wpmT = tweened(untrack(() => data.totals.avg_wpm), { duration: motionMs(650), easing: expoOut });
   $effect(() => { wpmT.set(data.totals.avg_wpm); });
@@ -30,7 +44,9 @@
   $effect(() => { totalWordsT.set(data.totals.total_words); });
 
   const wpm = $derived(Math.round($wpmT));
-  const gaugeFill = $derived(Math.min(1, Math.max(0, wpm / GAUGE_MAX)));
+  // Lit tick count, so the meter fills in discrete steps as the tween runs.
+  const litTicks = $derived(Math.round(Math.min(1, Math.max(0, $wpmT / scaleMax)) * TICKS));
+  const bestTick = $derived(scale.bestTick);
 
   const words = $derived(fmtCompact($totalWordsT));
   // Derived from the tweened count so the book equivalent stays in sync with
@@ -45,40 +61,38 @@
 </script>
 
 <div class="hero">
-  <section class="tile tile-gauge" aria-label="Average words per minute">
-    <svg class="gauge" viewBox="-10 -12 148 98" aria-hidden="true">
-      <path
-        d="M 12 70 A 52 52 0 0 1 116 70"
-        fill="none"
-        stroke="var(--control-hover)"
-        stroke-width="11"
-        stroke-linecap="round"
-      />
-      <path
-        d="M 12 70 A 52 52 0 0 1 116 70"
-        fill="none"
-        stroke="var(--accent)"
-        stroke-width="11"
-        stroke-linecap="round"
-        stroke-dasharray={`${ARC_LENGTH * gaugeFill} ${ARC_LENGTH}`}
-        class="gauge-fill"
-      />
-      <!-- Scale labels — 0 / 100 / 200 wpm — so the arc reads as a fixed
-           reference, not a bare unlabelled sweep. Each centred on its own
-           mark so "0" and "200" sit at identical, mirrored distances from
-           the arc's two ends. -->
-      <text x="4" y="86" class="gauge-tick" text-anchor="middle">0</text>
-      <text x="64" y="0" class="gauge-tick gauge-tick-mid" text-anchor="middle">{GAUGE_MID}</text>
-      <text x="124" y="86" class="gauge-tick" text-anchor="middle">{GAUGE_MAX}</text>
-      <!-- Sits low in the arc's hollow, where the semicircle is widest, so
-           a 3-digit reading never reaches the curve above it. No "wpm"
-           suffix — the label right below already says it. -->
-      <text x="64" y="63" class="gauge-value" text-anchor="middle">{wpm > 0 ? wpm : '—'}</text>
-    </svg>
-    <p class="tile-label">words per minute</p>
-    <p class="tile-note">
+  <section
+    class="tile tile-pace"
+    aria-label={wpm > 0
+      ? `Average speaking pace ${wpm} words per minute, best ${Math.round(data.totals.best_wpm)}`
+      : 'Average speaking pace, not measured yet'}
+  >
+    <div class="tile-head">
+      <span class="big">{wpm > 0 ? wpm : '—'}<small class="unit">wpm</small></span>
+    </div>
+    <p class="tile-label">average speaking pace</p>
+
+    <div class="meter" aria-hidden="true">
+      <div class="ruler" bind:clientWidth={rulerW}>
+        {#each tickIndices as i}
+          <span
+            class="tick"
+            class:major={i % 11 === 0}
+            class:on={i < litTicks}
+            class:best={i === bestTick}
+            style="left: {paceTickOffset(i, rulerW)}"
+          ></span>
+        {/each}
+      </div>
+      <div class="scale">
+        <span>0</span>
+        <span>{scaleMax}</span>
+      </div>
+    </div>
+
+    <p class="tile-note tile-note-dim">
       {#if data.totals.best_wpm > 0}
-        Your best is {Math.round(data.totals.best_wpm)} wpm
+        <span class="best-key" aria-hidden="true"></span>Best <strong>{Math.round(data.totals.best_wpm)}</strong> wpm
       {:else}
         Speak a little longer to measure this
       {/if}
@@ -238,38 +252,77 @@
     font-size: 11.5px;
   }
 
-  .tile-gauge {
-    align-items: center;
-    text-align: center;
+  .big .unit {
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    margin-left: 5px;
   }
 
-  .tile-gauge .tile-label {
-    margin-top: 13px;
+  /* Ruler, not a bar: discrete hairline ticks read as an instrument scale and
+     match the bar language used by the charts below. */
+  .meter { margin-top: 14px; }
+
+  .ruler {
+    position: relative;
+    height: 18px;
   }
 
-  .gauge {
-    width: 100%;
-    max-width: min(150px, 100%);
-    height: auto;
-    display: block;
+  /* Fixed hairline width — flex-grown ticks turn into fat blocks and the whole
+     thing reads as a loading bar instead of a scale. Absolutely positioned at
+     whole-pixel offsets rather than spaced by flexbox, so no tick straddles a
+     pixel boundary and renders heavier than the rest. */
+  .tick {
+    position: absolute;
+    bottom: 0;
+    width: 2px;
+    height: 10px;
+    border-radius: 1px;
+    background: var(--line-strong);
+    transition:
+      background-color var(--ui-duration-base, 200ms) ease,
+      height var(--ui-duration-base, 200ms) ease;
   }
-  .gauge-tick {
-    font-family: var(--serif);
+  /* Quarter marks, so the scale can be read without counting hairlines. The
+     last tick is deliberately not one — the "250" label already ends the
+     scale, and a tall mark there competes with the personal-best marker. */
+  .tick.major { height: 14px; }
+  .tick.on { background: var(--accent); }
+  /* The best marker outranks the fill — it must stay findable inside the lit
+     run, which is where it usually sits. */
+  .tick.best {
+    height: 18px;
+    background: var(--ink-soft);
+  }
+
+  .scale {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 7px;
+    font-family: var(--sans);
     font-size: 10px;
-    font-weight: 600;
-    fill: var(--ink-mute);
+    font-weight: 500;
+    color: var(--ink-faint);
     font-variant-numeric: tabular-nums;
   }
-  .gauge-tick-mid {
-    font-size: 11px;
-    fill: var(--ink-soft);
+
+  /* Ties the tall tick to the words underneath it without a floating label
+     that would overflow the column. */
+  .best-key {
+    display: inline-block;
+    width: 2px;
+    height: 10px;
+    border-radius: 1px;
+    background: var(--ink-soft);
+    margin-right: 7px;
+    vertical-align: -1px;
   }
 
-  .gauge-value {
-    font-family: var(--sans);
-    font-size: 24px;
+  .tile-pace .tile-note-dim strong {
+    color: var(--ink-soft);
     font-weight: 600;
-    fill: var(--ink);
     font-variant-numeric: tabular-nums;
   }
 
@@ -305,19 +358,21 @@
 
   /* Container queries against the insights column (owned by Insights.svelte):
      viewport queries fired too late because the sidebar consumes ~220px.
-     The band stays 3-up as long as possible — stacking early is what left a
-     150px gauge stranded in a full-width row with empty space beside it. */
+     The band stays 3-up as long as possible — stacking early strands one
+     narrow tile in a full-width row with empty space beside it. */
   @container insights (max-width: 680px) {
-    /* Compact 3-up: tighter gutters and a smaller gauge/number so all three
-       tiles still fit side by side instead of stacking. */
+    /* Compact 3-up: tighter gutters and smaller numbers so all three tiles
+       still fit side by side instead of stacking. */
     .hero { gap: 14px; }
     .tile + .tile { padding-left: 14px; }
     .tile-relative .tile-head { padding-right: 84px; }
     .delta { font-size: 10px; padding: 2px 7px; }
     .big { font-size: 24px; }
     .big small { font-size: 15px; }
-    .gauge { max-width: min(120px, 100%); }
-    .gauge-value { font-size: 20px; }
+    .big .unit { font-size: 11px; margin-left: 4px; }
+    .ruler { height: 16px; }
+    .tick { height: 9px; }
+    .tick.best { height: 16px; }
     .tile-note { font-size: 11.5px; }
     .stat-num { font-size: 14px; }
     .stat-label { font-size: 10.5px; }
@@ -334,22 +389,6 @@
       padding-top: 18px;
       margin-top: 18px;
     }
-    /* Stacked, the gauge goes horizontal — dial on the left, labels on the
-       right — so the row reads as one full-width fact instead of a small
-       centred dial with empty space beside it. */
-    .tile-gauge {
-      display: grid;
-      grid-template-columns: 110px minmax(0, 1fr);
-      column-gap: 14px;
-      align-items: center;
-      text-align: left;
-    }
-    .tile-gauge .gauge {
-      grid-row: span 2;
-      max-width: 110px;
-    }
-    .tile-gauge .tile-label { margin-top: 0; }
-    .tile-gauge .tile-note { margin-top: 4px; }
   }
 
   /* Very narrow: the delta pill joins the flow instead of floating over the

--- a/src/lib/views/insights/helpers.test.ts
+++ b/src/lib/views/insights/helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { PACE_TICKS, PACE_TICK_W, paceScale, paceTickOffset } from './helpers';
+
+describe('pace meter scale', () => {
+  it('never leaves a lone tick trailing past the best marker', () => {
+    // The regression: best 245 on a 250 ceiling put the marker one tick short
+    // of the end, so a single orphan hairline sat after it.
+    for (let best = 1; best <= 600; best++) {
+      const { bestTick } = paceScale(best);
+      expect(bestTick, `best=${best}`).not.toBe(PACE_TICKS - 2);
+      expect(bestTick).toBeGreaterThanOrEqual(0);
+      expect(bestTick).toBeLessThan(PACE_TICKS);
+    }
+  });
+
+  it('grows the ceiling past the best instead of pinning it to the last tick', () => {
+    expect(paceScale(120).max).toBe(200); // floor, so slow talkers keep a stable scale
+    expect(paceScale(245).max).toBe(250);
+    expect(paceScale(251).max).toBe(300);
+  });
+
+  it('has no marker before a best is measured', () => {
+    expect(paceScale(0)).toEqual({ max: 200, bestTick: -1 });
+  });
+});
+
+describe('pace meter tick placement', () => {
+  // 1.25 and 1.5 are the Windows display-scaling factors where whole CSS
+  // pixels are not whole device pixels.
+  it('puts every tick on a device pixel once measured', () => {
+    for (const dpr of [1, 1.25, 1.5, 2, 3]) {
+      for (const width of [159, 186, 237, 268, 348, 428, 486.7]) {
+        for (let i = 0; i < PACE_TICKS; i++) {
+          const px = Number(paceTickOffset(i, width, dpr).replace('px', ''));
+          expect(Number.isInteger(px * dpr), `dpr=${dpr} w=${width} i=${i}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('keeps every tick at the same subpixel phase', () => {
+    for (const dpr of [1, 1.25, 1.5, 2]) {
+      const phases = new Set(
+        Array.from({ length: PACE_TICKS }, (_, i) =>
+          ((Number(paceTickOffset(i, 237, dpr).replace('px', '')) * dpr) % 1).toFixed(6)
+        )
+      );
+      expect(phases, `dpr=${dpr}`).toHaveLength(1);
+    }
+  });
+
+  it('spans the full row without overflowing it', () => {
+    const width = 237;
+    expect(paceTickOffset(0, width, 1)).toBe('0px');
+    expect(paceTickOffset(PACE_TICKS - 1, width, 1)).toBe(`${width - PACE_TICK_W}px`);
+  });
+
+  it('falls back to percentages before the row is measured', () => {
+    expect(paceTickOffset(0, 0, 1)).toBe('0%');
+    expect(paceTickOffset(PACE_TICKS - 1, 0, 1)).toBe('100%');
+  });
+});

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -143,3 +143,55 @@ export function intensityLevel(value: number, max: number): 0 | 1 | 2 | 3 | 4 {
   if (ratio > 0.12) return 2;
   return 1;
 }
+
+/** Hairline count on the Insights pace meter. */
+export const PACE_TICKS = 44;
+
+/**
+ * Scale for the pace meter: a round ceiling that always clears the personal
+ * best, plus the tick the best marker sits on (-1 when there is no best yet).
+ *
+ * Because the ceiling rounds up to the next 50, the best always lands in the
+ * last handful of ticks. Landing on the second-to-last one leaves a single
+ * orphan hairline trailing past the marker, which reads as a rendering
+ * artifact rather than scale — so within a tick of the end, the marker takes
+ * the end.
+ */
+export function paceScale(bestWpm: number, ticks = PACE_TICKS): { max: number; bestTick: number } {
+  const max = Math.max(200, Math.ceil(bestWpm / 50) * 50);
+  if (bestWpm <= 0) return { max, bestTick: -1 };
+  // Lower clamp: a best under half a tick still deserves a marker on tick 0
+  // rather than rounding away to "no best".
+  const tick = Math.max(0, Math.round((bestWpm / max) * ticks) - 1);
+  return { max, bestTick: tick >= ticks - 2 ? ticks - 1 : tick };
+}
+
+/** Hairline width on the pace meter, in CSS px. Mirrors `.tick { width }`. */
+export const PACE_TICK_W = 2;
+
+/**
+ * Left offset for pace-meter tick `i`, snapped to the device pixel grid.
+ *
+ * Letting flexbox spread the fractional slack put each hairline at a different
+ * subpixel phase: one starting mid-pixel antialiases across three columns and
+ * renders visibly wider and paler than a neighbour that happens to land on the
+ * grid, so an evenly-spaced row reads as mismatched line weights. Snapping is
+ * against *device* pixels, not CSS ones — under Windows display scaling (1.25×,
+ * 1.5×) whole CSS pixels still straddle the real grid. Costs at most one device
+ * pixel of spacing variance, which is invisible, and buys identical weight on
+ * every tick.
+ *
+ * Falls back to percentages until the row has been measured, so the first frame
+ * isn't every tick piled up at zero.
+ */
+export function paceTickOffset(
+  i: number,
+  rulerWidth: number,
+  dpr: number = (typeof window === 'undefined' ? 1 : window.devicePixelRatio) || 1,
+  ticks = PACE_TICKS
+): string {
+  const span = ticks - 1;
+  if (rulerWidth <= PACE_TICK_W) return `${(i * 100) / span}%`;
+  const raw = (i * (rulerWidth - PACE_TICK_W)) / span;
+  return `${Math.round(raw * dpr) / dpr}px`;
+}


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - UI: the Insights page, specifically the three-tile hero band at the top
> - The speaking-pace tile was a semicircular dial - the only curved, centre-aligned instrument on a page otherwise built from flat bars, hairlines and tabular numerals. It read as visually inconsistent with its two neighbour tiles.
> - It needed fixing now because it was called out directly as "vibed" - the wrong instrument for this page, not a matter of polish
> - This pull request replaces the dial with a tick-scale meter that shares the same tile anatomy (big number + unit, label, dim note) as its neighbours, and moves the scale math into tested helpers
> - The benefit is a hero band that reads as one consistent instrument panel instead of one tile standing out

## What Changed

- Replaced the semicircular WPM dial with a 44-tick hairline ruler: quarter marks every 11th tick, fill lights tick-by-tick off the existing tween, tile is left-aligned on the same baseline grid as its two neighbours instead of centered
- Scale ceiling is derived (`max(200, ceil(best/50)*50)`) instead of hardcoded to 200, so a personal best above 200 grows the scale instead of pinning the marker to the last tick
- Personal best is marked on the scale itself (a tall tick) instead of only being named in the caption below
- Moved the scale math into `src/lib/views/insights/helpers.ts` as two pure functions with unit tests:
  - `paceScale(bestWpm)` — the ceiling + best-tick index. Snaps the marker to the very last tick whenever it would otherwise land on the second-to-last, which used to leave one orphan hairline trailing past it
  - `paceTickOffset(i, rulerWidth, dpr)` — positions each tick at a device-pixel-snapped offset instead of letting flexbox spread fractional slack between them, which put each hairline at a different subpixel phase and made ticks of identical CSS width render at visibly different weights
- Added a CHANGELOG entry under Unreleased

## Verification

- `npm run check` — 0 errors
- `npx vitest run src` — 91 passed, including new `helpers.test.ts` covering: no orphan tick past the best marker for every best 1-600 wpm, ceiling growth behavior, tick placement snapped to a single device-pixel phase across DPR 1/1.25/1.5/2/3 and seven ruler widths
- Manually verified in the running dev build, both themes, across container widths 340-1100px (the point where the 3-tile band is tightest before stacking): no overflow at any width, ticks read as discrete hairlines even at the narrowest gap (~1.7px)
- `npm run lint`'s Rust half could not be verified in this session - `build.rs` can't copy `Verenu.WindowsChrome.dll` while a locally running instance of the app holds it open. Unrelated to this change; no Rust files are touched.

## Risks

Low risk. Frontend-only, scoped to one Svelte component's markup/styles and two new pure helper functions with no I/O. No pipeline, injection, or data-layer paths touched.

## Model Used

Claude (Claude Code, Sonnet 5), interactive session with iterative visual review against the running dev build.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) - Rust half blocked by a locally running app instance holding a DLL; no Rust files changed
- [ ] `npm run test:rust` passes - not run; no Rust files changed
- [ ] Smoke tests - not run this session; change is isolated to Insights hero tile markup, no smoke-test-covered selectors touched
- [x] Tests added or updated where applicable
- [x] UI changes include screenshots (after only — see comment; the before/dial shot didn't survive a hot-reload file swap this session)
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: n/a, no version bump in this PR
- [x] Relevant documentation updated to reflect changes (CHANGELOG)
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791091241&installation_model_id=432577&pr_number=339&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F339&signature=60783d2d955d62ca48cc3a55f8f4b784ba34a755654f2e7348ece6fd83d46f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

