### PR TITLE
Fix stale modifier release after hands-free conversion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Fixed hands-free conversion from an active hold-to-talk dictation ending when
+  the original Windows modifier chord is released; stale release events now
+  have a three-second handoff window before hands-free stop gestures are
+  accepted.
 - Replaced the Insights speaking-pace dial with a tick-scale meter that matches the rest of the page: the tile is now left-aligned on the same baseline grid as its two neighbours, quarter marks make the scale readable at a glance, the scale ceiling grows to always clear your personal best, and the best itself is marked on the scale instead of only being named underneath.
 - Fixed the main window stuttering and spiking CPU when dragged or resized quickly on Windows: moving the window no longer re-runs title-bar and icon updates per mouse event, resizes coalesce to a single refresh once the size settles, title-bar metrics are only forwarded when visible values change, and themed icons reuse cached artwork instead of re-rendering on every focus or settings event.
 - Restored the Windows tray icon's classic proportions — the accent-theming rework had grown the waveform to fill ~70% of the tile edge to edge; it sits back inside the tile with real margins, keeping the sharper native-size rendering.

--- a/src-tauri/src/app_hotkey.rs
+++ b/src-tauri/src/app_hotkey.rs
@@ -32,6 +32,13 @@ enum HotkeyEvent {
 /// interrupt the transcription that the first click just started.
 const HANDSFREE_STOP_GUARD: Duration = Duration::from_millis(350);
 
+/// Space can convert a hold-to-talk recording into hands-free while the
+/// original chord is still physically held. Windows can report one of that
+/// chord's release events after the Space toggle has already reached the
+/// async dispatcher, so give the conversion a short handoff window in which
+/// release/cancel events cannot stop the new hands-free recording.
+const HANDSFREE_CONVERSION_GUARD: Duration = Duration::from_secs(3);
+
 #[derive(Default)]
 struct HandsfreeStopGuard {
     until: Option<Instant>,
@@ -57,6 +64,32 @@ impl HandsfreeStopGuard {
                 | HotkeyEvent::HandlessToggle
                 | HotkeyEvent::Cancel
         )
+    }
+}
+
+#[derive(Default)]
+struct HandsfreeConversionGuard {
+    until: Option<Instant>,
+}
+
+impl HandsfreeConversionGuard {
+    fn arm(&mut self, now: Instant) {
+        self.until = Some(now + HANDSFREE_CONVERSION_GUARD);
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        self.until.is_some_and(|until| now >= until)
+    }
+
+    fn suppresses(&mut self, event: HotkeyEvent, now: Instant) -> bool {
+        let Some(until) = self.until else {
+            return false;
+        };
+        if now >= until {
+            self.until = None;
+            return false;
+        }
+        matches!(event, HotkeyEvent::Release | HotkeyEvent::Cancel)
     }
 }
 
