### PR TITLE
Fix GitHub stable and beta update selection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+  Normal pull requests target master directly. Do not target dev or another
+  integration branch.
+-->
+
 ## Thinking Path
 
 <!--
@@ -56,6 +61,7 @@
 
 ## Checklist
 
+- [ ] This PR targets `master` directly
 - [ ] Thinking path traces from Verenu context down to this specific change
 - [ ] Model used is specified (provider + version)
 - [ ] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: master
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: master
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,6 @@ name: Dependency Review
 on:
   pull_request:
     branches:
-      - dev
       - master
 
 permissions:

--- a/.github/workflows/morning-release.yml
+++ b/.github/workflows/morning-release.yml
@@ -1,9 +1,9 @@
-name: Morning Dev Release
+name: Morning Nightly Release
 
 on:
   schedule:
-    # GitHub schedules run on the default branch. Keep this workflow on master,
-    # then explicitly inspect dev below. The timezone keeps 08:00 local time
+    # GitHub schedules run on the default branch. This workflow inspects master.
+    # The timezone keeps 08:00 local time
     # across daylight-saving changes.
     - cron: '0 8 * * *'
       timezone: America/Vancouver
@@ -14,12 +14,12 @@ permissions:
   models: read
 
 concurrency:
-  group: morning-dev-release
+  group: morning-nightly-release
   cancel-in-progress: false
 
 jobs:
   prepare:
-    name: Prepare changed dev snapshot
+    name: Prepare changed master snapshot
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.changes.outputs.should_release }}
@@ -28,14 +28,14 @@ jobs:
       app_version: ${{ steps.changes.outputs.app_version }}
       release_sha: ${{ steps.tag.outputs.release_sha || steps.changes.outputs.release_sha }}
     steps:
-      - name: Check out dev history
+      - name: Check out master history
         uses: actions/checkout@v6
         with:
-          ref: dev
+          ref: master
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Find changes since the previous dev release
+      - name: Find changes since the previous nightly release
         id: changes
         shell: bash
         env:
@@ -43,15 +43,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin dev --tags --force
-          dev_sha="$(git rev-parse origin/dev)"
+          git fetch origin master --tags --force
+          master_sha="$(git rev-parse origin/master)"
           baseline_sha=""
           baseline_tag=""
           last_nightly=""
 
           # A nightly tag points at a release-only metadata commit whose
-          # parent is the dev snapshot it released. Find the newest such tag
-          # whose parent is still reachable from the current dev branch.
+          # parent is the master snapshot it released. Find the newest such tag
+          # whose parent is still reachable from the current master branch.
           last_nightly_date=""
           while IFS= read -r candidate; do
             if [[ ! "$candidate" =~ ^Verenu-[0-9]+\.[0-9]+\.[0-9]+-nightly\.([0-9]{8})$ ]]; then
@@ -60,7 +60,7 @@ jobs:
             candidate_date="${BASH_REMATCH[1]}"
             nightly_commit="$(git rev-parse "${candidate}^{commit}")"
             candidate_sha="$(git rev-parse "${nightly_commit}^")"
-            if git merge-base --is-ancestor "$candidate_sha" "$dev_sha" && [[ -z "$last_nightly" || "$candidate_date" > "$last_nightly_date" ]]; then
+            if git merge-base --is-ancestor "$candidate_sha" "$master_sha" && [[ -z "$last_nightly" || "$candidate_date" > "$last_nightly_date" ]]; then
               last_nightly="$candidate"
               last_nightly_date="$candidate_date"
               baseline_sha="$candidate_sha"
@@ -70,45 +70,45 @@ jobs:
 
           # Nightlies keep the latest stable release as their numeric version
           # base. The fallback is used only before the first reachable stable
-          # tag exists in the dev history.
+          # tag exists in the master history.
           nightly_base_version="$NIGHTLY_START_VERSION"
