### PR TITLE
Fix repair-hotkey references after merge

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -32,7 +32,6 @@ enum SettingKind {
     SoundEffectsVolume,
     AppMappings,
     Hotkey,
-    RepairHotkey,
     ClipboardPhrase,
 }
 
@@ -123,7 +122,6 @@ const SETTING_SPECS: &[SettingSpec] = &[
     ),
     setting_spec(store::CLEANUP_ENABLED, SettingKind::Bool, true, true),
     setting_spec(store::HOTKEY, SettingKind::Hotkey, true, true),
-    setting_spec(store::REPAIR_HOTKEY, SettingKind::RepairHotkey, true, true),
     setting_spec(
         store::MICROPHONE_DEVICE,
         SettingKind::StringOrNull,
@@ -407,20 +405,6 @@ pub fn validate_setting(key: &str, value: &serde_json::Value) -> Result<(), Stri
                     second.is_empty() || crate::core::hotkey::is_known_key_code(second)
                 })
         }),
-        // Two modifiers + one regular trigger key (default Ctrl+Alt+Z) — see
-        // core::hotkey::win's REPAIR_MOD1 doc comment for why a modifier-only
-        // combo isn't allowed. Unlike the main hotkey, all three slots empty
-        // is also valid: it disables the feature rather than requiring one
-        // be bound (the built-in Ctrl+Alt+Z default needs no setting saved).
-        SettingKind::RepairHotkey => value.as_array().is_some_and(|keys| {
-            keys.len() == 3
-                && keys.iter().all(serde_json::Value::is_string)
-                && (keys.iter().all(|k| k.as_str() == Some(""))
-                    || keys.iter().all(|k| {
-                        k.as_str()
-                            .is_some_and(crate::core::hotkey::is_known_key_code)
-                    }))
-        }),
     };
 
     if valid {
@@ -617,7 +601,6 @@ pub struct AllSettings {
     pub beta_updates_enabled: Option<bool>,
     pub verenu_service_checks_enabled: Option<bool>,
     pub hotkey: Option<Vec<String>>,
-    pub repair_hotkey: Option<Vec<String>>,
     pub appearance_mode: Option<String>,
     pub accent_color: Option<String>,
     pub cleanup_prompt_override: Option<String>,
@@ -688,13 +671,6 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         beta_updates_enabled: bool_val(store::BETA_UPDATES_ENABLED),
         verenu_service_checks_enabled: bool_val(store::VERENU_SERVICE_CHECKS_ENABLED),
         hotkey: s.get(store::HOTKEY).and_then(|v| {
-            v.as_array().map(|arr| {
-                arr.iter()
-                    .filter_map(|x| x.as_str().map(String::from))
-                    .collect()
-            })
-        }),
-        repair_hotkey: s.get(store::REPAIR_HOTKEY).and_then(|v| {
             v.as_array().map(|arr| {
                 arr.iter()
                     .filter_map(|x| x.as_str().map(String::from))


### PR DESCRIPTION
## Summary\n\n- Remove the obsolete repair-hotkey settings registrations that survived the post-dictation repair-flow removal merge.\n- Restore the repair-free settings implementation on top of current master.\n\n## Verification\n\n- Rust CI and frontend CI run on this follow-up PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791256673&installation_model_id=432577&pr_number=361&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F361&signature=76cfbeceabf1a38098fb09e31604a15a9069a5544866704a81d89bdb5b8ca1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->