### PR TITLE
Add durable dictation failover for crash and reboot recovery

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Dictations now survive a crash, force-quit, or reboot: in-progress audio is checkpointed locally and comes back as an Interrupted Continue offer (same Continue/Dismiss flow as a cancelled take). Always on, no settings toggle. The spool is deleted after the take is saved to history, dismissed, or 24 hours.
+
 - Replaced the Insights speaking-pace dial with a tick-scale meter that matches the rest of the page: the tile is now left-aligned on the same baseline grid as its two neighbours, quarter marks make the scale readable at a glance, the scale ceiling grows to always clear your personal best, and the best itself is marked on the scale instead of only being named underneath.
 - Fixed the main window stuttering and spiking CPU when dragged or resized quickly on Windows: moving the window no longer re-runs title-bar and icon updates per mouse event, resizes coalesce to a single refresh once the size settles, title-bar metrics are only forwarded when visible values change, and themed icons reuse cached artwork instead of re-rendering on every focus or settings event.
 - Restored the Windows tray icon's classic proportions — the accent-theming rework had grown the waveform to fill ~70% of the tile edge to edge; it sits back inside the tile with real margins, keeping the sharper native-size rendering.

--- a/docs/DATA_AND_PRIVACY.md
+++ b/docs/DATA_AND_PRIVACY.md
@@ -28,6 +28,7 @@ Stored locally in app storage and SQLite:
 - Transcription history
 - Auto-learn events and candidate data
 - Update-dismiss state
+- A short-lived dictation failover spool (dictation-failover/ under the app data directory): in-progress audio so a crash or reboot can offer Continue. Deleted after history is saved, on dismiss, or after 24 hours. Not included in backups or LAN sync.
 
 ### Logs
 
@@ -170,7 +171,7 @@ That said, once data is sent to a third-party AI provider, that provider's reten
 
 | Feature | Stays local | Leaves device |
 | --- | --- | --- |
-| Hold-to-record audio capture | audio before release | nothing until transcription starts |
+| Hold-to-record audio capture | audio before release, plus a local crash-recovery spool until the take is saved, dismissed, or 24 hours old | nothing until transcription starts |
 | Local transcription + Cleanup Off | audio, transcript, settings, and history | nothing after the model download |
 | Local transcription + cloud cleanup | audio, local model, local capture state | transcript text and cleanup context to selected cleanup provider |
 | Cloud transcription | local capture state | audio to selected transcription provider |

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -367,6 +367,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                             &app_hk,
                             &state_hk,
                             active.captured_audio,
+                            pipeline::CaptureOrigin::UserCancelled,
                         );
                         continue;
                     }
@@ -393,6 +394,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // offer, Escape dismisses it (same as clicking the
                         // pill's own dismiss button).
                         if pipeline::take_cancelled_capture_if_fresh(&state_hk).is_some() {
+                            pipeline::failover::discard_durable();
                             pipeline::emit_cancelled_capture_cleared(&app_hk);
                         }
                         hide_pill(&app_hk);

--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -108,7 +108,9 @@ pub(crate) fn start_frontend_watchdog(app: &AppHandle, readiness: FrontendReadin
             // the main UI is healthy because a hidden WebView2 renderer can
             // suspend before it reports its own readiness.
             show_main_window(&app);
-            crate::pipeline::show_pill(&app, "idle");
+            if !crate::pipeline::failover::offer_restored_capture_pill(&app) {
+                crate::pipeline::show_pill(&app, "idle");
+            }
         };
 
         // WebView2 normally mounts in well under a second. This grace period
@@ -179,7 +181,9 @@ pub(crate) fn start_frontend_watchdog(app: &AppHandle, readiness: FrontendReadin
 
 #[cfg(not(target_os = "windows"))]
 pub(crate) fn start_frontend_watchdog(app: &AppHandle, _readiness: FrontendReadiness) {
-    crate::pipeline::show_pill(app, "idle");
+    if !crate::pipeline::failover::offer_restored_capture_pill(app) {
+        crate::pipeline::show_pill(app, "idle");
+    }
     show_main_window(app);
 }
 

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -551,6 +551,12 @@ pub async fn resume_cancelled_capture(
         }
         Err(err) => {
             pipeline::cancel_starting_reservation(state.inner());
+            if let Ok(mut st) = lock_state(&state) {
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
+            }
+            pipeline::failover::abandon_live();
             Err(err)
         }
     }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -68,6 +68,7 @@ pub async fn start_input_recording(
                 show_recording_pill: true,
                 emit_globally: false,
                 start_cue_delay_ms: None,
+                durable: false,
             },
         )
     })
@@ -136,6 +137,7 @@ pub async fn start_setup_try_recording(
                 } else {
                     None
                 },
+                durable: false,
             },
         )
     })
@@ -214,6 +216,7 @@ pub async fn start_calibration_monitoring(
                 show_recording_pill: false,
                 emit_globally: true,
                 start_cue_delay_ms: None,
+                durable: false,
             },
         )
     })
@@ -344,6 +347,7 @@ pub async fn start_repair_complaint_recording(
             show_recording_pill: true,
             emit_globally: false,
             start_cue_delay_ms: None,
+            durable: false,
         },
     )
 }
