### PR TITLE
Fix pill appearance themes

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -528,6 +528,14 @@ pub async fn save_setting(
     if crate::app_tray::setting_updates_runtime_icons(&key) {
         crate::apply_runtime_icons(&app, None);
     }
+    if key == store::APPEARANCE_MODE {
+        if let Some(mode) = store::settings_handle(&app)?
+            .get(&key)
+            .and_then(|value| value.as_str().map(str::to_owned))
+        {
+            let _ = app.emit("verenu:appearance-mode-changed", mode);
+        }
+    }
     #[cfg(target_os = "windows")]
     if key == store::APPEARANCE_MODE {
         crate::system::windows_titlebar::refresh_for_app(&app);

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1171,8 +1171,9 @@
     font-size: 10.5px;
     font-weight: 500;
     letter-spacing: 0.02em;
-    color: var(--pill-muted);
-    background: var(--pill-bg);
+    color: var(--pill-context-fg);
+    background: var(--pill-context-bg);
+    box-shadow: 0 0 0 1px var(--pill-context-line) inset;
     border-radius: 999px;
     padding: 2px 8px;
     white-space: nowrap;
@@ -1197,7 +1198,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 0 0 1px rgba(255,255,255,0.07) inset;
+    box-shadow: 0 0 0 1px var(--pill-line) inset;
     animation: pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
 
@@ -1243,7 +1244,8 @@
   .bar {
     width: var(--bar-w, 3px);
     background: var(--pill-bar);
-    border-radius: 999px;
+    border-radius: calc(var(--bar-w, 3px) / 2);
+    clip-path: inset(0 round 999px);
     flex-shrink: 0;
     /* Instant response — no CSS transition so bars snap cleanly */
   }
@@ -1405,8 +1407,8 @@
     position: relative;
     height: 16px;
     line-height: 16px;
-    font-size: 11px;
-    font-weight: 600;
+    font-size: var(--pill-stage-size);
+    font-weight: var(--pill-stage-weight);
     white-space: nowrap;
     display: block;
   }
@@ -1416,7 +1418,7 @@
      sits at 45% so the moving highlight has something to be brighter than. */
   .stage-label {
     display: block;
-    color: rgba(255, 255, 255, 0.45);
+    color: var(--pill-muted);
   }
   .stage-shine {
     position: absolute;
@@ -1427,11 +1429,11 @@
        half-white shoulders either side, fading out at both edges. */
     background-image: linear-gradient(
       90deg,
-      rgba(255, 255, 255, 0) 0%,
-      rgba(255, 255, 255, 0.5) 25%,
-      rgba(255, 255, 255, 1) 50%,
-      rgba(255, 255, 255, 0.5) 75%,
-      rgba(255, 255, 255, 0) 100%
+      var(--pill-shine-clear) 0%,
+      var(--pill-shine-mid) 25%,
+      var(--pill-shine-strong) 50%,
+      var(--pill-shine-mid) 75%,
+      var(--pill-shine-clear) 100%
     );
     background-size: 24px 100%;
     background-repeat: no-repeat;
@@ -1461,8 +1463,8 @@
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    border: 2px solid rgba(255,255,255,0.16);
-    border-top-color: var(--accent);
+    border: 2px solid var(--pill-spinner-track);
+    border-top-color: var(--pill-fg);
     animation: spin 0.8s linear infinite;
     flex-shrink: 0;
   }
@@ -1680,7 +1682,7 @@
     padding: 0 8px 0 14px;
     white-space: nowrap;
   }
-  .copied-icon { color: var(--accent); flex-shrink: 0; }
+  .copied-icon { color: var(--pill-fg); flex-shrink: 0; }
   .copied-text {
     font-size: 11.5px; font-weight: 500;
     white-space: nowrap;
@@ -1689,7 +1691,7 @@
     color: var(--pill-muted);
     animation: hfBtnIn 0.12s cubic-bezier(0.34, 1.56, 0.64, 1) 0.05s both;
   }
