### PR TITLE
Surface settings disk-full failures

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -470,6 +470,20 @@ mod setting_key_tests {
 }
 // ---------- generic settings ----------
 
+/// Enables a process-local failure mode for exercising full-disk error UI.
+/// The flag intentionally never touches settings.json, so it can be disabled
+/// even while simulated saves are failing.
+#[tauri::command]
+pub fn set_storage_full_simulation(enabled: bool) -> Result<(), String> {
+    store::set_storage_full_simulation(enabled);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_storage_full_simulation() -> bool {
+    store::storage_full_simulation_enabled()
+}
+
 #[tauri::command]
 pub async fn save_setting(
     app: AppHandle,
@@ -489,19 +503,25 @@ pub async fn save_setting(
     };
     let settings = store::settings_handle(&app)?;
     let key_clone = key.clone();
-    run_blocking("save_setting", move || {
+    let save_result = run_blocking("save_setting", move || {
+        if store::storage_full_simulation_enabled() {
+            return Err(format!(
+                "{}: simulated settings write failure",
+                store::STORAGE_FULL_ERROR
+            ));
+        }
         if key_clone == store::CONTEXTUAL_FORMATTING {
-            settings.set_many([
+            settings.save_values([
                 (store::CONTEXTUAL_FORMATTING, value.clone()),
                 (store::CONTEXTUAL_CAPS, value.clone()),
                 (store::AUTO_SPACING, value),
-            ])?;
-            settings.save()
+            ])
         } else {
             settings.save_value(key_clone, value)
         }
     })
-    .await?;
+    .await;
+    save_result?;
 
     // LAN sync: stamp the change so peers LWW-compare it, and nudge the sync
     // manager to schedule a session. Both are best-effort — a sync failure

--- a/src-tauri/src/data/store/mod.rs
+++ b/src-tauri/src/data/store/mod.rs
@@ -1,9 +1,21 @@
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 
 const SETTINGS_FILE: &str = "settings.json";
+pub(crate) const STORAGE_FULL_ERROR: &str = "STORAGE_FULL";
+
+static SIMULATE_STORAGE_FULL: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn set_storage_full_simulation(enabled: bool) {
+    SIMULATE_STORAGE_FULL.store(enabled, Ordering::Relaxed);
+}
+
+pub(crate) fn storage_full_simulation_enabled() -> bool {
+    SIMULATE_STORAGE_FULL.load(Ordering::Relaxed)
+}
 
 #[derive(Clone)]
 pub struct SettingsHandle {
@@ -102,8 +114,25 @@ impl SettingsHandle {
     }
 
     pub fn save_value(&self, key: impl Into<String>, value: Value) -> Result<(), String> {
-        self.set(key, value)?;
-        self.save()
+        self.save_values([(key, value)])
+    }
+
+    pub fn save_values<I, K>(&self, values: I) -> Result<(), String>
+    where
+        I: IntoIterator<Item = (K, Value)>,
+        K: Into<String>,
+    {
+        let mut settings = self
+            .values
+            .lock()
+            .map_err(|_| "Settings lock was poisoned".to_string())?;
+        let mut next = settings.clone();
+        for (key, value) in values {
+            next.insert(key.into(), value);
+        }
+        write_settings_file(&self.path, &next)?;
+        *settings = next;
+        Ok(())
     }
 }
 
@@ -165,7 +194,7 @@ fn backup_corrupt_settings(path: &Path) {
 fn write_settings_file(path: &Path, values: &Map<String, Value>) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create settings directory: {e}"))?;
+            .map_err(|e| settings_write_error("Failed to create settings directory", &e))?;
     }
     let json = serde_json::to_string_pretty(values)
         .map_err(|e| format!("Failed to serialize settings.json: {e}"))?;
@@ -175,14 +204,35 @@ fn write_settings_file(path: &Path, values: &Map<String, Value>) -> Result<(), S
     if let Err(e) = std::fs::write(&tmp_path, json) {
         // A failed/partial write shouldn't leave a stale temp file behind.
         let _ = std::fs::remove_file(&tmp_path);
-        return Err(format!("Failed to write temporary settings file: {e}"));
+        return Err(settings_write_error("Failed to write temporary settings file", &e));
     }
     if let Err(e) = std::fs::rename(&tmp_path, path) {
         // Don't leave the temp file behind if the swap failed.
         let _ = std::fs::remove_file(&tmp_path);
-        return Err(format!("Failed to replace settings.json atomically: {e}"));
+        return Err(settings_write_error("Failed to replace settings.json atomically", &e));
     }
     Ok(())
+}
+
+fn settings_write_error(operation: &str, error: &impl std::fmt::Display) -> String {
+    let detail = error.to_string();
+    if is_storage_full_error(&detail) {
+        format!("{STORAGE_FULL_ERROR}: {operation}")
+    } else {
+        format!("{operation}: {detail}")
+    }
+}
+
+pub(crate) fn is_storage_full_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("storage_full")
+        || lower.contains("no space left on device")
+        || lower.contains("not enough space")
+        || lower.contains("disk is full")
+        || lower.contains("disk full")
+        || lower.contains("database or disk is full")
+        || lower.contains("os error 112")
+        || lower.contains("error 112")
 }
 
 /// API key names in the store — never expose values to the frontend after write.

--- a/src-tauri/src/data/store/tests.rs
+++ b/src-tauri/src/data/store/tests.rs
@@ -31,6 +31,14 @@ fn write_settings_file_overwrites_existing() {
     let _ = std::fs::remove_file(&path);
 }
 
+#[test]
+fn storage_full_errors_are_recognized() {
+    assert!(is_storage_full_error("STORAGE_FULL: simulated settings write failure"));
+    assert!(is_storage_full_error("os error 112"));
+    assert!(is_storage_full_error("database or disk is full"));
+    assert!(!is_storage_full_error("permission denied"));
+}
+
 // A corrupt settings.json must not surface an error; it is backed up and the
 // app starts from empty defaults.
 #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -437,6 +437,8 @@ fn main() {
             commands::check_keychain_access,
             commands::save_setting,
             commands::get_setting,
+            commands::set_storage_full_simulation,
+            commands::get_storage_full_simulation,
             commands::get_all_settings,
             commands::list_local_stt_models,
             commands::list_local_llm_models,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,6 +25,7 @@
   import { refreshTranscriptionModel } from './lib/transcriptionModelStore.svelte';
   import { startProviderStatusChecks } from './lib/serviceStatus';
   import { classifyIpcError, settingsSectionForKind, type ErrorKind } from './lib/errors';
+  import { SETTINGS_SAVE_ERROR_EVENT } from './lib/settings';
   import type { SettingsSectionId } from './lib/settingsSections';
   import { scrollEdges } from './lib/scrollFade';
   import { fly } from 'svelte/transition';
@@ -165,6 +166,14 @@
     clearTimeout(toastTimer);
   }
 
+  function showErrorToast(raw: string) {
+    const classified = classifyIpcError(raw);
+    errorToast = raw ? classified.message : 'Something went wrong';
+    errorToastKind = raw ? classified.kind : null;
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { errorToast = ''; errorToastKind = null; }, 5000);
+  }
+
   onMount(() => {
     let mounted = true;
     let cleanupFn: (() => void) | undefined;
@@ -178,6 +187,11 @@
     let stopProviderStatusChecks: (() => void) | undefined;
     let stopSyncListeners: (() => void) | undefined;
     let stopTitleBarMetricsListener: (() => void) | undefined;
+    const onSettingsSaveError = (event: Event) => {
+      const message = (event as CustomEvent<unknown>).detail;
+      showErrorToast(typeof message === 'string' ? message : 'Something went wrong');
+    };
+    window.addEventListener(SETTINGS_SAVE_ERROR_EVENT, onSettingsSaveError);
 
     if (isWindows && isTauriRuntime()) {
       invoke<NativeTitleBarMetrics>('get_native_titlebar_metrics')
@@ -226,12 +240,7 @@
       }
 
       const unlisten = await listen<string>('verenu:error', (ev) => {
-        const raw = ev.payload ?? '';
-        const classified = classifyIpcError(raw);
-        errorToast = raw ? classified.message : 'Something went wrong';
-        errorToastKind = raw ? classified.kind : null;
-        clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => { errorToast = ''; errorToastKind = null; }, 5000);
+        showErrorToast(ev.payload ?? '');
       });
       cleanupFn = unlisten;
     })();
