### PR TITLE
Fix light-mode Windows title bar contrast

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -542,6 +542,10 @@ pub async fn save_setting(
     if crate::app_tray::setting_updates_runtime_icons(&key) {
         crate::apply_runtime_icons(&app, None);
     }
+    #[cfg(target_os = "windows")]
+    if key == store::APPEARANCE_MODE {
+        crate::system::windows_titlebar::refresh_for_app(&app);
+    }
     if let Some(volume) = sound_effects_volume {
         crate::media::sound::set_volume(volume);
     }

--- a/src-tauri/src/commands/settings/import_export.rs
+++ b/src-tauri/src/commands/settings/import_export.rs
@@ -150,6 +150,7 @@ pub async fn import_data(
         let mut settings_applied = 0usize;
         let mut settings_skipped = 0usize;
         let mut runtime_icon_setting_applied = false;
+        #[cfg(target_os = "windows")]
         let mut appearance_setting_applied = false;
         let mut history_prune_days: Option<i64> = None;
 
@@ -168,6 +169,7 @@ pub async fn import_data(
                         if crate::app_tray::setting_updates_runtime_icons(key) {
                             runtime_icon_setting_applied = true;
                         }
+                        #[cfg(target_os = "windows")]
                         if key == store::APPEARANCE_MODE {
                             appearance_setting_applied = true;
                         }

--- a/src-tauri/src/commands/settings/import_export.rs
+++ b/src-tauri/src/commands/settings/import_export.rs
@@ -150,6 +150,7 @@ pub async fn import_data(
         let mut settings_applied = 0usize;
         let mut settings_skipped = 0usize;
         let mut runtime_icon_setting_applied = false;
+        let mut appearance_setting_applied = false;
         let mut history_prune_days: Option<i64> = None;
 
         if !payload.settings.is_object() {
@@ -166,6 +167,9 @@ pub async fn import_data(
                         settings.set(key.clone(), value.clone())?;
                         if crate::app_tray::setting_updates_runtime_icons(key) {
                             runtime_icon_setting_applied = true;
+                        }
+                        if key == store::APPEARANCE_MODE {
+                            appearance_setting_applied = true;
                         }
                         // Mirror save_setting's side effect: a backup that
                         // tightens history retention must prune immediately,
@@ -187,6 +191,10 @@ pub async fn import_data(
 
         if runtime_icon_setting_applied {
             crate::apply_runtime_icons(&app, None);
+        }
+        #[cfg(target_os = "windows")]
+        if appearance_setting_applied {
+            crate::system::windows_titlebar::refresh_for_app(&app);
         }
 
         if let Some(days) = history_prune_days {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -428,6 +428,7 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             system::windows_titlebar::get_native_titlebar_metrics,
+            system::windows_titlebar::set_native_titlebar_theme,
             commands::save_hotkey,
             commands::check_hotkey,
             commands::save_repair_hotkey,

--- a/src-tauri/src/system/mod.rs
+++ b/src-tauri/src/system/mod.rs
@@ -20,6 +20,9 @@ pub mod windows_titlebar {
     pub fn get_native_titlebar_metrics() -> Result<(), String> {
         Err("native title bar metrics are only available on Windows".to_owned())
     }
+
+    #[tauri::command]
+    pub fn set_native_titlebar_theme(_window: tauri::WebviewWindow, _dark: bool) {}
 }
 
 /// Stops and unloads both local model engines (LLM + STT) before the process

--- a/src-tauri/src/system/windows_titlebar.rs
+++ b/src-tauri/src/system/windows_titlebar.rs
@@ -3,7 +3,7 @@ use std::{
     os::windows::ffi::OsStrExt,
     sync::{Mutex, OnceLock},
 };
-use tauri::{Emitter, Theme, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, Theme, WebviewWindow};
 use windows::{
     core::PCSTR,
     Win32::{
@@ -165,14 +165,26 @@ fn convert(native: NativeMetrics) -> TitleBarMetrics {
     }
 }
 
-fn dark(theme: Option<Theme>) -> bool {
-    !matches!(theme, Some(Theme::Light))
+fn dark(theme: Option<Theme>, appearance_mode: Option<&str>) -> bool {
+    match appearance_mode {
+        Some("light") => false,
+        Some("dark") => true,
+        _ => !matches!(theme, Some(Theme::Light)),
+    }
+}
+
+fn resolved_dark(window: &WebviewWindow, theme: Option<Theme>) -> bool {
+    dark(
+        theme,
+        crate::app_tray::appearance_mode(window.app_handle()).as_deref(),
+    )
 }
 
 pub fn enable(window: &WebviewWindow, theme: Option<Theme>) -> Result<TitleBarMetrics, String> {
     let hwnd = window.hwnd().map_err(|e| e.to_string())?.0 as isize;
     let mut native = NativeMetrics::default();
-    let hr = unsafe { (bridge()?.enable)(hwnd, i32::from(dark(theme)), &mut native) };
+    let hr =
+        unsafe { (bridge()?.enable)(hwnd, i32::from(resolved_dark(window, theme)), &mut native) };
     if hr < 0 {
         return Err(format!(
             "AppWindowTitleBar initialization failed with HRESULT 0x{:08X}",
@@ -194,10 +206,22 @@ pub fn refresh(window: &WebviewWindow, theme: Option<Theme>) {
     let Ok(hwnd) = window.hwnd() else { return };
     let mut native = NativeMetrics::default();
     if let Ok(bridge) = bridge() {
-        let hr = unsafe { (bridge.update)(hwnd.0 as isize, i32::from(dark(theme)), &mut native) };
+        let hr = unsafe {
+            (bridge.update)(
+                hwnd.0 as isize,
+                i32::from(resolved_dark(window, theme)),
+                &mut native,
+            )
+        };
         if hr >= 0 {
             emit_if_changed(window, &native);
         }
+    }
+}
+
+pub(crate) fn refresh_for_app(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        refresh(&window, window.theme().ok());
     }
 }
 
@@ -241,7 +265,20 @@ pub fn get_native_titlebar_metrics(window: WebviewWindow) -> Result<TitleBarMetr
 
 #[cfg(test)]
 mod tests {
-    use super::NativeMetrics;
+    use super::{dark, NativeMetrics};
+
+    #[test]
+    fn explicit_appearance_overrides_system_theme() {
+        assert!(!dark(Some(tauri::Theme::Dark), Some("light")));
+        assert!(dark(Some(tauri::Theme::Light), Some("dark")));
+    }
+
+    #[test]
+    fn system_appearance_uses_native_theme() {
+        assert!(!dark(Some(tauri::Theme::Light), Some("system")));
+        assert!(dark(Some(tauri::Theme::Dark), Some("system")));
+        assert!(dark(None, None));
+    }
 
     fn metrics() -> NativeMetrics {
         let mut m = NativeMetrics::default();

--- a/src-tauri/src/system/windows_titlebar.rs
+++ b/src-tauri/src/system/windows_titlebar.rs
@@ -203,13 +203,17 @@ pub fn enable(window: &WebviewWindow, theme: Option<Theme>) -> Result<TitleBarMe
 }
 
 pub fn refresh(window: &WebviewWindow, theme: Option<Theme>) {
+    refresh_with_dark(window, resolved_dark(window, theme));
+}
+
+fn refresh_with_dark(window: &WebviewWindow, dark: bool) {
     let Ok(hwnd) = window.hwnd() else { return };
     let mut native = NativeMetrics::default();
     if let Ok(bridge) = bridge() {
         let hr = unsafe {
             (bridge.update)(
                 hwnd.0 as isize,
-                i32::from(resolved_dark(window, theme)),
+                i32::from(dark),
                 &mut native,
             )
         };
@@ -217,6 +221,13 @@ pub fn refresh(window: &WebviewWindow, theme: Option<Theme>) {
             emit_if_changed(window, &native);
         }
     }
+}
+
+/// Apply the theme the frontend is actually rendering. The native window theme
+/// can follow the OS while Verenu is explicitly set to the opposite appearance.
+#[tauri::command]
+pub fn set_native_titlebar_theme(window: WebviewWindow, dark: bool) {
+    refresh_with_dark(&window, dark);
 }
 
 pub(crate) fn refresh_for_app(app: &AppHandle) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -55,6 +55,11 @@
   function applyTheme() {
     const theme = effectiveTheme(appStore.appearanceMode);
     document.documentElement.dataset.theme = theme;
+    if (isWindows && isTauriRuntime()) {
+      invoke('set_native_titlebar_theme', { dark: theme === 'dark' }).catch((error) => {
+        console.error('Failed to sync native title bar theme:', error);
+      });
+    }
   }
 
   $effect(() => {


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold, audio capture, transcription, cleanup, and text injection.
> - This PR addresses the Windows native title-bar and appearance-settings boundary.
> - The app content could be light while the native minimize, maximize, and close glyphs still used the system dark-theme color.
> - That mismatch made the caption controls nearly invisible against the light caption background.
> - This pull request makes native caption theming follow Verenu's explicit appearance setting.
> - The benefit is readable and usable Windows window controls in light mode without changing the existing visual design.

## What Changed

- Resolve native caption button colors from Verenu's saved `light`, `dark`, or `system` appearance mode, with the OS theme used only for `system`.
- Refresh the native title bar when appearance settings are saved or imported.
- Add focused Rust tests covering explicit appearance overrides and system-theme fallback.

## Verification

- `npm run check` passes with zero Svelte diagnostics.
- `cargo test --manifest-path src-tauri/Cargo.toml windows_titlebar` passed: 4 tests.
- Focused `git diff --check` passes.
- Native visual launch was attempted, but the shared workspace currently has unrelated edits removing `REPAIR_HOTKEY`, so the dev app cannot compile for a screenshot smoke check.

## Risks

- Low risk. The change is limited to Windows native caption color selection and refresh timing.
- `system` appearance behavior remains unchanged.
- No settings schema, API key, clipboard, injection, or migration behavior changes.

## Model Used

- OpenAI GPT-5.6-luna, Codex, high reasoning effort.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`; this PR does not duplicate planned work
- [x] `npm run check` passes
- [ ] `npm run lint` passes; not run because the shared workspace backend is currently inconsistent
- [x] Focused Rust title-bar tests pass
- [ ] Smoke tests pass; native app launch is blocked by unrelated workspace edits
- [x] Tests added where applicable
- [ ] UI changes include before/after screenshots; the native app could not launch for capture
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249989&installation_model_id=432577&pr_number=355&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F355&signature=c571954d2af49fd7c974fb3aabb584c41c1ab23450bc576c219bfb64c1a45f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->