### PR TITLE
Reduce idle work and dictation memory retention

### DIFF
--- a/docs/efficiency-pass-2026-09.md
+++ b/docs/efficiency-pass-2026-09.md
@@ -1,0 +1,85 @@
+# Efficiency pass, September 2026
+
+The local checkout was the reference, including its in-progress durable audio recovery and settings work. This pass follows `transcription-ram-reliability-plan.md`. It adds no runtime dependencies, changes no controls or styles, and leaves microphone gain, denoising, resampling mathematics, quality gates, provider fallbacks, and injection order intact.
+
+## Before and after
+
+Polling rates below exclude initial loads, explicit user actions, and backend events. Completion-based scheduling also prevents requests accumulating behind a slow backend.
+
+| Work | Before | After |
+| --- | --- | --- |
+| Idle sync reconciliation, when sync is enabled | 60 IPC requests/minute | 2/minute, a 96.7% reduction |
+| Visible active pairing | 1-second polling plus events | Same cadence plus events; concurrent event refreshes coalesce |
+| Hidden sync | 1-second fallback | 30-second fallback; incoming pairing events still refresh immediately |
+| Sidebar memory diagnostic while hidden | 12 process-tree measurements/minute | 0; immediate refresh on return |
+| Sidebar while visible | 5-second interval | Same nominal cadence, no overlapping requests |
+| Insights while visible | 6 fallback database queries/minute | 1/minute, an 83.3% reduction; dictation events still refresh immediately |
+| Insights while hidden | 6 fallback queries/minute plus dictation events | No periodic queries or dictation-triggered queries; reconciles on return |
+| Mounted macOS permission view while hidden | Up to 40 snapshots/minute | 0 periodic snapshots; visible 1.5-second checks and explicit permission actions remain |
+| Connectivity | Visible 60-second checks; startup check even if hidden | Same visible cadence and failure-event rechecks; hidden startup polling suspended; overlapping checks suppressed |
+| Unused service health | One startup request, then 3/hour, plus opt-in check | Removed automatic work; backend diagnostic command remains available |
+| Sync worker with no discovered devices | Peer database query every 5 seconds | Returns before querying the database |
+| Icon cache retention | Unbounded module-level maps | Each cache limited to 128 entries and 4 MiB of resolved string data, using conservative UTF-16 accounting |
+| Expired retry/resume audio | Retained until a later user action or replacement | Released by the existing 30-second maintenance loop after the 10-minute window |
+
+The icon limits concern cache-owned references. Visible components and in-flight requests can still own images independently. Eviction does not blank mounted icons. Negative results remain cached while resident, and recently used entries survive preferentially.
+
+Sync is already opt-in in this checkout. The sync reductions do not apply to users who have it disabled. Listeners register before the initial status reconstruction, and a 30-second fallback remains even while hidden. A missed idle pairing event can therefore take up to 30 seconds to recover instead of one second. Once visible pairing is known, the fast cadence resumes.
+
+## Audio allocation measurements
+
+A deterministic Rust fixture encodes 60 seconds of synthetic 16 kHz audio with the previous grow-from-empty WAV allocation and the new allocation. Both outputs are byte-identical and round-trip through hound.
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| WAV vector capacity | 2,883,584 bytes | 1,920,044 bytes |
+| Live sample/WAV buffer capacity during stop at 16 kHz, excluding the capture queue | 10,563,584 bytes | 5,760,044 bytes |
+
+The second row is a 45.5% reduction in these buffers, not a claim about total process RAM. At 16 kHz the input allocation moves into the result instead of being cloned. Other input rates retain the same resampling output, tested at 8, 16, 44.1, 48, and 96 kHz, and release the native-rate buffer before WAV encoding. During resampling at other rates, input and output still overlap.
+
+The 320,000-sample queue retains its existing capacity and backpressure behavior. It now drops before output allocation once the callback and worker stop. Its sample payload alone is 1,280,000 bytes, excluding queue bookkeeping. Failed stream construction, unsupported formats, and playback startup failures now stop and join the processing worker instead of leaving it polling every 2 ms with its queue and optional recovery sink retained.
+
+Expired capture cleanup drops only the state's audio references. A live pipeline's shared `Arc`/`Bytes` owners remain valid. Small expiry metadata remains so retry errors and recovery bookkeeping keep their existing behavior. The recovery files are not deleted by this maintenance operation.
+
+## Other investigations
+
+- `system/memory.rs` measures the process tree, so suspending the hidden sidebar avoids both IPC and native enumeration. RAM/VRAM pressure probes already run only while a local model is loaded. Manual resource diagnostics remain on demand.
+- Local STT and LLM idle unloading already skips unloaded models. LLM request admission protects active cleanup. STT drops its engine and LLM stops its child server. Their memory policies and 30-second pressure checks remain unchanged to preserve model readiness and safety behavior.
+- Audio capture keeps its native-rate processed buffer and 2 ms worker wait during recording. Changing buffering, worker wakeups, denoising, or streaming resampling would need native device and long-recording measurements. The startup failure leak is fixed without changing the capture callback.
+- `CapturedAudio` already shares WAV bytes and 16 kHz samples across retries and parallel transcription. Those clones are reference-counted handles. Successful finalization clears the matching retry slot; expired unsuccessful/cancelled slots were the remaining retention gap addressed here.
+- Auto-learn monitors have a bounded 60-second lifetime and per-session deduplication. Concurrent monitors intentionally preserve corrections from separate dictations. Event hooks have fallback polling. Their timing is unchanged because reducing it could miss corrections.
+- Sync's listener blocks on incoming connections; its five-second worker preserves discovery, retry backoff, and change reconciliation. Only the no-target database work was removed.
+- Home history remains paginated, with the backend page limit clamped to 1–500. The unbounded `query_recent` entrypoint is used by the test fixture, not Home.
+- Insights streams text rows but builds a vocabulary map for exact unique-word counts and ranking. It now moves strings from that map into the ranking vector instead of duplicating the complete vocabulary. SQL date semantics and exact analytics remain unchanged; the larger saving comes from fewer refreshes.
+- Cleanup cache entries live in SQLite, have expiry/inactivity rules, and are pruned at startup. This is not an in-memory whole-history cache. No schema or cache-key behavior changed.
+- Provider model catalog caching has freshness/retry rules. Download/model listener registration already protects against late unlisten promises and remounts. These remain unchanged.
+- The logger ring is limited to 1,000 entries. Silero VAD creates its inference object within the per-recording analysis call; its static state is the embedded model and staged path, not retained session audio. No new logs contain dictated text or private content.
+- Provider-status checks stay at five minutes and automatic updates at six hours. Both can notify users while the window is hidden, so suspending them would change behavior. The separate API-health value had no readers and no UI.
+- Route imports and frontend dependencies are unchanged. Lazy-loading views could trade startup work for first-navigation latency; that tradeoff was not justified by this pass's measurements.
+
+## Verification
+
+- Frontend unit tests: 101 passed, including polling visibility, slow requests, trailing event reconciliation, disposal, error recovery, adaptive intervals, bounded icon-cache eviction, and sync listener startup/hidden pairing/late-registration cleanup.
+- `npm run check`: zero errors and warnings; macOS identity contract passed.
+- Production build passed from the resolved checkout path. It retains the existing large-chunk warning.
+- Audio tests: 7 passed, including worker cleanup, sample equivalence, WAV equivalence/allocation, and existing gain/backpressure tests.
+- Expired capture test passed, including preservation of fresh captures and other live shared owners.
+- Final `npm run test:rust`: 630 passed, 1 failed, 4 ignored. The failure is `api::prompts::tests::every_cleanup_tone_combination_renders_the_actual_contract`, reporting 933 tokens for medium/formal. The prompt files had unrelated edits before this pass and were not changed here.
+- Final `npm test`: 26 passed, 5 failed. Besides the prompt failure, four browser tests timed out during navigation on the development server: content surfaces, element contracts, app mount, and app mappings. An earlier full run had 28 passes and three failures. The onboarding failure from that run passed on the final run.
+- Targeted checks against the production build passed for offline errors, content surfaces, and simulated macOS permissions. These use browser fixtures, not native microphone/TCC calls.
+- Further unchanged smoke tests against the production build passed app mounting and the App Mappings add/remove flow. The element-contract test reached Settings, then timed out looking for a `Microphone` tab. The current app labels this tab `Audio`; neither that UI label nor the frozen test was changed by this pass.
+
+The existing performance test and unchanged baseline passed in the final full run:
+
+| Metric | Measured | Existing budget |
+| --- | ---: | ---: |
+| Navigation visible | 523.04 ms | 2,500 ms |
+| Settings open | 55.80 ms | 900 ms |
+| Section change p95 | 389.80 ms | 650 ms |
+| Settings close | 855.32 ms | 1,000 ms |
+| Tasks over 50 ms | 1 | 4 |
+| Uncaught errors | 0 | 0 |
+
+The same test against the production build also passed: 85.55/44.69/396.38/849.77 ms respectively, zero long tasks and errors. Those timings are from a different serving environment and are not a before/after startup speed claim. The pre-edit browser measurement was blocked by a missing Chromium executable, which was subsequently installed. Repeated dev-server runs also encountered navigation stalls. Launching the build through the `G:\Verenu` alias produced an emitted-HTML path error; building from the resolved checkout path passed.
+
+No controlled native idle-RAM, OS wakeup, real microphone, or macOS hardware run was performed. Allocation capacities and deterministic polling tests establish the reductions above; native process working set, capture under device backpressure, and installed macOS permission behavior remain manual verification limits. Smoke tests and performance budgets were not edited.

