### PR TITLE
Refresh documentation for current app behavior

### DIFF
--- a/.github/workflows/morning-release.yml
+++ b/.github/workflows/morning-release.yml
@@ -230,13 +230,13 @@ jobs:
               echo
               echo '1. Download the installer for your platform from the assets below'
               echo '2. Add your API key for Groq, OpenAI, or Google'
-              echo '3. Hold **Ctrl+Win** on Windows or **fn+Control** on macOS and start talking'
+              echo '3. Hold **Ctrl+Win** on Windows or **Option+Space** on macOS and start talking'
               echo '4. Release the hotkey and your cleaned-up text appears in the active app'
               echo
               echo '## Shortcuts'
               echo
               echo '- **Windows hold-to-record** - Hold **Ctrl+Win** to record, release to transcribe and inject'
-              echo '- **macOS hold-to-record** - Hold **fn+Control** to record, release to transcribe and inject'
+              echo '- **macOS hold-to-record** - Hold **Option+Space** to record, release to transcribe and inject'
               echo
               echo '## Lightweight & Local'
               echo

--- a/Agent-Skills/Release_Description_Writing.md
+++ b/Agent-Skills/Release_Description_Writing.md
@@ -66,7 +66,7 @@ Rules:
 - This section is evergreen. Update it as features land, not just at release time.
 - Categories used: Transcription, Text Cleanup, Dictionary & Snippets, History & Stats, Settings.
 - Bold-label bullets (`**Label** - description`) for major features. Use plain bullets for supporting details.
-- Use bold format for hotkeys (e.g., `**Ctrl+Win**` for Windows, `**fn+Control**` for macOS) with no backticks.
+- Use bold format for hotkeys (e.g., `**Ctrl+Win**` for Windows, `**Option+Space**` for macOS) with no backticks.
 - Keep descriptions present-tense and functional ("Start a continuous dictation session").
 
 ### 5. Getting Started
@@ -76,7 +76,7 @@ Rules:
 
 1. Download the installer from releases
 2. Add your API key for Groq, OpenAI, or Google