@@ -322,6 +331,7 @@
       if (stopProviderStatusChecks) stopProviderStatusChecks();
       if (stopSyncListeners) stopSyncListeners();
       if (stopTitleBarMetricsListener) stopTitleBarMetricsListener();
+      window.removeEventListener(SETTINGS_SAVE_ERROR_EVENT, onSettingsSaveError);
       media?.removeEventListener?.('change', onSystemThemeChange);
       connectivityPoll.stop();
     };
@@ -376,7 +386,12 @@
   <DictationPill />
 
   {#if errorToast}
-    <div class="error-toast" role="alert" style:bottom={!appStore.isOnline ? '66px' : '18px'}>
+    <div
+      class="error-toast"
+      role="alert"
+      style:bottom={!appStore.isOnline ? '66px' : '18px'}
+      transition:fly={{ y: motionPx(MOTION_PX.nudge), duration: motionMs(MOTION_MS.base), easing: expoOut }}
+    >
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
         <circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/>
       </svg>
@@ -553,15 +568,11 @@
     font-size: 12.5px;
     color: var(--danger);
     box-shadow: var(--shadow-popover);
-    z-index: 20;
+    /* Settings sits above the app content; errors must remain visible while a
+       setting change fails inside that page. */
+    z-index: 80;
     max-width: 480px;
-    animation: toastIn 0.18s cubic-bezier(0.22, 1, 0.36, 1);
     transition: bottom 0.15s ease;
-  }
-
-  @keyframes toastIn {
-    from { opacity: 0; transform: translateX(-50%) translateY(6px); }
-    to   { opacity: 1; transform: translateX(-50%) translateY(0); }
   }
 
   .toast-close {

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -34,6 +34,7 @@
   let simulationMessage = $state('');
   let simulatedProvider = $state<ProviderId>('groq');
   let providerDropdownOpen = $state(false);
+  let storageFullSimulation = $state(false);
   let syncEnabled = $state(false);
   let syncApprovalOpen = $state(false);
   let syncMessage = $state('');
@@ -157,6 +158,7 @@
       appStore.betaUpdatesEnabled = betaUpdates ?? false;
       syncEnabled = sync ?? false;
       appStore.syncEnabled = sync ?? false;
+      storageFullSimulation = await invoke<boolean>('get_storage_full_simulation');
     } catch (err) {
       console.error('Failed to load dev flags:', err);
     }