@@ -500,11 +504,11 @@ pub async fn resume_cancelled_capture(
     // underway — a mid-start failure (mic permissions, poisoned lock) must
     // leave it resumable rather than destroying the audio.
     pipeline::reserve_starting(state.inner())?;
-    let Some(audio) = pipeline::peek_cancelled_capture_if_fresh(state.inner()) else {
+    let Some(capture) = pipeline::peek_cancelled_capture_if_fresh(state.inner()) else {
         pipeline::cancel_starting_reservation(state.inner());
         return Err("Nothing to resume".to_string());
     };
-    pipeline::set_starting_prepend_audio(state.inner(), audio);
+    pipeline::set_starting_prepend_audio(state.inner(), capture.audio.clone());
     let target = WindowTarget::capture_foreground();
     {
         let mut st = match lock_state(&state) {
@@ -516,12 +520,60 @@ pub async fn resume_cancelled_capture(
         };
         st.target = target;
         st.pill_placement_stale = true;
+        st.failover_session_id = Some(capture.id.clone());
+        st.failover_reuse_id = true;
+        st.failover_started_at_unix = capture.started_at_unix;
     }
-    pipeline::start_recording_session(&app, state.inner(), "handsfree", true);
-    crate::core::hotkey::set_handless_active(true);
-    pipeline::clear_cancelled_capture(state.inner());
-    pipeline::emit_cancelled_capture_cleared(&app);
-    Ok(())
+    let start_result = pipeline::start_recording_session_ex(
+        &app,
+        state.inner(),
+        "handsfree",
+        true,
+        None,
+        pipeline::RecordingStartOptions {
+            show_recording_pill: true,
+            emit_globally: false,
+            start_cue_delay_ms: if pipeline::start_stop_sounds_enabled(&app) {
+                Some(crate::media::sound::START_CUE_HANDSFREE_DELAY_MS)
+            } else {
+                None
+            },
+            durable: true,
+        },
+    );
+    match start_result {
+        Ok(()) => {
+            crate::core::hotkey::set_handless_active(true);
+            pipeline::failover::retire_committed();
+            pipeline::clear_cancelled_capture(state.inner());
+            pipeline::emit_cancelled_capture_cleared(&app);
+            Ok(())
+        }
+        Err(err) => {
+            pipeline::cancel_starting_reservation(state.inner());
+            Err(err)
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct CancelledCaptureStatus {
+    pub created_at: String,
+    pub kind: String,
+}
+
+#[tauri::command]
+pub fn get_cancelled_capture(
+    state: tauri::State<'_, SharedState>,
+) -> Result<Option<CancelledCaptureStatus>, String> {
+    Ok(
+        pipeline::peek_cancelled_capture_if_fresh(state.inner()).map(|capture| {
+            CancelledCaptureStatus {
+                created_at: capture.created_at_rfc3339,
+                kind: capture.origin.as_str().to_string(),
+            }
+        }),
+    )
 }
 
 /// Discards a cancelled recording's stashed audio without resuming it —
@@ -536,6 +588,7 @@ pub async fn dismiss_cancelled_capture(
     state: tauri::State<'_, SharedState>,
 ) -> Result<(), String> {
     if pipeline::take_cancelled_capture_if_fresh(state.inner()).is_some() {
+        pipeline::failover::discard_durable();
         pipeline::emit_cancelled_capture_cleared(&app);
     }
     Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -70,7 +70,6 @@ fn main() {
         failover_reuse_id: false,
         failover_started_at_unix: 0,
     }));
-    pipeline::failover::restore_into_state(&shared);
 
     std::fs::create_dir_all(app_data_dir()).ok();
     // The logger must be live before the database opens: a corrupt DB,
@@ -79,6 +78,7 @@ fn main() {
     // exists. init_early captures those records in the ring buffer;
     // attach_app in setup enables frontend forwarding.
     crate::system::logger::init_early();
+    pipeline::failover::restore_into_state(&shared);
     let db_handle: DbHandle = match db::open_with_recovery(app_db_path()) {
         Ok(db) => db,
         Err(err) => fatal_startup_error(&format!("failed to open database: {err}")),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,7 +66,11 @@ fn main() {
         paste_failure: None,
         repair: None,
         hotkey_recording_repair_complaint: false,
+        failover_session_id: None,
+        failover_reuse_id: false,
+        failover_started_at_unix: 0,
     }));
+    pipeline::failover::restore_into_state(&shared);
 
     std::fs::create_dir_all(app_data_dir()).ok();
     // The logger must be live before the database opens: a corrupt DB,
@@ -499,6 +503,7 @@ fn main() {
             commands::stop_handless_mode,
             commands::resume_cancelled_capture,
             commands::dismiss_cancelled_capture,
+            commands::get_cancelled_capture,
             commands::copy_paste_failure_to_clipboard,
             commands::set_pill_size,
             commands::get_installed_apps,
@@ -580,6 +585,7 @@ fn main() {
             // indefinitely and holding the loaded model's RAM/VRAM.
             if let tauri::RunEvent::Exit = _event {
                 log::info!("app exiting; unloading local models");
+                crate::pipeline::failover::flush_on_exit(_app);
                 crate::system::shutdown_local_models(_app);
                 #[cfg(target_os = "windows")]
                 app_tray::cleanup_runtime_icon_files();

--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -166,6 +166,14 @@ impl EnvelopeTap {
     }
 }
 
+/// Optional crash-recovery sink for a dictation. The audio worker pushes
+/// gain-adjusted (and optionally denoised) native-rate samples here; the
+/// implementation must not run on the CPAL callback thread.
+pub trait DurableSink: Send {
+    fn extend(&mut self, native_samples: &[f32], native_rate: u32);
+    fn finish(&mut self);
+}
+
 pub struct RecordingSession {
     stop_tx: mpsc::SyncSender<()>,
     result_rx: mpsc::Receiver<Result<RecordingResult>>,
@@ -186,7 +194,12 @@ pub struct RecordingResult {
 }
 
 impl RecordingSession {
-    pub fn start(device_name: Option<String>, noise_reduction: bool, gain: f32) -> Result<Self> {
+    pub fn start(
+        device_name: Option<String>,
+        noise_reduction: bool,
+        gain: f32,
+        durable: Option<Box<dyn DurableSink>>,
+    ) -> Result<Self> {
         let host = cpal::default_host();
         let device = if let Some(name) = device_name {
             host.input_devices()?
@@ -233,6 +246,7 @@ impl RecordingSession {
             let worker_stop = Arc::clone(&stop_processing);
             let worker_envelope = Arc::clone(&envelope_w);
             let worker = std::thread::spawn(move || {
+                let mut durable = durable;
                 let mut processed = Vec::<f32>::new();
                 let mut batch = Vec::<f32>::with_capacity(2048);
                 let mut raw_sum_sq = 0.0f64;
@@ -280,6 +294,9 @@ impl RecordingSession {
                         for &sample in &processed[before_len..] {
                             worker_envelope.push_sample(sample, processed_display_gain);
                         }
+                        if let Some(sink) = durable.as_mut() {
+                            sink.extend(&processed[before_len..], sample_rate);
+                        }
                     }
 
                     if worker_stop.load(Ordering::Relaxed) && worker_queue.is_empty() {
@@ -293,12 +310,21 @@ impl RecordingSession {
 
                 if let Some(d) = denoiser.as_mut() {
                     if !recording_truncated {
+                        let before_len = processed.len();
                         d.flush(&mut processed);
                         if processed.len() > max_processed_samples {
                             processed.truncate(max_processed_samples);
                             recording_truncated = true;
                         }
+                        if let Some(sink) = durable.as_mut() {
+                            if processed.len() > before_len {
+                                sink.extend(&processed[before_len..], sample_rate);
+                            }
+                        }
                     }
+                }
+                if let Some(mut sink) = durable.take() {
+                    sink.finish();
                 }
 
                 let raw_rms = if raw_sample_count == 0 {

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -116,14 +116,21 @@ fn slot_dir(root: &Path, live: bool) -> PathBuf {
 }
 
 fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
-    let _ = fs::remove_file(to);
+    // Prefer rename-first so POSIX keeps an atomic overwrite. Only delete the
+    // destination when Windows refuses the replace (access denied / sharing /
+    // already-exists), then retry rename or fall back to copy.
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
-        // Windows: access denied (5), sharing violation (32), already exists (183).
         Err(e) if matches!(e.raw_os_error(), Some(5 | 32 | 183)) => {
-            fs::copy(from, to)?;
-            let _ = fs::remove_file(from);
-            Ok(())
+            let _ = fs::remove_file(to);
+            match fs::rename(from, to) {
+                Ok(()) => Ok(()),
+                Err(_) => {
+                    fs::copy(from, to)?;
+                    let _ = fs::remove_file(from);
+                    Ok(())
+                }
+            }
         }
         Err(e) => Err(e),
     }
@@ -179,10 +186,10 @@ pub fn load_slot(root: &Path, live: bool) -> Option<LoadedTake> {
     let mut buf = vec![0u8; byte_len];
     file.read_exact(&mut buf).ok()?;
     let mut samples = Vec::with_capacity(usable as usize);
-    // Keep chunks_exact for the PCM pair decode; allow the clippy hint that prefers as_chunks.
-    #[allow(clippy::manual_slice_chunks)]
-    for chunk in buf.chunks_exact(2) {
-        samples.push(i16_to_f32(i16::from_le_bytes(chunk.try_into().unwrap())));
+    let mut i = 0;
+    while i + 1 < buf.len() {
+        samples.push(i16_to_f32(i16::from_le_bytes([buf[i], buf[i + 1]])));
+        i += 2;
     }
     meta.sample_count = usable;
     meta.duration_ms = usable * 1000 / u64::from(TARGET_RATE);

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -610,7 +610,7 @@ impl LiveWriter {
         }
         self.superseded = true;
         delete_committed(&self.root);
-        if let Some(state) = &self.state {
+        let emit_cleared = if let Some(state) = &self.state {
             if let Ok(mut st) = lock_state(state) {
                 let current_id = self.meta.id.as_str();
                 let stale = st
@@ -619,10 +619,19 @@ impl LiveWriter {
                     .is_some_and(|c| c.id != current_id);
                 if stale {
                     st.cancelled_capture = None;
-                    if let Some(app) = &self.app {
-                        state::emit_cancelled_capture_cleared(app);
-                    }
+                    true
+                } else {
+                    false
                 }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if emit_cleared {
+            if let Some(app) = &self.app {
+                state::emit_cancelled_capture_cleared(app);
             }
         }
         log::debug!(

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -641,8 +641,10 @@ impl DurableSink for LiveWriter {
         if self.native_rate == 0 {
             self.native_rate = native_rate;
         } else if self.native_rate != native_rate {
-            // Flush the previous rate's tail before switching ratios.
-            self.checkpoint(false);
+            // Finish-flush so convert_native drains the old-rate interpolator
+            // tail instead of leaving a sample that would be resampled with the
+            // new ratio.
+            self.checkpoint(true);
             self.native_rate = native_rate;
         }
         self.native_tail.extend_from_slice(native_samples);

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -640,6 +640,10 @@ impl DurableSink for LiveWriter {
         }
         if self.native_rate == 0 {
             self.native_rate = native_rate;
+        } else if self.native_rate != native_rate {
+            // Flush the previous rate's tail before switching ratios.
+            self.checkpoint(false);
+            self.native_rate = native_rate;
         }
         self.native_tail.extend_from_slice(native_samples);
         let one_sec = self.native_rate.max(1) as usize;

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -337,7 +337,7 @@ pub fn restore_choice(root: &Path, now_unix: i64) -> Option<LoadedTake> {
             }
         }
         (Some(l), Some(c)) => {
-            if l.duration_ms() >= MIN_RECORDING_MS {
+            if l.meta.started_at_unix >= c.meta.started_at_unix {
                 delete_committed(root);
                 Some(l)
             } else {
@@ -864,14 +864,48 @@ mod tests {
     fn long_new_live_wins_over_committed() {
         let root = test_root();
         let old = loud_ms(1200);
-        write_committed(&root, "old-id", FailoverKind::Cancelled, now_unix(), &old).unwrap();
+        let now = now_unix();
+        write_committed(&root, "old-id", FailoverKind::Cancelled, now - 1, &old).unwrap();
         let neu = loud_ms(900);
-        let mut w = LiveWriter::open(root.clone(), "new-id".into(), Some(&neu), None, None).unwrap();
-        w.finish();
-        drop(w);
-        let restored = restore_choice(&root, now_unix()).unwrap();
+        write_slot(
+            &root,
+            true,
+            "new-id",
+            FailoverKind::Recording,
+            now,
+            &neu,
+        )
+        .unwrap();
+        let restored = restore_choice(&root, now).unwrap();
         assert_eq!(restored.meta.id, "new-id");
         assert!(load_slot(&root, false).is_none());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn newer_committed_beats_older_live() {
+        let root = test_root();
+        let now = now_unix();
+        write_slot(
+            &root,
+            true,
+            "old-live",
+            FailoverKind::Recording,
+            now - 2,
+            &loud_ms(1200),
+        )
+        .unwrap();
+        write_committed(
+            &root,
+            "new-committed",
+            FailoverKind::Cancelled,
+            now - 1,
+            &loud_ms(900),
+        )
+        .unwrap();
+        let restored = restore_choice(&root, now).unwrap();
+        assert_eq!(restored.meta.id, "new-committed");
+        assert!(load_slot(&root, true).is_none());
         delete_all(&root);
     }
 

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -119,7 +119,8 @@ fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
     let _ = fs::remove_file(to);
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
-        Err(e) if e.raw_os_error() == Some(5) => {
+        // Windows: access denied (5), sharing violation (32), already exists (183).
+        Err(e) if matches!(e.raw_os_error(), Some(5 | 32 | 183)) => {
             fs::copy(from, to)?;
             let _ = fs::remove_file(from);
             Ok(())
@@ -178,8 +179,8 @@ pub fn load_slot(root: &Path, live: bool) -> Option<LoadedTake> {
     let mut buf = vec![0u8; byte_len];
     file.read_exact(&mut buf).ok()?;
     let mut samples = Vec::with_capacity(usable as usize);
-    for chunk in buf.chunks_exact(2) {
-        samples.push(i16_to_f32(i16::from_le_bytes([chunk[0], chunk[1]])));
+    for chunk in buf.as_chunks::<2>().0 {
+        samples.push(i16_to_f32(i16::from_le_bytes(*chunk)));
     }
     meta.sample_count = usable;
     meta.duration_ms = usable * 1000 / u64::from(TARGET_RATE);

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -179,8 +179,10 @@ pub fn load_slot(root: &Path, live: bool) -> Option<LoadedTake> {
     let mut buf = vec![0u8; byte_len];
     file.read_exact(&mut buf).ok()?;
     let mut samples = Vec::with_capacity(usable as usize);
-    for chunk in buf.as_chunks::<2>().0 {
-        samples.push(i16_to_f32(i16::from_le_bytes(*chunk)));
+    // Keep chunks_exact for the PCM pair decode; allow the clippy hint that prefers as_chunks.
+    #[allow(clippy::manual_slice_chunks)]
+    for chunk in buf.chunks_exact(2) {
+        samples.push(i16_to_f32(i16::from_le_bytes(chunk.try_into().unwrap())));
     }
     meta.sample_count = usable;
     meta.duration_ms = usable * 1000 / u64::from(TARGET_RATE);

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -297,25 +297,19 @@ pub fn restore_choice(root: &Path, now_unix: i64) -> Option<LoadedTake> {
     let committed_raw = load_slot(root, false);
 
     let live = live_raw.filter(|t| {
-        if !t.is_fresh(now_unix) {
-            delete_live(root);
-            false
-        } else if !t.passes_gates() {
-            delete_live(root);
-            false
-        } else {
+        if t.is_fresh(now_unix) && t.passes_gates() {
             true
+        } else {
+            delete_live(root);
+            false
         }
     });
     let committed = committed_raw.filter(|t| {
-        if !t.is_fresh(now_unix) {
-            delete_committed(root);
-            false
-        } else if !t.passes_gates() {
-            delete_committed(root);
-            false
-        } else {
+        if t.is_fresh(now_unix) && t.passes_gates() {
             true
+        } else {
+            delete_committed(root);
+            false
         }
     });
 

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -1,0 +1,912 @@
+//! Disk-backed dictation failover: crash/reboot survival for in-progress takes.
+//!
+//! Audio is stored as append-only i16le mono 16 kHz PCM plus an atomic JSON
+//! sidecar. The sidecar `sample_count` is published only after the matching
+//! PCM bytes have been flushed, and load clamps to the shorter of the two.
+
+use super::gates::{MIN_RECORDING_MS, MIN_RECORDING_RMS};
+use super::pill::{show_cancelled_pill, show_interrupted_pill};
+use super::state::{
+    lock_state, CaptureOrigin, CancelledCapture, SharedState, CANCEL_RESUME_WINDOW,
+};
+use super::{state, CapturedAudio};
+use crate::media::audio::{self, DurableSink};
+use chrono::{SecondsFormat, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter, Manager};
+
+const SESSION_VERSION: u32 = 1;
+const TARGET_RATE: u32 = 16_000;
+const LIVE_DIR: &str = "live";
+const COMMITTED_DIR: &str = "committed";
+const SESSION_FILE: &str = "session.json";
+const AUDIO_FILE: &str = "audio.pcm";
+const TTL_SECS: i64 = 24 * 60 * 60;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailoverKind {
+    Recording,
+    Cancelled,
+    Processing,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionMeta {
+    pub version: u32,
+    pub id: String,
+    pub kind: FailoverKind,
+    pub started_at_unix: i64,
+    pub sample_rate: u32,
+    pub sample_count: u64,
+    pub duration_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct LoadedTake {
+    pub meta: SessionMeta,
+    pub samples_16k: Vec<f32>,
+}
+
+impl LoadedTake {
+    fn usable_samples(&self) -> u64 {
+        self.samples_16k.len() as u64
+    }
+
+    fn duration_ms(&self) -> u64 {
+        if self.meta.sample_rate == 0 {
+            0
+        } else {
+            self.usable_samples() * 1000 / u64::from(self.meta.sample_rate)
+        }
+    }
+
+    fn passes_gates(&self) -> bool {
+        if self.duration_ms() < MIN_RECORDING_MS {
+            return false;
+        }
+        audio::rms_f32(&self.samples_16k) >= MIN_RECORDING_RMS
+    }
+
+    fn is_fresh(&self, now_unix: i64) -> bool {
+        now_unix.saturating_sub(self.meta.started_at_unix) < TTL_SECS
+    }
+
+    fn origin(&self) -> CaptureOrigin {
+        match self.meta.kind {
+            FailoverKind::Cancelled => CaptureOrigin::UserCancelled,
+            FailoverKind::Recording | FailoverKind::Processing => CaptureOrigin::Interrupted,
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct CancelledCapturePayload {
+    pub created_at: String,
+    pub kind: String,
+}
+
+pub fn failover_dir() -> PathBuf {
+    crate::app_data_dir().join("dictation-failover")
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn f32_to_i16(s: f32) -> i16 {
+    let v = if s.is_finite() { s.clamp(-1.0, 1.0) } else { 0.0 };
+    (v * i16::MAX as f32) as i16
+}
+
+fn i16_to_f32(s: i16) -> f32 {
+    s as f32 / i16::MAX as f32
+}
+
+fn slot_dir(root: &Path, live: bool) -> PathBuf {
+    root.join(if live { LIVE_DIR } else { COMMITTED_DIR })
+}
+
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    let _ = fs::remove_file(to);
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(e) if e.raw_os_error() == Some(5) => {
+            fs::copy(from, to)?;
+            let _ = fs::remove_file(from);
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn write_session_atomic(path: &Path, meta: &SessionMeta) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_vec_pretty(meta)?;
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(&json)?;
+        f.sync_all()?;
+    }
+    if let Err(e) = replace_file(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+fn load_session(path: &Path) -> Option<SessionMeta> {
+    let raw = fs::read_to_string(path).ok()?;
+    let meta: SessionMeta = serde_json::from_str(&raw).ok()?;
+    if meta.version != SESSION_VERSION || meta.sample_rate != TARGET_RATE {
+        return None;
+    }
+    if meta.id.is_empty() {
+        return None;
+    }
+    Some(meta)
+}
+
+/// Load a slot, clamping published `sample_count` to the PCM file length.
+pub fn load_slot(root: &Path, live: bool) -> Option<LoadedTake> {
+    let dir = slot_dir(root, live);
+    let mut meta = load_session(&dir.join(SESSION_FILE))?;
+    let pcm_path = dir.join(AUDIO_FILE);
+    let mut file = File::open(&pcm_path).ok()?;
+    let file_len = file.metadata().ok()?.len();
+    let file_samples = file_len / 2;
+    let usable = meta.sample_count.min(file_samples);
+    if usable == 0 {
+        return None;
+    }
+    let byte_len = (usable * 2) as usize;
+    let mut buf = vec![0u8; byte_len];
+    file.read_exact(&mut buf).ok()?;
+    let mut samples = Vec::with_capacity(usable as usize);
+    for chunk in buf.chunks_exact(2) {
+        samples.push(i16_to_f32(i16::from_le_bytes([chunk[0], chunk[1]])));
+    }
+    meta.sample_count = usable;
+    meta.duration_ms = usable * 1000 / u64::from(TARGET_RATE);
+    Some(LoadedTake {
+        meta,
+        samples_16k: samples,
+    })
+}
+
+pub fn delete_slot(root: &Path, live: bool) {
+    let dir = slot_dir(root, live);
+    let _ = fs::remove_file(dir.join(AUDIO_FILE));
+    let _ = fs::remove_file(dir.join(SESSION_FILE));
+    let _ = fs::remove_file(dir.join("session.json.tmp"));
+    let _ = fs::remove_file(dir.join("audio.pcm.tmp"));
+    let _ = fs::remove_dir(&dir);
+}
+
+pub fn delete_live(root: &Path) {
+    delete_slot(root, true);
+}
+
+pub fn delete_committed(root: &Path) {
+    delete_slot(root, false);
+}
+
+pub fn delete_all(root: &Path) {
+    delete_live(root);
+    delete_committed(root);
+    let _ = fs::remove_dir(root);
+}
+
+pub fn abandon_live() {
+    delete_live(&failover_dir());
+}
+
+pub fn discard_durable() {
+    delete_all(&failover_dir());
+}
+
+fn samples_to_pcm(samples: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(samples.len() * 2);
+    for &s in samples {
+        out.extend_from_slice(&f32_to_i16(s).to_le_bytes());
+    }
+    out
+}
+
+fn write_slot(
+    root: &Path,
+    live: bool,
+    id: &str,
+    kind: FailoverKind,
+    started_at_unix: i64,
+    samples_16k: &[f32],
+) -> anyhow::Result<()> {
+    if samples_16k.is_empty() {
+        anyhow::bail!("no samples to commit");
+    }
+    let dir = slot_dir(root, live);
+    fs::create_dir_all(&dir)?;
+    let pcm = samples_to_pcm(samples_16k);
+    let tmp = dir.join("audio.pcm.tmp");
+    let dest = dir.join(AUDIO_FILE);
+    {
+        let mut f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(&pcm)?;
+        f.sync_all()?;
+    }
+    replace_file(&tmp, &dest)?;
+    let sample_count = samples_16k.len() as u64;
+    let meta = SessionMeta {
+        version: SESSION_VERSION,
+        id: id.to_string(),
+        kind,
+        started_at_unix,
+        sample_rate: TARGET_RATE,
+        sample_count,
+        duration_ms: sample_count * 1000 / u64::from(TARGET_RATE),
+    };
+    write_session_atomic(&dir.join(SESSION_FILE), &meta)?;
+    Ok(())
+}
+
+pub fn write_committed(
+    root: &Path,
+    id: &str,
+    kind: FailoverKind,
+    started_at_unix: i64,
+    samples_16k: &[f32],
+) -> anyhow::Result<()> {
+    write_slot(root, false, id, kind, started_at_unix, samples_16k)?;
+    delete_live(root);
+    log::info!(
+        "failover: committed id_prefix={} kind={:?} samples={} duration_ms={}",
+        id_prefix(id),
+        kind,
+        samples_16k.len(),
+        samples_16k.len() as u64 * 1000 / u64::from(TARGET_RATE)
+    );
+    Ok(())
+}
+
+fn id_prefix(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
+/// Startup restore: pick live vs committed, delete the loser, return the winner.
+pub fn restore_choice(root: &Path, now_unix: i64) -> Option<LoadedTake> {
+    let live_raw = load_slot(root, true);
+    let committed_raw = load_slot(root, false);
+
+    let live = live_raw.filter(|t| {
+        if !t.is_fresh(now_unix) {
+            delete_live(root);
+            false
+        } else if !t.passes_gates() {
+            delete_live(root);
+            false
+        } else {
+            true
+        }
+    });
+    let committed = committed_raw.filter(|t| {
+        if !t.is_fresh(now_unix) {
+            delete_committed(root);
+            false
+        } else if !t.passes_gates() {
+            delete_committed(root);
+            false
+        } else {
+            true
+        }
+    });
+
+    match (live, committed) {
+        (Some(l), Some(c)) if l.meta.id == c.meta.id => {
+            if c.meta.kind == FailoverKind::Processing {
+                delete_live(root);
+                Some(c)
+            } else if l.usable_samples() >= c.usable_samples() {
+                delete_committed(root);
+                Some(l)
+            } else {
+                delete_live(root);
+                Some(c)
+            }
+        }
+        (Some(l), Some(c)) => {
+            if l.duration_ms() >= MIN_RECORDING_MS {
+                delete_committed(root);
+                Some(l)
+            } else {
+                delete_live(root);
+                Some(c)
+            }
+        }
+        (Some(l), None) => Some(l),
+        (None, Some(c)) => {
+            delete_live(root);
+            Some(c)
+        }
+        (None, None) => {
+            delete_all(root);
+            None
+        }
+    }
+}
+
+fn loaded_to_capture(take: LoadedTake) -> Option<CancelledCapture> {
+    let duration_ms = take.duration_ms();
+    let origin = take.origin();
+    let started_at_unix = take.meta.started_at_unix;
+    let id = take.meta.id.clone();
+    let wav = audio::encode_wav(&take.samples_16k, TARGET_RATE, 1).ok()?;
+    let created_at_rfc3339 = Utc
+        .timestamp_opt(started_at_unix, 0)
+        .single()
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339_opts(SecondsFormat::Secs, true);
+    Some(CancelledCapture {
+        audio: CapturedAudio {
+            wav: bytes::Bytes::from(wav),
+            samples_16k: Arc::new(take.samples_16k),
+            sample_rate: TARGET_RATE,
+            duration_ms,
+        },
+        captured_at: Instant::now(),
+        id,
+        origin,
+        created_at_rfc3339,
+        started_at_unix,
+    })
+}
+
+/// Load a surviving take into RAM. Does not show the pill (the watchdog does).
+pub fn restore_into_state(state: &SharedState) {
+    let Some(take) = restore_choice(&failover_dir(), now_unix()) else {
+        return;
+    };
+    let origin = take.origin();
+    let samples = take.usable_samples();
+    let Some(capture) = loaded_to_capture(take) else {
+        log::warn!("failover: restore encode failed samples={samples}");
+        return;
+    };
+    match lock_state(state) {
+        Ok(mut st) => {
+            if !st.lifecycle.is_idle() {
+                return;
+            }
+            log::info!(
+                "failover: restored id_prefix={} origin={:?} samples={}",
+                id_prefix(&capture.id),
+                origin,
+                samples
+            );
+            st.cancelled_capture = Some(capture);
+        }
+        Err(_) => log::warn!("failover: restore skipped (state lock poisoned)"),
+    }
+}
+
+/// After the pill window can be shown, surface a restored take.
+pub fn offer_restored_capture_pill(app: &AppHandle) -> bool {
+    let Some(state) = app.try_state::<SharedState>() else {
+        return false;
+    };
+    let Some(capture) = state::peek_cancelled_capture_if_fresh(state.inner()) else {
+        return false;
+    };
+    if capture.captured_at.elapsed() >= CANCEL_RESUME_WINDOW {
+        return false;
+    }
+    emit_cancelled_payload(app, &capture.created_at_rfc3339, capture.origin.as_str());
+    match capture.origin {
+        CaptureOrigin::UserCancelled => show_cancelled_pill(app),
+        CaptureOrigin::Interrupted => show_interrupted_pill(app),
+    }
+    true
+}
+
+pub fn emit_cancelled_payload(app: &AppHandle, created_at: &str, kind: &str) {
+    app.emit(
+        "verenu:cancelled-capture",
+        CancelledCapturePayload {
+            created_at: created_at.to_string(),
+            kind: kind.to_string(),
+        },
+    )
+    .ok();
+}
+
+pub fn commit_capture(audio: &CapturedAudio, id: &str, kind: FailoverKind, started_at_unix: i64) {
+    if let Err(e) = write_committed(
+        &failover_dir(),
+        id,
+        kind,
+        started_at_unix,
+        &audio.samples_16k,
+    ) {
+        log::warn!(
+            "failover: commit failed id_prefix={} samples={}: {e}",
+            id_prefix(id),
+            audio.samples_16k.len()
+        );
+    }
+}
+
+pub fn retire_committed() {
+    delete_committed(&failover_dir());
+}
+
+/// Incremental live writer. PCM is appended and synced before `sample_count`
+/// is published in the sidecar.
+pub struct LiveWriter {
+    root: PathBuf,
+    file: File,
+    meta: SessionMeta,
+    native_tail: Vec<f32>,
+    native_rate: u32,
+    src_pos: f64,
+    last_checkpoint: Instant,
+    superseded: bool,
+    app: Option<AppHandle>,
+    state: Option<SharedState>,
+}
+
+impl LiveWriter {
+    pub fn open(
+        root: PathBuf,
+        id: String,
+        prepend_16k: Option<&[f32]>,
+        app: Option<AppHandle>,
+        state: Option<SharedState>,
+    ) -> anyhow::Result<Self> {
+        let dir = slot_dir(&root, true);
+        fs::create_dir_all(&dir)?;
+        let pcm_path = dir.join(AUDIO_FILE);
+        let _ = fs::remove_file(&pcm_path);
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&pcm_path)?;
+        let started_at_unix = now_unix();
+        let mut meta = SessionMeta {
+            version: SESSION_VERSION,
+            id,
+            kind: FailoverKind::Recording,
+            started_at_unix,
+            sample_rate: TARGET_RATE,
+            sample_count: 0,
+            duration_ms: 0,
+        };
+        if let Some(prepend) = prepend_16k {
+            if !prepend.is_empty() {
+                let pcm = samples_to_pcm(prepend);
+                file.write_all(&pcm)?;
+                file.flush()?;
+                file.sync_data()?;
+                meta.sample_count = prepend.len() as u64;
+                meta.duration_ms = meta.sample_count * 1000 / u64::from(TARGET_RATE);
+            }
+        }
+        write_session_atomic(&dir.join(SESSION_FILE), &meta)?;
+        Ok(Self {
+            root,
+            file,
+            meta,
+            native_tail: Vec::new(),
+            native_rate: 0,
+            src_pos: 0.0,
+            last_checkpoint: Instant::now(),
+            superseded: false,
+            app,
+            state,
+        })
+    }
+
+    fn convert_native(&mut self, finish: bool) -> Vec<f32> {
+        if self.native_rate == 0 || self.native_tail.is_empty() {
+            if finish {
+                self.native_tail.clear();
+                self.src_pos = 0.0;
+            }
+            return Vec::new();
+        }
+        if self.native_rate == TARGET_RATE {
+            let out = std::mem::take(&mut self.native_tail);
+            self.src_pos = 0.0;
+            return out;
+        }
+        let ratio = f64::from(self.native_rate) / f64::from(TARGET_RATE);
+        let last = self.native_tail.len().saturating_sub(1);
+        let mut out = Vec::new();
+        loop {
+            let lo = self.src_pos.floor() as usize;
+            let hi = lo + 1;
+            if !finish && hi >= self.native_tail.len() {
+                break;
+            }
+            if lo > last {
+                break;
+            }
+            let hi = hi.min(last);
+            let t = (self.src_pos - lo as f64) as f32;
+            out.push(self.native_tail[lo] * (1.0 - t) + self.native_tail[hi] * t);
+            self.src_pos += ratio;
+            if finish && lo >= last {
+                break;
+            }
+        }
+        if finish {
+            self.native_tail.clear();
+            self.src_pos = 0.0;
+        } else {
+            let drop = self.src_pos.floor() as usize;
+            if drop > 0 {
+                let drop = drop.min(self.native_tail.len());
+                self.native_tail.drain(..drop);
+                self.src_pos -= drop as f64;
+                if self.src_pos < 0.0 {
+                    self.src_pos = 0.0;
+                }
+            }
+        }
+        out
+    }
+
+    fn checkpoint(&mut self, finish: bool) {
+        let samples = self.convert_native(finish);
+        if samples.is_empty() && !finish {
+            return;
+        }
+        if !samples.is_empty() {
+            let pcm = samples_to_pcm(&samples);
+            if let Err(e) = self.file.write_all(&pcm).and_then(|_| self.file.flush()) {
+                log::warn!("failover: live pcm write failed: {e}");
+                return;
+            }
+            if let Err(e) = self.file.sync_data() {
+                log::warn!("failover: live pcm sync failed: {e}");
+                return;
+            }
+            self.meta.sample_count += samples.len() as u64;
+            self.meta.duration_ms = self.meta.sample_count * 1000 / u64::from(TARGET_RATE);
+            let session_path = slot_dir(&self.root, true).join(SESSION_FILE);
+            if let Err(e) = write_session_atomic(&session_path, &self.meta) {
+                log::warn!("failover: live sidecar write failed: {e}");
+            }
+        }
+        self.last_checkpoint = Instant::now();
+        self.maybe_supersede();
+    }
+
+    fn maybe_supersede(&mut self) {
+        if self.superseded || self.meta.duration_ms < MIN_RECORDING_MS {
+            return;
+        }
+        self.superseded = true;
+        delete_committed(&self.root);
+        if let Some(state) = &self.state {
+            if let Ok(mut st) = lock_state(state) {
+                let current_id = self.meta.id.as_str();
+                let stale = st
+                    .cancelled_capture
+                    .as_ref()
+                    .is_some_and(|c| c.id != current_id);
+                if stale {
+                    st.cancelled_capture = None;
+                    if let Some(app) = &self.app {
+                        state::emit_cancelled_capture_cleared(app);
+                    }
+                }
+            }
+        }
+        log::debug!(
+            "failover: live superseded committed id_prefix={} duration_ms={}",
+            id_prefix(&self.meta.id),
+            self.meta.duration_ms
+        );
+    }
+}
+
+impl DurableSink for LiveWriter {
+    fn extend(&mut self, native_samples: &[f32], native_rate: u32) {
+        if native_samples.is_empty() {
+            return;
+        }
+        if self.native_rate == 0 {
+            self.native_rate = native_rate;
+        }
+        self.native_tail.extend_from_slice(native_samples);
+        let one_sec = self.native_rate.max(1) as usize;
+        if self.native_tail.len() >= one_sec
+            || self.last_checkpoint.elapsed() >= Duration::from_secs(1)
+        {
+            self.checkpoint(false);
+        }
+    }
+
+    fn finish(&mut self) {
+        self.checkpoint(true);
+        let _ = self.file.flush();
+        let _ = self.file.sync_all();
+    }
+}
+
+pub fn open_live_writer(
+    id: String,
+    prepend_16k: Option<&[f32]>,
+    app: &AppHandle,
+    state: &SharedState,
+) -> Option<Box<dyn DurableSink>> {
+    match LiveWriter::open(
+        failover_dir(),
+        id,
+        prepend_16k,
+        Some(app.clone()),
+        Some(state.clone()),
+    ) {
+        Ok(w) => Some(Box::new(w)),
+        Err(e) => {
+            log::warn!("failover: live writer open failed: {e}");
+            None
+        }
+    }
+}
+
+pub fn new_session_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+pub fn flush_on_exit(app: &AppHandle) {
+    let Some(state) = app.try_state::<SharedState>() else {
+        return;
+    };
+    let (id, started) = match lock_state(state.inner()) {
+        Ok(st) => (
+            st.failover_session_id.clone(),
+            if st.failover_started_at_unix != 0 {
+                st.failover_started_at_unix
+            } else {
+                now_unix()
+            },
+        ),
+        Err(_) => return,
+    };
+    let Some((session, mic_id)) = state::take_recording_plain(state.inner()) else {
+        return;
+    };
+    match session.stop() {
+        Ok(result) => {
+            if let Some(id) = id {
+                if result.duration_ms >= MIN_RECORDING_MS {
+                    let samples = result.samples_16k;
+                    let _ = write_committed(
+                        &failover_dir(),
+                        &id,
+                        FailoverKind::Recording,
+                        started,
+                        &samples,
+                    );
+                }
+            }
+        }
+        Err(e) => log::warn!("failover: exit flush stop failed: {e}"),
+    }
+    if let Some(session_id) = mic_id {
+        crate::system::volume::release_mic(session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_root() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("verenu-failover-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn tone(samples: usize, amp: f32) -> Vec<f32> {
+        (0..samples)
+            .map(|i| amp * ((i as f32) * 0.1).sin())
+            .collect()
+    }
+
+    fn loud_ms(ms: u64) -> Vec<f32> {
+        tone((TARGET_RATE as u64 * ms / 1000) as usize, 0.4)
+    }
+
+    #[test]
+    fn round_trip_write_read() {
+        let root = test_root();
+        let samples = loud_ms(800);
+        write_committed(&root, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", FailoverKind::Cancelled, 1_700_000_000, &samples)
+            .unwrap();
+        let loaded = load_slot(&root, false).unwrap();
+        assert_eq!(loaded.samples_16k.len(), samples.len());
+        assert!(loaded.passes_gates());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn pcm_ahead_of_sidecar_uses_published_count() {
+        let root = test_root();
+        let samples = loud_ms(800);
+        write_committed(&root, "id-published", FailoverKind::Recording, now_unix(), &samples).unwrap();
+        let pcm_path = slot_dir(&root, false).join(AUDIO_FILE);
+        let extra = samples_to_pcm(&loud_ms(200));
+        let mut f = OpenOptions::new().append(true).open(&pcm_path).unwrap();
+        f.write_all(&extra).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+        let loaded = load_slot(&root, false).unwrap();
+        assert_eq!(loaded.samples_16k.len(), samples.len());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn sidecar_ahead_of_pcm_clamps_to_file() {
+        let root = test_root();
+        let samples = loud_ms(800);
+        write_committed(&root, "id-clamp", FailoverKind::Recording, now_unix(), &samples).unwrap();
+        let mut meta = load_session(&slot_dir(&root, false).join(SESSION_FILE)).unwrap();
+        meta.sample_count = samples.len() as u64 + 4000;
+        write_session_atomic(&slot_dir(&root, false).join(SESSION_FILE), &meta).unwrap();
+        let loaded = load_slot(&root, false).unwrap();
+        assert_eq!(loaded.samples_16k.len(), samples.len());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn odd_trailing_byte_is_dropped() {
+        let root = test_root();
+        let samples = loud_ms(800);
+        write_committed(&root, "id-odd", FailoverKind::Recording, now_unix(), &samples).unwrap();
+        let pcm_path = slot_dir(&root, false).join(AUDIO_FILE);
+        let mut f = OpenOptions::new().append(true).open(&pcm_path).unwrap();
+        f.write_all(&[0x7f]).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+        let loaded = load_slot(&root, false).unwrap();
+        assert_eq!(loaded.samples_16k.len(), samples.len());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn expired_sidecar_is_not_restored() {
+        let root = test_root();
+        let samples = loud_ms(800);
+        write_committed(&root, "id-old", FailoverKind::Cancelled, 1_000, &samples).unwrap();
+        assert!(restore_choice(&root, 1_000 + TTL_SECS + 10).is_none());
+        assert!(load_slot(&root, false).is_none());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn processing_committed_beats_same_id_live() {
+        let root = test_root();
+        let committed = loud_ms(1200);
+        let live = loud_ms(2000);
+        let t = now_unix();
+        write_committed(&root, "same-id", FailoverKind::Processing, t, &committed).unwrap();
+        write_slot(
+            &root,
+            true,
+            "same-id",
+            FailoverKind::Recording,
+            t,
+            &live,
+        )
+        .unwrap();
+        let restored = restore_choice(&root, t).unwrap();
+        assert_eq!(restored.meta.kind, FailoverKind::Processing);
+        assert_eq!(restored.samples_16k.len(), committed.len());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn short_new_live_keeps_old_committed() {
+        let root = test_root();
+        let old = loud_ms(1200);
+        write_committed(&root, "old-id", FailoverKind::Cancelled, now_unix(), &old).unwrap();
+        let short = loud_ms(200);
+        let mut w = LiveWriter::open(root.clone(), "new-id".into(), Some(&short), None, None).unwrap();
+        w.finish();
+        drop(w);
+        // 200ms fails gates, so restore_choice drops live and keeps committed.
+        let restored = restore_choice(&root, now_unix()).unwrap();
+        assert_eq!(restored.meta.id, "old-id");
+        delete_all(&root);
+    }
+
+    #[test]
+    fn long_new_live_wins_over_committed() {
+        let root = test_root();
+        let old = loud_ms(1200);
+        write_committed(&root, "old-id", FailoverKind::Cancelled, now_unix(), &old).unwrap();
+        let neu = loud_ms(900);
+        let mut w = LiveWriter::open(root.clone(), "new-id".into(), Some(&neu), None, None).unwrap();
+        w.finish();
+        drop(w);
+        let restored = restore_choice(&root, now_unix()).unwrap();
+        assert_eq!(restored.meta.id, "new-id");
+        assert!(load_slot(&root, false).is_none());
+        delete_all(&root);
+    }
+
+    #[test]
+    fn live_writer_publish_after_sync() {
+        let root = test_root();
+        let mut w = LiveWriter::open(root.clone(), "live-1".into(), None, None, None).unwrap();
+        w.extend(&loud_ms(1000), TARGET_RATE);
+        w.finish();
+        drop(w);
+        let loaded = load_slot(&root, true).unwrap();
+        assert!(loaded.samples_16k.len() >= 15_000);
+        delete_all(&root);
+    }
+
+    #[test]
+    fn resume_seed_without_supersede_keeps_committed() {
+        let root = test_root();
+        let original = loud_ms(1000);
+        let t = now_unix();
+        write_committed(&root, "resume-id", FailoverKind::Cancelled, t, &original).unwrap();
+        write_slot(
+            &root,
+            true,
+            "resume-id",
+            FailoverKind::Recording,
+            t,
+            &original,
+        )
+        .unwrap();
+        assert!(load_slot(&root, false).is_some());
+        assert!(load_slot(&root, true).is_some());
+        let restored = restore_choice(&root, t).unwrap();
+        assert_eq!(restored.meta.id, "resume-id");
+        delete_all(&root);
+    }
+
+    #[test]
+    fn crash_before_seed_keeps_committed() {
+        let root = test_root();
+        let original = loud_ms(1000);
+        write_committed(&root, "resume-id", FailoverKind::Cancelled, now_unix(), &original).unwrap();
+        let restored = restore_choice(&root, now_unix()).unwrap();
+        assert_eq!(restored.meta.id, "resume-id");
+        assert_eq!(restored.meta.kind, FailoverKind::Cancelled);
+        delete_all(&root);
+    }
+
+    #[test]
+    fn too_quiet_is_not_restored() {
+        let root = test_root();
+        let quiet = vec![0.0f32; (TARGET_RATE as u64 * 800 / 1000) as usize];
+        write_committed(&root, "quiet", FailoverKind::Cancelled, now_unix(), &quiet).unwrap();
+        assert!(restore_choice(&root, now_unix()).is_none());
+        delete_all(&root);
+    }
+}

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -184,7 +184,15 @@ pub(super) async fn finalize_pipeline_completion(
     })
     .await
     {
-        Ok(Ok(entry)) => entry,
+        Ok(Ok(entry)) => {
+            super::failover::discard_durable();
+            if let Ok(mut st) = lock_state(state) {
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
+            }
+            entry
+        }
         Ok(Err(e)) => {
             show_error_pill(
                 app,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -338,6 +338,9 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     let Some((mut captured_audio, mut rms, mut raw_rms)) =
         stop_and_capture_audio(&app, session, exclusive_mic_session_id).await
     else {
+        // stop_and_capture_audio already abandons live on its own failure
+        // paths; call again so a future None return cannot leave a spool.
+        failover::abandon_live();
         state::leave_stopping_if_owned(&state, generation);
         return;
     };

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -15,6 +15,7 @@ use chrono::{DateTime, Duration, NaiveDateTime, SecondsFormat, Utc};
 mod cache;
 mod chains;
 mod clipboard_phrase;
+pub(crate) mod failover;
 mod finalize;
 #[cfg(any(test, debug_assertions))]
 mod fixture;
@@ -48,7 +49,10 @@ pub(crate) use pill::{
     emit_pill_context, emit_pill_stage, hide_pill, pill_wants_repair_focus,
     show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
 };
-use pill::{reject_with_pill, show_cancelled_pill, show_error_pill, show_paste_failed_pill};
+use pill::{
+    reject_with_pill, show_cancelled_pill, show_error_pill, show_interrupted_pill,
+    show_paste_failed_pill,
+};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };
@@ -344,6 +348,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
                 Err(err) => {
                     log::error!("pipeline: {err}");
                     reject_with_pill(&app, "Failed to prepare recording audio");
+                    failover::abandon_live();
                     state::leave_stopping_if_owned(&state, generation);
                     return;
                 }
@@ -367,6 +372,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         silence_floor,
         active_gain,
     ) {
+        failover::abandon_live();
         state::leave_stopping_if_owned(&state, generation);
         return;
     }
@@ -388,6 +394,28 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         captured_audio: captured_audio.clone(),
         target,
     };
+    {
+        let (id, started) = lock_state(&state)
+            .ok()
+            .map(|st| (st.failover_session_id.clone(), st.failover_started_at_unix))
+            .unwrap_or((None, 0));
+        if let Some(id) = id {
+            let started = if started != 0 {
+                started
+            } else {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0)
+            };
+            failover::commit_capture(
+                &captured_audio,
+                &id,
+                failover::FailoverKind::Processing,
+                started,
+            );
+        }
+    }
     if !state::install_processing(&state, generation, active) {
         // Superseded between Stopping and here (should not happen in
         // practice — nothing else can transition out of Stopping — but an

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -49,10 +49,7 @@ pub(crate) use pill::{
     emit_pill_context, emit_pill_stage, hide_pill, pill_wants_repair_focus,
     show_clipboard_warning_pill, show_copied_pill, show_pill, update_pill_state,
 };
-use pill::{
-    reject_with_pill, show_cancelled_pill, show_error_pill, show_interrupted_pill,
-    show_paste_failed_pill,
-};
+use pill::{reject_with_pill, show_error_pill, show_paste_failed_pill};
 pub(crate) use pill_position::{
     apply_pill_placement, placement_for_current_monitor, PillPlacement,
 };

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -589,7 +589,7 @@ pub(crate) fn hide_pill(app: &AppHandle) {
 
         pill.emit("pill-state", "idle").ok();
         // Re-enable click-through: after a button-bearing state (handsfree,
-        // error, cancelled, paste_failed) reveal_pill left the window
+        // error, cancelled, interrupted, paste_failed) reveal_pill left the window
         // click-capturing. Idle is invisible, so it must never swallow clicks
         // in the pill's zone even though the pill content has disappeared.
         pill.set_ignore_cursor_events(true).ok();
@@ -607,6 +607,10 @@ pub(crate) fn hide_pill(app: &AppHandle) {
 /// frontend (`PillApp.svelte`), same as `show_error_pill`.
 pub(super) fn show_cancelled_pill(app: &AppHandle) {
     show_pill_msg(app, "cancelled", None);
+}
+
+pub(super) fn show_interrupted_pill(app: &AppHandle) {
+    show_pill_msg(app, "interrupted", None);
 }
 
 /// Shows the pill's "Paste failed" state — injection didn't land (or

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -419,7 +419,7 @@ pub fn stash_cancelled_capture(
         SessionActive,
     }
     let outcome = match lock_state(state) {
-        Ok(st) => {
+        Ok(mut st) => {
             // Only stash while the system is genuinely idle. Between
             // `stop_and_capture_audio` (which released the Recording
             // lifecycle) and this call the user may have already started a
@@ -444,6 +444,12 @@ pub fn stash_cancelled_capture(
                     CaptureOrigin::UserCancelled => super::failover::FailoverKind::Cancelled,
                     CaptureOrigin::Interrupted => super::failover::FailoverKind::Recording,
                 };
+                // Reserve this capture's identity before releasing the lock.
+                // A new recording may start while commit_capture performs
+                // blocking disk I/O and must receive fresh failover metadata.
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
                 // Drop the state lock before disk I/O so hotkey/UI paths are
                 // not stalled on fsync.
                 drop(st);

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::pill::{show_cancelled_pill, show_interrupted_pill};
 use chrono::{SecondsFormat, Utc};
 
 // ---------- recording session helpers ----------
@@ -213,6 +214,9 @@ pub fn start_recording_session_ex(
                     log::warn!(
                         "start_recording_session_ex: lifecycle was not Starting when installing Recording"
                     );
+                    st.failover_session_id = None;
+                    st.failover_reuse_id = false;
+                    st.failover_started_at_unix = 0;
                     drop(st);
                     let _ = session.stop();
                     if let Some(session_id) = exclusive_mic_session_id {
@@ -484,6 +488,9 @@ pub fn stash_cancelled_capture(
 /// Releases a `Starting` reservation back to `Idle` when the mic failed to
 /// open — the carried prepend audio (if any) is simply dropped, not
 /// retained anywhere a later, unrelated dictation could inherit it.
+///
+/// Also clears in-memory failover fields so a failed durable start cannot
+/// leave a stale `failover_started_at_unix` that later sessions inherit.
 pub(crate) fn release_starting_reservation(state: &SharedState) {
     let mut st = match state.lock() {
         Ok(st) => st,
@@ -497,6 +504,9 @@ pub(crate) fn release_starting_reservation(state: &SharedState) {
     if matches!(st.lifecycle, DictationLifecycle::Starting { .. }) {
         st.lifecycle = DictationLifecycle::Idle;
     }
+    st.failover_session_id = None;
+    st.failover_reuse_id = false;
+    st.failover_started_at_unix = 0;
 }
 
 /// Spawns a Tokio task that emits `audio-level` events to the pill every 50ms

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -130,7 +130,9 @@ pub fn start_recording_session_ex(
         None
     };
 
-    let (durable_sink, prepend_for_lifecycle) = {
+    // Keep the state lock off the disk path: collect durable session ids under
+    // the lock, then open the live spool after dropping it.
+    let (durable_id, prepend_for_lifecycle) = {
         let mut st = match lock_state(state) {
             Ok(st) => st,
             Err(e) => {
@@ -157,7 +159,7 @@ pub fn start_recording_session_ex(
                 );
             }
         };
-        let sink = if options.durable {
+        let durable_id = if options.durable {
             let id = if st.failover_reuse_id {
                 st.failover_reuse_id = false;
                 st.failover_session_id
@@ -173,20 +175,25 @@ pub fn start_recording_session_ex(
                     .map(|d| d.as_secs() as i64)
                     .unwrap_or(0);
             }
-            super::failover::open_live_writer(
-                id,
-                prepend_audio.as_ref().map(|a| a.samples_16k.as_slice()),
-                app,
-                state,
-            )
+            Some(id)
         } else {
             st.failover_session_id = None;
             st.failover_reuse_id = false;
             st.failover_started_at_unix = 0;
             None
         };
-        (sink, prepend_audio)
+        (durable_id, prepend_audio)
     };
+    let durable_sink = durable_id.and_then(|id| {
+        super::failover::open_live_writer(
+            id,
+            prepend_for_lifecycle
+                .as_ref()
+                .map(|a| a.samples_16k.as_slice()),
+            app,
+            state,
+        )
+    });
 
     match audio::RecordingSession::start(device, noise_reduction, mic_gain, durable_sink) {
         Ok(session) => {
@@ -462,7 +469,9 @@ pub fn stash_cancelled_capture(
     };
     match outcome {
         StashOutcome::Stashed(capture) => {
-            if start_stop_sounds_enabled(app) {
+            if start_stop_sounds_enabled(app)
+                && matches!(capture.origin, CaptureOrigin::UserCancelled)
+            {
                 crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
             }
             emit_cancelled_capture(app, &capture);

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -1,4 +1,5 @@
 use super::*;
+use chrono::{SecondsFormat, Utc};
 
 // ---------- recording session helpers ----------
 
@@ -7,6 +8,8 @@ pub struct RecordingStartOptions {
     pub show_recording_pill: bool,
     pub emit_globally: bool,
     pub start_cue_delay_ms: Option<u64>,
+    /// Crash-recovery spool. Only hold-to-talk and hands-free dictation.
+    pub durable: bool,
 }
 
 /// Starts a new recording session, stores it in shared state, shows the pill,
@@ -39,6 +42,7 @@ pub fn start_recording_session(
             show_recording_pill: true,
             emit_globally: false,
             start_cue_delay_ms,
+            durable: pill_state == "recording" || pill_state == "handsfree",
         },
     ) {
         log::error!("start recording: {e}");
@@ -125,7 +129,65 @@ pub fn start_recording_session_ex(
         None
     };
 
-    match audio::RecordingSession::start(device, noise_reduction, mic_gain) {
+    let (durable_sink, prepend_for_lifecycle) = {
+        let mut st = match lock_state(state) {
+            Ok(st) => st,
+            Err(e) => {
+                if let Some(session_id) = exclusive_mic_session_id {
+                    crate::system::volume::release_mic(session_id);
+                }
+                release_starting_reservation(state);
+                return Err(e.to_string());
+            }
+        };
+        let prepend_audio = match &st.lifecycle {
+            DictationLifecycle::Starting { prepend_audio } => prepend_audio.clone(),
+            _ => {
+                log::warn!(
+                    "start_recording_session_ex: lifecycle was not Starting when installing Recording"
+                );
+                drop(st);
+                if let Some(session_id) = exclusive_mic_session_id {
+                    crate::system::volume::release_mic(session_id);
+                }
+                release_starting_reservation(state);
+                return Err(
+                    "Recording start reservation was lost before the microphone opened".to_string(),
+                );
+            }
+        };
+        let sink = if options.durable {
+            let id = if st.failover_reuse_id {
+                st.failover_reuse_id = false;
+                st.failover_session_id
+                    .clone()
+                    .unwrap_or_else(super::failover::new_session_id)
+            } else {
+                super::failover::new_session_id()
+            };
+            st.failover_session_id = Some(id.clone());
+            if st.failover_started_at_unix == 0 {
+                st.failover_started_at_unix = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+            }
+            super::failover::open_live_writer(
+                id,
+                prepend_audio.as_ref().map(|a| a.samples_16k.as_slice()),
+                app,
+                state,
+            )
+        } else {
+            st.failover_session_id = None;
+            st.failover_reuse_id = false;
+            st.failover_started_at_unix = 0;
+            None
+        };
+        (sink, prepend_audio)
+    };
+
+    match audio::RecordingSession::start(device, noise_reduction, mic_gain, durable_sink) {
         Ok(session) => {
             let level_arc = session.level.clone();
             let raw_level_arc = session.raw_level.clone();
@@ -144,30 +206,44 @@ pub fn start_recording_session_ex(
                         return Err(e.to_string());
                     }
                 };
-                let prepend_audio = match &st.lifecycle {
-                    DictationLifecycle::Starting { prepend_audio } => prepend_audio.clone(),
-                    _ => {
-                        log::warn!(
-                            "start_recording_session_ex: lifecycle was not Starting when installing Recording"
-                        );
-                        drop(st);
-                        let _ = session.stop();
-                        if let Some(session_id) = exclusive_mic_session_id {
-                            crate::system::volume::release_mic(session_id);
-                        }
-                        return Err(
-                            "Recording start reservation was lost before the microphone opened"
-                                .to_string(),
-                        );
+                if !matches!(&st.lifecycle, DictationLifecycle::Starting { .. }) {
+                    log::warn!(
+                        "start_recording_session_ex: lifecycle was not Starting when installing Recording"
+                    );
+                    drop(st);
+                    let _ = session.stop();
+                    if let Some(session_id) = exclusive_mic_session_id {
+                        crate::system::volume::release_mic(session_id);
                     }
-                };
+                    return Err(
+                        "Recording start reservation was lost before the microphone opened"
+                            .to_string(),
+                    );
+                }
                 st.lifecycle = DictationLifecycle::Recording {
                     session,
                     exclusive_mic_session_id,
                     handless,
                     handless_from_hold: false,
-                    prepend_audio,
+                    prepend_audio: prepend_for_lifecycle.clone(),
                 };
+            }
+            if options.durable
+                && prepend_for_lifecycle
+                    .as_ref()
+                    .is_some_and(|audio| audio.duration_ms >= MIN_RECORDING_MS)
+            {
+                super::failover::retire_committed();
+                if let Ok(mut st) = lock_state(state) {
+                    let current_id = st.failover_session_id.clone();
+                    let stale = st.cancelled_capture.as_ref().is_some_and(|c| {
+                        current_id.as_ref().is_some_and(|id| &c.id != id)
+                    });
+                    if stale {
+                        st.cancelled_capture = None;
+                        emit_cancelled_capture_cleared(app);
+                    }
+                }
             }
             if let Some(manager) = app.try_state::<crate::local_stt::LocalTranscriptionManager>() {
                 manager.set_recording_active(true);
@@ -219,6 +295,9 @@ pub fn start_recording_session_ex(
             if let Some(session_id) = exclusive_mic_session_id {
                 crate::system::volume::release_mic(session_id);
             }
+            if options.durable {
+                super::failover::abandon_live();
+            }
             release_starting_reservation(state);
             Err(e.to_string())
         }
@@ -259,6 +338,7 @@ pub async fn cancel_recording_with_resume(
 
     if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
         log::info!("recording: cancelled — capture discarded (duration/quiet gate)");
+        super::failover::abandon_live();
         if start_stop_sounds_enabled(app) {
             crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
         }
@@ -271,7 +351,7 @@ pub async fn cancel_recording_with_resume(
     }
 
     log::info!("recording: cancelled — capture stashed for resume");
-    stash_cancelled_capture(app, state, captured_audio);
+    stash_cancelled_capture(app, state, captured_audio, CaptureOrigin::UserCancelled);
 }
 
 /// Stops and discards a recording that belongs to a transient flow such as
@@ -303,9 +383,14 @@ fn state_is_idle(state: &SharedState) -> bool {
 /// (`cancel_recording_with_resume` applies the normal recording quality
 /// gates before calling this; a cancel mid-processing has already cleared
 /// the pipeline's own gate by the time it gets here).
-pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: CapturedAudio) {
+pub fn stash_cancelled_capture(
+    app: &AppHandle,
+    state: &SharedState,
+    audio: CapturedAudio,
+    origin: CaptureOrigin,
+) {
     enum StashOutcome {
-        Stashed,
+        Stashed(CancelledCapture),
         LockPoisoned,
         SessionActive,
     }
@@ -319,36 +404,63 @@ pub fn stash_cancelled_capture(app: &AppHandle, state: &SharedState, audio: Capt
             if !st.lifecycle.is_idle() {
                 StashOutcome::SessionActive
             } else {
-                st.cancelled_capture = Some(CancelledCapture {
+                let id = st
+                    .failover_session_id
+                    .clone()
+                    .unwrap_or_else(super::failover::new_session_id);
+                let started_at_unix = if st.failover_started_at_unix != 0 {
+                    st.failover_started_at_unix
+                } else {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0)
+                };
+                let kind = match origin {
+                    CaptureOrigin::UserCancelled => super::failover::FailoverKind::Cancelled,
+                    CaptureOrigin::Interrupted => super::failover::FailoverKind::Recording,
+                };
+                super::failover::commit_capture(&audio, &id, kind, started_at_unix);
+                let capture = CancelledCapture {
                     audio,
                     captured_at: std::time::Instant::now(),
-                });
-                StashOutcome::Stashed
+                    id,
+                    origin,
+                    created_at_rfc3339: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+                    started_at_unix,
+                };
+                st.cancelled_capture = Some(capture.clone());
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
+                StashOutcome::Stashed(capture)
             }
         }
         Err(_) => StashOutcome::LockPoisoned,
     };
     match outcome {
-        StashOutcome::Stashed => {}
+        StashOutcome::Stashed(capture) => {
+            if start_stop_sounds_enabled(app) {
+                crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
+            }
+            emit_cancelled_capture(app, &capture);
+            match capture.origin {
+                CaptureOrigin::UserCancelled => show_cancelled_pill(app),
+                CaptureOrigin::Interrupted => show_interrupted_pill(app),
+            }
+        }
         StashOutcome::SessionActive => {
             // A newer dictation owns the pill now — don't touch it, and
             // don't offer a resume that would fight the live session.
             log::debug!("skipping cancelled-capture pill: a new session is active");
-            return;
         }
         StashOutcome::LockPoisoned => {
             // Poisoned lock: the pill's Continue button would offer a resume
             // that can't work since nothing was stashed. Hide the pill.
             log::warn!("failed to stash cancelled capture (state lock poisoned)");
             hide_pill(app);
-            return;
         }
     }
-    if start_stop_sounds_enabled(app) {
-        crate::media::sound::play(crate::media::sound::SoundCue::Cancel);
-    }
-    emit_cancelled_capture(app);
-    show_cancelled_pill(app);
 }
 
 /// Releases a `Starting` reservation back to `Idle` when the mic failed to

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -202,6 +202,9 @@ pub fn start_recording_session_ex(
                         if let Some(session_id) = exclusive_mic_session_id {
                             crate::system::volume::release_mic(session_id);
                         }
+                        if options.durable {
+                            super::failover::abandon_live();
+                        }
                         release_starting_reservation(state);
                         return Err(e.to_string());
                     }
@@ -214,6 +217,9 @@ pub fn start_recording_session_ex(
                     let _ = session.stop();
                     if let Some(session_id) = exclusive_mic_session_id {
                         crate::system::volume::release_mic(session_id);
+                    }
+                    if options.durable {
+                        super::failover::abandon_live();
                     }
                     return Err(
                         "Recording start reservation was lost before the microphone opened"
@@ -395,7 +401,7 @@ pub fn stash_cancelled_capture(
         SessionActive,
     }
     let outcome = match lock_state(state) {
-        Ok(mut st) => {
+        Ok(st) => {
             // Only stash while the system is genuinely idle. Between
             // `stop_and_capture_audio` (which released the Recording
             // lifecycle) and this call the user may have already started a
@@ -420,6 +426,9 @@ pub fn stash_cancelled_capture(
                     CaptureOrigin::UserCancelled => super::failover::FailoverKind::Cancelled,
                     CaptureOrigin::Interrupted => super::failover::FailoverKind::Recording,
                 };
+                // Drop the state lock before disk I/O so hotkey/UI paths are
+                // not stalled on fsync.
+                drop(st);
                 super::failover::commit_capture(&audio, &id, kind, started_at_unix);
                 let capture = CancelledCapture {
                     audio,
@@ -429,11 +438,20 @@ pub fn stash_cancelled_capture(
                     created_at_rfc3339: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
                     started_at_unix,
                 };
-                st.cancelled_capture = Some(capture.clone());
-                st.failover_session_id = None;
-                st.failover_reuse_id = false;
-                st.failover_started_at_unix = 0;
-                StashOutcome::Stashed(capture)
+                match lock_state(state) {
+                    Ok(mut st) => {
+                        if !st.lifecycle.is_idle() {
+                            StashOutcome::SessionActive
+                        } else {
+                            st.cancelled_capture = Some(capture.clone());
+                            st.failover_session_id = None;
+                            st.failover_reuse_id = false;
+                            st.failover_started_at_unix = 0;
+                            StashOutcome::Stashed(capture)
+                        }
+                    }
+                    Err(_) => StashOutcome::LockPoisoned,
+                }
             }
         }
         Err(_) => StashOutcome::LockPoisoned,

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -251,15 +251,22 @@ pub fn start_recording_session_ex(
                     .is_some_and(|audio| audio.duration_ms >= MIN_RECORDING_MS)
             {
                 super::failover::retire_committed();
-                if let Ok(mut st) = lock_state(state) {
+                let emit_cleared = if let Ok(mut st) = lock_state(state) {
                     let current_id = st.failover_session_id.clone();
                     let stale = st.cancelled_capture.as_ref().is_some_and(|c| {
                         current_id.as_ref().is_some_and(|id| &c.id != id)
                     });
                     if stale {
                         st.cancelled_capture = None;
-                        emit_cancelled_capture_cleared(app);
+                        true
+                    } else {
+                        false
                     }
+                } else {
+                    false
+                };
+                if emit_cleared {
+                    emit_cancelled_capture_cleared(app);
                 }
             }
             if let Some(manager) = app.try_state::<crate::local_stt::LocalTranscriptionManager>() {

--- a/src-tauri/src/pipeline/stages_transcription.rs
+++ b/src-tauri/src/pipeline/stages_transcription.rs
@@ -43,11 +43,13 @@ pub(super) async fn stop_and_capture_audio(
         Ok(Ok(v)) => v,
         Ok(Err(e)) => {
             log::error!("audio stop: {e}");
+            super::failover::abandon_live();
             hide_pill(app);
             return None;
         }
         Err(e) => {
             log::error!("audio stop task panicked: {e}");
+            super::failover::abandon_live();
             hide_pill(app);
             return None;
         }
@@ -67,6 +69,7 @@ pub(super) async fn stop_and_capture_audio(
             ),
         )
         .await;
+        super::failover::abandon_live();
         return None;
     }
     Some((

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -55,6 +55,12 @@ pub struct AppState {
     pub cancelled_capture: Option<CancelledCapture>,
     pub paste_failure: Option<PasteFailure>,
     pub repair: Option<super::repair::RepairSession>,
+    /// Id of the in-flight durable dictation, if any.
+    pub failover_session_id: Option<String>,
+    /// When true, the next durable start reuses `failover_session_id` (resume).
+    pub failover_reuse_id: bool,
+    /// Wall-clock start of the current durable take, used when committing.
+    pub failover_started_at_unix: i64,
     /// Set only by the hotkey path when a Press was routed into the repair
     /// pill's complaint recording (see app_hotkey.rs) — checked and cleared
     /// on the matching Release so that release routes to the same place the
@@ -156,6 +162,21 @@ pub struct RetryCapture {
     pub caps_lock_on: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureOrigin {
+    UserCancelled,
+    Interrupted,
+}
+
+impl CaptureOrigin {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CaptureOrigin::UserCancelled => "cancelled",
+            CaptureOrigin::Interrupted => "interrupted",
+        }
+    }
+}
+
 /// Audio from a recording the user cancelled, kept around briefly so the
 /// pill's "Cancelled" state can offer a Continue button that resumes
 /// recording (hands-free) with this audio prepended — see
@@ -165,6 +186,10 @@ pub struct RetryCapture {
 pub struct CancelledCapture {
     pub audio: CapturedAudio,
     pub captured_at: std::time::Instant,
+    pub id: String,
+    pub origin: CaptureOrigin,
+    pub created_at_rfc3339: String,
+    pub started_at_unix: i64,
 }
 
 /// Final injected text from a dictation whose paste couldn't be confirmed
@@ -217,11 +242,11 @@ pub fn reserve_starting(state: &SharedState) -> Result<(), String> {
 /// Reads the stashed cancelled capture (cloned) if present and fresh, without
 /// consuming it — so a resume attempt that fails partway doesn't destroy the
 /// resumable audio.
-pub fn peek_cancelled_capture_if_fresh(state: &SharedState) -> Option<CapturedAudio> {
+pub fn peek_cancelled_capture_if_fresh(state: &SharedState) -> Option<CancelledCapture> {
     let st = lock_state(state).ok()?;
     st.cancelled_capture.as_ref().and_then(|c| {
         if c.captured_at.elapsed() < CANCEL_RESUME_WINDOW {
-            Some(c.audio.clone())
+            Some(c.clone())
         } else {
             None
         }
@@ -611,13 +636,9 @@ pub(super) fn emit_pipeline_failed(app: &AppHandle) {
 
 /// Tells any open window (Home's history list in particular) that a
 /// recording was just cancelled and its audio is resumable for
-/// `CANCEL_RESUME_WINDOW`. Mirrors `emit_pipeline_failed`'s payload shape.
-pub(super) fn emit_cancelled_capture(app: &AppHandle) {
-    app.emit(
-        "verenu:cancelled-capture",
-        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
-    )
-    .ok();
+/// `CANCEL_RESUME_WINDOW`.
+pub(super) fn emit_cancelled_capture(app: &AppHandle, capture: &CancelledCapture) {
+    super::failover::emit_cancelled_payload(app, &capture.created_at_rfc3339, capture.origin.as_str());
 }
 
 /// Tells any open window that the current cancelled capture is gone —
@@ -708,6 +729,9 @@ mod tests {
             paste_failure: None,
             repair: None,
             hotkey_recording_repair_complaint: false,
+            failover_session_id: None,
+            failover_reuse_id: false,
+            failover_started_at_unix: 0,
         }))
     }
 
@@ -746,11 +770,18 @@ mod tests {
             st.cancelled_capture = Some(CancelledCapture {
                 audio: fake_audio(500),
                 captured_at: std::time::Instant::now(),
+                id: "test-id".into(),
+                origin: CaptureOrigin::UserCancelled,
+                created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
+                started_at_unix: 0,
             });
         }
         // Peeking clones — the slot must survive for the later clear.
         assert_eq!(
-            peek_cancelled_capture_if_fresh(&state).unwrap().duration_ms,
+            peek_cancelled_capture_if_fresh(&state)
+                .unwrap()
+                .audio
+                .duration_ms,
             500
         );
         assert!(lock_state(&state).unwrap().cancelled_capture.is_some());
@@ -764,6 +795,10 @@ mod tests {
             st.cancelled_capture = Some(CancelledCapture {
                 audio: fake_audio(500),
                 captured_at: std::time::Instant::now(),
+                id: "test-id".into(),
+                origin: CaptureOrigin::UserCancelled,
+                created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
+                started_at_unix: 0,
             });
         }
         clear_cancelled_capture(&state);

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -3,7 +3,8 @@
   import { formatKeyLabel } from './lib/platform';
   import { BARS, createPillVisualizer } from './lib/pillVisualizer';
 
-  type PillState = 'idle' | 'recording' | 'repair_recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'paste_failed' | 'copied' | 'clipboard_warning' | 'feedback_prompt' | 'repair_input' | 'repair_processing' | 'repair_proposal' | 'repair_applying' | 'repair_done' | 'repair_error';
+  type PillState = 'idle' | 'recording' | 'repair_recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'interrupted' | 'paste_failed' | 'copied' | 'clipboard_warning' | 'feedback_prompt' | 'repair_input' | 'repair_processing' | 'repair_proposal' | 'repair_applying' | 'repair_done' | 'repair_error';
+  const isCancelLike = (s: PillState) => s === 'cancelled' || s === 'interrupted';
   type RepairProposal = { id: number; summary: string; scope: string };
   let state: PillState = 'idle';
   let errorMsg = '';
@@ -651,6 +652,7 @@
         } else if (
           incoming === 'error' ||
           incoming === 'cancelled' ||
+          incoming === 'interrupted' ||
           incoming === 'paste_failed' ||
           incoming === 'copied'
         ) {
@@ -718,6 +720,7 @@
         state = incoming;
         void setPillInteractive(
           incoming === 'cancelled' ||
+          incoming === 'interrupted' ||
           incoming === 'paste_failed' ||
           incoming === 'copied' ||
           incoming === 'repair_input' ||
@@ -785,16 +788,16 @@
           errScroll = false;
         }
 
-        if (state === 'cancelled') {
+        if (isCancelLike(state)) {
           cancelOpen = false;
           showCancelBtn = false;
           requestAnimationFrame(() => {
-            if (state === 'cancelled') cancelOpen = true;
+            if (isCancelLike(state)) cancelOpen = true;
           });
           if (cancelBtnTimer) clearTimeout(cancelBtnTimer);
           cancelBtnTimer = setTimeout(() => {
             cancelBtnTimer = null;
-            if (state === 'cancelled') showCancelBtn = true;
+            if (isCancelLike(state)) showCancelBtn = true;
           }, 200);
           if (cancelDismissTimer) clearTimeout(cancelDismissTimer);
           cancelDismissTimer = setTimeout(() => {
@@ -802,7 +805,7 @@
             // Just hide the toast — the capture itself stays resumable from
             // Home for the full backend window. Only the explicit dismiss
             // button actually discards it (see dismissCancelled()).
-            if (state === 'cancelled') goIdle();
+            if (isCancelLike(state)) goIdle();
           }, 10000);
         } else {
           if (cancelBtnTimer) {
@@ -909,7 +912,7 @@
       // *another* window (Home's banner) — if this toast is still showing,
       // it's now stale, so drop it without re-invoking dismiss.
       const l4 = await listen('verenu:cancelled-capture-cleared', () => {
-        if (state === 'cancelled') goIdle();
+        if (isCancelLike(state)) goIdle();
       });
       if (!mounted) { l4(); return; }
       unlisteners.push(l4);
@@ -1340,14 +1343,14 @@
       {/if}
     </div>
 
-  {:else if state === 'cancelled'}
-    <div class="pill cancelled" class:cancel-open={cancelOpen} class:dying={dying}>
+  {:else if isCancelLike(state)}
+    <div class="pill cancelled" class:interrupted={state === 'interrupted'} class:cancel-open={cancelOpen} class:dying={dying}>
       <button class="hf-btn cancel" onclick={dismissCancelled} aria-label="Dismiss">
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
           <path d="M6 6l12 12M6 18 18 6"/>
         </svg>
       </button>
-      <span class="cancel-text">Cancelled</span>
+      <span class="cancel-text">{state === 'interrupted' ? 'Interrupted' : 'Cancelled'}</span>
       {#if showCancelBtn}
         <button class="hf-btn confirm" onclick={continueCancelled} aria-label="Undo — keep recording">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
@@ -2113,6 +2116,9 @@
   .pill.cancelled.cancel-open {
     width: 158px;
     padding: 0 8px;
+  }
+  .pill.cancelled.interrupted.cancel-open {
+    width: 172px;
   }
   .cancel-text {
     font-size: 11.5px; font-weight: 500;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1398,6 +1398,8 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       // (as the shared case below does) crashes the history list, which
       // reads entry.created_at. See get_history_apps for the app filter list.
       return [] as T;
+    case 'get_cancelled_capture':
+      return null as T;
     case 'get_recent_auto_learn_activity':
     case 'get_microphones':
     case 'get_recent_logs':

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -22,7 +22,7 @@
   let failedEntry: { created_at: string } | null = null;
   let retrying = false;
   let failedTimer: ReturnType<typeof setTimeout> | null = null;
-  let cancelledEntry: { created_at: string } | null = null;
+  let cancelledEntry: { created_at: string; kind: 'cancelled' | 'interrupted' } | null = null;
   let resumingCancelled = false;
   let cancelledTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -208,6 +208,20 @@
       .then(hk => { if (hk?.length === 2) hotkey = hk; })
       .catch(() => { /* use platform default if setting unavailable */ });
     load();
+    invoke<{ created_at: string; kind: string } | null>('get_cancelled_capture')
+      .then((pending) => {
+        if (!pending) return;
+        cancelledEntry = {
+          created_at: pending.created_at,
+          kind: pending.kind === 'interrupted' ? 'interrupted' : 'cancelled',
+        };
+        if (cancelledTimer) clearTimeout(cancelledTimer);
+        cancelledTimer = setTimeout(() => {
+          cancelledEntry = null;
+          cancelledTimer = null;
+        }, 10 * 60 * 1000);
+      })
+      .catch(() => {});
 
     let mounted = true;
     const unlisteners: (() => void)[] = [];
@@ -248,8 +262,11 @@
       }, 10 * 60 * 1000);
     }));
 
-    trackListener(listen<string>('verenu:cancelled-capture', (ev) => {
-      cancelledEntry = { created_at: ev.payload };
+    trackListener(listen<{ created_at: string; kind?: string }>('verenu:cancelled-capture', (ev) => {
+      cancelledEntry = {
+        created_at: ev.payload.created_at,
+        kind: ev.payload.kind === 'interrupted' ? 'interrupted' : 'cancelled',
+      };
       if (cancelledTimer) clearTimeout(cancelledTimer);
       cancelledTimer = setTimeout(() => {
         cancelledEntry = null;

--- a/src/lib/views/home/HistoryList.svelte
+++ b/src/lib/views/home/HistoryList.svelte
@@ -11,7 +11,7 @@
 
   export let recents: Entry[];
   export let failedEntry: { created_at: string } | null;
-  export let cancelledEntry: { created_at: string } | null;
+  export let cancelledEntry: { created_at: string; kind?: 'cancelled' | 'interrupted' } | null;
   export let loading: boolean;
   export let historyError = '';
   export let onRetryHistory: () => void = () => {};
@@ -373,7 +373,11 @@
           transition:fly={{ y: -10, duration: motionMs(400), easing: expoOut }}
         >
           <div class="day-time">{fmtTime(cancelledEntry.created_at)}</div>
-          <div class="day-text error-msg">You cancelled a recording — pick it back up?</div>
+          <div class="day-text error-msg">
+            {cancelledEntry.kind === 'interrupted'
+              ? 'A dictation was interrupted — pick it back up?'
+              : 'You cancelled a recording — pick it back up?'}
+          </div>
           <div class="row-actions">
             <button
               class="retry-btn"


### PR DESCRIPTION
﻿## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Recording audio and cancelled/retry captures lived only in process RAM
> - A crash, force-quit, or reboot wiped in-progress dictations with no recovery path
> - Continue already existed for in-session cancels; crash recovery needs the same UX after restart
> - This pull request adds an always-on disk spool and restores interrupted takes as Continue/Dismiss
> - The benefit is that spoken audio survives process death without auto-pasting into the wrong window

## What Changed

- Added `pipeline/failover.rs`: append-only 16 kHz PCM spool with session ids, torn-write clamping, live vs committed slots, and 24h restore
- Wired live checkpoints into the audio worker for hold-to-talk and hands-free only
- Commit on cancel/processing; delete after history insert, dismiss, or expiry
- Startup restore plus Interrupted pill/Home banner; `get_cancelled_capture` for mount races
- Resume keeps committed audio until the new live seed is durable
- Documented the spool in `DATA_AND_PRIVACY.md` and Unreleased changelog

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` (623 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml failover` (12 passed)
- `npm run check`
- Manual: hands-free dictation, kill Verenu, relaunch, Interrupted Continue restored the take

## Risks

- Local AppData now briefly holds in-progress audio (deleted on success/dismiss/24h; not synced/backed up)
- Resume/start failure paths must not delete the only remaining copy (covered by unit tests)
- Line-ending / parallel-branch churn around GitButler made packaging this PR noisy; review the failover module and wiring carefully

## Model Used

- xAI Grok 4.6 (Grok Build / tool use)

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [x] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791094678&installation_model_id=432577&pr_number=344&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F344&signature=0401758655481cc97aba425d58df7323570638a6bd900cf165dc38e6781a591d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->