### PR TITLE
Migrate Groq cleanup defaults to Qwen 3.8

### DIFF
--- a/src-tauri/src/data/store/config.rs
+++ b/src-tauri/src/data/store/config.rs
@@ -40,6 +40,7 @@ pub const ASSEMBLYAI: &str = "assemblyai";
 pub(crate) const LOCAL: &str = "local";
 pub const GROQ_GPT_OSS_20B_MODEL: &str = "openai/gpt-oss-20b";
 pub const GROQ_QWEN_3_6_27B_MODEL: &str = "qwen/qwen3.6-27b";
+pub const GROQ_QWEN_3_8_27B_MODEL: &str = "qwen/qwen3.8-27b";
 pub const DEPRECATED_GROQ_LLAMA_8B_MODEL: &str = "llama-3.1-8b-instant";
 pub const DEPRECATED_GROQ_LLAMA_70B_MODEL: &str = "llama-3.3-70b-versatile";
 pub const PROVIDERS: [&str; 5] = [GROQ, OPENAI, GOOGLE, ASSEMBLYAI, LOCAL];
@@ -59,7 +60,7 @@ pub fn default_cleanup_model_for(provider: &str) -> &'static str {
         LOCAL => "gemma-4-e2b",
         OPENAI => "gpt-4o-mini",
         GOOGLE => "gemini-3.5-flash-lite",
-        _ => GROQ_QWEN_3_6_27B_MODEL,
+        _ => GROQ_QWEN_3_8_27B_MODEL,
     }
 }
 
@@ -70,13 +71,14 @@ pub fn migrate_deprecated_model_id(id: &str) -> String {
     if provider == GROQ
         && matches!(
             model.as_str(),
-            DEPRECATED_GROQ_LLAMA_8B_MODEL
+                DEPRECATED_GROQ_LLAMA_8B_MODEL
                 | DEPRECATED_GROQ_LLAMA_70B_MODEL
                 | GROQ_GPT_OSS_20B_MODEL
                 | "openai/gpt-oss-120b"
+                | GROQ_QWEN_3_6_27B_MODEL
         )
     {
-        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
     } else if provider == GOOGLE && matches!(model.as_str(), "gemini-3.7-flash" | "gemini-2.5-pro")
     {
         format!("{GOOGLE}/gemini-3.5-flash-lite")

--- a/src-tauri/src/data/store/tests.rs
+++ b/src-tauri/src/data/store/tests.rs
@@ -104,7 +104,7 @@ fn setting_audit_empty_store_resolves_to_documented_defaults() {
     );
     assert_eq!(
         cfg.cleanup_default_model,
-        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
     );
     assert!(cfg.transcription_fallback_models.is_empty());
     assert!(cfg.cleanup_fallback_models.is_empty());
@@ -170,7 +170,7 @@ fn setting_audit_malformed_model_id_resolves_to_safe_default() {
     );
     assert_eq!(
         cfg.cleanup_default_model,
-        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
     );
 }
 
@@ -189,12 +189,12 @@ fn deprecated_groq_cleanup_models_migrate_to_no_thinking_qwen() {
     let cfg = load_pipeline_config(&store);
     assert_eq!(
         cfg.cleanup_default_model,
-        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
     );
     assert_eq!(
         cfg.cleanup_fallback_models,
         vec![
-            format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}"),
+            format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}"),
             "openai/gpt-4o-mini".to_string()
         ]
     );
