### PR TITLE
Gate disabled sync and filter virtual discovery adapters

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
                 "release"
             };
             log::info!(
-                "verenu {} starting — {} {}, {} build — verbose logging {}",
+                "verenu {} starting ? {} {}, {} build ? verbose logging {}",
                 env!("CARGO_PKG_VERSION"),
                 std::env::consts::OS,
                 std::env::consts::ARCH,
@@ -137,7 +137,7 @@ fn main() {
                                 // On macOS the hotkey is now a modifier+key combo
                                 // (RegisterEventHotKey, no Input Monitoring). A stored
                                 // modifier-only chord from an earlier build (e.g. Fn+Control)
-                                // is not registrable — migrate it to the ⌥+Space default so
+                                // is not registrable ? migrate it to the ?+Space default so
                                 // the backend and the settings label stay in sync.
                                 #[cfg(target_os = "macos")]
                                 let (k1, k2) = if !crate::core::hotkey::is_hotkey_available(k1, k2)
@@ -225,11 +225,19 @@ fn main() {
             }
 
             // LAN device sync: identity, mDNS discovery, listener, sessions.
-            // Soft-fails internally — never blocks startup.
-            app.manage(sync::SyncManager::start(
-                app.handle().clone(),
-                app.state::<DbHandle>().inner().clone(),
-            ));
+            // Soft-fails internally ? never blocks startup.
+            let sync_enabled = settings
+                .get(crate::data::store::SYNC_ENABLED)
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false);
+            if sync_enabled {
+                app.manage(sync::SyncManager::start(
+                    app.handle().clone(),
+                    app.state::<DbHandle>().inner().clone(),
+                ));
+            } else {
+                log::info!("sync: disabled by setting");
+            }
 
             app_tray::setup_tray(app)?;
             #[cfg(target_os = "windows")]
@@ -246,7 +254,7 @@ fn main() {
             }
             app_hotkey::setup_hotkey(app, shared.clone());
             // setup_tray() already applies runtime icons (both platforms) via
-            // apply_runtime_icons() — no need to call it again here.
+            // apply_runtime_icons() ? no need to call it again here.
             #[cfg(target_os = "macos")]
             {
                 crate::system::mac_app::set_accessory_activation_policy_on_main_thread(
@@ -303,7 +311,7 @@ fn main() {
 
                     // Proactive safety unload: don't wait out the configured
                     // idle timeout if the system is genuinely low on RAM or
-                    // (NVIDIA) VRAM right now — e.g. launching a demanding
+                    // (NVIDIA) VRAM right now ? e.g. launching a demanding
                     // game shouldn't have to wait 15 minutes for Verenu to
                     // give back memory its local models are holding.
                     let stt_loaded = local_stt_manager
@@ -318,7 +326,7 @@ fn main() {
                         .unwrap_or(false);
                     if stt_loaded || llm_loaded {
                         // detect_resource_pressure() does blocking process
-                        // I/O (bounded by its own internal timeout) — run it
+                        // I/O (bounded by its own internal timeout) ? run it
                         // off the async worker thread so a slow/wedged
                         // nvidia-smi can never stall this loop or other
                         // tasks sharing the runtime.
@@ -392,7 +400,7 @@ fn main() {
                             == "system"
                         {
                             // apply_runtime_icons() already applies runtime icons
-                            // internally — no separate call needed here.
+                            // internally ? no separate call needed here.
                             apply_runtime_icons(app, Some(*theme));
                         }
                     }
@@ -405,7 +413,7 @@ fn main() {
                         // (theme/accent/DPI-dependent). Refreshing either here
                         // re-ran WinRT title-bar updates, child-window
                         // enumeration, full icon rasterization, and a frontend
-                        // style recalc on every mouse-move event of a drag —
+                        // style recalc on every mouse-move event of a drag ?
                         // the stutter when jiggling the window. A
                         // cross-monitor move that changes DPI arrives
                         // separately as ScaleFactorChanged below.
@@ -417,7 +425,7 @@ fn main() {
                         // (WinRT calls plus child-window enumeration) stalls
                         // the drag. Coalesce to a single refresh once the size
                         // settles so maximize/snap changes are still picked
-                        // up. Icons are size-independent — they refresh on
+                        // up. Icons are size-independent ? they refresh on
                         // ScaleFactorChanged/ThemeChanged/settings instead.
                         schedule_settled_titlebar_refresh(window.app_handle());
                     }
@@ -581,7 +589,7 @@ fn main() {
             }
             // Local cleanup runs llama-server.exe as a real child OS process
             // (unlike local_stt, which is in-process). Child processes are
-            // not automatically killed when their parent exits on Windows —
+            // not automatically killed when their parent exits on Windows ?
             // without this, quitting Verenu while a local cleanup model is
             // loaded would orphan llama-server.exe, leaving it running
             // indefinitely and holding the loaded model's RAM/VRAM.
@@ -602,7 +610,7 @@ static TITLEBAR_REFRESH_GEN: std::sync::atomic::AtomicU64 =
 
 /// Re-read native title-bar metrics once the window size has settled (150ms
 /// with no further `Resized` event). A live resize delivers one event per
-/// frame, so each event just bumps the generation and schedules a check —
+/// frame, so each event just bumps the generation and schedules a check ?
 /// only the last one in a burst performs the refresh. See the `Resized` arm
 /// in `on_window_event`.
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -454,12 +454,14 @@ impl SyncManager {
         // Some directly launched macOS app binaries see only loopback through
         // getifaddrs. A UDP route lookup does not send traffic and reliably
         // reveals the primary interface address in that environment.
-        if let Ok(route_probe) = std::net::UdpSocket::bind("0.0.0.0:0") {
-            if route_probe.connect("192.0.2.1:9").is_ok() {
-                if let Ok(local) = route_probe.local_addr() {
-                    let address = local.ip();
-                    if is_discovery_advertised_address_allowed(address) {
-                        lan_addresses.push(address);
+        if lan_addresses.is_empty() {
+            if let Ok(route_probe) = std::net::UdpSocket::bind("0.0.0.0:0") {
+                if route_probe.connect("192.0.2.1:9").is_ok() {
+                    if let Ok(local) = route_probe.local_addr() {
+                        let address = local.ip();
+                        if is_discovery_advertised_address_allowed(address) {
+                            lan_addresses.push(address);
+                        }
                     }
                 }
             }

--- a/src-tauri/src/sync/manager.rs
+++ b/src-tauri/src/sync/manager.rs
@@ -10,10 +10,10 @@
 //! - Failed attempts back off exponentially up to 10 minutes.
 
 use anyhow::{anyhow, Result};
-use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use mdns_sd::{IfKind, IfPredicate, ServiceDaemon, ServiceEvent, ServiceInfo};
 use rusqlite::OptionalExtension;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -40,6 +40,65 @@ const PAIRING_PROMPT_LIFETIME: Duration = Duration::from_secs(180);
 const MAX_BACKOFF: Duration = Duration::from_secs(600);
 const PRIVATE_PORT_START: u16 = 49_152;
 const PRIVATE_PORT_COUNT: u32 = 16_384;
+const VIRTUAL_INTERFACE_MARKERS: &[&str] = &[
+    "tailscale",
+    "wireguard",
+    "zerotier",
+    "hamachi",
+    "openvpn",
+    "anyconnect",
+    "wintun",
+    "hyper-v",
+    "hyperv",
+    "vethernet",
+    "virtualbox",
+    "vmware",
+    "virtual",
+    "docker",
+    "wsl",
+    "teredo",
+    "isatap",
+];
+
+fn is_tailscale_address(address: Ipv4Addr) -> bool {
+    let [first, second, ..] = address.octets();
+    first == 100 && (64..=127).contains(&second)
+}
+
+fn is_link_local_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => address.is_link_local(),
+        IpAddr::V6(address) => address.is_unicast_link_local(),
+    }
+}
+
+fn is_discovery_advertised_address_allowed(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            !address.is_loopback()
+                && !address.is_unspecified()
+                && !address.is_link_local()
+                && !is_tailscale_address(address)
+        }
+        IpAddr::V6(_) => false,
+    }
+}
+
+pub(crate) fn is_discovery_interface_allowed(name: &str, address: IpAddr, is_p2p: bool) -> bool {
+    if is_p2p || address.is_loopback() || address.is_unspecified() || is_link_local_address(address)
+    {
+        return false;
+    }
+
+    if matches!(address, IpAddr::V4(address) if is_tailscale_address(address)) {
+        return false;
+    }
+
+    let normalized_name = name.trim().to_ascii_lowercase();
+    !VIRTUAL_INTERFACE_MARKERS
+        .iter()
+        .any(|marker| normalized_name.contains(marker))
+}
 
 /// Keep a device on the same private TCP port across app restarts. mDNS
 /// caches can retain the previous advertisement for part of its TTL; a random
@@ -325,7 +384,7 @@ impl SyncManager {
         // resolution existed (or before it was applied to that row): a target
         // that doesn't look like this platform's own naming convention and
         // was never tagged gets a chance to resolve against apps installed
-        // right now. Best-effort — sync must start regardless.
+        // right now. Best-effort ? sync must start regardless.
         if let Err(err) = self.reconcile_stale_context_targets() {
             log::warn!("sync: stale context target reconciliation failed: {err:#}");
         }
@@ -352,6 +411,11 @@ impl SyncManager {
         }
         let daemon =
             ServiceDaemon::new().map_err(|e| anyhow!("mDNS daemon failed to start: {e}"))?;
+        daemon
+            .disable_interface(IfKind::Predicate(IfPredicate::new(|interface| {
+                !is_discovery_interface_allowed(&interface.name, interface.ip(), interface.is_p2p())
+            })))
+            .map_err(|e| anyhow!("mDNS interface filtering failed: {e}"))?;
         let (uuid, name, port) = {
             let guard = self.inner.identity.read().expect("identity lock");
             let identity = guard.as_ref().ok_or_else(|| anyhow!("identity missing"))?;
@@ -380,9 +444,11 @@ impl SyncManager {
         let mut lan_addresses: Vec<std::net::IpAddr> = if_addrs::get_if_addrs()
             .unwrap_or_default()
             .into_iter()
-            .map(|interface| interface.ip())
-            .filter(|address| {
-                address.is_ipv4() && !address.is_loopback() && !address.is_unspecified()
+            .filter_map(|interface| {
+                let address = interface.ip();
+                (is_discovery_interface_allowed(&interface.name, address, interface.is_p2p())
+                    && is_discovery_advertised_address_allowed(address))
+                .then_some(address)
             })
             .collect();
         // Some directly launched macOS app binaries see only loopback through
@@ -392,7 +458,7 @@ impl SyncManager {
             if route_probe.connect("192.0.2.1:9").is_ok() {
                 if let Ok(local) = route_probe.local_addr() {
                     let address = local.ip();
-                    if address.is_ipv4() && !address.is_loopback() && !address.is_unspecified() {
+                    if is_discovery_advertised_address_allowed(address) {
                         lan_addresses.push(address);
                     }
                 }
@@ -522,7 +588,7 @@ impl SyncManager {
                 Ok(_) => {}
                 // The resolved executable already belongs to another row for
                 // this context (both devices' targets turned out to be the
-                // same app) — drop the now-redundant stale row instead of
+                // same app) ? drop the now-redundant stale row instead of
                 // erroring the whole pass.
                 Err(rusqlite::Error::SqliteFailure(err, _))
                     if err.code == rusqlite::ErrorCode::ConstraintViolation =>

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use serde_json::json;
+use std::net::IpAddr;
 
 use super::engine::{self, SyncHost, SYNCABLE_SETTINGS};
 use super::protocol::Message;
@@ -44,6 +45,35 @@ fn automatic_sync_has_exactly_one_initiator() {
     let b = "be256d68-0000-0000-0000-000000000000";
     assert!(super::manager::should_auto_initiate(a, b));
     assert!(!super::manager::should_auto_initiate(b, a));
+}
+
+#[test]
+fn discovery_excludes_tunnels_virtual_and_non_lan_interfaces() {
+    assert!(!super::manager::is_discovery_interface_allowed(
+        "Tailscale",
+        "100.99.57.54".parse::<IpAddr>().unwrap(),
+        true,
+    ));
+    assert!(!super::manager::is_discovery_interface_allowed(
+        "Ethernet",
+        "100.99.57.54".parse::<IpAddr>().unwrap(),
+        false,
+    ));
+    assert!(!super::manager::is_discovery_interface_allowed(
+        "vEthernet (Default Switch)",
+        "172.20.0.1".parse::<IpAddr>().unwrap(),
+        false,
+    ));
+    assert!(!super::manager::is_discovery_interface_allowed(
+        "Ethernet",
+        "169.254.61.34".parse::<IpAddr>().unwrap(),
+        false,
+    ));
+    assert!(super::manager::is_discovery_interface_allowed(
+        "Ethernet 2",
+        "192.168.0.187".parse::<IpAddr>().unwrap(),
+        false,
+    ));
 }
 
 fn test_db(device_uuid: &str) -> DbHandle {
@@ -830,7 +860,7 @@ fn test_context_op(
 /// A target this device already resolved for its own platform (whether by a
 /// prior successful auto-match or the user manually picking the app on an
 /// unresolved "?::" chip) must survive a later resync that re-derives a
-/// worse or unresolved match for the same context — see the "sticky" guard
+/// worse or unresolved match for the same context ? see the "sticky" guard
 /// in `reconcile_context_children`.
 #[test]
 fn resolved_context_target_survives_a_later_unresolved_resync() {
@@ -864,7 +894,7 @@ fn resolved_context_target_survives_a_later_unresolved_resync() {
     .expect("simulate local fix");
 
     // A later resync re-derives a bad/unresolved match again for the same
-    // context — e.g. an unrelated edit made on another device (rename, tone
+    // context ? e.g. an unrelated edit made on another device (rename, tone
     // change) after the fix, which still carries that device's now-stale
     // view of the target list, since a context syncs as one LWW aggregate.
     // Use a real "now" stamp so this op is unambiguously newer than the
@@ -888,7 +918,7 @@ fn resolved_context_target_survives_a_later_unresolved_resync() {
     // The sticky row must survive completely unchanged. (A stray unresolved
     // marker may additionally appear alongside it here, since this test's
     // synthetic resync payload deliberately carries a different raw source
-    // string than what actually produced "antigravity.app" — in the real
+    // string than what actually produced "antigravity.app" ? in the real
     // pipeline, `resolve_context_targets_in_ops` re-derives the same source
     // deterministically and would just re-affirm the sticky row instead. The
     // one guarantee this test enforces is what the user asked for: the fix


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app, while the sync subsystem is an optional local peer-discovery feature.
> - The sync manager owns the listener, mDNS daemon, advertiser, browser, and peer monitor.
> - Startup constructed that manager unconditionally, so the listener and mDNS traffic appeared even when sync was disabled.
> - Enabled discovery also accepted Tailscale and other virtual adapters, causing responses and advertisements on interfaces that are not local LAN links.
> - This pull request gates the complete sync stack on the persisted setting and applies the same interface policy to mDNS and advertised-address selection.
> - The result is no sync listener or discovery traffic when sync is off, with enabled discovery limited to usable physical LAN interfaces.

## What Changed

- Start `SyncManager` only when the persisted experimental sync setting is enabled.
- Exclude point-to-point, loopback, unspecified, link-local, Tailscale, and known VPN or virtual adapters from mDNS discovery.
- Apply the interface filter to both mDNS daemon setup and advertised IPv4 addresses.\n- Use the UDP route-probe fallback only when no allowed LAN address was enumerated.
- Add regression coverage for Tailscale, vEthernet, link-local, and physical LAN addresses.

## Verification

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `npm run test:rust` (635 passed, 4 ignored)
- [x] Sync discovery regression test
- [x] `git diff --check`
- [x] Confirmed the change does not alter the dictation provider pipeline
- [ ] `npm run check` / frontend lint not run
- [ ] Full installer smoke test not run

## Risks

- Low. Sync remains opt-in, and enabled sync still supports physical IPv4 LAN interfaces.
- The third-party mDNS parser behavior is unchanged; this removes the unwanted disabled-mode listener and avoids default discovery over tunnel or virtual adapters.

## Model Used

- OpenAI GPT-5.6 Luna (Codex), tool-assisted code analysis and testing.

## Checklist

- [x] Target branch is `master`.
- [x] Roadmap checked for duplicate or conflicting work.
- [x] Rust check and test suite completed.
- [x] No secrets or credentials added.
- [x] No unrelated files committed.
- [ ] Frontend check or lint completed.
- [ ] Smoke test completed.
- [ ] Documentation updated (not needed for this internal behavior fix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791178294&installation_model_id=432577&pr_number=348&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F348&signature=b7e1ca637accdcf9c2e048073786effb4c09ce1a079985fe168580f092230661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