@@ -115,8 +148,23 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
 
     tauri::async_runtime::spawn(async move {
         let mut handsfree_stop_guard = HandsfreeStopGuard::default();
+        let mut handsfree_conversion_guard = HandsfreeConversionGuard::default();
         while let Some(event) = hotkey_rx.recv().await {
-            if handsfree_stop_guard.suppresses(event, Instant::now()) {
+            let now = Instant::now();
+            if handsfree_conversion_guard.expired(now) {
+                // Once the handoff window has elapsed, the next genuine
+                // hands-free stop must not be mistaken for the original hold
+                // release by the lifecycle marker.
+                pipeline::clear_handless_hold_marker(&state_hk);
+            }
+            if handsfree_conversion_guard.suppresses(event, now) {
+                // This event belongs to the chord that was converted by
+                // Space, not to a new hands-free stop gesture.
+                pipeline::clear_handless_hold_marker(&state_hk);
+                log::debug!("hotkey: ignored stale input after Space hands-free conversion");
+                continue;
+            }
+            if handsfree_stop_guard.suppresses(event, now) {
                 log::debug!("hotkey: ignored follow-up input after hands-free stop");
                 continue;
             }
@@ -218,6 +266,7 @@ pub(crate) fn setup_hotkey(app: &mut tauri::App, shared: SharedState) {
                         // Space converts an active hold-to-talk recording in
                         // place. The existing session stays open, and the
                         // hook suppresses the original chord release.
+                        handsfree_conversion_guard.arm(Instant::now());
                         crate::core::hotkey::set_handless_active(true);
                         pipeline::update_pill_state(&app_hk, "handsfree");
                     } else if !has_session && pipeline::reserve_starting(&state_hk).is_ok() {
@@ -420,5 +469,30 @@ mod tests {
             HotkeyEvent::Press,
             now + HANDSFREE_STOP_GUARD + Duration::from_millis(2),
         ));
+    }
+
+    #[test]
+    fn handsfree_conversion_guard_swallows_stale_stop_events_for_three_seconds() {
+        let now = Instant::now();
+        let mut guard = HandsfreeConversionGuard::default();
+        guard.arm(now);
+
+        assert!(guard.suppresses(HotkeyEvent::Release, now + Duration::from_secs(1)));
+        assert!(guard.suppresses(HotkeyEvent::Cancel, now + Duration::from_secs(2)));
+        assert!(!guard.suppresses(
+            HotkeyEvent::Cancel,
+            now + HANDSFREE_CONVERSION_GUARD + Duration::from_millis(1),
+        ));
+    }
+
+    #[test]
+    fn handsfree_conversion_guard_does_not_block_escape_or_toggle_events() {
+        let now = Instant::now();
+        let mut guard = HandsfreeConversionGuard::default();
+        guard.arm(now);
+
+        assert!(!guard.suppresses(HotkeyEvent::EscapeCancel, now + Duration::from_millis(1)));
+        assert!(!guard.suppresses(HotkeyEvent::HandlessToggle, now + Duration::from_millis(1)));
+        assert!(!guard.suppresses(HotkeyEvent::CopyLast, now + Duration::from_millis(1)));
     }
 }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that captures audio from a hotkey, transcribes it, cleans it up, and injects the result.
> - This change is in the native hotkey and dictation lifecycle path.
> - Space can convert an active hold-to-talk recording into hands-free while the original Win and Control chord is still held.
> - A stale Release or Cancel event can arrive after that conversion and stop the new hands-free recording.
> - This pull request adds a bounded three-second handoff guard in the async dispatcher and keeps Escape and toggle events available.
> - The result is that releasing the original modifier chord no longer ends the converted dictation.

## What Changed

- Added a three-second guard after Space promotes an active recording to hands-free.
- Suppressed stale Release and Cancel events during the handoff window.
- Cleared the one-shot hold marker when stale input is absorbed or the window expires, so the first real stop afterward works.
- Added regression tests and documented the fix in the Unreleased changelog.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml handsfree`
- `cargo test --manifest-path src-tauri/Cargo.toml chord_tests`
- `rustfmt --check --edition 2021 src-tauri/src/app_hotkey.rs`
- `git diff --check`
- Clippy was attempted but could not complete because another process held the generated native title-bar DLL.

## Risks

Low risk. The guard only arms when an active hold-to-talk recording is converted by Space. Intentional hands-free stop clicks during the three-second handoff are ignored, while Escape remains available.

## Model Used

OpenAI GPT-5.6-Luna, high reasoning, with repository tool use.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`
- [ ] `npm run check` passes (not run; no frontend files changed)
- [ ] `npm run lint` passes (Clippy blocked by a locked native DLL)
- [ ] `npm run test:rust` passes (focused Rust tests passed instead)
- [ ] Smoke tests pass (not run; no UI changes)
- [x] Tests added or updated where applicable
- [x] No UI changes requiring screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] No version bump required
- [x] Relevant documentation updated
- [x] Risks documented above