@@ -215,12 +215,38 @@ fn deprecated_groq_llama_70b_migrates_to_qwen() {
     let cfg = load_pipeline_config(&store);
     assert_eq!(
         cfg.cleanup_default_model,
-        format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}")
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
     );
     assert_eq!(
         cfg.cleanup_fallback_models,
         vec![
-            format!("{GROQ}/{GROQ_QWEN_3_6_27B_MODEL}"),
+            format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}"),
+            "openai/gpt-4o-mini".to_string()
+        ]
+    );
+}
+
+#[test]
+fn deprecated_qwen_36_migrates_to_qwen_38() {
+    let store = SettingsSnapshot::from_pairs([
+        (
+            CLEANUP_DEFAULT_MODEL.to_string(),
+            json!("groq/qwen/qwen3.6-27b"),
+        ),
+        (
+            CLEANUP_FALLBACK_MODELS.to_string(),
+            json!(["groq/qwen/qwen3.6-27b", "openai/gpt-4o-mini"]),
+        ),
+    ]);
+    let cfg = load_pipeline_config(&store);
+    assert_eq!(
+        cfg.cleanup_default_model,
+        format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}")
+    );
+    assert_eq!(
+        cfg.cleanup_fallback_models,
+        vec![
+            format!("{GROQ}/{GROQ_QWEN_3_8_27B_MODEL}"),
             "openai/gpt-4o-mini".to_string()
         ]
     );

--- a/src/lib/components/settings/ModelsSection.svelte
+++ b/src/lib/components/settings/ModelsSection.svelte
@@ -80,7 +80,7 @@
   let cleanupModelsByProvider = $state<ProviderModelMap>(emptyProviderModelMap());
 
   let transcriptionDefaultModel = $state('groq/whisper-large-v3-turbo');
-  let cleanupDefaultModel = $state('groq/qwen/qwen3.6-27b');
+  let cleanupDefaultModel = $state('groq/qwen/qwen3.8-27b');
   let transcriptionFallbackModels = $state<string[]>([]);
   let dualTranscriptionEnabled = $state(false);
   let cleanupFallbackModels = $state<string[]>([]);
@@ -560,7 +560,7 @@
       : 'groq/whisper-large-v3-turbo';
     const legacyCleanup = rawLegacyCleanup
       ? (rawLegacyCleanup.includes('/') ? rawLegacyCleanup : `groq/${rawLegacyCleanup}`)
-      : 'groq/qwen/qwen3.6-27b';
+      : 'groq/qwen/qwen3.8-27b';
 
     transcriptionDefaultModel = migrateDeprecatedGoogleModel(all.transcription_default_model ?? legacyTranscription);
     cleanupDefaultModel = migrateDeprecatedGoogleModel(all.cleanup_default_model ?? legacyCleanup);

--- a/src/lib/components/settings/modelPresets.ts
+++ b/src/lib/components/settings/modelPresets.ts
@@ -9,7 +9,13 @@
 
 import { invoke } from '../../tauri';
 import type { ProviderId } from '../../settings';