-          nightly_base_tag="$(git tag --merged "$dev_sha" --list 'Verenu-*' | grep -E '^Verenu-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+          nightly_base_tag="$(git tag --merged "$master_sha" --list 'Verenu-*' | grep -E '^Verenu-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
           if [[ -n "$nightly_base_tag" ]]; then
             nightly_base_version="${nightly_base_tag#Verenu-}"
           fi
 
           # Before the first nightly, use the newest release tag reachable
-          # from dev. Tags are branch-agnostic, so reachability is the branch
+          # from master. Tags are branch-agnostic, so reachability is the branch
           # association we can verify safely.
           if [[ -z "$baseline_sha" ]]; then
             baseline_tag="$nightly_base_tag"
             if [[ -z "$baseline_tag" ]]; then
-              baseline_tag="$(git tag --merged "$dev_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
+              baseline_tag="$(git tag --merged "$master_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
             fi
             if [[ -z "$baseline_tag" ]]; then
-              echo 'No release tag reachable from dev; refusing to guess a baseline.' >&2
+              echo 'No release tag reachable from master; refusing to guess a baseline.' >&2
               exit 1
             fi
             baseline_sha="$(git rev-parse "${baseline_tag}^{commit}")"
           fi
 
-          changed_lines="$(git diff --numstat "$baseline_sha..$dev_sha" -- . ':(exclude)package-lock.json' | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ { total += $1 + $2 } END { print total + 0 }')"
+          changed_lines="$(git diff --numstat "$baseline_sha..$master_sha" -- . ':(exclude)package-lock.json' | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ { total += $1 + $2 } END { print total + 0 }')"
           changed_lines="${changed_lines:-0}"
           release_date="$(TZ=America/Vancouver date +%Y%m%d)"
 
           # If a prior run created today's tag but failed while building or
           # publishing, resume that exact dated release instead of creating a
-          # second release for the same dev snapshot.
+          # second release for the same master snapshot.
           resume_existing=false
-          if [[ -n "$last_nightly" && "$baseline_sha" == "$dev_sha" && "$last_nightly" =~ \.nightly\.${release_date}$ ]]; then
+          if [[ -n "$last_nightly" && "$baseline_sha" == "$master_sha" && "$last_nightly" =~ \.nightly\.${release_date}$ ]]; then
             resume_existing=true
           fi
 
           echo "Baseline: $baseline_tag ($baseline_sha)"
-          echo "Dev:      $dev_sha"
+          echo "Master:   $master_sha"
           echo "Nightly base: $nightly_base_version"
           echo "Changed lines: $changed_lines"
-          git diff --stat "$baseline_sha..$dev_sha" -- . ':(exclude)package-lock.json'
+          git diff --stat "$baseline_sha..$master_sha" -- . ':(exclude)package-lock.json'
 
           if (( changed_lines <= 10 )) && [[ "$resume_existing" != true ]]; then
             echo 'should_release=false' >> "$GITHUB_OUTPUT"
@@ -133,16 +133,16 @@ jobs:
             exit 1
           fi
 
-          git log --no-merges -n 100 --format='- %h %s' "$baseline_sha..$dev_sha" > commit-summary.md
-          git diff --stat "$baseline_sha..$dev_sha" -- . ':(exclude)package-lock.json' > diff-stat.md
-          git diff --unified=0 "$baseline_sha..$dev_sha" -- . ':(exclude)package-lock.json' > full-diff.patch
+          git log --no-merges -n 100 --format='- %h %s' "$baseline_sha..$master_sha" > commit-summary.md
+          git diff --stat "$baseline_sha..$master_sha" -- . ':(exclude)package-lock.json' > diff-stat.md
+          git diff --unified=0 "$baseline_sha..$master_sha" -- . ':(exclude)package-lock.json' > full-diff.patch
           head -c 60000 full-diff.patch > diff-preview.patch
           rm full-diff.patch
 
           {
             echo "Release version: $release_version"
-            echo "Source branch: dev"
-            echo "Source commit: $dev_sha"
+            echo "Source branch: master"
+            echo "Source commit: $master_sha"
             echo "Baseline tag: $baseline_tag"
             echo "Changed lines: $changed_lines"
             echo "Embedded app version: $app_version"
@@ -164,7 +164,7 @@ jobs:
 
           {
             echo "should_release=true"
-            echo "dev_sha=$dev_sha"
+            echo "master_sha=$master_sha"
             echo "baseline_tag=$baseline_tag"
             echo "baseline_sha=$baseline_sha"
             echo "changed_lines=$changed_lines"
@@ -219,12 +219,12 @@ jobs:
               if [[ -s commit-summary.md ]]; then
                 cat commit-summary.md
               else
-                echo '- Updated dev snapshot available in this nightly build'
+                echo '- Updated master snapshot available in this nightly build'
               fi
               echo
               echo '## Features'
               echo
-              echo 'This nightly contains the changed dev snapshot and the attached Windows and macOS installers.'
+              echo 'This nightly contains the changed master snapshot and the attached Windows and macOS installers.'
               echo
               echo '## Getting Started'
               echo
@@ -265,26 +265,26 @@ jobs:
         if: steps.changes.outputs.should_release == 'true' && steps.changes.outputs.tag_exists != 'true'
         shell: bash
         env:
-          DEV_SHA: ${{ steps.changes.outputs.dev_sha }}
+          MASTER_SHA: ${{ steps.changes.outputs.master_sha }}
           APP_VERSION: ${{ steps.changes.outputs.app_version }}
           RELEASE_VERSION: ${{ steps.changes.outputs.release_version }}
           RELEASE_TAG: ${{ steps.changes.outputs.release_tag }}
         run: |
           set -euo pipefail
 
-          # The commit is intentionally not pushed to dev or master. The tag
+          # The commit is intentionally not pushed to master. The tag
           # contains the release-only version while its parent remains the
-          # exact dev snapshot that was inspected above.
-          git checkout --detach "$DEV_SHA"
+          # exact master snapshot that was inspected above.
+          git checkout --detach "$MASTER_SHA"
           version_files=(
             package.json
             src-tauri/tauri.conf.json
             src-tauri/Cargo.toml
           )
-          restore_dev_versions() {
-            git restore --source "$DEV_SHA" -- "${version_files[@]}"
+          restore_master_versions() {
+            git restore --source "$MASTER_SHA" -- "${version_files[@]}"
           }
-          trap restore_dev_versions EXIT
+          trap restore_master_versions EXIT
 
           node - "$APP_VERSION" <<'NODE'
           const fs = require('node:fs');
@@ -330,10 +330,10 @@ jobs:
           git push origin "$RELEASE_TAG"
 
           # The version bump belongs only to the tag snapshot. Restore the
-          # exact dev values before this job exits, including on failure.
-          restore_dev_versions
-          if ! git diff --quiet "$DEV_SHA" -- "${version_files[@]}"; then
-            echo 'Release-only version files did not roll back to dev.' >&2
+          # exact master values before this job exits, including on failure.
+          restore_master_versions
+          if ! git diff --quiet "$MASTER_SHA" -- "${version_files[@]}"; then
+            echo 'Release-only version files did not roll back to master.' >&2
             exit 1
           fi
           trap - EXIT

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,92 @@
-See [CLAUDE.md](./CLAUDE.md) for all project context, conventions, and instructions. Before adding or changing frontend controls, also read [DESIGN.md](./DESIGN.md): it defines the global button and dropdown primitives, animation rules, and control inventory.
+# Verenu agent instructions
+
+## Project model
+
+Verenu is a Tauri 2 desktop dictation app for Windows and macOS. The Rust
+backend owns native integration, SQLite, settings storage, provider calls, and
+the dictation pipeline; the Svelte 5 frontend owns the application UI. Keep
+the app privacy-aware, lightweight, and offline-capable where the feature
+allows it. Do not replace Tauri with Electron or turn the product into a web
+app.
+
+Contexts are the primary home for app and website targets, tone, cleanup
+intensity, custom instructions, vocabulary, and snippets. Legacy Dictionary,
+Snippets, and App Mappings pages remain for compatibility; do not build new
+features on them without an explicit request.
+
+## Before changing code
+
+- Read the relevant docs and nearby implementation before making assumptions.
+- Read `DESIGN.md` before adding or restyling frontend controls. Reuse shared
+  buttons, dropdowns, motion, colors, and selectors.
+- Treat `docs/ROADMAP.md` as recorded bugs and future context, not approved
+  scope.
+- Check the `Unreleased` section of `docs/CHANGELOG.md`; the latest release is
+  currently 0.18.0.
+- Read the task-specific playbook in `Agent-Skills/` when one applies.
+
+## Branches, commits, and files
+
+- `master` is the only integration and release branch. Create short-lived
+  branches from it and open pull requests directly into `master`; never use a
+  `dev` integration branch.
+- In GitButler workspaces, the target should be `origin/master`. Use `but` for
+  Git writes and inspect dirty files or hunks before committing. Do not absorb
+  unrelated work from other agents.
+- Use `apply_patch` for local edits. Never kill a process you did not start.
+- Keep API keys, dictated text, clipboard contents, private screenshots, and
+  local secrets out of code, logs, fixtures, commits, and test output.
+- Every commit needs an agent co-author trailer. Do not add a co-author note
+  at the bottom of a pull request description.
+
+## Commands and verification
+
+```bash
+npm install
+npm run tauri dev
+npm run check
+npm run lint
+npm run test:rust
+npm test
+npm run test:smoke
+```
+
+- `npm run check` is the minimum frontend check. Use `npm run lint` when Rust
+  or frontend linting is relevant.
+- Use `cargo test --manifest-path src-tauri/Cargo.toml <test_name>` for a
+  focused Rust test, and `npm run test:unit` for focused frontend tests.
+- `npm test` runs the deterministic fast profile. Live API and native profiles
+  are opt-in; do not require credentials for ordinary checks.
+- Keep `tests/smoke/` frozen. Fix application code when those contracts fail.
+- Changes involving hotkeys, injection, permissions, onboarding, or Keychain
+  need macOS verification when practical.
+- For UI changes, use the relevant Playwright or integration test and report
+  any skipped manual verification.
+
+## Safety and contracts
+
+- Store API keys only in the native credential store. Never put secrets in
+  SQLite, `settings.json`, logs, or IPC responses. Use store-key constants from
+  `src-tauri/src/data/store/mod.rs`, not raw key strings.
+- Keep frontend settings types in `src/lib/settings.ts` synchronized with
+  backend validation and store constants.
+- Update application versions together in `package.json`,
+  `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`.
+- Release installers belong under `installers/<version>/` with matching
+  checksums; the scheduled nightly release and manual installer workflow use
+  `master`.
+- The Windows low-level hotkey callback must return quickly, with pipeline work
+  spawned outside the hook. Never hide the pill window; hidden WebView state
+  events can be lost.
+- Text injection is clipboard-based and must restore focus and selection safely.
+  Do not log raw dictated or cleaned text.
+- Preserve exact selectors asserted by `tests/smoke/`, including accessibility
+  roles and required classes, when changing the UI.
+
+## Useful references
+
+- Architecture and testing: `docs/ARCHITECTURE.md`, `docs/TESTING.md`
+- Contribution and release flow: `docs/CONTRIBUTING.md`, `docs/RELEASE.md`
+- Privacy: `docs/DATA_AND_PRIVACY.md`
+- Shared frontend controls: `DESIGN.md`, `src/ui.css`
+- CI and PR policy: `.github/workflows/`, `.github/pull_request_template.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,8 @@ npm run test:smoke
 - Update application versions together in `package.json`,
   `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`.
 - Release installers belong under `installers/<version>/` with matching
-  checksums; the scheduled nightly release and manual installer workflow use
-  `master`.
+  checksums; the scheduled nightly release reads `master`. Run the manual
+  installer workflow from `master` for a production build.
 - The Windows low-level hotkey callback must return quickly, with pipeline work
   spawned outside the hook. Never hide the pill window; hidden WebView state
   events can be lost.

--- a/Agent-Skills/Updating_version.md
+++ b/Agent-Skills/Updating_version.md
@@ -11,7 +11,7 @@ When you are asked to update the application version (e.g., bump the version to 
 
 **Crucial:** Ensure the version numbers match exactly in all three files to prevent build issues and keep the frontend and backend in sync.
 
-4. `CLAUDE.md`
+4. `AGENTS.md`
    - Update the version note under "Notes from user" (the "Latest release is X.Y.Z" line). This drifted before (stuck at 0.15.0 while the app shipped 0.17.0), so it is part of this checklist now.
 
-**Note:** The version is now read dynamically from `@tauri-apps/api/app` via `getVersion()` in `Settings.svelte` and `Home.svelte`, so hardcoded version strings in those files are no longer used. The three version files above are the only source of truth for versioning; the CLAUDE.md note is documentation, not a build input.
+**Note:** The version is now read dynamically from `@tauri-apps/api/app` via `getVersion()` in `Settings.svelte` and `Home.svelte`, so hardcoded version strings in those files are no longer used. The three version files above are the only source of truth for versioning; the AGENTS.md note is documentation, not a build input.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,10 @@ When executing tasks, refer to the guidelines in the `Agent-Skills/` directory:
 
 ## CI/CD & Review
 
-- **PR checks workflow** (`.github/workflows/pr-checks.yml`) keeps frontend and OS-matrix Rust jobs, then runs the unified fast profile with JSON/JUnit reports
+- `master` is the only shared integration and release branch. Open pull requests directly into `master`; do not use an intermediate `dev` branch or merge `dev` into `master`
+- GitButler workspaces should use `origin/master` as their target; verify with `but config target` before creating a pull request
+- **PR checks workflow** (`.github/workflows/pr-checks.yml`) runs for pull requests targeting `master`, keeps frontend and OS-matrix Rust jobs, then runs the unified fast profile with JSON/JUnit reports
+- **Morning nightly release workflow** (`.github/workflows/morning-release.yml`) runs on schedule or manual dispatch, compares the current `master` snapshot with the latest reachable nightly baseline, and publishes prerelease installers from `master`
 - **Extended profiles workflow** (`.github/workflows/extended-test-profiles.yml`) runs opt-in live/native profiles on schedule or manual dispatch
 - **Build installers workflow** (`.github/workflows/build-installers.yml`) is manual (`workflow_dispatch`) — builds release installers on demand, not on every push
 - **Dependency review** (`.github/workflows/dependency-review.yml`) gates new dependencies for supply-chain risk
@@ -310,7 +313,7 @@ The `transcription_language` setting (ISO 639-1, default `en`) is sent to Groq/O
 
 The frontend polls `api.verenu.com/v1/provider-status` every 5 minutes (`src/lib/serviceStatus.ts`) and shows an in-app banner (`ProviderStatusBanner.svelte`, replacing the update-available banner when both are pending) only when a provider the user has actually selected for transcription or cleanup is flagged with a real issue. "Real issue" means the backend's `showToUsers` flag is true AND `status` is neither `operational` nor `unknown` (`unknown` means the provider doesn't publish a machine-readable feed, not that something is broken) — `filter_alerts()` in `service_status.rs` is the single source of truth for that gate. `api.verenu.com/v1/health` is polled every 20 minutes into `appStore.apiHealthy` with no UI yet, for future use. Settings → Developer has a "Run Check" button (`check_provider_status_raw`) that shows the unfiltered API response for debugging.
 
-About has an opt-in "Beta updates" toggle backed by `beta_updates_enabled`. Enabling it requires a warning confirmation and switches update checks to published releases whose GitHub `target_commitish` is `dev`; stable checks use `master`. The updater ignores drafts and selects the highest numeric version on the selected branch.
+About has an opt-in "Beta updates" toggle backed by `beta_updates_enabled`. Enabling it requires a warning confirmation and switches update checks to published prereleases/nightlies from `master`; stable checks also use `master` but ignore prereleases. The updater ignores drafts and selects the highest numeric version on the selected channel.
 
 If a transcription or cleanup call fails with a provider-side error (`is_retryable_provider_error()` — quota, or a retryable timeout/429/5xx), the pipeline emits `verenu:recheck-provider-status` so the frontend re-polls immediately instead of waiting for the next scheduled check. These are the app's only calls to a Verenu-owned server; they are plain GETs that never include dictated audio, text, keys, or history (see [docs/DATA_AND_PRIVACY.md](docs/DATA_AND_PRIVACY.md)).
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,1 +1,0 @@
-See [CLAUDE.md](./CLAUDE.md) for all project context, conventions, and instructions.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,4 +124,4 @@ Audit performed 2026-08-05. The app contains 172 `<button>` elements, two visual
 2. Start a new dropdown with the five `ui-dropdown` classes and the headless `Dropdown` controller. Give a feature its own behavior only when the selection logic needs it.
 3. Before extracting another control, confirm the same semantic intent appears at least three times. Similar pixels are not enough.
 4. Keep colors, radii, focus states, and core motion in `src/theme.css`, `src/ui.css`, or `src/lib/motion.ts`, never in a copied component rule.
-5. Preserve selectors named in `CLAUDE.md`'s smoke-test contract, even when their visual treatment moves into a shared primitive.
+5. Preserve selectors named in `AGENTS.md`'s smoke-test contract, even when their visual treatment moves into a shared primitive.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-See [CLAUDE.md](./CLAUDE.md) for all project context, conventions, and instructions.

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ For more details: [Install Verenu](docs/INSTALL.md), [Contributing](docs/CONTRIB
 
 ## Release Flow
 
-Most day-to-day work lands on `dev` first.
+`master` is the only shared integration and release branch.
 
 The normal flow is:
 
-1. Commit to `dev` for most changes.
-2. Review and test on `dev`.
-3. Merge `dev` into `master` when it is ready.
-4. Cut and ship the release from there.
+1. Create a short-lived feature or fix branch from `master`.
+2. Open a pull request directly into `master`.
+3. Let the required CI checks run, review the change, and merge it into `master`.
+4. The morning nightly workflow and manual installer workflow use `master`.
 
 If you are contributing, read [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) before you start.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ The normal flow is:
 1. Create a short-lived feature or fix branch from `master`.
 2. Open a pull request directly into `master`.
 3. Let the required CI checks run, review the change, and merge it into `master`.
-4. The morning nightly workflow and manual installer workflow use `master`.
+4. The morning nightly workflow reads `master`; run the manual installer
+   workflow from `master` when a production build is needed.
 
 If you are contributing, read [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) before you start.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,23 +4,44 @@ Verenu is a Tauri desktop app for Windows and macOS. Keep changes focused, light
 
 ## Branch Flow
 
-This repo is not trying to force everything through a heavyweight PR loop.
+`master` is the only shared integration and release branch. All changes go
+through a pull request directly into `master`; there is no separate `dev`
+integration branch.
 
 The default workflow is:
 
-1. Most changes go straight onto `dev`.
-2. `dev` gets reviewed and tested.
-3. Once `dev` is in good shape, it is merged into `master`.
-4. Releases are cut from that stabilized path.
+1. Create a short-lived feature or fix branch from `master`.
+2. Make the change and run the smallest useful local checks.
+3. Open a pull request targeting `master`.
+4. Address review feedback and CI failures, then merge once the checks pass.
 
-If you have direct write access and the change is normal project work, commit to `dev`.
+Direct pushes to `master` should be reserved for repository administration or
+urgent recovery. Normal project work belongs in a PR, including work that
+changes release flow, privacy boundaries, provider behavior, core dictation
+behavior, or updater behavior.
 
-Use a PR when one of these is true:
+## Pull Requests
 
-- You do not have write access
-- The change is risky, broad, or hard to review in a direct push
-- You want line-by-line discussion before it lands
-- The work changes release flow, privacy boundaries, provider behavior, core dictation behavior, or updater behavior
+Normal changes use one pull request directly into `master`.
+
+- Start the branch from `master`.
+- Set the pull request base to `master`.
+- Wait for PR Checks and Dependency Review to pass.
+- Address review feedback and CI failures before merging.
+- Do not open an intermediate pull request into `dev`.
+
+For GitButler workspaces, verify the target before creating a pull request:
+
+```powershell
+but config target
+```
+
+It should report `origin/master`. If no branches are applied, set the target
+and push remote with:
+
+```powershell
+but config target origin/master --push-remote origin
+```
 
 ## Before You Start
 
@@ -159,7 +180,8 @@ Whether work lands by direct commit or PR, the bar is the same:
 - Call out privacy, provider, hotkey, clipboard, updater, database, or platform impacts
 - Say plainly if something was not tested
 
-If you open a PR, target `dev` unless there is a specific reason not to.
+If you open a PR, target `master`. Do not open an intermediate PR into `dev` or
+merge `dev` into `master`.
 
 ## Related Docs
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,10 +4,11 @@ This document is the practical release checklist for Verenu. For release note wo
 
 ## Branch Flow
 
-1. Land normal work on `dev`.
-2. Review and test `dev`.
-3. Merge `dev` into `master` when it is stable.
-4. Cut the release from the stabilized branch.
+1. Merge reviewed pull requests directly into `master`.
+2. Keep `master` green with the required CI checks.
+3. The scheduled morning nightly release inspects `master` and publishes the
+   next prerelease when enough changes have accumulated.
+4. Use the manual installer workflow when an on-demand build is needed.
 
 ## Version Bump
 
@@ -35,7 +36,7 @@ For UI-affecting work, also run the relevant Playwright smoke or integration tes
 
 ## Build Installers
 
-The manual GitHub Actions workflow [`../.github/workflows/build-installers.yml`](../.github/workflows/build-installers.yml) builds:
+The manual GitHub Actions workflow [`../.github/workflows/build-installers.yml`](../.github/workflows/build-installers.yml) checks out `master` and builds:
 
 - Windows NSIS installer
 - Windows MSI installer

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,7 +8,8 @@ This document is the practical release checklist for Verenu. For release note wo
 2. Keep `master` green with the required CI checks.
 3. The scheduled morning nightly release inspects `master` and publishes the
    next prerelease when enough changes have accumulated.
-4. Use the manual installer workflow when an on-demand build is needed.
+4. Run the manual installer workflow from `master` when an on-demand
+   production build is needed; it builds the ref selected at dispatch.
 
 ## Version Bump
 
@@ -36,7 +37,7 @@ For UI-affecting work, also run the relevant Playwright smoke or integration tes
 
 ## Build Installers
 
-The manual GitHub Actions workflow [`../.github/workflows/build-installers.yml`](../.github/workflows/build-installers.yml) checks out `master` and builds:
+The manual GitHub Actions workflow [`../.github/workflows/build-installers.yml`](../.github/workflows/build-installers.yml) builds the ref selected at dispatch:
 
 - Windows NSIS installer
 - Windows MSI installer

--- a/docs/insights-backend-brief.md
+++ b/docs/insights-backend-brief.md
@@ -103,7 +103,7 @@ export interface InsightsPayload {
    state keyed off `totals.total_transcriptions == 0`.
 8. **Privacy.** This runs entirely locally. Do not log dictated text, top words, or any
    `clean_text` content — counts, ids, and model names only (see the logging rules in
-   `CLAUDE.md`).
+   `AGENTS.md`).
 
 ## Schema — what already exists
 

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -174,18 +174,6 @@ async fn check_repo(
     let Some(release) = select_release(&releases, channel) else {
         return Ok(None);
     };
-    let Some(display_version) = release_display_version(&release, channel) else {
-        log::warn!(
-            "Ignoring release with malformed version tag: {}",
-            release.tag_name
-        );
-        return Ok(None);
-    };
-
-    if !should_offer_release(&display_version, &current_package_version(), require_newer) {
-        return Ok(None);
-    }
-
     let Some((asset, install_mode)) =
         select_release_asset_for_target(&release.assets, current_update_target())
     else {
@@ -196,6 +184,17 @@ async fn check_repo(
         );
         return Ok(None);
     };
+    let Some(display_version) = installer_version(&asset.name) else {
+        log::warn!(
+            "Ignoring release with malformed installer filename: {}",
+            asset.name
+        );
+        return Ok(None);
+    };
+
+    if !should_offer_release(&display_version, &current_package_version(), require_newer) {
+        return Ok(None);
+    }
 
     Ok(Some(UpdateInfo {
         version: display_version,
@@ -205,30 +204,13 @@ async fn check_repo(
     }))
 }
 
-fn release_display_version(release: &GhRelease, channel: UpdateChannel) -> Option<String> {
-    let version = release_version(&release.tag_name)?;
-
-    // The current 0.18.0 release was published under a legacy `-beta` tag,
-    // but GitHub marks it as a normal release and its release name is stable.
-    // Keep that tag detail out of the version shown to stable users.
-    if matches!(channel, UpdateChannel::Stable)
-        && !release.prerelease
-        && !release_is_explicitly_beta(release)
-        && is_beta_release_tag(&version)
-    {
-        return version.split('-').next().map(str::to_owned);
-    }
-
-    Some(version)
-}
-
 fn select_release(releases: &[GhRelease], channel: UpdateChannel) -> Option<&GhRelease> {
     releases
         .iter()
         .enumerate()
         .filter(|(_, release)| !release.draft && release_matches_channel(release, channel))
         .filter_map(|(index, release)| {
-            release_version(&release.tag_name).map(|version| (index, release, version))
+            release_installer_version(release).map(|version| (index, release, version))
         })
         // Keep the first release when normalized versions tie. GitHub returns
         // releases newest-first, so this preserves the newest prerelease build.
@@ -239,6 +221,32 @@ fn select_release(releases: &[GhRelease], channel: UpdateChannel) -> Option<&GhR
             },
         )
         .map(|(_, release, _)| release)
+}
+
+/// Installer filenames are the version source of truth. Release tags have
+/// historically included stale beta/nightly suffixes, while the filenames
+/// are also the names the user actually installs.
+fn release_installer_version(release: &GhRelease) -> Option<String> {
+    release
+        .assets
+        .iter()
+        .find_map(|asset| installer_version(&asset.name))
+}
+
+fn installer_version(asset_name: &str) -> Option<String> {
+    let lowercase_name = asset_name.to_ascii_lowercase();
+    let prefix_start = lowercase_name.find("verenu_")?;
+    let version_and_platform = &asset_name[prefix_start + "verenu_".len()..];
+    let version_end = version_and_platform
+        .find('_')
+        .unwrap_or(version_and_platform.len());
+    let version = &version_and_platform[..version_end];
+    let version = version
+        .strip_suffix(".dmg")
+        .or_else(|| version.strip_suffix(".msi"))
+        .or_else(|| version.strip_suffix(".exe"))
+        .unwrap_or(version);
+    release_version(version)
 }
 
 fn release_matches_channel(release: &GhRelease, channel: UpdateChannel) -> bool {
@@ -581,9 +589,9 @@ fn find_asset_with_suffix_and_hints<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        current_package_version, find_asset_with_suffix, is_authorized_release_asset_url,
-        is_beta_version, is_newer, normalize_version, parse_prerelease_parts,
-        release_display_version, release_version, select_release, select_release_asset_for_target,
+        current_package_version, find_asset_with_suffix, installer_version,
+        is_authorized_release_asset_url, is_beta_version, is_newer, normalize_version,
+        parse_prerelease_parts, release_version, select_release, select_release_asset_for_target,
         should_offer_release, GhAsset, GhRelease, InstallMode, UpdateChannel, UpdateTarget,
         VersionPart,
     };
@@ -608,13 +616,16 @@ mod tests {
         target_commitish: &str,
         prerelease: bool,
     ) -> GhRelease {
+        let assets = release_version(tag_name)
+            .map(|version| vec![asset(&format!("Verenu_{version}_x64-setup.exe"))])
+            .unwrap_or_default();
         GhRelease {
             tag_name: tag_name.to_string(),
             name: Some(tag_name.to_string()),
             target_commitish: target_commitish.to_string(),
             draft: false,
             prerelease,
-            assets: vec![asset("Verenu_0.15.0_x64-setup.exe")],
+            assets,
         }
     }
 
@@ -731,21 +742,41 @@ mod tests {
     }
 
     #[test]
-    fn stable_display_version_removes_stale_beta_suffix() {
+    fn installer_filename_version_ignores_stale_release_tag() {
         let release = release_with_name(
             "Verenu-0.18.0-beta",
             "Verenu 0.18.0 - Colors!",
             "master",
             false,
         );
+        let installer = "Verenu_0.18.0_x64-setup.exe";
+
+        assert_eq!(installer_version(installer), Some("0.18.0".into()));
+        assert!(!is_newer("0.18.0", "0.18.0"));
+        assert_eq!(release.assets[0].name, "Verenu_0.18.0-beta_x64-setup.exe");
+
+        let mut release = release;
+        release.assets = vec![asset(installer)];
+        assert_eq!(
+            select_release(&[release], UpdateChannel::Stable)
+                .expect("stable release")
+                .assets[0]
+                .name,
+            installer
+        );
+    }
+
+    #[test]
+    fn release_selection_uses_installer_version_over_release_tag() {
+        let mut current_release = release("Verenu-0.17.0", "master");
+        current_release.assets = vec![asset("Verenu_0.18.0_x64-setup.exe")];
+        let other = release("Verenu-0.19.0", "feature/testing");
 
         assert_eq!(
-            release_display_version(&release, UpdateChannel::Stable),
-            Some("0.18.0".into())
-        );
-        assert_eq!(
-            release_display_version(&release, UpdateChannel::Beta),
-            Some("0.18.0-beta".into())
+            select_release(&[current_release, other], UpdateChannel::Stable)
+                .expect("stable release")
+                .tag_name,
+            "Verenu-0.17.0"
         );
     }
 

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -264,7 +264,7 @@ fn release_matches_channel(release: &GhRelease, channel: UpdateChannel) -> bool 
         // those historical publication styles so the beta toggle does not
         // silently miss them.
         UpdateChannel::Beta => {
-            (release.prerelease || beta_tag)
+            (release.prerelease || beta_tag || beta_name)
                 && (target_is_branch || target_is_sha || legacy_beta_branch)
         }
         UpdateChannel::Stable => {
@@ -739,6 +739,18 @@ mod tests {
             release_with_name("Verenu-0.15.0-beta", "Verenu 0.15.0 beta", "master", false);
 
         assert!(select_release(&[release], UpdateChannel::Stable).is_none());
+    }
+
+    #[test]
+    fn explicitly_named_beta_releases_are_selected_for_beta_channel() {
+        let release = release_with_name("Verenu-0.15.0", "Verenu 0.15.0 beta", "master", false);
+
+        assert_eq!(
+            select_release(&[release], UpdateChannel::Beta)
+                .expect("beta release")
+                .tag_name,
+            "Verenu-0.15.0"
+        );
     }
 
     #[test]

--- a/src-tauri/src/api/updater.rs
+++ b/src-tauri/src/api/updater.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 struct GhRelease {
     tag_name: String,
     #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
     target_commitish: String,
     #[serde(default)]
     draft: bool,
@@ -64,15 +66,16 @@ pub enum UpdateChannel {
 
 impl UpdateChannel {
     fn target_branch(self) -> &'static str {
-        match self {
-            Self::Stable => "master",
-            Self::Beta => "dev",
-        }
+        // Stable releases and nightly/beta prereleases are both published
+        // from the single master integration branch. GitHub may report the
+        // release-only commit SHA instead, which is accepted below.
+        "master"
     }
 }
 
 /// Repo to check for releases.
-const RELEASE_REPO: &str = "Verenu/Verenu";
+const RELEASE_REPO: &str = "MONKE2525E/Verenu";
+const LEGACY_RELEASE_REPO: &str = "Verenu/Verenu";
 
 /// Returns true only for URLs that point at an official release asset for
 /// [`RELEASE_REPO`]. GitHub serves release assets from
@@ -104,11 +107,13 @@ pub fn is_authorized_release_asset_url(url: &str) -> bool {
     };
 
     // GitHub owner/repo names are case-insensitive, so match them that way.
-    let mut expected = RELEASE_REPO.split('/');
-    let expected_owner = expected.next().unwrap_or_default();
-    let expected_repo = expected.next().unwrap_or_default();
-    if !owner.eq_ignore_ascii_case(expected_owner)
-        || !repo.eq_ignore_ascii_case(expected_repo)
+    let is_expected_repo = |expected_repo_path: &str| {
+        let mut expected = expected_repo_path.split('/');
+        let expected_owner = expected.next().unwrap_or_default();
+        let expected_repo = expected.next().unwrap_or_default();
+        owner.eq_ignore_ascii_case(expected_owner) && repo.eq_ignore_ascii_case(expected_repo)
+    };
+    if !(is_expected_repo(RELEASE_REPO) || is_expected_repo(LEGACY_RELEASE_REPO))
         || !releases.eq_ignore_ascii_case("releases")
         || !download.eq_ignore_ascii_case("download")
     {
@@ -169,7 +174,7 @@ async fn check_repo(
     let Some(release) = select_release(&releases, channel) else {
         return Ok(None);
     };
-    let Some(display_version) = release_version(&release.tag_name) else {
+    let Some(display_version) = release_display_version(&release, channel) else {
         log::warn!(
             "Ignoring release with malformed version tag: {}",
             release.tag_name
@@ -200,6 +205,23 @@ async fn check_repo(
     }))
 }
 
+fn release_display_version(release: &GhRelease, channel: UpdateChannel) -> Option<String> {
+    let version = release_version(&release.tag_name)?;
+
+    // The current 0.18.0 release was published under a legacy `-beta` tag,
+    // but GitHub marks it as a normal release and its release name is stable.
+    // Keep that tag detail out of the version shown to stable users.
+    if matches!(channel, UpdateChannel::Stable)
+        && !release.prerelease
+        && !release_is_explicitly_beta(release)
+        && is_beta_release_tag(&version)
+    {
+        return version.split('-').next().map(str::to_owned);
+    }
+
+    Some(version)
+}
+
 fn select_release(releases: &[GhRelease], channel: UpdateChannel) -> Option<&GhRelease> {
     releases
         .iter()
@@ -225,18 +247,44 @@ fn release_matches_channel(release: &GhRelease, channel: UpdateChannel) -> bool 
         .eq_ignore_ascii_case(channel.target_branch());
     let target_is_sha = is_commit_sha(&release.target_commitish);
     let beta_tag = is_beta_release_tag(&release.tag_name);
+    let beta_name = release_is_explicitly_beta(release);
+    let legacy_beta_branch = release.target_commitish.eq_ignore_ascii_case("dev");
 
     match channel {
         // Older beta releases were published with GitHub's prerelease flag
-        // off, but used either the dev branch or a `-beta` tag. Accept both
-        // publication styles so the beta toggle does not silently miss them.
+        // off, used the retired dev branch, or used a `-beta` tag. Accept
+        // those historical publication styles so the beta toggle does not
+        // silently miss them.
         UpdateChannel::Beta => {
-            (release.prerelease || beta_tag) && (target_is_branch || target_is_sha)
+            (release.prerelease || beta_tag)
+                && (target_is_branch || target_is_sha || legacy_beta_branch)
         }
         UpdateChannel::Stable => {
-            !release.prerelease && !beta_tag && (target_is_branch || target_is_sha)
+            // GitHub's prerelease flag is authoritative for current releases.
+            // A historical Verenu release was accidentally tagged `-beta` but
+            // published as a normal release; accept that shape when its name
+            // does not identify it as beta, while continuing to exclude the
+            // older releases explicitly named beta or published from `dev`.
+            !release.prerelease
+                && !beta_name
+                && !legacy_beta_branch
+                && (target_is_branch || target_is_sha)
         }
     }
+}
+
+fn release_name_indicates_beta(name: &str) -> bool {
+    name.to_ascii_lowercase()
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|word| matches!(word, "beta" | "nightly" | "preview" | "prerelease"))
+}
+
+fn release_is_explicitly_beta(release: &GhRelease) -> bool {
+    release
+        .name
+        .as_deref()
+        .map(release_name_indicates_beta)
+        .unwrap_or_else(|| is_beta_release_tag(&release.tag_name))
 }
 
 pub fn is_beta_version(version: &str) -> bool {
@@ -534,9 +582,10 @@ fn find_asset_with_suffix_and_hints<'a>(
 mod tests {
     use super::{
         current_package_version, find_asset_with_suffix, is_authorized_release_asset_url,
-        is_beta_version, is_newer, normalize_version, parse_prerelease_parts, release_version,
-        select_release, select_release_asset_for_target, should_offer_release, GhAsset, GhRelease,
-        InstallMode, UpdateChannel, UpdateTarget, VersionPart,
+        is_beta_version, is_newer, normalize_version, parse_prerelease_parts,
+        release_display_version, release_version, select_release, select_release_asset_for_target,
+        should_offer_release, GhAsset, GhRelease, InstallMode, UpdateChannel, UpdateTarget,
+        VersionPart,
     };
 
     fn asset(name: &str) -> GhAsset {
@@ -561,6 +610,7 @@ mod tests {
     ) -> GhRelease {
         GhRelease {
             tag_name: tag_name.to_string(),
+            name: Some(tag_name.to_string()),
             target_commitish: target_commitish.to_string(),
             draft: false,
             prerelease,
@@ -568,11 +618,22 @@ mod tests {
         }
     }
 
+    fn release_with_name(
+        tag_name: &str,
+        name: &str,
+        target_commitish: &str,
+        prerelease: bool,
+    ) -> GhRelease {
+        let mut release = release_with_prerelease(tag_name, target_commitish, prerelease);
+        release.name = Some(name.to_string());
+        release
+    }
+
     #[test]
     fn release_channels_map_to_the_expected_branches() {
         let releases = [
             release("Verenu-0.15.0", "master"),
-            release("Verenu-0.15.1-beta", "dev"),
+            release_with_prerelease("Verenu-0.15.1-beta", "master", true),
             release("Verenu-0.99.0", "feature/testing"),
         ];
 
@@ -593,8 +654,8 @@ mod tests {
     #[test]
     fn release_channel_picks_the_highest_version_on_that_branch() {
         let releases = [
-            release("Verenu-0.15.1-beta", "dev"),
-            release("Verenu-0.16.0-beta", "dev"),
+            release_with_prerelease("Verenu-0.15.1-beta", "master", true),
+            release_with_prerelease("Verenu-0.16.0-beta", "master", true),
             release("Verenu-9.0.0", "master"),
         ];
 
@@ -608,7 +669,7 @@ mod tests {
 
     #[test]
     fn non_prerelease_beta_tags_are_selected_for_beta_channel() {
-        let release = release_with_prerelease("Verenu-0.16.2-beta", "dev", false);
+        let release = release_with_prerelease("Verenu-0.16.2-beta", "master", false);
         assert_eq!(
             select_release(&[release], UpdateChannel::Beta)
                 .expect("beta tag release")
@@ -628,6 +689,63 @@ mod tests {
                 .expect("stable release")
                 .tag_name,
             "Verenu-0.16.0"
+        );
+    }
+
+    #[test]
+    fn stable_channel_accepts_a_non_prerelease_release_with_a_stale_beta_tag() {
+        let release = release_with_name(
+            "Verenu-0.18.0-beta",
+            "Verenu 0.18.0 - Colors!",
+            "master",
+            false,
+        );
+
+        assert_eq!(
+            select_release(&[release], UpdateChannel::Stable)
+                .expect("stable release with legacy tag")
+                .tag_name,
+            "Verenu-0.18.0-beta"
+        );
+
+        let release = release_with_name(
+            "Verenu-0.18.0-beta",
+            "Verenu 0.18.0 - Colors!",
+            "master",
+            false,
+        );
+        assert_eq!(
+            select_release(&[release], UpdateChannel::Beta)
+                .expect("beta-compatible release with legacy tag")
+                .tag_name,
+            "Verenu-0.18.0-beta"
+        );
+    }
+
+    #[test]
+    fn explicitly_named_beta_releases_stay_out_of_stable_channel() {
+        let release =
+            release_with_name("Verenu-0.15.0-beta", "Verenu 0.15.0 beta", "master", false);
+
+        assert!(select_release(&[release], UpdateChannel::Stable).is_none());
+    }
+
+    #[test]
+    fn stable_display_version_removes_stale_beta_suffix() {
+        let release = release_with_name(
+            "Verenu-0.18.0-beta",
+            "Verenu 0.18.0 - Colors!",
+            "master",
+            false,
+        );
+
+        assert_eq!(
+            release_display_version(&release, UpdateChannel::Stable),
+            Some("0.18.0".into())
+        );
+        assert_eq!(
+            release_display_version(&release, UpdateChannel::Beta),
+            Some("0.18.0-beta".into())
         );
     }
 
@@ -655,9 +773,12 @@ mod tests {
 
     #[test]
     fn draft_releases_are_not_selected() {
-        let mut draft = release("Verenu-9.0.0-beta", "dev");
+        let mut draft = release_with_prerelease("Verenu-9.0.0-beta", "master", true);
         draft.draft = true;
-        let releases = [draft, release("Verenu-0.15.1-beta", "dev")];
+        let releases = [
+            draft,
+            release_with_prerelease("Verenu-0.15.1-beta", "master", true),
+        ];
 
         assert_eq!(
             select_release(&releases, UpdateChannel::Beta)
@@ -716,8 +837,8 @@ mod tests {
     #[test]
     fn equal_normalized_versions_keep_the_newest_release_first() {
         let releases = [
-            release("Verenu-0.15.1-beta.2", "dev"),
-            release("Verenu-0.15.1-beta.1", "dev"),
+            release_with_prerelease("Verenu-0.15.1-beta.2", "master", true),
+            release_with_prerelease("Verenu-0.15.1-beta.1", "master", true),
         ];
 
         assert_eq!(
@@ -888,6 +1009,9 @@ mod tests {
 
     #[test]
     fn authorized_url_accepts_official_release_assets() {
+        assert!(is_authorized_release_asset_url(
+            "https://github.com/MONKE2525E/Verenu/releases/download/Verenu-0.18.0-beta/Verenu_0.18.0_x64-setup.exe"
+        ));
         assert!(is_authorized_release_asset_url(
             "https://github.com/Verenu/Verenu/releases/download/v0.15.0/Verenu_0.15.0_x64-setup.exe"
         ));

--- a/src-tauri/src/local_llm/binary.rs
+++ b/src-tauri/src/local_llm/binary.rs
@@ -107,7 +107,7 @@ pub fn detect_backend() -> LlamaBackend {
             LlamaBackend::Cpu
         }
     }
-    // Not a supported release target (Windows/macOS only, see CLAUDE.md),
+    // Not a supported release target (Windows/macOS only, see AGENTS.md),
     // but this must still return something so the crate type-checks when
     // built or analyzed on other platforms (e.g. a Linux CI/dev machine).
     #[cfg(not(any(windows, target_os = "macos")))]
@@ -329,7 +329,7 @@ fn extract_archive(archive_path: &Path, dest: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-// Not a supported release target (Windows/macOS only, see CLAUDE.md), but
+// Not a supported release target (Windows/macOS only, see AGENTS.md), but
 // this must still exist so the crate type-checks when built or analyzed on
 // other platforms (e.g. a Linux CI/dev machine) — mirrors detect_backend()'s
 // Linux fallback above. Never actually reached in practice since nothing


### PR DESCRIPTION
## Thinking Path  > - Verenu is a Windows and macOS AI dictation app with a Rust/Tauri backend and Svelte frontend. > - The update subsystem in `src-tauri/src/api/updater.rs` reads GitHub Releases metadata and chooses a channel-specific installer asset. > - The live `0.18.0` release is published under a legacy `-beta` tag, while its actual installer filenames are `Verenu_0.18.0_...`. > - The previous updater compared the release tag to the installed package version, so stable `0.18.0` could be shown an update to `0.18.0-beta` or reinstall an older tag-selected release. > - Beta selection also depended on the retired `dev` branch, which excluded current master prereleases. > - This pull request makes the canonical repository, channel filtering, release ordering, and version comparison match the release assets users actually install. > - The benefit is that stable and beta checks and developer reinstalls resolve the intended installer without false same-version update prompts.  ## What Changed  - Query the canonical `MONKE2525E/Verenu` releases endpoint. - Continue authorizing official redirected `Verenu/Verenu` release asset URLs. - Select current master-based stable and beta releases while preserving historical beta compatibility. - Use the selected installer filename as the comparable and displayed version, including for release ordering. - Keep developer reinstall available when the selected installer version matches the installed version.  ## Verification  - `cargo test --manifest-path src-tauri/Cargo.toml api::updater::tests` passes, 35 tests. - `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` passes locally. - `rustfmt --edition 2021 --check src-tauri/src/api/updater.rs` passes. - Live GitHub release data confirms the current stable installer names report `0.18.0`; the same-version comparison does not offer an update. - The PR frontend, dependency, and large-file checks passed on the previous commit; checks are rerunning for this follow-up.  ## Risks  - Low risk. Changes are isolated to release discovery and installer selection. Historical redirected asset URLs remain accepted, and releases without a parseable installer filename are ignored rather than compared using an unreliable tag.  ## Model Used  - OpenAI `gpt-5.6-luna`, high reasoning, tool use.  ## Checklist  - [ ] This PR targets `master` directly - [x] Thinking path traces from Verenu context down to this specific change - [x] Model used is specified (provider + version) - [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work - [ ] `npm run check` passes (TypeScript) - [ ] `npm run lint` passes (ESLint + Clippy) - [ ] `npm run test:rust` passes - [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands) - [x] Tests added or updated where applicable - [ ] UI changes include before/after screenshots - [x] No API keys, secrets, or personal data in code or logs - [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) - [ ] Relevant documentation updated to reflect changes - [x] Risks documented above