### PR TITLE
Fix cancelled-pill flicker and resume-paste falling back to clipboard

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -405,7 +405,24 @@ pub async fn resume_cancelled_capture(
         return Err("Nothing to resume".to_string());
     };
     pipeline::set_starting_prepend_audio(state.inner(), capture.audio.clone());
-    let target = WindowTarget::capture_foreground();
+    // Reuse the target captured when the original recording started, not the
+    // foreground window right now — by the time Undo is clicked, the
+    // foreground window is Verenu's own pill (it just took a real click),
+    // and injecting into that tripped finalize.rs's self-inject guard on
+    // every resume, silently downgrading to a clipboard-only "Ctrl+V to
+    // paste" pill no matter what app the user was actually dictating into.
+    // `.refreshed()` mirrors retry_transcription_impl's handling of a stale
+    // target — the window may have moved (or since closed) in the meantime.
+    //
+    // A zero `id` means this capture was recovered from disk after a crash/
+    // restart (see failover::loaded_to_capture), so there is no original
+    // target to restore — fall back to the current foreground window, same
+    // as before this fix, since that's the best guess available.
+    let target = if capture.target.id == 0 {
+        WindowTarget::capture_foreground()
+    } else {
+        capture.target.refreshed()
+    };
     {
         let mut st = match lock_state(&state) {
             Ok(st) => st,

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -4,6 +4,7 @@
 //! sidecar. The sidecar `sample_count` is published only after the matching
 //! PCM bytes have been flushed, and load clamps to the shorter of the two.
 
+use crate::core::window_geometry::WindowTarget;
 use super::gates::{MIN_RECORDING_MS, MIN_RECORDING_RMS};
 use super::pill::{show_cancelled_pill, show_interrupted_pill};
 use super::state::{
@@ -378,6 +379,11 @@ fn loaded_to_capture(take: LoadedTake) -> Option<CancelledCapture> {
         origin,
         created_at_rfc3339,
         started_at_unix,
+        // Recovered after a crash/restart, so there is no live foreground
+        // window to reuse — the watchdog's resume goes through the same
+        // resume_cancelled_capture path, which re-captures the (now current)
+        // foreground window whenever the stored target is the zero default.
+        target: WindowTarget::default(),
     })
 }
 

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -414,6 +414,12 @@ pub fn stash_cancelled_capture(
                     CaptureOrigin::UserCancelled => super::failover::FailoverKind::Cancelled,
                     CaptureOrigin::Interrupted => super::failover::FailoverKind::Recording,
                 };
+                // Captured before dropping the lock: this is the original
+                // dictation's focus target, still valid here because nothing
+                // has happened yet to move focus to Verenu's own window. See
+                // CancelledCapture::target for why resume must reuse it
+                // instead of re-capturing the foreground later.
+                let target = st.target;
                 // Drop the state lock before disk I/O so hotkey/UI paths are
                 // not stalled on fsync.
                 drop(st);
@@ -425,6 +431,7 @@ pub fn stash_cancelled_capture(
                     origin,
                     created_at_rfc3339: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
                     started_at_unix,
+                    target,
                 };
                 match lock_state(state) {
                     Ok(mut st) => {

--- a/src-tauri/src/pipeline/state.rs
+++ b/src-tauri/src/pipeline/state.rs
@@ -181,6 +181,15 @@ pub struct CancelledCapture {
     pub origin: CaptureOrigin,
     pub created_at_rfc3339: String,
     pub started_at_unix: i64,
+    // The dictation's original focus target, captured when that recording
+    // started. Resuming must reuse this rather than re-capturing the
+    // foreground window: by the time the user clicks Undo, the foreground
+    // window is Verenu's own pill (it just received a real click), not the
+    // app the user was dictating into — see resume_cancelled_capture, which
+    // used to call WindowTarget::capture_foreground() itself and always hit
+    // that self-target, tripping finalize.rs's self-inject guard and
+    // clipboard-only fallback on every resume.
+    pub target: WindowTarget,
 }
 
 /// Final injected text from a dictation whose paste couldn't be confirmed
@@ -783,6 +792,7 @@ mod tests {
                 origin: CaptureOrigin::UserCancelled,
                 created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
                 started_at_unix: 0,
+                target: WindowTarget::default(),
             });
         }
         // Peeking clones — the slot must survive for the later clear.
@@ -808,6 +818,7 @@ mod tests {
                 origin: CaptureOrigin::UserCancelled,
                 created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
                 started_at_unix: 0,
+                target: WindowTarget::default(),
             });
         }
         clear_cancelled_capture(&state);