-import { modelId, recommendedModels, type TaskType, type UiProviderId } from './models';
+import {
+  GROQ_QWEN_3_8_27B_MODEL,
+  modelId,
+  recommendedModels,
+  type TaskType,
+  type UiProviderId,
+} from './models';
 
 export type Hardware = {
   totalRamMb: number;
@@ -234,7 +240,13 @@ function transcriptionModelFor(provider: UiProviderId, tier: 'standard' | 'premi
 function cleanupModelFor(provider: UiProviderId | undefined, tier: 'standard' | 'premium'): string | null {
   if (!provider) return null;
   const entry = recommendedModels.cleanup[provider];
-  return entry ? modelId(provider, entry[tier]) : null;
+  if (!entry) return null;
+  // Groq's former standard cleanup model is being retired. Keep the catalog
+  // entry for recognizing old selections, but never put it into a new preset.
+  if (provider === 'groq' && tier === 'standard') {
+    return modelId(provider, GROQ_QWEN_3_8_27B_MODEL);
+  }
+  return modelId(provider, entry[tier]);
 }
 
 // ── Public: build the preset list ─────────────────────────────────────────

--- a/src/lib/components/settings/models.test.ts
+++ b/src/lib/components/settings/models.test.ts
@@ -75,10 +75,11 @@ describe('catalogFor', () => {
     expect(migrateDeprecatedGoogleModel('gemini-3.5-flash')).toBe('gemini-3.5-flash');
   });
 
-  it('migrates Groq reasoning-only cleanup models to no-thinking Qwen', () => {
-    expect(migrateDeprecatedGroqCleanupModel('llama-3.1-8b-instant')).toBe('qwen/qwen3.6-27b');
-    expect(migrateDeprecatedGroqCleanupModel('openai/gpt-oss-20b')).toBe('qwen/qwen3.6-27b');
-    expect(migrateDeprecatedGroqCleanupModel('openai/gpt-oss-120b')).toBe('qwen/qwen3.6-27b');
+  it('migrates deprecated Groq cleanup models to Qwen 3.8', () => {
+    expect(migrateDeprecatedGroqCleanupModel('llama-3.1-8b-instant')).toBe('qwen/qwen3.8-27b');
+    expect(migrateDeprecatedGroqCleanupModel('openai/gpt-oss-20b')).toBe('qwen/qwen3.8-27b');
+    expect(migrateDeprecatedGroqCleanupModel('openai/gpt-oss-120b')).toBe('qwen/qwen3.8-27b');
+    expect(migrateDeprecatedGroqCleanupModel('qwen/qwen3.6-27b')).toBe('qwen/qwen3.8-27b');
   });
 });
 

--- a/src/lib/components/settings/models.ts
+++ b/src/lib/components/settings/models.ts
@@ -157,10 +157,14 @@ export const recommendedModels = buildRecommended(CATALOG);
 
 export function migrateDeprecatedGroqCleanupModel(model: string): string {
   const normalized = model.trim();
-  if (normalized === DEPRECATED_GROQ_LLAMA_8B_MODEL) return GROQ_QWEN_3_6_27B_MODEL;
-  if (normalized === DEPRECATED_GROQ_LLAMA_70B_MODEL) return GROQ_QWEN_3_6_27B_MODEL;
-  if (normalized === GROQ_GPT_OSS_20B_MODEL || normalized === 'openai/gpt-oss-120b') {
-    return GROQ_QWEN_3_6_27B_MODEL;
+  if (
+    normalized === DEPRECATED_GROQ_LLAMA_8B_MODEL
+    || normalized === DEPRECATED_GROQ_LLAMA_70B_MODEL
+    || normalized === GROQ_GPT_OSS_20B_MODEL
+    || normalized === 'openai/gpt-oss-120b'
+    || normalized === GROQ_QWEN_3_6_27B_MODEL
+  ) {
+    return GROQ_QWEN_3_8_27B_MODEL;
   }
   return normalized;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -214,7 +214,7 @@ const defaultProviderModels = {
 };
 
 const defaultCleanupModels = {
-  groq: ['qwen/qwen3.6-27b', 'openai/gpt-oss-20b', 'openai/gpt-oss-120b'],
+  groq: ['qwen/qwen3.8-27b', 'openai/gpt-oss-20b', 'openai/gpt-oss-120b'],
   openai: ['gpt-4o-mini', 'gpt-4o'],
   google: ['gemini-3.5-flash-lite', 'gemini-3.5-flash', 'gemini-2.5-flash-lite'],
   local: [],
@@ -228,9 +228,9 @@ const defaultSettings: Record<string, unknown> = {
   transcription_language: 'en',
   cleanup_provider: 'groq',
   transcription_model: 'groq/whisper-large-v3-turbo',
-  cleanup_model: 'groq/qwen/qwen3.6-27b',
+  cleanup_model: 'groq/qwen/qwen3.8-27b',
   transcription_default_model: 'groq/whisper-large-v3-turbo',
-  cleanup_default_model: 'groq/qwen/qwen3.6-27b',
+  cleanup_default_model: 'groq/qwen/qwen3.8-27b',
   transcription_models_by_provider: defaultProviderModels,
   cleanup_models_by_provider: defaultCleanupModels,
   transcription_fallback_models: [],
@@ -1094,7 +1094,7 @@ function devInsights(days: number, contextId: number | null): unknown {
         output_chars: 0,
       },
       {
-        model: 'qwen/qwen3.6-27b',
+        model: 'qwen/qwen3.8-27b',
         provider: 'groq',
         task: 'cleanup',
         calls: Math.round(transcriptions * 0.86),

--- a/src/lib/views/Setup.svelte
+++ b/src/lib/views/Setup.svelte
@@ -213,7 +213,7 @@
 
   function cleanupModelsByProvider(...selected: string[]): ProviderModelMap {
     const map: ProviderModelMap = {
-      groq: ['qwen/qwen3.6-27b'],
+      groq: ['qwen/qwen3.8-27b'],
       openai: ['gpt-4o-mini', 'gpt-4o'],
       google: ['gemini-3.5-flash-lite'],
       assemblyai: [],
@@ -244,9 +244,9 @@
       ? 'local/qwen2.5-3b-instruct'
       : provider === 'openai'
         ? 'openai/gpt-4o-mini'
-        : provider === 'google'
+      : provider === 'google'
         ? 'google/gemini-3.5-flash-lite'
-          : 'groq/qwen/qwen3.6-27b';
+          : 'groq/qwen/qwen3.8-27b';
 
     // The Models step is the more specific answer, so its target wins over the
     // provider-derived defaults whenever one was chosen.

--- a/src/lib/views/insights/pricing.ts
+++ b/src/lib/views/insights/pricing.ts
@@ -26,6 +26,7 @@ export const PRICING: Record<string, Rate> = {
   // Cleanup — billed on tokens
   'llama-3.3-70b-versatile': { kind: 'token', usd_per_m_in: 0.59, usd_per_m_out: 0.79 },
   'qwen3.6-27b': { kind: 'token', usd_per_m_in: 0.60, usd_per_m_out: 3.00 },
+  'qwen3.8-27b': { kind: 'token', usd_per_m_in: 0.80, usd_per_m_out: 4.00 },
   'gpt-4o-mini': { kind: 'token', usd_per_m_in: 0.15, usd_per_m_out: 0.6 },
   'gemini-3.5-flash': { kind: 'token', usd_per_m_in: 2.70, usd_per_m_out: 16.20 },
   'gemini-3.5-flash-lite': { kind: 'token', usd_per_m_in: 0.30, usd_per_m_out: 2.50 },


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The settings/model-catalog subsystem owns provider model IDs, defaults, presets, and legacy selection migration.
> - Groq is decommissioning `qwen/qwen3.6-27b` and replacing it with `qwen/qwen3.8-27b`.
> - Cleanup defaults and persisted legacy selections must converge on the replacement before the shutdown date.
> - This pull request updates Groq cleanup defaults and migrates old Groq Qwen selections to Qwen 3.8 while retaining legacy recognition.
> - The benefit is that existing users keep a working cleanup model without manually repairing settings.

## What Changed

- Updated Groq cleanup defaults, setup defaults, sample/dev defaults, and the standard Groq preset to `qwen/qwen3.8-27b`.
- Added frontend migration coverage for `qwen/qwen3.6-27b` and other deprecated Groq selections.
- Updated Qwen 3.8 pricing and Rust store migration expectations/tests.

## Verification

- `npm run check` passes.
- `npx vitest run src/lib/components/settings/models.test.ts` passes (9 tests).
- `git diff --check` passes.
- Rust Qwen tests were attempted but are blocked by unrelated existing `AppState.repair` compile errors in the shared workspace.

## Risks

- Low migration risk: old model IDs remain in the catalog solely for recognizing existing selections, then migrate to Qwen 3.8.
- The provider model ID and pricing are updated together; no API keys or user data are changed.

## Model Used

- OpenAI Codex (GPT-5.6), tool use and code review assistance.

## Checklist

- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (not applicable to settings-only model migration)
- [x] Tests added or updated where applicable
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791256343&installation_model_id=432577&pr_number=360&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F360&signature=977c91951912113fbf946ab82cd869a79637acd126134cac2b6804e085c266b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->