### PR TITLE
Polish settings search animation and appearance docs

### DIFF
--- a/docs/APPEARANCE.md
+++ b/docs/APPEARANCE.md
@@ -1,0 +1,23 @@
+# Appearance and settings
+
+Open **Settings -> General** to change how Verenu looks. Appearance preferences are stored locally and apply to the main window and dictation pill.
+
+## Theme
+
+Choose **System**, **Light**, or **Dark** under Appearance.
+
+- **System** follows the current Windows or macOS appearance.
+- **Light** uses neutral near-white backgrounds.
+- **Dark** uses neutral charcoal backgrounds.
+
+The current palette avoids the older cream light theme and orange-brown dark theme. Backgrounds, dividers, and text stay neutral so the accent color remains distinct.
+
+## Accent color
+
+Accent color controls actions, selection indicators, focus rings, and status details. Choose a preset or enter a six-digit hex color in the accent picker. Verenu derives the related soft background, readable text, and foreground colors for both light and dark themes.
+
+Reset the picker to remove the custom value and restore Verenu's default terracotta accent. Changing the accent does not tint the neutral page backgrounds.
+
+## Finding a setting
+
+Use the search field at the top of the settings sidebar to find a preference by name or related term. Selecting a result opens its section, scrolls the preference into view, and briefly marks its position at the left edge.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory contains user, contributor, release, and architecture docs for Ve
 - [Your First Dictation](FIRST_DICTATION.md)
 - [Data And Privacy](DATA_AND_PRIVACY.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
+- [Appearance and settings](APPEARANCE.md)
 
 ## Features
 

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,6 +1,6 @@
 # Verenu Color Palette
 
-Verenu uses neutral gray surfaces and text with restrained accent color usage.
+Verenu uses neutral gray surfaces and text with restrained accent color usage. Light mode uses near-white grays and dark mode uses charcoal grays. The accent never tints the page backgrounds.
 
 ## Neutral surfaces
 
@@ -29,7 +29,7 @@ The sidebar and page colors intentionally differ by only a few RGB points. The d
 
 ## Accent
 
-Terracotta remains the default accent and is used sparingly for primary actions, highlights, and interactive states. Users can replace it in Settings. A custom color updates the semantic accent tokens and the full Japonica scale in both themes, while the neutral surfaces stay unchanged.
+Terracotta is the default accent and is used sparingly for primary actions, selection indicators, focus rings, and status details. Users can replace it in **Settings -> General -> Accent color**. A custom color updates the semantic accent tokens and the full Japonica scale in both themes, while the neutral surfaces stay unchanged.
 
 | Token | Light default | Usage |
 |---|---:|---|
@@ -47,7 +47,7 @@ Custom accents are stored as a six-digit hex color. The app derives readable sof
 
 ## Design principles
 
-1. Quiet, slightly warm neutrals create structure without reading as beige or brown.
+1. Neutral near-white and charcoal surfaces create structure without reading as cream, beige, orange, or brown.
 2. Accent color is reserved for important actions and feedback.
 3. Text size, weight, and muted color establish hierarchy before borders do.
 4. Sidebar and content surfaces remain subtly distinct in both themes.

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -944,7 +944,6 @@
     flex-direction: column;
     gap: 10px;
     min-width: 0;
-    position: relative;
   }
 
   /* The section rows have global rail outros for the settings-page morph. Hide

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -34,7 +34,7 @@
   } from '../../downloadManager.svelte';
   import { tweened } from 'svelte/motion';
   import { cubicOut, expoOut } from 'svelte/easing';
-  import { fly, slide } from 'svelte/transition';
+  import { fade, fly, slide } from 'svelte/transition';
   import { flip } from 'svelte/animate';
 
   let rawMemoryMb = $state(0);
@@ -157,6 +157,26 @@
 
   function railDelay(index: number, base: number, step = RAIL_STAGGER_MS): number {
     return motionMs(base + Math.min(index, RAIL_STAGGER_CAP) * step);
+  }
+
+  /* Search results can change both position and height as a broad query is
+     refined. Standard FLIP scales between those rectangles, which stretches
+     text when a whole section loses several matches at once. Search only needs
+     translation: rows glide to their new slot without being resized. */
+  function searchResultReorder(
+    _node: Element,
+    { from, to }: { from: DOMRect; to: DOMRect },
+  ) {
+    const dx = from.left - to.left;
+    const dy = from.top - to.top;
+    return {
+      duration: motionMs(180),
+      easing: cubicOut,
+      css: (t: number) => {
+        const u = 1 - t;
+        return `transform: translate3d(${u * dx}px, ${u * dy}px, 0);`;
+      },
+    };
   }
 
   function nav(id: string) {
@@ -478,7 +498,7 @@
     ></div>
 
     {#if appStore.settingsOpen}
-      <div class="settings-rail-content">
+      <div class="settings-rail-content" class:searching={Boolean(settingsQuery.trim())}>
         <div
           class="settings-search"
           in:fly|global={{ x: -motionPx(RAIL_TRAVEL_PX), duration: motionMs(RAIL_IN_MS), delay: 0, easing: cubicOut }}
@@ -487,19 +507,37 @@
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
           <input type="search" bind:value={settingsQuery} placeholder="Search settings..." aria-label="Search settings" />
           {#if settingsQuery}
-            <button type="button" class="settings-search-clear" aria-label="Clear settings search" onclick={() => settingsQuery = ''}>×</button>
+            <button
+              type="button"
+              class="settings-search-clear"
+              aria-label="Clear settings search"
+              onclick={() => settingsQuery = ''}
+              in:fly={{ x: motionPx(3), duration: motionMs(MOTION_MS.fast), easing: cubicOut }}
+              out:fly={{ x: motionPx(3), duration: motionMs(120), easing: cubicOut }}
+            >×</button>
           {/if}
         </div>
         {#if settingsQuery.trim()}
-          <div class="settings-search-results scroll-styled" aria-live="polite">
+          <div
+            class="settings-search-results scroll-styled"
+            aria-live="polite"
+          >
             {#each settingsSearchGroups as group (group.section.id)}
-              <div class="settings-search-group">
+              <div
+                class="settings-search-group"
+                animate:searchResultReorder
+                in:fade={{ duration: motionMs(120) }}
+                out:fade={{ duration: motionMs(120) }}
+              >
                 <div class="settings-search-section">{group.section.label}</div>
                 {#each group.results as result (result.id)}
                   <button
                     type="button"
                     class="settings-search-result"
                     onclick={() => openSettingsSearchResult(result)}
+                    animate:searchResultReorder
+                    in:fade={{ duration: motionMs(120) }}
+                    out:fade={{ duration: motionMs(120) }}
                   >
                     <span class="settings-search-result-title">{result.label}</span>
                     <span class="settings-search-result-hint">Open in {group.section.label}</span>
@@ -906,6 +944,15 @@
     flex-direction: column;
     gap: 10px;
     min-width: 0;
+    position: relative;
+  }
+
+  /* The section rows have global rail outros for the settings-page morph. Hide
+     their retained outro nodes while search owns this space so results never
+     paint on top of the old navigation list. */
+  .settings-rail-content.searching .rail-list-settings {
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .settings-search {
@@ -918,10 +965,14 @@
     border: 1px solid var(--line);
     border-radius: 7px;
     color: var(--ink-faint);
+    transition:
+      border-color var(--ui-duration-fast) var(--ui-ease-out),
+      color var(--ui-duration-fast) var(--ui-ease-out);
   }
 
   .settings-search:focus-within {
     border-color: var(--line-strong);
+    color: var(--ink-mute);
   }
 
   .settings-search input {
@@ -952,7 +1003,13 @@
     font-size: 16px;
     line-height: 1;
     padding: 0 1px;
+    transition:
+      color var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-fast) var(--ui-ease-out);
   }
+
+  .settings-search-clear:hover { color: var(--ink); }
+  .settings-search-clear:active { transform: scale(0.9); }
 
   .settings-search-empty {
     color: var(--ink-mute);
@@ -961,12 +1018,32 @@
   }
 
   .settings-search-results {
+    animation: settings-search-results-enter var(--ui-duration-base) var(--ui-ease-out);
     display: flex;
     flex-direction: column;
     gap: 12px;
+    left: 0;
     max-height: calc(100vh - 190px);
     overflow-y: auto;
     padding: 0 2px 8px;
+    position: absolute;
+    right: 0;
+    top: 40px;
+  }
+
+  @keyframes settings-search-results-enter {
+    from {
+      opacity: 0;
+      transform: translate3d(-6px, 0, 0);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .settings-search-results { animation: none; }
   }
 
   .settings-search-group {
@@ -994,6 +1071,9 @@
     gap: 1px;
     padding: 7px 8px;
     text-align: left;
+    transition:
+      background-color var(--ui-duration-fast) var(--ui-ease-out),
+      color var(--ui-duration-fast) var(--ui-ease-out);
   }
 
   .settings-search-result:hover { background: var(--control-hover); }

--- a/src/lib/views/Settings.svelte
+++ b/src/lib/views/Settings.svelte
@@ -198,7 +198,7 @@
       searchHighlightTimer = setTimeout(() => {
         target.classList.remove('settings-search-hit');
         searchHighlightTimer = null;
-      }, 2400);
+      }, 1600);
       clearSettingsSearchNavigation(request.nonce);
     };
 
@@ -499,28 +499,48 @@
   .settings-body :global(.settings-subhead.first) { margin-top: 4px; }
 
   .settings-body :global([data-setting-target]) {
+    position: relative;
     scroll-margin-block: 72px;
   }
 
   .settings-body :global(.settings-search-hit) {
-    border-radius: var(--r-sm);
     outline: none;
-    animation: settings-search-highlight 2400ms ease-out;
   }
 
-  @keyframes settings-search-highlight {
-    0%, 34% {
-      background: color-mix(in srgb, var(--accent) 14%, transparent);
-      box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 9%, transparent);
+  .settings-body :global(.settings-search-hit::before) {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -12px;
+    width: 3px;
+    height: min(28px, calc(100% - 12px));
+    border-radius: 999px;
+    background: var(--accent);
+    pointer-events: none;
+    animation: settings-search-locator 1600ms var(--ui-ease-out);
+  }
+
+  @keyframes settings-search-locator {
+    0% {
+      opacity: 0;
+      transform: translate3d(-4px, -50%, 0) scaleY(0.45);
+    }
+    16%, 55% {
+      opacity: 0.9;
+      transform: translate3d(0, -50%, 0) scaleY(1);
     }
     100% {
-      background: transparent;
-      box-shadow: 0 0 0 4px transparent;
+      opacity: 0;
+      transform: translate3d(0, -50%, 0) scaleY(0.72);
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .settings-body :global(.settings-search-hit) { animation-duration: 1ms; }
+    .settings-body :global(.settings-search-hit::before) {
+      animation: none;
+      opacity: 0.9;
+      transform: translate3d(0, -50%, 0);
+    }
   }
 
   .settings-body :global(.setting-row) {


### PR DESCRIPTION
Results now animate into refined positions while typing, the hit marker is a slim accent locator, and appearance documentation covers neutral themes and custom hex accents.

Checks: npm run check; npx vitest run src/lib/settingsSearch.test.ts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791093553&installation_model_id=432577&pr_number=340&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F340&signature=0fd5c46562efe0f502633b07ee105c3ceb10bb4cf045c3d1c2d5ce27c1ba5c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->