@@ -215,10 +217,7 @@
   async function handleForceSetupOnLaunch(value: boolean) {
     forceSetupOnLaunch = value;
     try {
-      await invoke('save_setting', {
-        key: 'force_setup_on_launch',
-        value,
-      });
+      await saveSetting('force_setup_on_launch', value);
     } catch (err) {
       forceSetupOnLaunch = !value;
       console.error('Failed to save force_setup_on_launch:', err);
@@ -244,6 +243,21 @@
     simulationMessage = 'Offline state previewed.';
   }
 
+  async function toggleStorageFullSimulation(enabled: boolean) {
+    const previous = storageFullSimulation;
+    storageFullSimulation = enabled;
+    try {
+      await invoke('set_storage_full_simulation', { enabled });
+      simulationMessage = enabled
+        ? 'Full-storage failures enabled. Try changing any setting now.'
+        : 'Full-storage failures disabled.';
+    } catch (err) {
+      storageFullSimulation = previous;
+      simulationMessage = 'Storage simulation could not be changed.';
+      console.error('set_storage_full_simulation failed:', err);
+    }
+  }
+
   async function simulateGlobalMessage() {
     appStore.globalMessageSimulation = true;
     await refreshStatusPreview('Global message previewed.');
@@ -261,6 +275,12 @@
     appStore.globalMessage = null;
     appStore.globalMessageSimulation = false;
     appStore.isOnline = true;
+    try {
+      await invoke('set_storage_full_simulation', { enabled: false });
+      storageFullSimulation = false;
+    } catch (err) {
+      console.error('clear storage simulation failed:', err);
+    }
     await refreshStatusPreview('Simulations cleared.');
   }
 
@@ -474,6 +494,13 @@
     <button class="btn-ghost" onclick={simulateGlobalMessage}>Global Message</button>
     <button class="btn-ghost" onclick={clearSimulations}>Clear</button>
   </div>
+</div>
+<div class="setting-row" data-setting-target="developer-storage-simulation">
+  <div>
+    <div class="label">Full Storage Failure</div>
+    <div class="desc">Make setting saves fail as if the drive has no free space. This resets when Verenu restarts.</div>
+  </div>
+  <Toggle checked={storageFullSimulation} onchange={toggleStorageFullSimulation} label="Simulate full storage" />
 </div>
 <div class="setting-row" data-setting-target="developer-notifications">
   <div>

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { classifyIpcError } from './errors';
+
+describe('storage-full errors', () => {
+  it('recognizes the backend marker', () => {
+    expect(classifyIpcError('STORAGE_FULL: simulated settings write failure')).toEqual({
+      kind: 'storage-full',
+      message: 'Change failed because the drive is full. Free up storage, then try again.',
+    });
+  });
+
+  it('recognizes native full-disk wording', () => {
+    expect(classifyIpcError('Failed to write settings: No space left on device').kind).toBe(
+      'storage-full',
+    );
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -26,7 +26,8 @@ export type ErrorKind =
   | 'no-backend'
   | 'invalid-backup'
   | 'unsupported-backup'
-  | 'duplicate';
+  | 'duplicate'
+  | 'storage-full';
 
 interface ClassifiedError {
   kind: ErrorKind;
@@ -54,6 +55,20 @@ const KIND_HINTS: ReadonlyArray<readonly [ErrorKind, readonly string[]]> = [
   ['invalid-backup', ['invalid backup']],
   ['unsupported-backup', ['unsupported backup']],
   ['duplicate', ['unique constraint']],
+  [
+    'storage-full',
+    [
+      'storage_full',
+      'storage is full',
+      'disk is full',
+      'disk full',
+      'database or disk is full',
+      'no space left on device',
+      'not enough space',
+      'os error 112',
+      'error 112',
+    ],
+  ],
 ];
 
 /** Copy for kinds whose wording is fixed and shared across surfaces. */
@@ -70,6 +85,7 @@ const KIND_MESSAGES: Partial<Record<ErrorKind, string>> = {
   'unsupported-backup':
     "This backup was made by a newer Verenu version and can't be read. Update Verenu to import it.",
   duplicate: 'That term already exists.',
+  'storage-full': 'Change failed because the drive is full. Free up storage, then try again.',
 };
 
 /** Extracts a displayable string from any IPC/JS error shape. */

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,5 +1,8 @@
 import { invoke } from './tauri';
+import { classifyIpcError } from './errors';
 import type { TranscriptionLanguageCode } from './transcriptionLanguages';
+
+export const SETTINGS_SAVE_ERROR_EVENT = 'verenu:setting-save-error';
 
 export type ProviderId = 'groq' | 'openai' | 'google' | 'assemblyai' | 'local';
 export type ProviderModelMap = Record<ProviderId, string[]>;
@@ -78,5 +81,13 @@ type SettingsValueMap = {
 type SettingKey = keyof SettingsValueMap;
 
 export function saveSetting<K extends SettingKey>(key: K, value: SettingsValueMap[K]) {
-  return invoke('save_setting', { key, value });
+  return invoke('save_setting', { key, value }).catch((error) => {
+    const classified = classifyIpcError(error);
+    if (classified.kind === 'storage-full' && typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(SETTINGS_SAVE_ERROR_EVENT, {
+        detail: classified.message,
+      }));
+    }
+    throw error;
+  });
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -269,6 +269,8 @@ function hasTauriInternals(): boolean {
   return typeof maybeWindow.__TAURI_INTERNALS__?.invoke === 'function';
 }
 
+let devStorageFullSimulation = false;
+
 function readDevSettings(): Record<string, unknown> {
   if (typeof localStorage === 'undefined') return {};
   try {
@@ -1154,9 +1156,17 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
       return undefined as T;
     case 'get_setting':
       return getDevSetting(String(args?.key ?? '')) as T;
+    case 'get_storage_full_simulation':
+      return devStorageFullSimulation as T;
+    case 'set_storage_full_simulation':
+      devStorageFullSimulation = Boolean(args?.enabled);
+      return undefined as T;
     case 'save_setting':
       if (typeof args?.key !== 'string' || args.key.length === 0) {
         return undefined as T;
+      }
+      if (devStorageFullSimulation) {
+        throw new Error('STORAGE_FULL: simulated settings write failure');
       }
       writeDevSetting(args.key, args?.value);
       return undefined as T;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a Rust backend and Svelte settings UI.
> - Settings writes pass through Tauri commands and a local settings store.
> - A full drive prevented writes, but the settings UI could silently revert controls.
> - The storage error needs a stable backend marker and safe frontend copy.
> - Developers need a reversible simulation that does not write to disk.
> - Toggle failures need a same-window notification path, since backend events did not reliably surface there.
> - This pull request adds the simulation, transactional settings writes, and visible failure feedback.

## What Changed

- Detect and classify full-disk settings errors, including Windows and SQLite wording.
- Keep failed settings writes from mutating in-memory settings.
- Add a Developer toggle that simulates a full drive for the current app session.
- Show a five-second, animated error toast above Settings when a save fails for lack of storage.

## Verification

- `npm run check`
- `npm run test:unit`
- `cargo test --manifest-path src-tauri/Cargo.toml storage_full_errors_are_recognized`
- Visible Playwright run: a failed Settings toggle showed the storage-full toast, then dismissed after its exit animation.

## Risks

- Low risk. The simulation is process-local and never persists. Failed saves leave the existing settings value unchanged.

## Model Used

- OpenAI gpt-5.6-terra with high reasoning and tool use.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [ ] Relevant documentation updated to reflect changes
- [x] Risks documented above