-3. Hold **Ctrl+Win** (Windows) or **fn+Control** (macOS) and start talking
+3. Hold **Ctrl+Win** (Windows) or **Option+Space** (macOS) and start talking
 4. Release the hotkey and your cleaned-up text appears in the active app
 ```
 
@@ -88,7 +88,7 @@ This is static.
 ## Shortcuts
 
 - **Windows hold-to-record** - Hold **Ctrl+Win** to record, release to transcribe and inject
-- **macOS hold-to-record** - Hold **fn+Control** to record, release to transcribe and inject
+- **macOS hold-to-record** - Hold **Option+Space** to record, release to transcribe and inject
 ```
 
 Rules:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,12 @@ Core model: hold the hotkey, talk, release; Verenu transcribes (cloud or fully l
 - **Framework:** Tauri 2.x (Rust backend + WebView2 frontend — not Electron, not a web app)
 - **Frontend:** Svelte 5 + TypeScript + Tailwind CSS v4
 - **Database:** SQLite via `rusqlite` (direct, not `tauri-plugin-sql`)
-- **Settings store:** backend-owned JSON at Tauri `BaseDirectory::AppData/settings.json` via `src-tauri/src/data/store.rs` (non-secret settings only; see [Settings & Configuration](#settings--configuration) for where API keys actually live)
+- **Settings store:** backend-owned JSON at Tauri `BaseDirectory::AppData/settings.json` via `src-tauri/src/data/store/` (non-secret settings only; see [Settings & Configuration](#settings--configuration) for where API keys actually live)
 - **Audio capture:** `cpal` + `hound` for WAV encoding + `nnnoiseless` for noise reduction
-- **Local transcription:** `transcribe-rs` (ONNX runtime, Silero VAD) running Parakeet V3 fully offline
+- **Local transcription:** `transcribe-rs` adapters with ONNX runtime and Silero VAD, using downloaded local STT models fully offline
 - **Local cleanup:** managed local LLM server process (`src-tauri/src/local_llm/`) — binary runtime + models downloaded on demand, driven over a local HTTP endpoint
 - **Windows native APIs:** `windows` crate (hotkey hook, active window, SendInput, UI Automation, Credential Manager)
-- **macOS native APIs:** `core-graphics` (`CGEventTap` global hotkey), `security-framework` (Keychain), `accessibility-sys` (AX API), `objc2`/`objc2-foundation` (AppKit interop — `NSWorkspace`, `NSPasteboard`), `coreaudio-rs` (native mute control)
+- **macOS native APIs:** Carbon `RegisterEventHotKey` through `global-hotkey`, `security-framework` (Keychain), `accessibility-sys` (AX API), `objc2`/`objc2-foundation` (AppKit interop — `NSWorkspace`, `NSPasteboard`), `coreaudio-rs` (native mute control)
 - **HTTP:** `reqwest` (async API calls to AI providers)
 - **Async runtime:** `tokio`
 - **Utilities:** `chrono` (timestamps), `anyhow` (error handling)
@@ -106,7 +106,7 @@ src/                        # Svelte 5 frontend
     stores.svelte.ts        # Svelte 5 runes-based app stores
     settings.ts             # Typed settings registry: SettingsValueMap, saveSetting() helper, shared types (ProviderId, AppearanceMode, etc.)
     settingsSections.ts     # Settings section ids/order + visibility (macOnly/devOnly/legacyOnly)
-    transcriptionLanguages.ts  # ISO 639-1 language list + TranscriptionLanguageCode type (frontend mirror of store.rs validation)
+    transcriptionLanguages.ts  # ISO 639-1 language list + TranscriptionLanguageCode type (frontend mirror of data/store validation)
     calibration.ts          # Mic gain auto-calibration state machine (loud/whisper phases)
     platform.ts             # Runtime platform detection (Windows vs macOS)
     motion.ts               # Animation/transition utilities
@@ -149,13 +149,13 @@ src-tauri/
       mod.rs recording.rs settings.rs contexts.rs history.rs library.rs
       local_llm.rs local_stt.rs permissions.rs service_status.rs system.rs updater.rs
     local_llm/              # Local cleanup runtime: managed server process, model/runtime downloads
-    local_stt/              # Local transcription: Parakeet V3 engine, model downloads
+    local_stt/              # Local transcription engine and model downloads
     testing.rs              # Test fixture infrastructure — cfg(test)/debug_assertions only
     api/
       mod.rs                 # Shared retry/auth-error classification: AuthErrorCategory, is_retryable_provider_error(), quota_bail()
       client.rs              # Shared reqwest client construction
       gemini_types.rs        # Gemini request/response (de)serialization types
-      transcription.rs      # POST audio to Groq/OpenAI/Google → raw text
+      transcription.rs      # POST audio to Groq/OpenAI/Google/AssemblyAI → raw text
       cleanup.rs            # POST raw text to LLM with profile system prompt
       auto_learn.rs         # Auto-learn coordinator
       auto_learn/
@@ -238,7 +238,7 @@ The pill window is created at runtime by `create_pill_if_needed()` in `pipeline/
     4. context::resolve_context(): foreground exe (+ domain) → matching Context
        group, or the built-in "Everywhere" fallback
     5. Style overrides: Context tone/intensity → App Mapping → global default_tone
-    6. transcription.rs (or local_stt Parakeet) → raw_text; dual-model mode runs
+    6. transcription.rs (or a selected local_stt model) → raw_text; dual-model mode runs
        primary + first fallback concurrently and reconciles both candidates
     7. Cleanup-cache lookup (key includes model, prompt inputs, and ctx:<id>) —
        hit skips the LLM call entirely
@@ -300,7 +300,7 @@ Groq is the recommended cloud default — free tier, fast LPU inference. Google 
 
 Local models are first-class, not a side path: `local_stt/` runs Parakeet V3 fully offline; `local_llm/` spawns a managed server process (binary runtime downloaded on demand) and talks to it over a local HTTP endpoint. "Fully local" means local transcription paired with local (or no) cleanup. Model/runtime downloads, cancellation, and deletion are all exposed as Tauri commands (`commands/local_stt.rs`, `commands/local_llm.rs`).
 
-The `transcription_language` setting (ISO 639-1, default `en`) is sent to Groq/OpenAI as the `language` form field and to Gemini as a natural-language label via `transcription_language_label()` in `store.rs`. Supported languages: `src/lib/transcriptionLanguages.ts` (frontend), `is_supported_transcription_language()` (Rust).
+The `transcription_language` setting (ISO 639-1, default `en`) is sent to Groq/OpenAI as the `language` form field and to Gemini as a natural-language label via `transcription_language_label()` in `data/store`. Supported languages: `src/lib/transcriptionLanguages.ts` (frontend), `is_supported_transcription_language()` (Rust).
 
 **API fallback:** Retryable errors (timeouts, 429, 5xx) trigger automatic fallback to any configured fallback models. Fallback models are configured per task (transcription/cleanup) in the Models settings tab and stored as `transcription_fallback_models` / `cleanup_fallback_models` arrays. Fallback is implicit — if fallback models are configured, they are always tried in order. Quota errors (`QUOTA_EXCEEDED:` prefix string — use `quota_bail()` helper) fail immediately with no fallback. Non-retryable errors also fail immediately. `is_retryable_provider_error()` in `api/mod.rs` is the single source of truth for what counts as retryable (reqwest timeout/connect errors, HTTP 408/429/5xx, and a few message-substring heuristics).
 
@@ -317,7 +317,7 @@ If a transcription or cleanup call fails with a provider-side error (`is_retryab
 ## Global Hotkey Behavior
 
 - **Windows:** Ctrl+Windows (hold) → start recording; release → stop and process. Implemented with a raw `SetWindowsHookExW(WH_KEYBOARD_LL)` hook; both chord keys and the repair hotkey are user-configurable.
-- **macOS:** Carbon `RegisterEventHotKey` via the `global-hotkey` crate (app_hotkey.rs / core/hotkey/mac.rs). This needs **no** Input Monitoring or Accessibility permission, but Carbon hotkeys require a real key — a pure modifier chord (the old CGEventTap Fn+Control) is no longer possible on macOS.
+- **macOS:** Carbon `RegisterEventHotKey` via the `global-hotkey` crate (app_hotkey.rs / core/hotkey/mac.rs). This needs **no** Input Monitoring or Accessibility permission. Carbon hotkeys require a real key, so the default is Option + Space.
 
 Beyond hold-to-dictate, the hook layer handles:
 - **Handsfree mode** — double-tap the chord (or press Space while holding it) toggles a discrete recording session; Escape cancels.
@@ -329,7 +329,7 @@ Beyond hold-to-dictate, the hook layer handles:
 
 ## Contexts & Style Resolution
 
-Context groups are the primary organizer (0.17.0). A context ties together:
+Context groups are the primary organizer. A context ties together:
 - **Targets** — executables (`context_targets`, matched case-insensitively by `.exe` name on Windows / bundle id on macOS) and website domains (`context_website_targets`, matched against the browser address-bar domain read by `core/browser_probe.rs`). A target belongs to at most one context; assigning it elsewhere moves it. Website domains are DNS-checked before being accepted.
 - **Style** — optional `tone` and `cleanup_intensity` overrides and `custom_instructions` appended to the cleanup prompt.
 - **Content** — dictionary and snippet items scoped to the group via the `dictionary_contexts` / `snippet_contexts` junction tables.
@@ -346,14 +346,14 @@ Built-in tone profiles: `casual`, `formal`, `very_casual`. Profile system prompt
 
 **Insights** (primary nav view) is read-only analytics over the local DB: usage charts, streaks, cost breakdown, context stats (`data/db/insights.rs`, `commands` `get_insights`, `src/lib/views/insights/`).
 
-Store keys (settings, plus the API key *identifiers* used as credential usernames) are defined as constants in `src-tauri/src/data/store.rs` — always use the constant, never a raw string literal. When adding a new setting, update both `store.rs` (Rust constant + validation) and `src/lib/settings.ts` (frontend `SettingsValueMap` type entry).
+Store keys (settings, plus the API key *identifiers* used as credential usernames) are defined as constants in `src-tauri/src/data/store/mod.rs` — always use the constant, never a raw string literal. When adding a new setting, update both `store/mod.rs` (Rust constant + validation) and `src/lib/settings.ts` (frontend `SettingsValueMap` type entry).
 
 ## Settings & Configuration
 
 - **Frontend settings registry** lives in `src/lib/settings.ts` as the `SettingsValueMap` TypeScript type. Add new setting entries here.
-- **Backend settings storage, validation & constants** live in `src-tauri/src/data/store.rs` and `src-tauri/src/commands/settings.rs`. All settings keys are constants; never use raw string literals.
-- **Type mirrors**: `transcriptionLanguages.ts` (frontend) mirrors the backend's supported language validation in `store.rs` — keep them synchronized.
-- **API keys do not live in settings.json.** They are stored in the native OS credential store via `src-tauri/src/data/credentials.rs`: Windows Credential Manager (`CredWriteW`/`CredReadW`/`CredDeleteW`, target `{user}.verenu`) or macOS Keychain (`security-framework` generic-password items). `store.rs`'s `KEY_GROQ`/`KEY_OPENAI`/`KEY_GOOGLE` constants are only used as the credential's username/identifier; the secret value itself never touches settings.json or SQLite. Commands that check key presence return a boolean status only, never the key itself.
+- **Backend settings storage, validation & constants** live in `src-tauri/src/data/store/` and `src-tauri/src/commands/settings.rs`. All settings keys are constants; never use raw string literals.
+- **Type mirrors**: `transcriptionLanguages.ts` (frontend) mirrors the backend's supported language validation in `data/store` — keep them synchronized.
+- **API keys do not live in settings.json.** They are stored in the native OS credential store via `src-tauri/src/data/credentials.rs`: Windows Credential Manager (`CredWriteW`/`CredReadW`/`CredDeleteW`, target `{user}.verenu`) or macOS Keychain (`security-framework` generic-password items). The key-identifier constants in `data/store` are used as credential usernames; the secret value itself never touches settings.json or SQLite. Commands that check key presence return a boolean status only, never the key itself.
 
 ## Prompt Assembly (`api/prompts/`)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   Hold the hotkey, talk, release, and Verenu drops cleaned-up text into the app you were already using.
   <br/>
-  <em>Local-first AI dictation for Windows and macOS. Bring your own API keys. No subscriptions. No telemetry.</em>
+  <em>Local-first AI dictation for Windows and macOS. Bring your own cloud API keys when needed. No subscriptions. No telemetry.</em>
 </p>
 
 <p align="center">
@@ -32,6 +32,8 @@ Contexts are the main place to configure app-specific behavior. They connect app
 
 For more details: [Contexts](docs/CONTEXTS.md), [Vocabulary](docs/VOCABULARY.md), [Snippets](docs/SNIPPETS.md), [Cleanup Levels](docs/CLEANUP_LEVELS.md), and [Local Transcription](docs/LOCAL_TRANSCRIPTION.md).
 
+Appearance can follow the operating system or stay in light or dark mode. Page surfaces use neutral near-white and charcoal colors, and the accent can be changed independently to any six-digit hex color. See [Appearance and settings](docs/APPEARANCE.md).
+
 ## Platform Support
 
 Verenu supports both Windows and macOS.
@@ -46,12 +48,12 @@ Verenu supports both Windows and macOS.
 ### macOS
 
 - Apple Silicon and Intel builds are supported
-- Default hold-to-record hotkey: <kbd>Fn</kbd> + <kbd>Control</kbd>
+- Default hold-to-record hotkey: <kbd>Option</kbd> + <kbd>Space</kbd>
 - API keys are stored in Keychain
 - Verenu needs macOS permissions for real-world use:
   - Microphone, to capture audio
   - Accessibility, to inject text and interact with focused apps
-  - Input Monitoring, to detect the global hotkey while other apps are focused
+  - Notifications are optional and only affect status and update alerts
 
 macOS support is not an afterthought anymore. It is part of the normal app flow, and the repo includes macOS-specific hotkey, permissions, injection, updater, and key-storage logic.
 
@@ -82,7 +84,7 @@ Verenu's own server (`api.verenu.com`) serves only public app metadata — relea
 
 ### Leaves your device
 
-- Local transcription plus Cleanup Off keeps both audio and transcript on device after the model download
+- Local transcription plus local cleanup, or Cleanup Off, keeps audio and transcript on device after the model download
 - Local transcription plus cloud cleanup keeps audio on device but sends transcript text to the cleanup provider
 - Cloud transcription sends recorded audio to your chosen transcription provider
 - Context instructions, cleanup settings, and selected model metadata go with cleanup requests
@@ -98,10 +100,11 @@ You choose the providers. Verenu does not lock you into one stack.
 
 | Provider | Transcription | Cleanup |
 | --- | --- | --- |
-| Local | `parakeet-v3` | none |
+| Local | On-device models | On-device models or none |
 | Groq | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` |
 | OpenAI | `gpt-4o-transcribe` | `gpt-4o-mini` |
 | Google | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` |
+| AssemblyAI | `universal-3-5-pro` or `universal-2` | not available |
 
 If you care about privacy, speed, retention, or cost, judge the provider on its own policy. Once data leaves Verenu and hits a provider API, that provider's rules apply. Local transcription with cloud cleanup is still not fully local because the transcript text leaves the device.
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -1,58 +1,70 @@
-# Add Your API Key
+# Add your API key
 
-Verenu doesn't have its own servers or subscription — it sends your audio and text directly to an AI provider you choose, using an API key you provide. You only need one provider to get started.
+Verenu does not require an account or subscription. Cloud providers use API keys that you provide. Local transcription and local cleanup do not require an API key.
 
 ## Choosing a provider
 
 | Provider | Transcription | Cleanup | Notes |
 | --- | --- | --- | --- |
-| **Groq** (recommended) | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` | Free tier with generous limits, and the fastest of the three (LPU inference) |
-| **OpenAI** | `gpt-4o-transcribe` | `gpt-4o-mini` | Best cleanup quality |
-| **Google** | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` | Dedicated transcription plus cheap, fast cleanup |
+| **Local** | On-device models | On-device models | No API key. Models are downloaded from Settings -> Models. |
+| **Groq** (recommended) | `whisper-large-v3-turbo` | `qwen/qwen3.6-27b` | Free tier with generous limits and fast inference |
+| **OpenAI** | `gpt-4o-transcribe` | `gpt-4o-mini` | Cloud transcription and cleanup |
+| **Gemini (Google)** | `gemini-3.5-transcribe` | `gemini-3.5-flash-lite` | Dedicated transcription plus cloud cleanup |
+| **AssemblyAI** | `universal-3-5-pro` or `universal-2` | Not available | Transcription-only provider |
 
-You can add keys for more than one provider and configure fallback models later in Settings, but a single Groq key is enough to start dictating immediately.
+One cloud provider key is enough to start dictating. You can add other keys and configure model fallbacks later in Settings. The local path needs no key.
 
-The optional Dual model transcription strategy uses the existing transcription fallback chain and therefore may require API keys for more than one configured provider. It is disabled by default.
+The optional Dual model transcription strategy uses the existing transcription fallback chain and may require keys for more than one configured cloud provider. It is disabled by default.
 
 ## Getting a key
 
 ### Groq
-1. Go to [console.groq.com/keys](https://console.groq.com/keys)
-2. Sign in or create a free account
-3. Click **Create API Key**
-4. Copy the key and paste it into Verenu
+
+1. Go to [console.groq.com/keys](https://console.groq.com/keys).
+2. Sign in or create a free account.
+3. Click **Create API Key**.
+4. Copy the key and paste it into Verenu.
 
 ### OpenAI
-1. Go to [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
-2. Sign in to your OpenAI account
-3. Click **Create new secret key**
-4. Copy the key and paste it into Verenu
+
+1. Go to [platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+2. Sign in to your OpenAI account.
+3. Click **Create new secret key**.
+4. Copy the key and paste it into Verenu.
 
 ### Google
-1. Go to [aistudio.google.com](https://aistudio.google.com)
-2. Sign in with your Google account
-3. Click **Get API key** → **Create API key**
-4. Copy the key and paste it into Verenu
+
+1. Go to [aistudio.google.com](https://aistudio.google.com).
+2. Sign in with your Google account.
+3. Click **Get API key** -> **Create API key**.
+4. Copy the key and paste it into Verenu.
+
+### AssemblyAI
+
+1. Open the AssemblyAI dashboard.
+2. Sign in or create an account.
+3. Create or copy an API key from the API keys page.
+4. Paste the key into Verenu. AssemblyAI can be selected for transcription, not cleanup.
 
 ## Where to enter it
 
-- **First run**: Verenu's setup walks you through choosing a provider and pasting in your key on the spot.
-- **Later**: open **Settings → API Keys**, paste your key into the field for any provider, and save. A saved key shows as "● saved" — the key itself is never shown again or readable from the UI. Use **Clear** to remove a stored key.
+- **First run**: setup lets you choose a cloud provider and paste its key, or choose a local model path.
+- **Later**: open **Settings -> API Keys**, paste a key into the provider field, and save. A saved key shows only as saved. Use **Clear** to remove it.
 
 ## How keys are stored
 
-Your API key never touches Verenu's database. It's stored using your operating system's secure credential storage:
+Your API key never touches Verenu's database or settings file. It is stored using the operating system's secure credential storage:
 
 - **Windows**: Windows Credential Manager
 - **macOS**: Keychain
 
-On macOS, if you're prompted for your login password the first time Verenu saves a key, choose **Always Allow** so you aren't asked again.
+On macOS, if you are prompted for your login password the first time Verenu saves a key, choose **Always Allow** so you are not asked again.
 
 ## Next step
 
-With a key saved, you're ready for [Your First Dictation](FIRST_DICTATION.md).
+With a cloud key saved, or a local model selected, continue with [Your First Dictation](FIRST_DICTATION.md).
 
-## Related Docs
+## Related docs
 
 <p align="center">
   <a href="INSTALL.md"><img alt="Install" src="https://img.shields.io/badge/Back-Install-7e7266"></a>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,1 +1,68 @@
-| Frontend settings and stores | [`../src/lib/settings.ts`](../src/lib/settings.ts), [`../src/lib/stores.svelte.ts`](../src/lib/stores.svelte.ts) |
+# Verenu architecture
+
+Verenu is a Tauri desktop app. The Svelte frontend owns the interface and local state, while the Rust backend owns audio capture, provider calls, local models, persistence, and text injection.
+
+## Main components
+
+| Area | Implementation | Responsibility |
+| --- | --- | --- |
+| Desktop shell | Tauri 2 | Windows and macOS windows, commands, events, and packaging |
+| Frontend | Svelte 5, TypeScript, Tailwind CSS | Setup, settings, contexts, history, insights, and the dictation pill |
+| Backend | Rust, Tokio | Pipeline orchestration, platform integration, provider requests, and background work |
+| Audio | `cpal`, `hound`, `nnnoiseless` | Microphone capture, WAV encoding, gain, and noise reduction |
+| Cloud AI | `reqwest` provider clients | Cloud transcription and cleanup through the configured providers |
+| Local transcription | `transcribe-rs` and downloaded model files | On-device speech-to-text |
+| Local cleanup | Managed local LLM runtime and downloaded model files | On-device text cleanup |
+| Storage | SQLite plus an app-data JSON settings file | History, contexts, vocabulary, snippets, insights, cache, and non-secret settings |
+| Credentials | Windows Credential Manager or macOS Keychain | API keys, kept outside SQLite and the settings file |
+
+## Dictation flow
+
+1. The user holds the platform hotkey. The audio layer captures microphone PCM and sends RMS levels to the floating pill.
+2. Releasing the hotkey stops capture and hands the recording to the pipeline.
+3. The pipeline rejects recordings below its duration or volume thresholds before making an AI request.
+4. It captures the foreground window, reads a browser domain when the target is a supported browser, and resolves the matching Context. The built-in Everywhere context is the fallback.
+5. Style resolution combines the matching Context with legacy App Mapping settings and the global tone setting.
+6. The transcription chain runs the selected cloud or local model. Dual transcription can run the primary model and the first fallback concurrently, then reconcile two successful candidates.
+7. The pipeline checks the cleanup cache and the pure-snippet fast path. If cleanup is needed, it assembles the shared prompt and calls the selected cloud or local cleanup model.
+8. Cleanup guards can retry unusable output once, then fall back to the pre-cleanup text. Remaining snippets and context-scoped vocabulary are applied afterward.
+9. The final text and metadata are written to local SQLite history.
+10. The injection layer restores focus to the captured window, pastes through the clipboard, restores the previous clipboard contents, and emits the completed-dictation event.
+11. Auto-learn can monitor the focused field for a limited period to detect user corrections.
+
+## Contexts and style
+
+Contexts are the primary way to configure app- and website-specific behavior. A Context contains:
+
+- executable and website targets
+- optional tone, cleanup intensity, and custom instructions
+- vocabulary and snippets scoped to that Context
+
+Verenu resolves a foreground executable and, when available, a browser domain to one Context. If nothing matches, it uses Everywhere. App Mappings, Dictionary, and Snippets remain available as legacy pages, hidden by default.
+
+## Persistence and data boundaries
+
+- API keys live only in the operating system credential store.
+- Settings live in the Tauri app-data directory as JSON.
+- History, Contexts, vocabulary, snippets, insights, and cleanup-cache records live in local SQLite.
+- Downloaded transcription models are stored below the app-data `models/stt` directory.
+- Downloaded cleanup models and the local cleanup runtime are stored below the app-data `models` directory.
+- Cloud transcription sends audio to the selected transcription provider.
+- Cloud cleanup sends raw transcript text and the cleanup context to the selected cleanup provider.
+- Local transcription and local cleanup keep the processing data on the device after the required model files have been downloaded.
+
+## Platform integration
+
+- Windows uses a low-level keyboard hook for hold/release state, UI Automation for focused-text reads and Auto-learn, native clipboard paste, and Credential Manager.
+- macOS uses Carbon `RegisterEventHotKey`, Accessibility APIs for focused-text reads and paste, NSPasteboard for clipboard work, and Keychain for credentials.
+- The recording pill is created at runtime as an always-on-top, transparent Tauri window. It stays available while idle and becomes interactive only when its state requires user input.
+
+## Code map
+
+- `src/` contains the Svelte application, settings registry, stores, setup wizard, views, and shared components.
+- `src-tauri/src/pipeline/` contains pipeline orchestration and its transcription, cleanup, style, injection, persistence, and repair stages.
+- `src-tauri/src/api/` contains cloud provider clients, prompt assembly, status checks, and update logic.
+- `src-tauri/src/local_stt/` and `src-tauri/src/local_llm/` manage local model manifests, downloads, verification, runtimes, and inference.
+- `src-tauri/src/core/` contains hotkeys, injection, Context resolution, browser probing, and contextual formatting.
+- `src-tauri/src/data/` contains SQLite access, the settings store, credentials, vocabulary, and snippets.
+- `tests/` contains the unified test runner, smoke tests, integration tests, and manual platform checks.

--- a/docs/CLEANUP_LEVELS.md
+++ b/docs/CLEANUP_LEVELS.md
@@ -1,31 +1,29 @@
-# Cleanup Levels
+# Cleanup levels
 
-After Verenu transcribes your audio, it can run the raw text through an AI cleanup step before pasting it. **Cleanup intensity** controls how much that step is allowed to change, from leaving your words exactly as spoken to rewriting them for brevity.
-
-This is separate from **tone** (Casual, Formal, or Very Casual), which controls the voice of the output, including capitalization, punctuation style, and phrasing. Cleanup intensity controls how much editing happens. You choose both during setup, and both can be changed later.
+After transcription, Verenu can run the raw text through an LLM cleanup step before pasting it. Cleanup intensity controls how much that step may change. Tone is separate and controls the voice, casing, punctuation style, and phrasing.
 
 ## The four levels
 
 | Level | What it does |
 | --- | --- |
-| **Verbatim** | Raw transcription. No AI cleanup at all. |
-| **Light** | Removes filler words and repeated phrases. Keeps everything else. |
-| **Medium** (default) | Removes fillers, cuts repetition, tightens phrasing. Keeps your detail. |
-| **Direct** | Aggressive rewrite. Punchy and concise, about half the words. |
+| **Off** | Keeps the raw transcript. If Dual transcription is enabled, Verenu may still make a second call to reconcile two transcript candidates. |
+| **Light** | Removes speech artifacts and fixes basic issues while keeping wording, order, and structure. |
+| **Medium** (default) | Improves flow and removes redundancy while preserving each distinct detail. |
+| **Strong** | Rewrites concisely while preserving facts, constraints, qualifiers, and emphasis. |
 
-**Verbatim** is useful when you need exact wording, code, quotes, or technical content. **Medium** is the default and works well for everyday writing such as notes, messages, and emails. **Direct** is for when you want the gist fast, such as a quick chat reply or an idea you'll edit later.
+Use **Off** when you need the raw model output. **Light** is useful when wording and structure should remain close to what you said. **Medium** is the default for everyday dictation. **Strong** is for concise output when the important details still need to remain intact.
 
 ## Changing it
 
-- **During setup**: you pick a default cleanup level as part of first-run setup.
-- **Later**: change the default anytime in Settings.
-- **Per app or website**: override the cleanup level for a group of apps and sites. For example, use Verbatim in your code editor but Medium everywhere else. See [Contexts](CONTEXTS.md).
+- **During setup**: choose the default cleanup level in the first-run setup.
+- **Later**: change the global setting in **Settings -> General**.
+- **Per app or website**: configure a Context with its own cleanup intensity. See [Contexts](CONTEXTS.md).
 
 ## Next step
 
-Explore [Contexts](CONTEXTS.md) to scope cleanup and tone, then see [Vocabulary](VOCABULARY.md) and [Snippets](SNIPPETS.md) for the content that belongs in each context.
+Explore [Contexts](CONTEXTS.md) to scope cleanup and tone, then see [Vocabulary](VOCABULARY.md) and [Snippets](SNIPPETS.md) for the content that belongs in each Context.
 
-## Related Docs
+## Related docs
 
 <p align="center">
   <a href="FIRST_DICTATION.md"><img alt="First Dictation" src="https://img.shields.io/badge/Back-First%20Dictation-7e7266"></a>

--- a/docs/CONTEXTS.md
+++ b/docs/CONTEXTS.md
@@ -4,7 +4,7 @@ Contexts are Verenu's main way to control what happens in different places. A co
 
 For example, you might create:
 
-- **Development** for your editor and terminal, with Verbatim cleanup and technical vocabulary.
+- **Development** for your editor and terminal, with Off cleanup and technical vocabulary.
 - **Writing** for your document apps, with Medium cleanup and a formal tone.
 - **Support** for your help desk, with custom instructions for dates, names, and reply style.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -71,8 +71,9 @@ npm run dev
 
 ### macOS
 
-- Default hold-to-record hotkey is <kbd>Fn</kbd> + <kbd>Control</kbd>.
+- Default hold-to-record hotkey is <kbd>Option</kbd> + <kbd>Space</kbd>.
 - API keys live in Keychain.
+- The global hotkey needs no Input Monitoring permission. Accessibility is used for focused-text reads and text injection.
 - Real macOS testing matters because permissions are part of the feature, not an edge case.
 - Changes that touch hotkeys, injection, onboarding, setup, or key storage should be checked on macOS if they can possibly affect it.
 
@@ -80,7 +81,7 @@ npm run dev
 
 - Keep Tauri. Do not replace the app shell with Electron.
 - Keep API keys out of SQLite, logs, screenshots, fixtures, and test output.
-- Use constants from [`../src-tauri/src/data/store.rs`](../src-tauri/src/data/store.rs) for store keys. Do not add raw string keys.
+- Use constants from [`../src-tauri/src/data/store/mod.rs`](../src-tauri/src/data/store/mod.rs) for store keys. Do not add raw string keys.
 - Keep [`../tests/smoke/`](../tests/smoke/) as a contract. Fix app code when smoke tests fail.
 - Keep dependencies lean. The app has a low idle RAM target.
 - Follow existing Rust, Svelte, TypeScript, and Tailwind patterns before inventing new abstractions.

--- a/docs/DATA_AND_PRIVACY.md
+++ b/docs/DATA_AND_PRIVACY.md
@@ -132,9 +132,9 @@ Each hostname is requested at most once: the result is cached on disk under the 
 
 ### Connectivity check
 
-While the app window is open, Verenu periodically sends a lightweight `HEAD` request to `api.github.com` to detect whether you are online and show the offline indicator.
+Verenu first reads the operating system's network state. Windows uses the Network List Manager and macOS checks route reachability. These checks do not send traffic.
 
-That request carries no dictated text, history, snippets, or API keys.
+If a real provider or Verenu service request fails, Verenu can run a short active probe to distinguish a local connection problem from a provider outage. When service checks are enabled, it checks Verenu's health endpoint first, then uses `www.google.com` as an independent second check. This probe is limited to the failure path and carries no dictated text, history, snippets, or API keys.
 
 ### Provider status checks
 
@@ -180,7 +180,7 @@ That said, once data is sent to a third-party AI provider, that provider's reten
 | Context website check | current app state stays local | the typed domain, via a plain DNS lookup, when you attach a website to a context group |
 | Auto-learn | local monitoring data and promoted entries | nothing by default |
 | Update check | current app state stays local | GitHub release metadata request |
-| Connectivity check | current app state stays local | periodic `HEAD` request to `api.github.com` |
+| Connectivity check | current app state stays local | native OS network-state check; a short active probe only after a real request fails |
 | Provider status check | current app state stays local | optional periodic GET to `api.verenu.com/v1/provider-status` (every 5 min, plus an immediate recheck after a provider-side pipeline failure) |
 | API health check | current app state stays local | optional periodic GET to `api.verenu.com/v1/health` (every 20 min) |
 | Export data | backup file on local disk | nothing unless you share the file yourself |

--- a/docs/FIRST_DICTATION.md
+++ b/docs/FIRST_DICTATION.md
@@ -1,44 +1,42 @@
-# Your First Dictation
+# Your first dictation
 
-Verenu works with a single hold-to-record hotkey — no clicking, no app switching.
+Verenu works with a single hold-to-record hotkey. You do not need to click the app or switch windows.
 
 ## The hotkey
 
 - **Windows**: hold <kbd>Ctrl</kbd> + <kbd>Windows</kbd>
-- **macOS**: hold <kbd>Fn</kbd> + <kbd>Control</kbd>
+- **macOS**: hold <kbd>Option</kbd> + <kbd>Space</kbd>
 
-Click into any text field — a document, an email, a chat box — then hold the hotkey and start talking.
+Click into any text field, then hold the hotkey and start talking.
 
-## What happens while you hold it
+## While you hold it
 
-A small floating pill appears on screen with animated bars that move with your voice in real time. This is just a visual indicator that Verenu is listening; it doesn't take focus away from the app you're typing into.
+A small floating pill appears with animated bars that respond to your voice. It shows that Verenu is listening without taking focus from the app you are typing in.
 
-## What happens when you release it
+## When you release it
 
-1. The pill switches to a processing state while Verenu transcribes your audio and runs it through cleanup.
-2. The cleaned-up text is pasted directly into whatever field had focus when you started recording — even if a few seconds have passed.
-3. The dictation is saved to your local history automatically, so you can find it again later.
+1. Verenu checks the recording, transcribes it with the selected transcription model, and runs the optional cleanup step.
+2. It pastes the final text into the field that had focus when you started recording.
+3. It saves the dictation to local history.
 
-## If nothing happens
+## If no text appears
 
-Verenu silently skips processing — with no error and no output — in two cases:
+Verenu rejects recordings that are too short or too quiet, and the pill reports which check failed:
 
-- **The recording was too short** (under ~0.7 seconds). This avoids the transcription model hallucinating text from a near-empty clip.
-- **The recording was too quiet** (near-silence). This usually means the hotkey was triggered accidentally, or your microphone input level is very low.
+- **Too short**: the recording is under about 0.7 seconds.
+- **Too quiet**: the recording is near silence, often because the hotkey was triggered accidentally or the microphone level is low.
 
-If you consistently get no output, check your microphone input level in **Settings → Microphone**.
+If this happens repeatedly, open **Settings -> Audio**, check the selected microphone, and run microphone calibration.
 
-## macOS tip
+## macOS permissions
 
-The <kbd>Fn</kbd> key can also open the emoji picker on macOS. To avoid that popping up every time you dictate, go to **System Settings → Keyboard** and set "Press 🌐 key to: **Do Nothing**".
-
-If you'd rather keep the emoji picker on <kbd>Fn</kbd>, you can change Verenu's hotkey instead. In Verenu, go to **Settings → General** — the **Hotkey** option is right at the top. Click it, then press the new key combination you want to use.
+If text is not inserted on macOS, open **Settings -> Permissions** and confirm that Verenu has Microphone and Accessibility access. Accessibility is needed for focused-text reads and text injection.
 
 ## Next step
 
-Want more control over how your text is cleaned up? See [Cleanup Levels](CLEANUP_LEVELS.md).
+For more control over how text is edited, see [Cleanup Levels](CLEANUP_LEVELS.md).
 
-## Related Docs
+## Related docs
 
 <p align="center">
   <a href="API_KEYS.md"><img alt="API Keys" src="https://img.shields.io/badge/Back-API%20Keys-7e7266"></a>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
 # Install Verenu
 
-Verenu is a free, open-source dictation app for Windows and macOS. There's no account, no subscription, and nothing to install beyond the app itself — you bring your own API key for transcription and cleanup (see [Add Your API Key](API_KEYS.md)).
+Verenu is a free, open-source dictation app for Windows and macOS. There is no account or subscription. Cloud providers use API keys that you provide, while local transcription and cleanup need no key. See [Add Your API Key](API_KEYS.md).
 
 ## Windows
 
@@ -8,7 +8,7 @@ Verenu is a free, open-source dictation app for Windows and macOS. There's no ac
    - `Verenu_X.Y.Z_x64_en-US.msi`, or
    - `Verenu_X.Y.Z_x64-setup.exe`
 2. Run the installer and follow the prompts.
-3. Launch Verenu. The first-run setup walks you through picking a provider and adding your API key.
+3. Launch Verenu. The first-run setup walks you through choosing local models or a cloud provider and adding a key when one is required.
 
 Requires Windows 10 or 11. Verenu uses the built-in WebView2 runtime — no separate browser engine to install.
 
@@ -16,10 +16,11 @@ Requires Windows 10 or 11. Verenu uses the built-in WebView2 runtime — no sepa
 
 1. Download the build that matches your Mac from the [GitHub Releases](https://github.com/MONKE2525E/Verenu/releases) page — Apple Silicon or Intel.
 2. Move Verenu to your Applications folder and open it.
-3. macOS will ask for a few permissions the first time you use Verenu — grant all of them, since dictation won't work correctly without them:
+3. macOS may ask for permissions the first time you use Verenu. Dictation requires:
    - **Microphone** — to capture your voice while you hold the hotkey
    - **Accessibility** — to paste cleaned-up text into the app you're using and read text for corrections
-   - **Input Monitoring** — to detect the global hotkey (Fn+Control) even when Verenu isn't the focused app
+
+Notifications are optional and only affect status and update alerts. The macOS hotkey does not require Input Monitoring.
 
 If macOS prompts for your login password when Verenu first saves your API key to Keychain, choose **Always Allow** — this avoids repeated prompts later.
 
@@ -74,7 +75,7 @@ If you want independent confirmation that an installer is clean, every release o
 
 ## Next step
 
-Once Verenu is installed, continue with [Add Your API Key](API_KEYS.md).
+Once Verenu is installed, continue with [Add Your API Key](API_KEYS.md) if you plan to use a cloud provider, or go straight to [Your First Dictation](FIRST_DICTATION.md) for a local setup.
 
 ## Related Docs
 

--- a/docs/LOCAL_TRANSCRIPTION.md
+++ b/docs/LOCAL_TRANSCRIPTION.md
@@ -1,79 +1,65 @@
-# Local Transcription
+# Local transcription and cleanup
 
-Verenu now supports local transcription as a first-class transcription backend.
+Verenu supports on-device transcription and on-device cleanup. Models and the local cleanup runtime are downloaded from Settings -> Models when you choose them.
 
-## Beta Scope
+## How the local path works
 
-This beta ships one clear local path:
+1. Verenu records the audio on your device.
+2. A selected `local/<model>` transcription model receives the captured audio through the local STT adapter.
+3. The local model returns raw transcript text.
+4. With Cleanup Off, Verenu keeps that text as-is. With cleanup enabled, it sends the text to either a downloaded local cleanup model or a cloud cleanup provider.
+5. Verenu pastes the final text and stores the dictation in local history.
 
-- Local transcription with `local/parakeet-v3`
-- Optional cloud cleanup after local transcription
-- `Cleanup: Off` for a no-cleanup path
+Local transcription with local cleanup keeps the dictation data on the device after the model files have been downloaded. Local transcription with cloud cleanup keeps the audio local but sends the transcript and cleanup context to the selected cloud provider.
 
-What this beta does **not** claim:
+## Local transcription models
 
-- It is not "fully local" unless cleanup is also Off
-- It does not include local cleanup LLMs
-- It does not expose Moonshine, Whisper.cpp, or custom local models as the default path
+The built-in local transcription catalog currently includes:
 
-Those advanced models are present behind the advanced local section for follow-up work and compatibility testing.
+- Parakeet V3 and Parakeet V2
+- Moonshine Tiny, Base, Small, and Medium
+- SenseVoice
+- GigaAM V3
+- Canary 180M Flash and Canary 1B V2
+- Cohere
 
-## How It Works
+The model picker shows download state, verifies completed downloads before marking them ready, and allows a downloaded model to be cancelled or removed.
 
-1. Verenu records audio locally.
-2. If transcription is set to `Local/offline`, Verenu sends 16 kHz mono PCM directly to the local STT adapter instead of re-decoding a WAV.
-3. The adapter loads the selected local model from `models/stt/` under the app-data directory.
-4. The local model returns raw transcription text.
-5. Verenu either:
-   - keeps that text as-is when `Cleanup: Off`, or
-   - sends only the transcript text to the selected cloud cleanup provider.
-6. Verenu pastes the final result and stores history locally.
+## Local cleanup models
 
-## Privacy Modes
+The built-in local cleanup catalog currently includes:
 
-### Local transcription + Cleanup Off
+- Gemma 4 E2B and E4B
+- Qwen 2.5 0.5B, 1.5B, 3B, and 7B Instruct
+- Phi-3 Mini 4K Instruct
+- SmolLM2 360M and 1.7B Instruct
+- Granite 3.3 2B and 8B Instruct
 
-After the model download, both audio and transcript stay on the device.
+All local cleanup models share one downloaded runtime. Verenu downloads that runtime once, then manages the individual cleanup model files separately.
 
-### Local transcription + cloud cleanup
+## Storage and downloads
 
-Audio stays on the device.
+- Local transcription models are stored in the app-data `models/stt` directory.
+- Local cleanup models are stored in the app-data `models/cleanup` directory.
+- The local cleanup runtime is stored in the app-data `models/bin` directory.
+- Downloads are verified and installed atomically before a model becomes selectable.
+- Settings -> Models provides download, cancel, and delete actions for local models and the cleanup runtime.
 
-The transcript text, cleanup instructions, and related cleanup context leave the device because the cleanup provider needs them.
+## Fallback behavior
 
-### Cloud transcription
+- A missing selected model produces a download prompt in the model picker.
+- A retryable local transcription failure can move to a configured cloud transcription fallback.
+- A non-retryable local model or configuration error is reported instead of silently switching to the cloud path.
+- Cloud fallback models still require the corresponding provider key.
 
-Recorded audio leaves the device and goes to the selected transcription provider.
+## Platform limits
 
-## Models
+Local model downloads and inference are currently available on Windows and Apple Silicon Macs. Local models are gated off on Intel Macs until that path has been validated on real hardware. Linux is not a supported desktop target.
 
-### Recommended
+Speed, memory use, and output quality depend on the selected model and the computer running it. Larger local cleanup models need more memory and may take longer to answer.
 
-- `local/parakeet-v3`
+## Choosing a private path
 
-### Advanced
+For a fully on-device dictation path, select a local transcription model, select a local cleanup model or turn Cleanup Off, and download the required files. Model downloads and any normal update or service-status requests are separate from dictation processing.
 
-- `local/moonshine-base`
-- `local/whisper-custom`
-
-Advanced models are intentionally de-emphasized in this beta. Parakeet V3 is the supported path that the rest of the UX is built around.
-
-## Downloads and Storage
-
-- Local models are stored in `models/stt/` inside Verenu's app-data directory
-- Downloads use resumable HTTP range requests when the server supports them
-- Partial archives use `.partial`
-- In-progress extraction uses `.extracting`
-- Models are only treated as usable after download verification and atomic install finish
-
-## Failure Behavior
-
-- Missing selected local model: Verenu shows `Download the selected local model.`
-- Retryable local runtime failures can fall back to a configured cloud transcription model
-- Non-retryable local model and configuration failures do not silently fall through to cloud
-
-## Current Limits
-
-- No Linux-specific local support work in this beta
-- No local cleanup model support
-- Local transcription quality, speed, and RAM use still depend heavily on the machine and the selected model
+See [Privacy & Data](PRIVACY_SUMMARY.md) for the short privacy summary and [Data And Privacy](DATA_AND_PRIVACY.md) for the complete data map.

--- a/docs/PRIVACY_SUMMARY.md
+++ b/docs/PRIVACY_SUMMARY.md
@@ -23,7 +23,7 @@ Verenu doesn't run its own servers, doesn't have an account system, and doesn't 
 
 ## One important caveat
 
-Once your audio or text reaches a third-party AI provider like Groq, OpenAI, or Google, that provider's own retention and privacy policies apply. Verenu has no control over what happens on their end.
+Once your audio or text reaches a third-party AI provider like Groq, OpenAI, Google, or AssemblyAI, that provider's own retention and privacy policies apply. Verenu has no control over what happens on their end.
 
 If you want the strictest local path today, use local transcription with `Cleanup: Off`. Local transcription with cloud cleanup still sends transcript text to the cleanup provider.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,38 +1,29 @@
 # Roadmap: Verenu
 
-## In Progress - post-0.17.0 (see "Unreleased" in docs/CHANGELOG.md for the current line of work)
+## Current line: 0.18.0
 
-## 0. Local Transcription Beta
-- **Goal**: Ship local transcription as a first-class backend in the normal pipeline instead of as a separate workflow.
-- **Current Scope**:
-    - Recommended local path is `local/parakeet-v3`
-    - Cleanup can be `Off` or a cloud provider
-    - "Fully local" only applies when local transcription is paired with `Cleanup: Off`
-    - Moonshine, Whisper.cpp, and custom local models stay behind advanced UI until Parakeet is boringly reliable
-- **Relevant Files**: `src-tauri/src/local_stt/`, `src-tauri/src/pipeline/`, `src/lib/components/settings/ModelsSection.svelte`, `src/PillApp.svelte`, `docs/LOCAL_TRANSCRIPTION.md`.
+The current release is 0.18.0. Short-lived release work belongs in the `Unreleased` section of [CHANGELOG.md](CHANGELOG.md). This page records open follow-up work and longer-term status.
 
-## 1. Models and Settings Redesign
-- **Goal**: Finish the model picker cleanup so provider selection, advanced mode, and key validation feel predictable instead of fragile.
-- **Implementation Plan**:
-    - Keep simple mode and advanced mode in sync so changing defaults, fallbacks, and provider keys never leaves the UI in a half-valid state.
-    - Make active transcription and cleanup chains easier to inspect before the user starts dictating.
-    - Keep provider key validation and model selection persistence consistent across reloads and provider switches.
-- **Relevant Files**: `src/lib/components/settings/ModelsSection.svelte`, `src/lib/components/settings/ApiKeysSection.svelte`, `src-tauri/src/data/store.rs`, `src-tauri/src/commands/mod.rs`.
+## Completed foundations
 
-## 2. Groq API Key Auth Regression (401/403 After Time)
-- **Goal**: Fix the regression where Groq keys can work after save, then fail with `401` or `403` after roughly an hour until re-entered.
-- **Implementation Plan**:
-    - Reproduce with a soak test: save key once, run repeated transcription and cleanup calls for 2+ hours, and capture first failure timestamp and exact status code.
-    - Compare 0.10.0 key path versus 0.11.x Windows Credential Manager path, including save, read, normalization, and request header generation.
-    - Add temporary diagnostics that log sanitized key fingerprint continuity (`save -> read -> request`) for Groq and compare against OpenAI and Google behavior in the same session.
-    - Capture provider response metadata (request ID, status, classified auth category, model name) so `invalid key` and `access denied` failures are separated.
-    - Verify fallback and routing behavior on auth errors so a hidden provider or model switch is not masking the real source of failure.
-- **Relevant Files**: `src-tauri/src/data/credentials.rs`, `src-tauri/src/api/transcription.rs`, `src-tauri/src/api/cleanup.rs`, `src-tauri/src/api/mod.rs`, `src-tauri/src/pipeline/mod.rs`, `src-tauri/src/main.rs`.
+### Local models
 
-## 3. Contextual Capitalization Reliability Regression
-- **Goal**: Replace the brittle history-only contextual capitalization path with a deterministic context engine that reliably starts new chat messages with proper casing and preserves punctuation across Gemini, browser chat inputs, normal text boxes, and contenteditable editors.
-- **Current Failure Pattern**:
-    - The existing implementation mostly trusts `LAST_INJECTION`, an internal tail of text injected by Verenu.
+Local transcription and local cleanup are part of the normal pipeline. Settings -> Models manages downloaded STT models, cleanup models, and the shared local cleanup runtime. Intel Mac local models remain deliberately gated until that path has been validated on real hardware. See [LOCAL_TRANSCRIPTION.md](LOCAL_TRANSCRIPTION.md).
+
+### Models and settings
+
+The model picker now supports curated and provider-reported cloud models, provider-prefixed defaults and fallback chains, local model download state, and persistence across reloads. Remaining model work should be recorded as a specific bug or feature instead of leaving the original redesign plan open.
+
+## Open follow-up
+
+### Groq credential reliability
+
+The backend now classifies 401/403 responses, reports the provider and request metadata safely, and distinguishes retryable provider failures from invalid credentials. Keep long-running Groq credential soak testing as an open follow-up rather than describing the old credential-storage migration as current work.
+
+## Completed: contextual formatting
+- **Status**: The planned context engine is implemented. Verenu now uses a layered caret-local probe, clipboard-sniff fallback, and guarded history fallback for contextual casing and spacing across supported text controls.
+- **Former failure pattern**:
+    - The former implementation mostly trusted `LAST_INJECTION`, an internal tail of text injected by Verenu.
     - Mouse-click send buttons, browser chat inputs clearing themselves after submit, DOM rewrites, and some Enter/send paths can leave that tail stale.
     - Once stale, the next dictation can be treated as a mid-sentence continuation and the first letter is lowercased even though the target field is empty.
     - Punctuation loss must be debugged separately from casing. Some missing punctuation is likely cleanup/transcription output, not paste-time capitalization.
@@ -40,7 +31,7 @@
     - Never lowercase the first letter unless Verenu has high-confidence evidence that the cursor is still inside the same editable control and immediately follows a non-sentence-ending character.
     - Unknown context must fail closed: preserve the cleanup output casing, or capitalize only through a deterministic sentence-start rule. It must not randomly force lowercase.
     - The old injection tail can remain as a last-resort cache, but it must not be the primary source of truth.
-- **Implementation Plan**:
+- **Implementation history**: The following phases describe the work that produced the current implementation. Keep them as historical context, not as open tasks.
     - **Phase 0 - Instrument the bug without leaking text**:
         - Add verbose diagnostics around injection decisions, but never log dictated text, clipboard contents, user names, emails, prompt contents, or full field contents.
         - Log only metadata: target HWND, process name, focused element identity hash, context source (`uia`, `selection_probe`, `history_tail`, `unknown`), previous-character class (`empty`, `sentence_end`, `word_char`, `space`, `separator`), capitalization decision, punctuation status, and whether the field looked empty.
@@ -89,34 +80,19 @@
         - No diagnostic path logs private dictated text, clipboard text, names, emails, API keys, or full field contents.
 - **Relevant Files**: `src-tauri/src/core/injection/mod.rs`, `src-tauri/src/core/hotkey.rs`, `src-tauri/src/api/auto_learn.rs`, `src-tauri/src/api/prompts/mod.rs`, `src-tauri/src/api/cleanup.rs`, `src-tauri/src/pipeline/mod.rs`, `src/lib/components/settings/GeneralSection.svelte`, `tests/manual/`, `tests/OnePyFone.py`.
 
-## 4. Shared Prompt Contract and Context Retention
-- **Goal**: Keep one token-efficient cleanup contract across models while preserving essential context, especially on `light` mode.
-- **Implementation Plan**:
-    - Maintain one shared default prompt with dynamic cleanup, tone, formatting, and context settings instead of separate provider templates that can drift.
-    - Define explicit edit budgets per intensity (`none`, `light`, `medium`, `high`) and enforce "must keep" constraints for factual clauses, entities, and user intent.
-    - Add regression fixtures where losing a single clause changes meaning, and compare outputs against known-good 0.10.0 medium-mode behavior.
-    - Audit snippet overrides, dictionary substitutions, and post-cleanup transforms so context is not dropped after the model already returned a good output.
-    - Add prompt-size and token-usage observability to validate efficiency improvements without over-compressing user content.
-- **Relevant Files**: `src-tauri/src/api/prompts/mod.rs`, `src-tauri/src/api/cleanup.rs`, `src-tauri/src/pipeline/mod.rs`, `src-tauri/src/data/snippets.rs`, `src-tauri/src/data/dictionary.rs`, `src/lib/components/settings/ModelsSection.svelte`.
+## Completed: shared cleanup prompt and context retention
 
-## 5. Fallback Chain and Model Persistence Hardening
-- **Goal**: Make transcription fallback, cleanup fallback, and model persistence behave consistently under real failure modes.
-- **Implementation Plan**:
-    - Trace transcription fallback end-to-end and align retry rules with cleanup fallback for `429`, timeout, and `5xx` scenarios.
-    - Validate `401` and `403` handling so non-retryable auth failures stop cleanly and retryable failures advance to the next configured model.
-    - Ensure provider-prefixed IDs, slash-containing model names, and custom entries round-trip correctly between frontend and backend settings.
-    - Add restart persistence checks for default models and fallback chains after provider switches and advanced-mode edits.
-- **Relevant Files**: `src-tauri/src/pipeline/mod.rs`, `src-tauri/src/api/transcription.rs`, `src-tauri/src/api/mod.rs`, `src-tauri/src/data/store.rs`, `src/lib/components/settings/ModelsSection.svelte`, `src-tauri/src/commands/mod.rs`.
+The cleanup pipeline now assembles one shared prompt for every cleanup model, applies explicit intensity rules, preserves factual clauses and qualifiers, and gives snippet instructions a defined priority. Prompt regression tests cover the contract. Future prompt work should be recorded as a focused quality issue.
 
-## 6. Pre-Release Stabilization Gate
-- **Goal**: Hold release until Groq auth reliability, contextual capitalization, light/medium cleanup quality, and fallback behavior match or beat 0.10.0 baseline.
-- **Implementation Plan**:
-    - Run direct A/B checks on 0.10.0 versus 0.11.x for Groq auth duration, capitalization behavior, cleanup preservation, and fallback reliability.
-    - Add targeted smoke and manual checks for the failure paths reported in daily dictation use.
-    - Keep release blocked until the core dictation loop is measurably better, not just feature-complete.
-- **Relevant Files**: `tests/OnePyFone.py`, `tests/smoke/`, `tests/manual/`, `src-tauri/src/pipeline/mod.rs`, `src-tauri/src/api/transcription.rs`, `src-tauri/src/api/cleanup.rs`, `src-tauri/src/core/injection/mod.rs`.
+## Completed: fallback chains and model persistence
 
-## 7. Intel Mac Support for Local Models (Currently Gated Off)
+The current pipeline stores provider-prefixed model IDs, persists defaults and fallback chains, classifies retryable provider failures, and advances through configured candidates. Keep new failures and provider-specific gaps as separate issues rather than reopening the original hardening plan.
+
+## Release stabilization
+
+The project is now on 0.18.0. Use the current test profiles and platform checks for release verification; the old 0.10.0 versus 0.11.x gate is historical and no longer describes the release process.
+
+## Intel Mac support for local models (currently gated off)
 - **Status**: Deliberately unavailable, not a bug. Local on-device STT/LLM (`local_stt`, `local_llm`) is blocked entirely on Intel (x86_64) Mac builds via `system::platform::is_macos_intel()` — the download commands return an error and the Settings → Models UI shows an explanatory notice instead of the download tiles.
 - **Why**: Zero real-world testing on Intel hardware (neither the maintainer nor any current tester owns an Intel Mac), and Intel Macs are old enough now to be both increasingly uncommon and generally underpowered for local LLM inference specifically. Shipping an untested first run there is a worse outcome than a clear "not yet" pointing at cloud providers.
 - **What already exists**: the Metal (Apple Silicon) vs. CPU (Intel) backend split for the local LLM runtime already has real code paths in `local_llm/binary.rs::detect_backend()` and downloads real `macos-x64` llama.cpp release assets — this was never architecturally impossible, just unvalidated.
@@ -209,23 +185,3 @@ These are educated guesses at problems that are likely to exist in the fully ins
 - Stale cache and dictionary pruning on quick output deletion
 - Full UI scrollbar consistency pass
 - Snippet inspector polish (scrollbar, modal height cap, truncation)
-
-
-# Far Future and Monetization (The Funding Plan)
-
-## 1. Cloud Sync ($2/mo Subscription)
-- **Goal**: Sync custom dictionaries, snippets, and API keys across devices.
-- **Rules**:
-    - Must be 100% optional.
-    - Use Supabase for database, efficient data storage.
-
-## 2. Managed "Cloud Optimized" Routing
-- **Goal**: One-click model selection where the cloud picks the best or cheapest model for the audio length.
-- **Implementation**:
-    - **Pay-as-you-go** with a thin **10% markup** over raw token costs.
-    - Aggressive context caching to reduce user latency and cost.
-
-## 3. Opt-in Analytics (PostHog)
-- **Goal**: Track feature usage to guide development.
-- **Strict Rule**: 100% Opt-in. Transparency regarding what is being tracked.
-

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,11 +23,11 @@ API keys should never appear in logs, screenshots, issues, PR comments, or expor
 
 ## Dictation Produces No Text
 
-Verenu intentionally rejects recordings that are too short or too quiet.
+Verenu intentionally rejects recordings that are too short or too quiet. The pill shows the reason instead of failing silently.
 
 - Hold the hotkey for more than about 0.7 seconds.
 - Check the microphone input device.
-- Open Settings and run microphone calibration.
+- Open Settings -> Audio and run microphone calibration.
 - Watch the floating pill bars while speaking. No movement usually means the app is not receiving usable audio.
 
 ## macOS Permissions
@@ -59,10 +59,10 @@ Verenu captures the focused app before provider calls start, then tries to resto
 
 Change cleanup intensity in [Cleanup Levels](CLEANUP_LEVELS.md):
 
-- **Verbatim** for exact wording.
+- **Off** to keep the raw transcript.
 - **Light** for filler removal only.
 - **Medium** for normal cleanup.
-- **Direct** for aggressive shortening.
+- **Strong** for concise rewriting that preserves important details.
 
 For app-specific behavior, configure [Contexts](CONTEXTS.md) so code editors, chat apps, and email clients can use different cleanup settings.
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app whose hotkey, audio, pipeline, provider, local-model, and injection behavior has evolved across the current release line.
> - This PR audits the documentation layer against those current frontend, Rust, provider, local-model, platform, and release surfaces.
> - The gap was a mix of placeholder architecture content, stale provider and model details, outdated hotkeys and permissions, and older cleanup, context, install, privacy, and roadmap wording.
> - The documentation now describes the current behavior and points readers at the current paths and settings.
> - This pull request refreshes those references without expanding unfinished product work.
> - The benefit is that users and contributors get instructions that match the current app.

## What Changed

- Updated README, installation, first-dictation, troubleshooting, privacy, API-key, local-model, cleanup, contexts, architecture, contributing, roadmap, and release-support documentation.
- Updated the contributor architecture references and generated release-note hotkey examples.
- Kept the documentation focused on shipped/current behavior.

## Verification

- Relative Markdown link checker passed for README.md and docs/*.md.
- Documentation scan found no references to the excluded unfinished feature.
- `git diff --check` passed for the documentation changes.
- Application test suites were not run because this PR changes documentation only.

## Risks

- Low risk: documentation-only changes. The only functional-adjacent edits update generated release-note text and contributor guidance.

## Model Used

- OpenAI Codex, GPT-5.6, high reasoning effort with repository inspection and tool use.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md`
- [ ] `npm run check` (not run; documentation-only)
- [ ] `npm run lint` (not run; documentation-only)
- [ ] `npm run test:rust` (not run; documentation-only)
- [ ] Smoke tests (not run; documentation-only)
- [x] Tests added or updated where applicable
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791094617&installation_model_id=432577&pr_number=343&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F343&signature=837495557877ac83649c7dbab33815b4ffe8b34d1b336041412e5616a8f6e608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->