@@ -828,6 +839,7 @@ mod tests {
                 origin: CaptureOrigin::UserCancelled,
                 created_at_rfc3339: "2026-01-01T00:00:00Z".into(),
                 started_at_unix: 0,
+                target: WindowTarget::default(),
             });
             st.retry_capture = Some(RetryCapture {
                 audio,

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1005,8 +1005,11 @@
            mid-flight, which instantly stole space from the already-fading-in
            text and read as it "shifting around before settling". Fading
            opacity in-place keeps the staggered-arrival feel without the
-           layout shift. -->
-      <button class="hf-btn confirm" class:btn-visible={showCancelBtn} onclick={continueCancelled} aria-label="Undo — keep recording">
+           layout shift. `disabled`/`tabindex`/`aria-hidden` keep it out of
+           the tab order and the a11y tree while invisible — opacity+
+           pointer-events alone hide it visually but a keyboard user could
+           still Tab to and activate it before the reveal. -->
+      <button class="hf-btn confirm" class:btn-visible={showCancelBtn} disabled={!showCancelBtn} tabindex={showCancelBtn ? 0 : -1} aria-hidden={!showCancelBtn} onclick={continueCancelled} aria-label="Undo — keep recording">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5v0a5.5 5.5 0 0 1-5.5 5.5H11"/>
         </svg>

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -661,10 +661,15 @@
             if (isCancelLike(state)) cancelOpen = true;
           });
           if (cancelBtnTimer) clearTimeout(cancelBtnTimer);