--- a/src-tauri/src/data/db/insights.rs
+++ b/src-tauri/src/data/db/insights.rs
@@ -687,19 +687,17 @@ fn query_words(
         }
     }
 
+    let unique_words = counts.len() as i64;
     let mut top: Vec<InsightsWordCount> = counts
-        .iter()
-        .map(|(word, count)| InsightsWordCount {
-            word: word.clone(),
-            count: *count,
-        })
+        .into_iter()
+        .map(|(word, count)| InsightsWordCount { word, count })
         .collect();
     top.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.word.cmp(&b.word)));
     top.truncate(TOP_WORDS_LIMIT);
 
     Ok(InsightsWords {
         top,
-        unique_words: counts.len() as i64,
+        unique_words,
         longest_word: longest,
         avg_word_length: if length_count > 0 {
             length_sum as f64 / length_count as f64

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -277,10 +277,12 @@ fn main() {
             }
             let local_stt_manager = local_transcription_manager.clone();
             let local_llm_manager = local_cleanup_manager.clone();
+            let capture_state = shared.clone();
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    pipeline::release_expired_capture_audio(&capture_state);
                     // && (not ||): either manager signalling shutdown on its
                     // own must not stop monitoring the other still-active one.
                     if local_stt_manager

--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -185,6 +185,29 @@ pub struct RecordingResult {
     pub truncated: bool,
 }
 
+// Stream setup can fail after the processing thread starts. Always stop and
+// join it, including those early returns, so its queue and recovery sink die.
+struct ProcessingWorker {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<(Vec<f32>, bool, f32)>>,
+}
+
+impl ProcessingWorker {
+    fn finish(mut self) -> std::thread::Result<(Vec<f32>, bool, f32)> {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.take().expect("processing worker handle").join()
+    }
+}
+
+impl Drop for ProcessingWorker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 impl RecordingSession {
     pub fn start(device_name: Option<String>, noise_reduction: bool, gain: f32) -> Result<Self> {
         let host = cpal::default_host();
@@ -312,6 +335,10 @@ impl RecordingSession {
                 };
                 (processed, recording_truncated, raw_rms)
             });
+            let worker = ProcessingWorker {
+                stop: Arc::clone(&stop_processing),
+                handle: Some(worker),
+            };
 
             let level_cb = Arc::clone(&level_w);
             let queue_cb = Arc::clone(&queue);
@@ -381,7 +408,7 @@ impl RecordingSession {
             raw_level_w.store(0f32.to_bits(), Ordering::Relaxed);
             stop_processing.store(true, Ordering::Relaxed);
 
-            let (data, recording_truncated, raw_rms) = match worker.join() {
+            let (data, recording_truncated, raw_rms) = match worker.finish() {
                 Ok(samples) => samples,
                 Err(_) => {
                     let _ =
@@ -389,6 +416,9 @@ impl RecordingSession {
                     return;
                 }
             };
+            // The callback and worker have both stopped. Release the bounded
+            // capture queue before allocating transcription output.
+            drop(queue);
 
             let dropped = dropped_samples.load(Ordering::Relaxed);
             if dropped > 0 {
@@ -397,7 +427,7 @@ impl RecordingSession {
 
             let dur_ms = data.len() as u64 * 1000 / sample_rate as u64;
             let overall_rms = rms_f32(&data);
-            let (encode_data, encode_rate) = resample_to_16k(&data, sample_rate);
+            let (encode_data, encode_rate) = resample_owned_to_16k(data, sample_rate);
             let result = encode_wav(&encode_data, encode_rate, 1).map(|wav| RecordingResult {
                 wav,
                 samples_16k: encode_data,
@@ -570,6 +600,14 @@ fn resample_to_16k(mono: &[f32], sample_rate: u32) -> (Vec<f32>, u32) {
     (resampled, TARGET)
 }
 
+fn resample_owned_to_16k(mono: Vec<f32>, sample_rate: u32) -> (Vec<f32>, u32) {
+    if sample_rate == 16_000 {
+        return (mono, 16_000);
+    }
+    // Dropping the native-rate input here prevents it overlapping WAV encoding.
+    resample_to_16k(&mono, sample_rate)
+}
+
 pub(crate) fn rms_f32(data: &[f32]) -> f32 {
     if data.is_empty() {
         return 0.0;
@@ -587,7 +625,9 @@ pub(crate) fn encode_wav(samples: &[f32], sample_rate: u32, channels: u16) -> Re
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
     };
-    let mut buf = std::io::Cursor::new(Vec::new());
+    // PCM16 payload plus hound's 44-byte PCM header. Avoid geometric growth
+    // and its unused retained capacity in every completed recording.
+    let mut buf = std::io::Cursor::new(Vec::with_capacity(44 + samples.len() * 2));
     let mut writer = hound::WavWriter::new(&mut buf, spec)?;
     for &s in samples {
         writer.write_sample((clamp_unit_sample(s) * i16::MAX as f32) as i16)?;
@@ -604,6 +644,82 @@ mod tests {
     };
     use crossbeam_queue::ArrayQueue;
     use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+    #[test]
+    fn failed_stream_setup_stops_and_joins_processing_worker() {
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_stop = stop.clone();
+        let retained = std::sync::Arc::new(vec![0.0f32; 320_000]);
+        let worker_retained = retained.clone();
+        let worker = super::ProcessingWorker {
+            stop,
+            handle: Some(std::thread::spawn(move || {
+                while !worker_stop.load(Ordering::Relaxed) {
+                    std::thread::yield_now();
+                }
+                drop(worker_retained);
+                (Vec::new(), false, 0.0)
+            })),
+        };
+        drop(worker);
+        assert_eq!(std::sync::Arc::strong_count(&retained), 1);
+    }
+
+    #[test]
+    fn owned_resampling_preserves_samples_and_reuses_16k_allocation() {
+        for rate in [8_000, 16_000, 44_100, 48_000, 96_000] {
+            let input: Vec<f32> = (0..rate).map(|i| (i as f32 * 0.01).sin()).collect();
+            let original_ptr = input.as_ptr();
+            let expected = super::resample_to_16k(&input, rate);
+            let actual = super::resample_owned_to_16k(input, rate);
+            assert_eq!(actual, expected);
+            if rate == 16_000 {
+                assert_eq!(actual.0.as_ptr(), original_ptr);
+            }
+        }
+    }
+
+    #[test]
+    fn wav_allocation_matches_pcm_payload_and_round_trips() {
+        let samples = vec![0.5; 16_000 * 60];
+        let wav = super::encode_wav(&samples, 16_000, 1).unwrap();
+        // Reproduce the previous grow-from-empty allocation on this fixture.
+        let mut legacy = std::io::Cursor::new(Vec::new());
+        let mut writer = hound::WavWriter::new(
+            &mut legacy,
+            hound::WavSpec {
+                channels: 1,
+                sample_rate: 16_000,
+                bits_per_sample: 16,
+                sample_format: hound::SampleFormat::Int,
+            },
+        )
+        .unwrap();
+        for &sample in &samples {
+            writer
+                .write_sample((sample * i16::MAX as f32) as i16)
+                .unwrap();
+        }
+        writer.finalize().unwrap();
+        let legacy = legacy.into_inner();
+        assert_eq!(wav, legacy);
+        println!(
+            "60s PCM16 WAV capacity bytes: before={} after={}",
+            legacy.capacity(),
+            wav.capacity()
+        );
+        println!(
+            "60s 16k stop live buffer bytes excluding queue: before={} after={}",
+            samples.capacity() * 4 * 2 + legacy.capacity(),
+            samples.capacity() * 4 + wav.capacity()
+        );
+        assert_eq!(wav.len(), 44 + samples.len() * 2);
+        assert_eq!(wav.capacity(), wav.len());
+        let reader = hound::WavReader::new(std::io::Cursor::new(wav)).unwrap();
+        assert_eq!(reader.spec().sample_rate, 16_000);
+        assert_eq!(reader.duration() as usize, samples.len());
+        assert!(reader.into_samples::<i16>().all(|s| s.unwrap() == 16383));
+    }
 
     #[test]
     fn push_overwrite_drops_oldest_when_queue_is_full() {

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -236,6 +236,31 @@ pub fn clear_cancelled_capture(state: &SharedState) {
     }
 }
 
+/// Expiry must release audio even if the user never invokes Retry or Resume.
+/// Keep the small metadata record so existing expired-retry errors and durable
+/// recovery bookkeeping retain their semantics. Other live owners keep their
+/// Arc/Bytes handles, so an in-flight pipeline is unaffected.
+pub fn release_expired_capture_audio(state: &SharedState) {
+    fn release(audio: &mut CapturedAudio) {
+        if !audio.wav.is_empty() || !audio.samples_16k.is_empty() {
+            audio.wav = bytes::Bytes::new();
+            audio.samples_16k = Arc::new(Vec::new());
+        }
+    }
+    if let Ok(mut st) = lock_state(state) {
+        if let Some(retry) = st.retry_capture.as_mut() {
+            if retry.captured_at.elapsed() > RETRY_WINDOW {
+                release(&mut retry.audio);
+            }
+        }
+        if let Some(cancelled) = st.cancelled_capture.as_mut() {
+            if cancelled.captured_at.elapsed() >= CANCEL_RESUME_WINDOW {
+                release(&mut cancelled.audio);
+            }
+        }
+    }
+}
+
 /// Attaches `audio` as the prepend audio of an already-reserved `Starting`
 /// lifecycle (see `commands::recording::resume_cancelled_capture`).
 pub fn set_starting_prepend_audio(state: &SharedState, audio: CapturedAudio) {
@@ -768,6 +793,55 @@ mod tests {
         }
         clear_cancelled_capture(&state);
         assert!(lock_state(&state).unwrap().cancelled_capture.is_none());
+    }
+
+    #[test]
+    fn expired_audio_is_released_without_consuming_fresh_or_live_owners() {
+        let state = fresh_state();
+        let audio = fake_audio(500);
+        let live_owner = audio.samples_16k.clone();
+        {
+            let mut st = lock_state(&state).unwrap();
+            st.cancelled_capture = Some(CancelledCapture {
+                audio: audio.clone(),
+                captured_at: std::time::Instant::now(),
+                id: "expiry-test".into(),
+                origin: CaptureOrigin::UserCancelled,
+                created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
+                started_at_unix: 0,
+            });
+            st.retry_capture = Some(RetryCapture {
+                audio,
+                captured_at: std::time::Instant::now()
+                    - RETRY_WINDOW
+                    - std::time::Duration::from_secs(1),
+                target: WindowTarget::default(),
+                process_name: String::new(),
+                context_id: 1,
+                profile: String::new(),
+                app_context: None,
+                caps_lock_on: false,
+            });
+        }
+        release_expired_capture_audio(&state);
+        {
+            let mut st = lock_state(&state).unwrap();
+            assert!(st
+                .retry_capture
+                .as_ref()
+                .unwrap()
+                .audio
+                .samples_16k
+                .is_empty());
+            let capture = st.cancelled_capture.as_mut().unwrap();
+            assert_eq!(capture.audio.samples_16k.len(), 16);
+            capture.captured_at = std::time::Instant::now() - CANCEL_RESUME_WINDOW;
+        }
+        release_expired_capture_audio(&state);
+        assert_eq!(Arc::strong_count(&live_owner), 1);
+        assert_eq!(live_owner.len(), 16);
+        assert!(peek_cancelled_capture_if_fresh(&state).is_none());
+        assert!(lock_state(&state).unwrap().retry_capture.is_some());
     }
 
     #[test]

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -1160,6 +1160,11 @@ impl SyncManager {
                 Ok(map) => map.values().cloned().collect::<Vec<_>>(),
                 Err(_) => return,
             };
+            // No possible targets: avoid opening/querying the peer database
+            // every five seconds on machines with no discovered devices.
+            if discovered.is_empty() {
+                return;
+            }
             let paired = paired_set(conn_peers(&self.inner.db));
             let backoff = match self.inner.backoff.lock() {
                 Ok(b) => b,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,11 +18,12 @@
   import Setup from './lib/views/Setup.svelte';
   import { getVersion, invoke, isTauriRuntime, listen } from './lib/tauri';
   import { startAutomaticUpdateChecks } from './lib/updates';
+  import { startPolling } from './lib/polling';
   import { startLocalSttListeners } from './lib/localSttStore.svelte';
   import { startLocalLlmListeners } from './lib/localLlmStore.svelte';
   import { startDownloadManagerListeners } from './lib/downloadManager.svelte';
   import { refreshTranscriptionModel } from './lib/transcriptionModelStore.svelte';
-  import { startProviderStatusChecks, startApiHealthChecks } from './lib/serviceStatus';
+  import { startProviderStatusChecks } from './lib/serviceStatus';
   import { classifyIpcError, settingsSectionForKind, type ErrorKind } from './lib/errors';
   import type { SettingsSectionId } from './lib/settingsSections';
   import { scrollEdges } from './lib/scrollFade';
@@ -116,12 +117,17 @@
     prevSetupComplete = complete;
   });
 
+  let connectivityInFlight = false;
   async function pingConnectivity() {
+    if (connectivityInFlight) return;
+    connectivityInFlight = true;
     try {
       const online = await invoke<boolean>('check_connectivity');
       appStore.isOnline = online;
     } catch {
       appStore.isOnline = false;
+    } finally {
+      connectivityInFlight = false;
     }
   }
 
@@ -165,7 +171,6 @@
     let stopLocalLlmListeners: (() => void) | undefined;
     let stopDownloadManagerListeners: (() => void) | undefined;
     let stopProviderStatusChecks: (() => void) | undefined;
-    let stopApiHealthChecks: (() => void) | undefined;
     let stopSyncListeners: (() => void) | undefined;
     let stopTitleBarMetricsListener: (() => void) | undefined;
 
@@ -278,7 +283,6 @@
       stopLocalLlmListeners = startLocalLlmListeners();
       stopDownloadManagerListeners = startDownloadManagerListeners();
       stopProviderStatusChecks = startProviderStatusChecks();
-      stopApiHealthChecks = startApiHealthChecks();
     } catch (error) {
       console.error('Failed to start listeners and status checks:', error);
     }
@@ -298,16 +302,7 @@
     };
     media?.addEventListener?.('change', onSystemThemeChange);
 
-    pingConnectivity();
-    let connectivityTimer = setInterval(pingConnectivity, 60_000);
-    const handleVisibility = () => {
-      clearInterval(connectivityTimer);
-      if (!document.hidden) {
-        pingConnectivity();
-        connectivityTimer = setInterval(pingConnectivity, 60_000);
-      }
-    };
-    document.addEventListener('visibilitychange', handleVisibility);
+    const connectivityPoll = startPolling(pingConnectivity, 60_000);
 
     return () => {
       mounted = false;
@@ -320,12 +315,10 @@
       if (stopLocalLlmListeners) stopLocalLlmListeners();
       if (stopDownloadManagerListeners) stopDownloadManagerListeners();
       if (stopProviderStatusChecks) stopProviderStatusChecks();
-      if (stopApiHealthChecks) stopApiHealthChecks();
       if (stopSyncListeners) stopSyncListeners();
       if (stopTitleBarMetricsListener) stopTitleBarMetricsListener();
       media?.removeEventListener?.('change', onSystemThemeChange);
-      clearInterval(connectivityTimer);
-      document.removeEventListener('visibilitychange', handleVisibility);
+      connectivityPoll.stop();
     };
   });
 </script>

--- a/src/lib/components/AppIcon.svelte
+++ b/src/lib/components/AppIcon.svelte
@@ -1,21 +1,17 @@
 <script lang="ts" module>
   import { invoke } from '../tauri';
   import { normalizeExe } from '../appMappings';
+  import { createIconCache } from '../iconCache';
 
   // Module-level so every AppIcon instance across the app shares one fetch
   // per exe — Contexts' picker/rows and AppMappingsEditor's rows all resolve
   // the same handful of icons without re-invoking the native extractor.
-  const iconCache = new Map<string, Promise<string | null>>();
+  const iconCache = createIconCache();
 
   function loadIcon(exe: string): Promise<string | null> {
     if (exe.startsWith('?::')) return Promise.resolve(null);
     const key = normalizeExe(exe);
-    let pending = iconCache.get(key);
-    if (!pending) {
-      pending = invoke<string | null>('get_app_icon', { exe: key }).catch(() => null);
-      iconCache.set(key, pending);
-    }
-    return pending;
+    return iconCache.get(key, () => invoke<string | null>('get_app_icon', { exe: key }));
   }
 </script>
 

--- a/src/lib/components/MacPermissions.svelte
+++ b/src/lib/components/MacPermissions.svelte
@@ -3,6 +3,7 @@
   import { fly, slide } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { invoke, listen } from '../tauri';
+  import { startPolling } from '../polling';
   import { isMac } from '../platform';
   import { motionMs } from '../motion';
   import { extractIpcErrorMessage } from '../errors';
@@ -110,7 +111,7 @@
   let restarting = $state(false);
 
   let accessibilityActionTaken = $state(false);
-  let watchInterval: ReturnType<typeof setInterval> | null = null;
+  let permissionPoll: ReturnType<typeof startPolling> | null = null;
   let restartTimeout: ReturnType<typeof setTimeout> | null = null;
   let refreshAnimationTimeout: ReturnType<typeof setTimeout> | null = null;
   let unlistenError: (() => void) | null = null;
@@ -272,21 +273,19 @@
 
   function startWatch() {
     if (!isMac) return;
-    if (watchInterval !== null) return;
-    watchInterval = setInterval(async () => {
+    if (permissionPoll !== null) return;
+    permissionPoll = startPolling(async () => {
       // Do not let a passive poll race an explicit native permission prompt.
       // The prompt handlers own the next snapshot generation and will apply
       // their post-request result when the OS callback completes.
       if (permissionsLoading || accessibilityPrompting || microphoneRequesting || notificationRequesting) return;
       await refreshMacPermissions(true);
-    }, WATCH_INTERVAL_MS);
+    }, WATCH_INTERVAL_MS, { immediate: false });
   }
 
   function stopWatch() {
-    if (watchInterval !== null) {
-      clearInterval(watchInterval);
-      watchInterval = null;
-    }
+    permissionPoll?.stop();
+    permissionPoll = null;
   }
 
   function looksLikePermissionError(message: string): boolean {

--- a/src/lib/components/SiteIcon.svelte
+++ b/src/lib/components/SiteIcon.svelte
@@ -29,14 +29,7 @@
   function loadSiteIcon(domain: string): Promise<string | null> {
     const host = normalizeHost(domain);
     if (!host) return Promise.resolve(null);
-    let pending = siteIconCache.get(host);
-    if (!pending) {
-      // A rejected/failed lookup stays cached as `null` — no retry storm on a
-      // site that simply has no reachable icon.
-      pending = invoke<string | null>('get_site_icon', { domain: host }).catch(() => null);
-      siteIconCache.set(host, pending);
-    }
-    return pending;
+    return siteIconCache.get(host, () => invoke<string | null>('get_site_icon', { domain: host }));
   }
 </script>
 

--- a/src/lib/components/SiteIcon.svelte
+++ b/src/lib/components/SiteIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" module>
   import { invoke } from '../tauri';
+  import { createIconCache } from '../iconCache';
 
   /**
    * Favicons are resolved by the backend (`get_site_icon`) rather than loaded
@@ -12,7 +13,7 @@
    * dedup on top, so a sidebar full of rows referencing the same site issues
    * one call, and remounting a row costs nothing.
    */
-  const siteIconCache = new Map<string, Promise<string | null>>();
+  const siteIconCache = createIconCache();
 
   /** Mirrors `normalize_favicon_host` in src-tauri/src/system/icons.rs. */
   function normalizeHost(input: string): string {

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { invoke } from '../../tauri';
+  import { startPolling } from '../../polling';
   import { appStore } from '../../stores';
   import { icons } from '../../icons';
   import { isMac, isWindows } from '../../platform';
@@ -42,21 +43,19 @@
   let memoryMb = tweened(0, { duration: motionMs(800), easing: expoOut });
 
   onMount(() => {
+    let active = true;
     const refresh = async () => {
       try {
         const next = await invoke<number>('get_memory_mb');
-        if (next !== rawMemoryMb) {
+        if (active && next !== rawMemoryMb) {
           memoryDir = next > rawMemoryMb ? 1 : -1;
           rawMemoryMb = next;
           memoryMb.set(next);
         }
       } catch { /* dev mode */ }
     };
-    refresh();
-    // A footer diagnostic, not live telemetry: 5s keeps the number honest
-    // while halving the IPC + tween churn of the old 2s cadence.
-    const id = setInterval(refresh, 5000);
-    return () => clearInterval(id);
+    const poll = startPolling(refresh, 5000);
+    return () => { active = false; poll.stop(); };
   });
 
   const HOME_NAV_ITEMS = [

--- a/src/lib/iconCache.test.ts
+++ b/src/lib/iconCache.test.ts
@@ -1,0 +1,41 @@
+import { expect, it, vi } from 'vitest';
+import { createIconCache } from './iconCache';
+
+it('deduplicates pending icons and retains negative results', async () => {
+  const cache = createIconCache();
+  const load = vi.fn(async () => { throw new Error('missing'); });
+  const first = cache.get('a', load);
+  expect(cache.get('a', load)).toBe(first);
+  expect(await first).toBeNull();
+  expect(await cache.get('a', load)).toBeNull();
+  expect(load).toHaveBeenCalledTimes(1);
+});
+
+it('evicts least recently used entries under the count and string budgets', async () => {
+  const cache = createIconCache(2, 12);
+  const load = vi.fn(async () => 'abc');
+  const first = cache.get('a', load);
+  await first;
+  await cache.get('b', load);
+  expect(cache.get('a', load)).toBe(first);
+  await cache.get('c', load);
+  expect(cache.get('a', load)).toBe(first);
+  await cache.get('b', load);
+  expect(load).toHaveBeenCalledTimes(4);
+  const large = vi.fn(async () => 'too large');
+  await cache.get('large', large);
+  await cache.get('large', large);
+  expect(large).toHaveBeenCalledTimes(2);
+});
+
+it('ignores late completion of evicted entries', async () => {
+  const cache = createIconCache(1, 8);
+  let resolve!: (value: string) => void;
+  const old = cache.get('old', () => new Promise<string>((done) => { resolve = done; }));
+  await Promise.resolve();
+  const current = cache.get('current', async () => 'ok');
+  await current;
+  resolve('a very large old icon');
+  await old;
+  expect(cache.get('current', async () => 'unexpected')).toBe(current);
+});

--- a/src/lib/iconCache.ts
+++ b/src/lib/iconCache.ts
@@ -1,0 +1,38 @@
+/** Bound the data-URI strings retained after icon components unmount.
+ * Eviction only removes the cache's reference; mounted icons keep their image.
+ */
+export function createIconCache(maxEntries = 128, maxBytes = 4 * 1024 * 1024) {
+  const entries = new Map<string, { promise: Promise<string | null>; bytes: number }>();
+  let bytes = 0;
+  function trim() {
+    while (entries.size > maxEntries || bytes > maxBytes) {
+      const key = entries.keys().next().value;
+      if (key === undefined) break;
+      bytes -= entries.get(key)!.bytes;
+      entries.delete(key);
+    }
+  }
+  return {
+    get(key: string, load: () => Promise<string | null>): Promise<string | null> {
+      const cached = entries.get(key);
+      if (cached) {
+        entries.delete(key);
+        entries.set(key, cached);
+        return cached.promise;
+      }
+      const entry = { promise: Promise.resolve(null) as Promise<string | null>, bytes: 0 };
+      entry.promise = Promise.resolve().then(load).catch(() => null).then((value) => {
+        if (entries.get(key) === entry) {
+          // UTF-16 is a conservative budget even on engines using Latin-1.
+          entry.bytes = (value?.length ?? 0) * 2;
+          bytes += entry.bytes;
+          trim();
+        }
+        return value;
+      });
+      entries.set(key, entry);
+      trim();
+      return entry.promise;
+    },
+  };
+}

--- a/src/lib/polling.test.ts
+++ b/src/lib/polling.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startPolling } from './polling';
+
+describe('background polling', () => {
+  let doc: EventTarget & { hidden: boolean };
+  beforeEach(() => {
+    vi.useFakeTimers();
+    doc = Object.assign(new EventTarget(), { hidden: false });
+    vi.stubGlobal('document', doc);
+  });
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+  const flush = () => vi.advanceTimersByTimeAsync(0);
+  function hide(hidden: boolean) {
+    doc.hidden = hidden;
+    doc.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  it('suspends hidden diagnostics and immediately reconciles on return', async () => {
+    const refresh = vi.fn(async () => {});
+    const poll = startPolling(refresh, 5000);
+    await flush();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refresh).toHaveBeenCalledTimes(3);
+    hide(true);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refresh).toHaveBeenCalledTimes(3);
+    hide(false);
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(4);
+    poll.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps a slow hidden fallback and accelerates active pairing', async () => {
+    let pairing = false;
+    const refresh = vi.fn(async () => {});
+    const poll = startPolling(refresh, () => pairing ? 1000 : 30_000,
+      { hiddenIntervalMs: 30_000 });
+    await flush();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refresh).toHaveBeenCalledTimes(3);
+    pairing = true;
+    poll.request();
+    await flush();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(refresh).toHaveBeenCalledTimes(7);
+    hide(true);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(refresh).toHaveBeenCalledTimes(8);
+    poll.stop();
+  });
+
+  it('coalesces events during slow requests without losing the last change', async () => {
+    let resolve!: () => void;
+    const refresh = vi.fn(() => new Promise<void>((done) => { resolve = done; }));
+    const poll = startPolling(refresh, 1000);
+    await flush();
+    poll.request(); poll.request(); poll.request();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    resolve();
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(2);
+    poll.stop();
+    resolve();
+    await flush();
+    hide(false);
+    poll.request();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('recovers after rejection and does no hidden startup work', async () => {
+    doc.hidden = true;
+    const refresh = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const poll = startPolling(refresh, 1000);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(refresh).not.toHaveBeenCalled();
+    hide(false);
+    await flush();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    poll.stop();
+    warn.mockRestore();
+  });
+});

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,0 +1,62 @@
+/** Completion-based polling with visibility suspension and one trailing refresh.
+ * Events during a request are reconciled once more so changes cannot be lost.
+ */
+export function startPolling(
+  refresh: () => Promise<unknown>,
+  intervalMs: number | (() => number),
+  options: { hiddenIntervalMs?: number; immediate?: boolean } = {},
+): { request: () => void; stop: () => void } {
+  let stopped = false;
+  let running = false;
+  let pending = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function schedule() {
+    clearTimeout(timer);
+    if (stopped) return;
+    const delay = document.hidden
+      ? options.hiddenIntervalMs
+      : typeof intervalMs === 'function' ? intervalMs() : intervalMs;
+    if (delay !== undefined) timer = setTimeout(request, delay);
+  }
+
+  function request() {
+    if (stopped) return;
+    clearTimeout(timer);
+    if (running) {
+      pending = true;
+      return;
+    }
+    running = true;
+    void Promise.resolve().then(() => stopped ? undefined : refresh()).catch((error) => {
+      console.warn('Background refresh failed:', error);
+    }).finally(() => {
+      running = false;
+      if (stopped) return;
+      if (pending) {
+        pending = false;
+        request();
+      } else {
+        schedule();
+      }
+    });
+  }
+
+  function visibilityChanged() {
+    if (!document.hidden) request();
+    else schedule();
+  }
+  document.addEventListener('visibilitychange', visibilityChanged);
+  if (options.immediate !== false && !document.hidden) request();
+  else schedule();
+
+  return {
+    request,
+    stop() {
+      stopped = true;
+      pending = false;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', visibilityChanged);
+    },
+  };
+}

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -14,9 +14,10 @@ export function startPolling(
   function schedule() {
     clearTimeout(timer);
     if (stopped) return;
-    const delay = document.hidden
-      ? options.hiddenIntervalMs
-      : typeof intervalMs === 'function' ? intervalMs() : intervalMs;
+    let delay = options.hiddenIntervalMs;
+    if (!document.hidden) {
+      delay = typeof intervalMs === 'function' ? intervalMs() : intervalMs;
+    }
     if (delay !== undefined) timer = setTimeout(request, delay);
   }
 

--- a/src/lib/serviceStatus.ts
+++ b/src/lib/serviceStatus.ts
@@ -4,7 +4,6 @@ import { invoke, listen } from './tauri';
 import { ensureNotificationPermission, isNotificationPermissionGranted } from './notifications';
 
 const PROVIDER_STATUS_INTERVAL_MS = 5 * 60 * 1000;
-const API_HEALTH_INTERVAL_MS = 20 * 60 * 1000;
 const SERVICE_CHECKS_SETTING = 'verenu_service_checks_enabled';
 
 let serviceChecksEnabled = true;
@@ -58,7 +57,6 @@ export function setServiceChecksEnabled(enabled: boolean): void {
   // An explicit opt-in should take effect immediately rather than waiting
   // for the next scheduled interval.
   void checkStatus();
-  void checkApiHealth();
 }
 
 export async function checkStatus(): Promise<void> {
@@ -156,26 +154,6 @@ export async function checkStatus(): Promise<void> {
   }
 }
 
-// Health has no UI today — it's polled in the background so the state is
-// already warm for future features that need to know whether api.verenu.com
-// is reachable.
-async function checkApiHealth(): Promise<void> {
-  if (!(await getServiceChecksEnabled())) {
-    appStore.apiHealthy = null;
-    return;
-  }
-
-  try {
-    const healthy = await invoke<boolean>('check_verenu_api_health');
-    appStore.apiHealthy = serviceChecksEnabled ? healthy : null;
-  } catch (error) {
-    // Don't leave a stale prior result in place — a failed check means we no
-    // longer know the current state, not that it's confirmed unhealthy.
-    appStore.apiHealthy = null;
-    console.warn('Verenu API health check failed:', error);
-  }
-}
-
 export function startProviderStatusChecks(): () => void {
   void checkStatus();
   const timer = window.setInterval(() => void checkStatus(), PROVIDER_STATUS_INTERVAL_MS);
@@ -200,10 +178,4 @@ export function startProviderStatusChecks(): () => void {
     window.clearInterval(timer);
     unlistenRecheck?.();
   };
-}
-
-export function startApiHealthChecks(): () => void {
-  void checkApiHealth();
-  const timer = window.setInterval(() => void checkApiHealth(), API_HEALTH_INTERVAL_MS);
-  return () => window.clearInterval(timer);
 }

--- a/src/lib/syncStore.svelte.ts
+++ b/src/lib/syncStore.svelte.ts
@@ -4,6 +4,7 @@
 import { invoke, listen } from './tauri';
 import { fetchSnippets, fetchDictionary } from './stores.svelte';
 import { loadContexts } from './contextsStore.svelte';
+import { startPolling } from './polling';
 
 export interface SyncDeviceInfo {
   uuid: string;
@@ -69,39 +70,40 @@ export function thisDeviceName(): string {
 
 /** Starts the backend event listeners. Returns a cleanup function. */
 export function startSyncListeners(): () => void {
-  void refreshSyncStatus();
-
   // Events reduce latency, but correctness does not depend on catching one.
   // Poll backend-owned state so a reload or suspended WebView can always
   // reconstruct an active incoming or outgoing pairing session.
-  const poll = window.setInterval(() => {
-    void refreshSyncStatus();
-  }, 1000);
+  const poll = startPolling(refreshSyncStatus,
+    () => syncStore.status?.pairing ? 1000 : 30_000,
+    { hiddenIntervalMs: 30_000, immediate: false });
 
   const unlisteners: Array<Promise<() => void>> = [
     listen('verenu:sync-devices-changed', () => {
-      void refreshSyncStatus();
+      poll.request();
     }),
     listen('verenu:sync-status', () => {
-      void refreshSyncStatus();
+      poll.request();
     }),
     listen<{ uuid: string; name: string }>('verenu:sync-pair-request', () => {
-      void refreshSyncStatus();
+      poll.request();
     }),
     listen<{ uuid: string; ok: boolean; message: string }>('verenu:sync-pair-result', () => {
-      void refreshSyncStatus();
+      poll.request();
     }),
     listen<{ tables: string[] }>('verenu:sync-data-changed', (event) => {
       const tables = event.payload.tables ?? [];
       if (tables.includes('dictionary')) void fetchDictionary();
       if (tables.includes('snippets')) void fetchSnippets();
       if (tables.includes('contexts')) void loadContexts(true);
-      void refreshSyncStatus();
+      poll.request();
     }),
   ];
+  // Reconstruct after registration, closing the startup event gap. This also
+  // runs when started in the tray, where incoming pairing must stay available.
+  void Promise.allSettled(unlisteners).then(() => poll.request());
 
   return () => {
-    window.clearInterval(poll);
+    poll.stop();
     for (const promise of unlisteners) {
       void promise.then((unlisten) => unlisten()).catch(() => {});
     }

--- a/src/lib/syncStore.test.ts
+++ b/src/lib/syncStore.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const ipc = vi.hoisted(() => ({ invoke: vi.fn(), listen: vi.fn() }));
+vi.mock('./tauri', () => ipc);
+vi.mock('./stores.svelte', () => ({ fetchSnippets: vi.fn(), fetchDictionary: vi.fn() }));
+vi.mock('./contextsStore.svelte', () => ({ loadContexts: vi.fn() }));
+import { startSyncListeners, syncStore } from './syncStore.svelte';
+
+let handlers: Map<string, () => void>;
+let doc: EventTarget & { hidden: boolean };
+let stop: (() => void) | undefined;
+beforeEach(() => {
+  vi.useFakeTimers();
+  doc = Object.assign(new EventTarget(), { hidden: false });
+  vi.stubGlobal('document', doc);
+  handlers = new Map();
+  ipc.invoke.mockReset().mockResolvedValue({ pairing: null });
+  ipc.listen.mockReset().mockImplementation(async (event, handler) => {
+    handlers.set(event, handler);
+    return () => handlers.delete(event);
+  });
+  syncStore.status = null;
+  syncStore.loaded = false;
+});
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+it('reconstructs initial state after listeners register and uses two idle polls per minute', async () => {
+  stop = startSyncListeners();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(handlers.size).toBe(5);
+  expect(ipc.invoke).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(ipc.invoke).toHaveBeenCalledTimes(3);
+});
+
+it('reacts to hidden incoming pairing events and retains the missed-event fallback', async () => {
+  doc.hidden = true;
+  stop = startSyncListeners();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(ipc.invoke).toHaveBeenCalledTimes(1);
+  ipc.invoke.mockResolvedValue({ pairing: { kind: 'incoming', phase: 'awaiting_code' } });
+  handlers.get('verenu:sync-pair-request')!();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(syncStore.status?.pairing?.kind).toBe('incoming');
+  expect(ipc.invoke).toHaveBeenCalledTimes(2);
+  await vi.advanceTimersByTimeAsync(30_000);
+  expect(ipc.invoke).toHaveBeenCalledTimes(3);
+  doc.hidden = false;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(3000);
+  expect(ipc.invoke).toHaveBeenCalledTimes(7);
+});
+
+it('cleans up late listener registrations without starting requests after disposal', async () => {
+  let register!: (unlisten: () => void) => void;
+  const unlisten = vi.fn();
+  ipc.listen.mockImplementationOnce(() => new Promise(resolve => { register = resolve; }));
+  stop = startSyncListeners();
+  stop();
+  register(unlisten);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(unlisten).toHaveBeenCalledTimes(1);
+  expect(ipc.invoke).not.toHaveBeenCalled();
+  expect(handlers.size).toBe(0);
+  expect(vi.getTimerCount()).toBe(0);
+  stop = undefined;
+});

--- a/src/lib/views/Insights.svelte
+++ b/src/lib/views/Insights.svelte
@@ -3,6 +3,7 @@
   import { fade, fly } from 'svelte/transition';
   import { expoOut } from 'svelte/easing';
   import { invoke, listen } from '../tauri';
+  import { startPolling } from '../polling';
   import { formatIpcError } from '../stores';
   import { MOTION_MS, motionMs } from '../motion';
   import Dropdown from '../components/Dropdown.svelte';
@@ -103,11 +104,14 @@
     mounted = true;
     void loadContexts();
     load();
+    // Events keep dictations current; reconcile missed events and date rollover
+    // once a minute while visible, and immediately when the window returns.
+    const poll = startPolling(() => load({ silent: true }), 60_000, { immediate: false });
     let unlisten: (() => void) | undefined;
     // Refresh live as new dictations land, so the page never shows stale
     // numbers while it's open. Silent so a background refresh never flashes
     // the loading state.
-    listen('verenu:transcribed', () => load({ silent: true }))
+    listen('verenu:transcribed', () => { if (!document.hidden) poll.request(); })
       .then((cleanup) => {
         // If the component already unmounted while `listen` was still
         // resolving, tear the listener down immediately rather than leaking
@@ -119,14 +123,10 @@
         }
       })
       .catch(() => {});
-    // Belt and suspenders: poll on a fixed cadence too, so the page catches
-    // up even when a transcription event was missed (e.g. it landed before
-    // the page opened). Silent ticks never flash the loading state.
-    const timer = setInterval(() => load({ silent: true }), 10_000);
     return () => {
       mounted = false;
       unlisten?.();
-      clearInterval(timer);
+      poll.stop();
     };
   });
 </script>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection.
> - This PR covers recurring frontend work, audio capture teardown, retained dictation buffers, and small backend query/cache costs.
> - Fixed polling loops and retained audio/cache allocations were doing work while views were hidden or after a dictation could no longer be resumed.
> - The reliability plan prioritizes capture correctness, event/fallback behavior, and roughly 200 MB idle RAM.
> - This pull request makes polling completion-based and visibility-aware, bounds icon caches, releases expired captures, and reduces audio output allocation overlap.
> - The benefit is fewer idle IPC/native wakeups and lower peak stop-time allocation without changing dictation or injection behavior.

## What Changed

- Added shared completion-based polling with visibility suspension, event coalescing, adaptive sync cadence, and teardown-safe listener registration.
- Applied adaptive polling to sync, Insights, connectivity, Sidebar memory diagnostics, and macOS permission checks. Removed automatic API-health polling because it had no UI readers.
- Bounded AppIcon and SiteIcon caches to 128 entries or 4 MiB of resolved data.
- Released expired retry/resume audio references from the existing maintenance loop and avoided duplicating the 16 kHz buffer at native rate.
- Added exact WAV preallocation and worker teardown guards for failed audio stream setup.
- Removed full vocabulary string duplication while building Insights rankings and skipped empty-device sync database work.
- Added frontend, sync, cache, audio, and expiry tests plus the efficiency measurement report.

## Verification

- `npm run check`: passes with zero errors and warnings.
- `npm run test:unit`: 101 tests passed.
- `npm run build`: passes from the resolved checkout path.
- Audio tests: 7 passed, including byte-identical WAV output and worker cleanup.
- `npm run test:rust`: 630 passed, 1 failed, 4 ignored. The remaining failure is the pre-existing cleanup prompt size contract for medium/formal (933 tokens).
- `npm test`: the performance test passed. The run also exposed development-server navigation timeouts in four browser tests; targeted production-build checks passed for offline state, content surfaces, simulated macOS permissions, app mount, and App Mappings.
- Performance budgets: navigation 523 ms, settings open 56 ms, section p95 390 ms, settings close 855 ms, one long task, zero uncaught errors.
- A 60-second 16 kHz fixture reduced stop-time sample/WAV capacity from 10,563,584 to 5,760,044 bytes, about 45.5%, with byte-identical output.

## Risks

- Polling fallback is slower while hidden: idle sync uses 30 seconds instead of 1 second, while visible pairing returns to 1 second and events still trigger immediate reconciliation.
- No changes were made to the audio callback, denoising, quality gates, provider fallback, clipboard injection, model lifecycle policy, or smoke tests.
- Native idle-RAM, real microphone, and installed macOS permission checks were not run in this environment.

## Model Used

- OpenAI, GPT-5 (Codex desktop, repository analysis and tool use).

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`; this PR does not duplicate planned work
- [x] `npm run check` passes
- [ ] `npm run lint` was not run because the checkout's Rust/Clippy environment is unavailable in the standard shell
- [ ] `npm run test:rust` has one unrelated prompt-size failure documented above
- [x] Targeted smoke/browser checks run where the environment allowed
- [x] Tests added or updated where applicable
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated
- [x] Risks documented above
