### PR TITLE
Fix Insights pace meter ceiling

### DIFF
--- a/src/lib/views/insights/helpers.test.ts
+++ b/src/lib/views/insights/helpers.test.ts
@@ -16,7 +16,8 @@ describe('pace meter scale', () => {
   it('grows the ceiling past the best instead of pinning it to the last tick', () => {
     expect(paceScale(120).max).toBe(200); // floor, so slow talkers keep a stable scale
     expect(paceScale(245).max).toBe(250);
-    expect(paceScale(251).max).toBe(300);
+    expect(paceScale(251).max).toBe(250);
+    expect(paceScale(254).bestTick).toBe(PACE_TICKS - 1);
   });
 
   it('has no marker before a best is measured', () => {

--- a/src/lib/views/insights/helpers.ts
+++ b/src/lib/views/insights/helpers.ts
@@ -158,7 +158,7 @@ export const PACE_TICKS = 44;
  * the end.
  */
 export function paceScale(bestWpm: number, ticks = PACE_TICKS): { max: number; bestTick: number } {
-  const max = Math.max(200, Math.ceil(bestWpm / 50) * 50);
+  const max = Math.min(250, Math.max(200, Math.ceil(bestWpm / 50) * 50));
   if (bestWpm <= 0) return { max, bestTick: -1 };
   // Lower clamp: a best under half a tick still deserves a marker on tick 0
   // rather than rounding away to "no best".


### PR DESCRIPTION
> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The UI subsystem owns the Insights speaking-pace meter.
> - The meter previously continued with unused ticks after the personal-best marker and could extend to 300 WPM.
> - This PR caps the readable scale at 250 WPM and makes the best marker terminal at the ceiling.
> - The benefit is a clearer meter with no misleading trailing ticks.

## What Changed

- Cap the pace-meter ceiling at 250 WPM.
- Keep a near-ceiling or over-ceiling best value on the final tick.
- Update the pace-scale regression test.

## Verification

- 
pm run build passes.
- 
pm run test:unit -- --run src/lib/views/insights/helpers.test.ts passes.
- Browser preview verified the meter ending at the tall marker.

## Risks

- Low risk. UI and pure helper logic only. No backend, data, or API behavior changes.

## Model Used

- OpenAI Codex GPT-5.6-Luna, high reasoning, tool use.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791255529&installation_model_id=432577&pr_number=359&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F359&signature=20e7759436b4d26fde8d4208be68b984053efd92854703907728fe30359b903c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->