-  .hf-btn.copied-dismiss:hover { color: var(--pill-muted-strong); background: rgba(255,255,255,0.14); }
+  .hf-btn.copied-dismiss:hover { color: var(--pill-muted-strong); background: var(--pill-hover); }
 
   /* Handsfree: starts compact (mirrors recording — same DPI-snapped width so the
      recording→handsfree continuation doesn't jump), expands to 112px after 450ms */
@@ -1718,9 +1720,9 @@
     transition: opacity 0.15s;
   }
   .hf-btn.cancel  { color: var(--pill-muted); }
-  .hf-btn.confirm { color: var(--accent); }
+  .hf-btn.confirm { color: var(--pill-fg); }
   .hf-btn.cancel:hover  { color: var(--pill-muted-strong); }
-  .hf-btn.confirm:hover { color: var(--accent-ink); }
+  .hf-btn.confirm:hover { color: var(--pill-fg); }
 
   @keyframes hfBtnIn {
     /* Gentle fade + tiny rise, deliberately no scale — a pop reads as the UI

--- a/src/lib/components/layout/DictationPill.svelte
+++ b/src/lib/components/layout/DictationPill.svelte
@@ -64,7 +64,7 @@
     align-items: center;
     justify-content: center;
     padding: 0 3px;
-    box-shadow: 0 0 0 1px rgba(255,255,255,0.05) inset;
+    box-shadow: 0 0 0 1px var(--pill-line) inset;
   }
 
   .pill.recording  { width: 132px; }
@@ -84,6 +84,7 @@
     width: 2px;
     background: var(--pill-bar);
     border-radius: 1px;
+    clip-path: inset(0 round 999px);
     animation: barwave 0.85s infinite ease-in-out;
   }
 
@@ -140,7 +141,7 @@
     transition: opacity 0.15s;
   }
   .hf-btn.cancel  { color: var(--pill-muted); }
-  .hf-btn.confirm { color: var(--accent); }
+  .hf-btn.confirm { color: var(--pill-fg); }
   .hf-btn.cancel:hover  { color: var(--pill-muted-strong); }
-  .hf-btn.confirm:hover { color: var(--accent-ink); }
+  .hf-btn.confirm:hover { color: var(--pill-fg); }
 </style>

--- a/src/pill-main.ts
+++ b/src/pill-main.ts
@@ -9,6 +9,7 @@ disableBrowserContextMenu(); // The pill webview lives until the process exits.
 
 type AppearanceMode = 'system' | 'light' | 'dark';
 type EffectiveTheme = 'light' | 'dark';
+const APPEARANCE_CHANGE_EVENT = 'verenu:appearance-mode-changed';
 
 function systemTheme(): EffectiveTheme {
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -38,6 +39,12 @@ applyTheme('system');
 
 void listen<string | null>(ACCENT_CHANGE_EVENT, (event) => {
   applyAccentTheme(document.documentElement, normalizeAccentColor(event.payload));
+});
+
+void listen<AppearanceMode>(APPEARANCE_CHANGE_EVENT, (event) => {
+  if (event.payload === 'system' || event.payload === 'light' || event.payload === 'dark') {
+    applyTheme(event.payload);
+  }
 });
 
 window.matchMedia?.('(prefers-color-scheme: dark)').addEventListener?.('change', () => {

--- a/src/theme.css
+++ b/src/theme.css
@@ -82,7 +82,7 @@
   --pill-shine-strong: #111110;
   --pill-stage-size: 10.5px;
   --pill-stage-weight: 600;
-  --pill-context-bg: #f1f1ef;
+  --pill-context-bg: var(--pill-bg);
   --pill-context-fg: rgba(17, 17, 16, 0.72);
   --pill-context-line: rgba(17, 17, 16, 0.13);
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -69,11 +69,22 @@
   --control-hover: #f2f2f1;
   --control-active: #ebeae7;
 
-  --pill-bg: var(--arm-950);
-  --pill-fg: #ffffff;
-  --pill-bar: #ffffff;
-  --pill-muted: rgba(255, 255, 255, 0.45);
-  --pill-muted-strong: rgba(255, 255, 255, 0.85);
+  --pill-bg: #ffffff;
+  --pill-fg: #111110;
+  --pill-bar: #111110;
+  --pill-muted: rgba(17, 17, 16, 0.45);
+  --pill-muted-strong: rgba(17, 17, 16, 0.85);
+  --pill-line: rgba(17, 17, 16, 0.12);
+  --pill-hover: rgba(17, 17, 16, 0.10);
+  --pill-spinner-track: rgba(17, 17, 16, 0.16);
+  --pill-shine-clear: rgba(17, 17, 16, 0);
+  --pill-shine-mid: rgba(17, 17, 16, 0.5);
+  --pill-shine-strong: #111110;
+  --pill-stage-size: 10.5px;
+  --pill-stage-weight: 600;
+  --pill-context-bg: #f1f1ef;
+  --pill-context-fg: rgba(17, 17, 16, 0.72);
+  --pill-context-line: rgba(17, 17, 16, 0.13);
 
   /* Error pill is always dark red-tinted, regardless of theme — matches the
      dark-theme --danger/--danger-bg/--danger-line so the pill and in-app
@@ -185,4 +196,17 @@
   --pill-bg: #0f0e0e;
   --pill-fg: #ffffff;
   --pill-bar: #ffffff;
+  --pill-muted: rgba(255, 255, 255, 0.45);
+  --pill-muted-strong: rgba(255, 255, 255, 0.85);
+  --pill-line: rgba(255, 255, 255, 0.07);
+  --pill-hover: rgba(255, 255, 255, 0.14);
+  --pill-spinner-track: rgba(255, 255, 255, 0.16);
+  --pill-shine-clear: rgba(255, 255, 255, 0);
+  --pill-shine-mid: rgba(255, 255, 255, 0.5);
+  --pill-shine-strong: #ffffff;
+  --pill-stage-size: 11px;
+  --pill-stage-weight: 600;
+  --pill-context-bg: var(--pill-bg);
+  --pill-context-fg: rgba(255, 255, 255, 0.72);
+  --pill-context-line: rgba(255, 255, 255, 0.08);
 }


### PR DESCRIPTION
> - Verenu is a Windows and macOS AI dictation app built around hotkey-driven capture, transcription, cleanup, and text injection.\n> - This change belongs to the pill UI and appearance settings path.\n> - The pill previously kept stale appearance colors, used hardcoded light-mode processing colors, and made the context chip blend into the surface.\n> - This pull request makes neutral pill states follow light and dark appearance tokens while preserving the existing pill geometry.\n> - The benefit is readable, consistent recording and processing feedback in both themes.\n\n## What changed\n\n- Added an appearance-change event from settings to the pill webview.\n- Added light and dark neutral pill tokens for surfaces, controls, processing animation, and context labels.\n- Restored rounded waveform bar rendering and removed accent leakage from neutral pill states.\n- Matched the dark context chip surface to the main pill and tuned light processing typography.\n\n## Verification\n\n- 
pm run check\n- 
pm run test:unit with 106 tests passing\n- cargo check --manifest-path src-tauri/Cargo.toml\n- git diff --check\n- Browser render checked for light recording, light processing, and dark pill token values.\n\n## Risks\n\nLow risk. The change is limited to pill styling and the appearance-setting event path. Error-state red styling remains separate.\n\n## Model used\n\nOpenAI Codex, GPT-5.6 Luna, with tool use and browser verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791270282&installation_model_id=432577&pr_number=362&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F362&signature=927254b7e5263c6dfe5a1e4c4f8a0681e634b19305a42eb3f8d90ba7a5ca9e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->