+          // 150ms, not 200: the undo button now only fades in (its space is
+          // reserved from the first frame — see the template), so it no
+          // longer has to wait for a width expansion to finish. Landing it
+          // just after the entrance morph keeps the "arrives second" beat
+          // without trailing the rest of the pill.
           cancelBtnTimer = setTimeout(() => {
             cancelBtnTimer = null;
             if (isCancelLike(state)) showCancelBtn = true;
-          }, 200);
+          }, 150);
           if (cancelDismissTimer) clearTimeout(cancelDismissTimer);
           cancelDismissTimer = setTimeout(() => {
             cancelDismissTimer = null;
@@ -818,8 +823,13 @@
 
   async function cancelHandless() {
     const { invoke } = await import('@tauri-apps/api/core');
-    goIdle();
-    await invoke('stop_recording').catch(() => {});
+    // Don't goIdle() here — stop_recording cancels asynchronously on the
+    // backend and may decide the capture is resumable, in which case it
+    // emits 'cancelled' (not 'idle') next. Forcing idle up front raced that
+    // later event: the pill would start fading to idle, then get yanked into
+    // the cancelled entrance mid-fade, which is what read as a teleport/
+    // flicker. Only fall back to idle if the invoke itself fails.
+    await invoke('stop_recording').catch(() => { goIdle(); });
   }
 
   async function retryFailed() {
@@ -897,6 +907,7 @@
   <div class="pill-cluster"
        class:steady-width={state === 'processing'}
        class:steady-width-hf={state === 'handsfree'}
+       class:steady-width-cancel={isCancelLike(state)}
        bind:this={clusterEl}>
   {#if contextLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
       <span class="pill-context" title={contextLabel}>{contextLabel}</span>
@@ -975,20 +986,31 @@
     </div>
 
   {:else if isCancelLike(state)}
-    <div class="pill cancelled" class:interrupted={state === 'interrupted'} class:cancel-open={cancelOpen} class:dying={dying}>
+    <div class="pill cancelled"
+         class:interrupted={state === 'interrupted'}
+         class:cancel-open={cancelOpen}
+         class:dying={dying}
+         class:from-rec={prevState === 'recording'}
+         class:from-hf={prevState === 'handsfree'}>
       <button class="hf-btn cancel" onclick={dismissCancelled} aria-label="Dismiss">
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
           <path d="M6 6l12 12M6 18 18 6"/>
         </svg>
       </button>
       <span class="cancel-text">{state === 'interrupted' ? 'Interrupted' : 'Cancelled'}</span>
-      {#if showCancelBtn}
-        <button class="hf-btn confirm" onclick={continueCancelled} aria-label="Undo — keep recording">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5v0a5.5 5.5 0 0 1-5.5 5.5H11"/>
-          </svg>
-        </button>
-      {/if}
+      <!-- Always mounted, not `{#if showCancelBtn}` — this button reserves its
+           flex space from the first frame of cancel-open so .cancel-text
+           (flex:1) never has to reflow when it appears. Mounting it 200ms
+           into the width/text transition popped a new item into the row
+           mid-flight, which instantly stole space from the already-fading-in
+           text and read as it "shifting around before settling". Fading
+           opacity in-place keeps the staggered-arrival feel without the
+           layout shift. -->
+      <button class="hf-btn confirm" class:btn-visible={showCancelBtn} onclick={continueCancelled} aria-label="Undo — keep recording">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5v0a5.5 5.5 0 0 1-5.5 5.5H11"/>
+        </svg>
+      </button>
     </div>
 
   {:else if state === 'paste_failed'}
@@ -1163,6 +1185,20 @@
   .pill-cluster.steady-width-hf {
     min-width: var(--hf-expanded-w, 132px);
   }
+  /* Same lock for the cancelled/interrupted toast. Its pill has one fixed
+     width, but the entrance morph animates into it from the previous pill's
+     (narrower) width — and without a lock the ResizeObserver chased that
+     animation frame by frame, issuing a native SetWindowPos per frame, which
+     is the documented cause of WebView2 presenting stale/clipped frames
+     mid-morph. Locking the cluster means the window is sized once, before
+     the morph starts, and never moves during it.
+
+     172px (the wider "Interrupted" variant) covers both: at PILL_STEP_W=24
+     quantization, 158px and 172px round up to the same 192px window, so
+     using the max costs nothing and avoids threading the variant down. */
+  .pill-cluster.steady-width-cancel {
+    min-width: 172px;
+  }
   /* Resolved context, shown as a small floating tag above the pill so the
      dictation's destination stays legible without crowding or offsetting
      the pill capsule itself. Fades in softly so its appearance
@@ -1182,7 +1218,6 @@
     max-width: 180px;
     overflow: hidden;
     text-overflow: ellipsis;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.35);
     animation: chipIn 0.18s ease-out both;
   }
   @keyframes chipIn {
@@ -1593,27 +1628,66 @@
   }
   .hf-btn.err-dismiss:hover { opacity: 1; background: rgba(255,255,255,0.14); }
 
-  /* Cancelled: neutral stadium pill (not the red error palette) — starts as
-     a dismiss (X) button only, expands to reveal the "Cancelled" label and
-     an Undo button that resumes recording hands-free with the cancelled
-     audio prepended. Both buttons are real, clickable controls (not status
-     icons) — dismiss discards the capture for good, Undo keeps it going. */
+  /* Cancelled: neutral stadium pill (not the red error palette) — a dismiss
+     (X) button, the "Cancelled" label, and an Undo button that resumes
+     recording hands-free with the cancelled audio prepended. Both buttons
+     are real, clickable controls (not status icons) — dismiss discards the
+     capture for good, Undo keeps it going. The pill arrives at full size and
+     staggers its contents in by opacity; only the label and Undo are
+     sequenced, never the layout. */
+  /* One fixed width, reached by the entrance morph below and never changed
+     again. This used to start collapsed at 42px and expand to 158px on
+     `cancel-open`, via a `transition: width` — which fought the entrance
+     `animation` on the same property. An animation overrides a transition
+     while it runs, so the pill shrank under the animation for 240ms, then
+     control snapped back to the transition (already most of the way to
+     158px) the instant the animation ended. That mid-flight snap, plus a
+     width that moved in three directions in ~300ms (bars-width -> 42 ->
+     158) and a padding shift underneath it, is what read as the contents
+     shifting around before settling. Now width moves exactly once, in one
+     direction, and only opacity is staggered. */
   .pill.cancelled {
-    width: 42px;
+    width: 158px;
     gap: 8px;
-    padding: 0 12px;
+    padding: 0 8px;
     border-radius: 999px;
     overflow: hidden;
-    /* No overshoot — see .pill.error's transition comment. */
-    transition: width 0.26s cubic-bezier(0.22, 1, 0.36, 1),
-                padding 0.26s cubic-bezier(0.22, 1, 0.36, 1);
   }
-  .pill.cancelled.cancel-open {
-    width: 158px;
-    padding: 0 8px;
+  /* Recording/handsfree→cancelled: without this the bars pill hard-cuts to
+     the toast and a fresh pillIn bounce plays on top — the teleport this
+     fixes. Growing from the previous pill's own width instead (72px
+     recording / 112px expanded handsfree, both narrower than the toast)
+     makes it read as one continuous capsule widening into the message,
+     same trick as processing's from-rec/from-hf. Only
+     `from` is set — the animation's own end value falls back to
+     `.pill.cancelled`'s own width (158px, or 172px when interrupted), so it
+     doesn't need repeating here and stays correct for both variants. */
+  .pill.cancelled.from-rec {
+    animation: cancelFromRec 0.24s cubic-bezier(0.22, 1, 0.36, 1) backwards,
+               pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
-  .pill.cancelled.interrupted.cancel-open {
+  @keyframes cancelFromRec {
+    from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 14px); }
+  }
+  .pill.cancelled.from-hf {
+    animation: cancelFromHf 0.24s cubic-bezier(0.22, 1, 0.36, 1) backwards,
+               pillIn 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+  @keyframes cancelFromHf {
+    /* handsfree's Cancel button is only reachable once it's expanded, so
+       start from the expanded width, not the collapsed one. */
+    from { width: calc(12 * var(--bar-w, 3px) + 11 * var(--bar-gap, 2px) + 54px); }
+  }
+  /* "Interrupted" is a longer word — same single fixed width treatment. */
+  .pill.cancelled.interrupted {
     width: 172px;
+  }
+  /* Same specificity guard as processing's from-rec/from-hf.dying override:
+     if the capture is dismissed before the entrance morph finishes, the exit
+     fade must win over the higher-specificity from-rec/from-hf rule above. */
+  .pill.cancelled.from-rec.dying,
+  .pill.cancelled.from-hf.dying {
+    animation: pillOut 0.18s cubic-bezier(0.4, 0, 1, 1) both;
   }
   .cancel-text {
     font-size: 11.5px; font-weight: 500;
@@ -1621,9 +1695,25 @@
     opacity: 0;
     flex: 1;
     text-align: center;
-    transition: opacity 0.18s ease 0.08s;
+    /* Settles at ~225ms, just inside the 240ms entrance morph, so the label
+       finishes arriving as the capsule stops moving rather than after it. */
+    transition: opacity 0.16s ease 0.05s;
   }
   .pill.cancelled.cancel-open .cancel-text { opacity: 1; }
+  /* Overrides the generic .hf-btn.confirm mount animation (hfBtnIn, below) —
+     this button is always in the DOM here (see the template comment), so it
+     needs its own opacity switch instead of an entrance animation that would
+     autoplay the moment the cancelled pill mounts, before the stagger delay. */
+  .pill.cancelled .hf-btn.confirm {
+    animation: none;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s ease;
+  }
+  .pill.cancelled .hf-btn.confirm.btn-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
 
   /* Paste failed: same red-tinted stadium pill as .pill.error, message-first
      (no collapsed-icon entry — the message is a fixed short string, not a

--- a/src/theme.css
+++ b/src/theme.css
@@ -90,8 +90,8 @@
   --pill-stage-size: 10.5px;
   --pill-stage-weight: 600;
   --pill-context-bg: var(--pill-bg);
-  --pill-context-fg: rgba(17, 17, 16, 0.72);
-  --pill-context-line: rgba(17, 17, 16, 0.13);
+  --pill-context-fg: var(--pill-fg);
+  --pill-context-line: var(--pill-line);
 
   /* Error pill is always dark red-tinted, regardless of theme — matches the
      dark-theme --danger/--danger-bg/--danger-line so the pill and in-app
@@ -216,6 +216,6 @@
   --pill-stage-size: 11px;
   --pill-stage-weight: 600;
   --pill-context-bg: var(--pill-bg);
-  --pill-context-fg: rgba(255, 255, 255, 0.72);
-  --pill-context-line: rgba(255, 255, 255, 0.08);
+  --pill-context-fg: var(--pill-fg);
+  --pill-context-line: var(--pill-line);
 }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - Subsystem: pill UI (frontend animation) and the pipeline's cancel/resume flow (injection targeting)
> - Cancelling a dictation snapped straight to the "Cancelled" toast with no transition, and once there its Undo button popped into the layout mid-animation, shoving the label sideways as things settled
> - Separately, using Undo to resume a cancelled capture never actually pasted the transcription — it always fell back to "copied to clipboard, press Ctrl+V", regardless of which app was focused before the cancel
> - This PR fixes both: the entrance is now one continuous morph with no property fighting, and resume reuses the dictation's original focus target instead of re-capturing the foreground (which by Undo-click time is Verenu's own pill)
> - The benefit is the cancel/resume loop now looks intentional and actually pastes, instead of degrading to a manual-paste toast every time

## What Changed

- Cancelled/interrupted pill: single fixed width reached by one entrance morph (previously an `animation` and a `transition` both targeted `width` at once, so the pill snapped mid-flight when the animation handed off to the transition)
- Locked the native pill window at the cluster level for the cancelled state (`steady-width-cancel`), matching the existing locks for `processing`/`handsfree`, so the resize observer doesn't chase the entrance animation frame by frame
- Undo button is now always mounted and only fades its opacity in on its stagger delay, instead of mounting as a new flex item mid-transition and reflowing the "Cancelled" label
- Dropped the pill-context chip's dimmed text color and hardcoded text-shadow — leftover from before the chip shared the main pill's opaque background, now just a visual mismatch
- `CancelledCapture` now stores the original dictation's `WindowTarget` (mirroring `RetryCapture`'s existing pattern) instead of `resume_cancelled_capture` re-capturing the foreground window at Undo-click time, which was always Verenu's own pill and tripped the self-inject clipboard-fallback guard on every resume
- Crash-recovered captures (loaded from disk after a restart, with no stored target) still fall back to capturing the current foreground, matching prior behavior for that path

## Verification

- `npm run check` — 0 errors, 0 warnings
- `cargo check` (isolated target dir, since a dev instance was running) — clean build
- `npx vitest run src` — 108 tests passed
- `svelte-check` — 0 errors, 0 warnings
- Extracted and visually inspected the actual cancel-entrance frames from a screen recording (ffmpeg) to confirm the original instant-snap bug before fixing it, rather than guessing from description alone
- Manual: cancel a dictation, confirm the toast eases in without settling/shifting; click Undo, confirm the resumed dictation pastes into the originally-focused app instead of falling back to clipboard
- Not run: `npm run lint` / `npm run test:rust` — an unrelated, already-broken `app_tray.rs` in this shared GitButler workspace (another session's in-flight work, not touched by this PR) currently fails full-crate compilation for tests/clippy; this branch's own files pass `cargo check` in isolation

## Risks

- Behavior change to `resume_cancelled_capture`'s injection target — low risk: it now matches the same "reuse the captured target, refresh for movement" pattern `retry_transcription_impl` already uses in production
- No new dependencies, no schema/migration changes, no smoke-test selectors touched

## Model Used

- Claude Sonnet 5 (claude-sonnet-5), via Claude Code, standard tool use — no extended thinking mode

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy) — blocked by unrelated in-progress `app_tray.rs` work in this shared workspace, see Verification
- [ ] `npm run test:rust` passes — same blocker
- [x] Smoke tests pass (no `tests/smoke/` selectors touched)
- [x] Tests added or updated where applicable (updated existing `CancelledCapture` unit tests for the new field)
- [ ] UI changes include before/after screenshots — animation-only change, described in What Changed instead
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: N/A, no version bump in this PR
- [x] Relevant documentation updated to reflect changes — N/A, no user-facing docs affected
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791290136&installation_model_id=432577&pr_number=368&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F368&signature=56eeceef86d114188df554742a0a01ca49b6d5449df250299cbde4395f447119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->