### PR TITLE
Add Windows mic mute-button dictation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Added an optional Windows Audio setting to toggle hands-free dictation with a mute→unmute pulse on the selected microphone. Matches the selected mic across WASAPI/CPAL name variants, watches the endpoint mute bit plus USB/headset hardware mute controls on the capture path, and uses a digital-silence PCM fallback when those controls are absent — releasing that idle capture client before dictation opens the mic so the pill visualizer is not starved. Mute watching runs only while the setting is on.
 - Removed orange from the native and packaged app icons. Runtime icons now use a pure black-and-white pair that follows light and dark appearance modes instead of the selected accent color.
 - Fixed hands-free conversion from an active hold-to-talk dictation ending when
   the original Windows modifier chord is released; stale release events now

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5843,6 +5843,7 @@ dependencies = [
  "transcribe-rs",
  "uuid",
  "windows 0.61.3",
+ "windows-core 0.61.2",
  "zip",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,6 +90,8 @@ windows = { version = "0.61", features = [
   "Win32_Graphics_Gdi",
   "Win32_System_LibraryLoader",
   ] }
+# Required so #[implement] expansions can resolve `::windows_core`.
+windows-core = "0.61"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 global-hotkey      = "0.8"    # Carbon RegisterEventHotKey global hotkey (no Input Monitoring / Accessibility needed)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -138,6 +138,12 @@ const SETTING_SPECS: &[SettingSpec] = &[
     setting_spec(store::APP_MAPPINGS, SettingKind::AppMappings, true, true),
     setting_spec(store::NOISE_REDUCTION, SettingKind::Bool, true, true),
     setting_spec(store::MUTE_AUDIO, SettingKind::Bool, true, true),
+    setting_spec(
+        store::MIC_MUTE_BUTTON_DICTATION,
+        SettingKind::Bool,
+        true,
+        true,
+    ),
     setting_spec(store::EXCLUSIVE_MIC, SettingKind::Bool, true, true),
     setting_spec(
         store::PAUSE_MEDIA_DURING_DICTATION,
@@ -564,6 +570,10 @@ pub async fn save_setting(
         crate::media::sound::set_volume(volume);
     }
 
+    if key == store::MIC_MUTE_BUTTON_DICTATION || key == store::MICROPHONE_DEVICE {
+        crate::media::mic_mute_trigger::reload(&app);
+    }
+
     if let Some(days) = history_prune_days {
         let db = app.state::<DbHandle>().inner().clone();
         let deleted =
@@ -609,6 +619,7 @@ pub struct AllSettings {
     pub cleanup_enabled: Option<bool>,
     pub noise_reduction: Option<bool>,
     pub mute_audio: Option<bool>,
+    pub mic_mute_button_dictation: Option<bool>,
     pub exclusive_mic: Option<bool>,
     pub pause_media_during_dictation: Option<bool>,
     pub play_start_stop_sounds: Option<bool>,
@@ -679,6 +690,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         cleanup_enabled: bool_val(store::CLEANUP_ENABLED),
         noise_reduction: bool_val(store::NOISE_REDUCTION),
         mute_audio: bool_val(store::MUTE_AUDIO),
+        mic_mute_button_dictation: bool_val(store::MIC_MUTE_BUTTON_DICTATION),
         exclusive_mic: bool_val(store::EXCLUSIVE_MIC),
         pause_media_during_dictation: bool_val(store::PAUSE_MEDIA_DURING_DICTATION),
         play_start_stop_sounds: bool_val(store::PLAY_START_STOP_SOUNDS),

--- a/src-tauri/src/data/store/mod.rs
+++ b/src-tauri/src/data/store/mod.rs
@@ -261,6 +261,7 @@ pub const CLEANUP_INTENSITY: &str = "cleanup_intensity";
 pub const APP_MAPPINGS: &str = "app_mappings";
 pub const NOISE_REDUCTION: &str = "noise_reduction";
 pub const MUTE_AUDIO: &str = "mute_audio";
+pub const MIC_MUTE_BUTTON_DICTATION: &str = "mic_mute_button_dictation";
 pub const EXCLUSIVE_MIC: &str = "exclusive_mic";
 pub const PAUSE_MEDIA_DURING_DICTATION: &str = "pause_media_during_dictation";
 pub const MIC_GAIN: &str = "mic_gain";

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -235,6 +235,7 @@ fn main() {
                 app_tray::apply_runtime_icons(app.handle(), theme);
             }
             app_hotkey::setup_hotkey(app, shared.clone());
+            media::mic_mute_trigger::setup(app, shared.clone());
             // setup_tray() already applies runtime icons (both platforms) via
             // apply_runtime_icons() — no need to call it again here.
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/media/device_match.rs
+++ b/src-tauri/src/media/device_match.rs
@@ -73,7 +73,7 @@ pub fn device_name_match_score(candidate: &str, desired: &str) -> u8 {
     } else {
         (&nd, &nc)
     };
-    if shorter.len() >= 6 && longer.contains(shorter.as_str()) {
+    if shorter.chars().count() >= 6 && longer.contains(shorter.as_str()) {
         return SCORE_CONTAINS;
     }
     SCORE_NONE
@@ -136,10 +136,7 @@ mod tests {
             device_name_match_score("Microphone (Yeti Nano)", "Yeti Nano"),
             SCORE_NORMALIZED
         );
-        assert_eq!(
-            normalize_device_name("Microphone (Yeti Nano)"),
-            "yeti nano"
-        );
+        assert_eq!(normalize_device_name("Microphone (Yeti Nano)"), "yeti nano");
     }
 
     #[test]
@@ -156,10 +153,7 @@ mod tests {
     #[test]
     fn bluetooth_product_substring_matches() {
         assert_eq!(
-            device_name_match_score(
-                "Headset (WH-1000XM5 Hands-Free AG Audio)",
-                "WH-1000XM5"
-            ),
+            device_name_match_score("Headset (WH-1000XM5 Hands-Free AG Audio)", "WH-1000XM5"),
             SCORE_CONTAINS
         );
     }

--- a/src-tauri/src/media/device_match.rs
+++ b/src-tauri/src/media/device_match.rs
@@ -1,0 +1,199 @@
+//! Match a stored microphone name to WASAPI/CPAL device names.
+//!
+//! The same hardware often appears as `Microphone (Yeti Nano)`, `Yeti Nano`,
+//! or `Microphone (Yeti Nano) (2)` after a replug. Exact string equality
+//! misses those, so mute watching would bind the default input instead.
+
+pub const SCORE_NONE: u8 = 0;
+pub const SCORE_CONTAINS: u8 = 1;
+pub const SCORE_NORMALIZED: u8 = 2;
+pub const SCORE_CASEFOLD: u8 = 3;
+pub const SCORE_EXACT: u8 = 4;
+
+/// Longer prefixes first so "headset microphone" wins over "headset".
+const ROLE_PREFIXES: &[&str] = &[
+    "headset microphone",
+    "headset mic",
+    "microphone array",
+    "microphone",
+    "headphones",
+    "headset",
+    "line in",
+    "line",
+    "mic",
+];
+
+/// Generic labels that would false-match under substring comparison.
+const GENERIC_NORMALIZED: &[&str] = &[
+    "usb audio device",
+    "usb audio",
+    "generic usb audio",
+    "microphone",
+    "headset",
+    "headphones",
+    "realtek audio",
+    "high definition audio device",
+    "microsoft sound mapper",
+    "primary sound capture driver",
+];
+
+#[allow(dead_code)]
+pub fn names_match(candidate: &str, desired: &str) -> bool {
+    device_name_match_score(candidate, desired) > SCORE_NONE
+}
+
+pub fn best_score_against(desired: &str, candidates: &[&str]) -> u8 {
+    candidates
+        .iter()
+        .map(|candidate| device_name_match_score(candidate, desired))
+        .max()
+        .unwrap_or(SCORE_NONE)
+}
+
+pub fn device_name_match_score(candidate: &str, desired: &str) -> u8 {
+    if candidate == desired {
+        return SCORE_EXACT;
+    }
+    if candidate.eq_ignore_ascii_case(desired) {
+        return SCORE_CASEFOLD;
+    }
+    let nc = normalize_device_name(candidate);
+    let nd = normalize_device_name(desired);
+    if nc.is_empty() || nd.is_empty() {
+        return SCORE_NONE;
+    }
+    if nc == nd {
+        return SCORE_NORMALIZED;
+    }
+    if is_generic(&nc) || is_generic(&nd) {
+        return SCORE_NONE;
+    }
+    let (shorter, longer) = if nc.len() <= nd.len() {
+        (&nc, &nd)
+    } else {
+        (&nd, &nc)
+    };
+    if shorter.len() >= 6 && longer.contains(shorter.as_str()) {
+        return SCORE_CONTAINS;
+    }
+    SCORE_NONE
+}
+
+pub fn normalize_device_name(name: &str) -> String {
+    let collapsed = collapse_ws(&name.to_lowercase());
+    let stripped = strip_instance_suffix(&collapsed);
+    unwrap_role_wrapper(stripped).to_string()
+}
+
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_instance_suffix(s: &str) -> &str {
+    if !s.ends_with(')') {
+        return s;
+    }
+    if let Some(open) = s.rfind(" (") {
+        let inner = &s[open + 2..s.len() - 1];
+        if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
+            return &s[..open];
+        }
+    }
+    s
+}
+
+fn unwrap_role_wrapper(s: &str) -> &str {
+    for prefix in ROLE_PREFIXES {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            let rest = rest.trim();
+            if rest.starts_with('(') && rest.ends_with(')') && rest.len() >= 3 {
+                return rest[1..rest.len() - 1].trim();
+            }
+        }
+    }
+    s
+}
+
+fn is_generic(normalized: &str) -> bool {
+    GENERIC_NORMALIZED.contains(&normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_name_is_highest_score() {
+        assert_eq!(
+            device_name_match_score("Microphone (Yeti Nano)", "Microphone (Yeti Nano)"),
+            SCORE_EXACT
+        );
+    }
+
+    #[test]
+    fn unwraps_microphone_role_prefix() {
+        assert_eq!(
+            device_name_match_score("Microphone (Yeti Nano)", "Yeti Nano"),
+            SCORE_NORMALIZED
+        );
+        assert_eq!(
+            normalize_device_name("Microphone (Yeti Nano)"),
+            "yeti nano"
+        );
+    }
+
+    #[test]
+    fn unwraps_headset_microphone_and_instance_suffix() {
+        assert_eq!(
+            device_name_match_score(
+                "Headset Microphone (Jabra Evolve 75) (2)",
+                "Microphone (Jabra Evolve 75)"
+            ),
+            SCORE_NORMALIZED
+        );
+    }
+
+    #[test]
+    fn bluetooth_product_substring_matches() {
+        assert_eq!(
+            device_name_match_score(
+                "Headset (WH-1000XM5 Hands-Free AG Audio)",
+                "WH-1000XM5"
+            ),
+            SCORE_CONTAINS
+        );
+    }
+
+    #[test]
+    fn generic_usb_audio_does_not_substring_match() {
+        assert_eq!(
+            device_name_match_score(
+                "Microphone (USB Audio Device)",
+                "Microphone (Other USB Audio Device)"
+            ),
+            SCORE_NONE
+        );
+    }
+
+    #[test]
+    fn distinct_mics_do_not_match() {
+        assert_eq!(
+            device_name_match_score("Microphone (Yeti Nano)", "Microphone (Elgato Wave:3)"),
+            SCORE_NONE
+        );
+    }
+
+    #[test]
+    fn case_insensitive_exact() {
+        assert_eq!(
+            device_name_match_score("Yeti Nano", "yeti nano"),
+            SCORE_CASEFOLD
+        );
+    }
+
+    #[test]
+    fn names_match_helper() {
+        assert!(names_match("Microphone (Yeti Nano)", "Yeti Nano"));
+        assert!(!names_match("Microphone (Yeti Nano)", "Shure MV7"));
+    }
+}

--- a/src-tauri/src/media/digital_silence.rs
+++ b/src-tauri/src/media/digital_silence.rs
@@ -74,24 +74,35 @@ impl DigitalSilenceDetector {
 
     /// Push a block of PCM samples observed at `now`. Returns a debounced
     /// transition when the mute state has been stable long enough.
-    pub fn push_samples(
-        &mut self,
-        samples: &[f32],
-        now: Instant,
-    ) -> Option<SilenceTransition> {
-        if !samples.is_empty() {
-            let mut silent = 0u32;
-            let mut abs_max = 0.0f32;
-            for &sample in samples {
-                let a = sample.abs();
-                if a > abs_max {
-                    abs_max = a;
-                }
-                if Self::is_digital_silent_sample(sample) {
-                    silent += 1;
-                }
+    pub fn push_samples(&mut self, samples: &[f32], now: Instant) -> Option<SilenceTransition> {
+        if samples.is_empty() {
+            self.prune(now);
+            return self.evaluate(now);
+        }
+        let mut silent = 0u32;
+        let mut abs_max = 0.0f32;
+        for &sample in samples {
+            let a = sample.abs();
+            if a > abs_max {
+                abs_max = a;
             }
-            let total = samples.len() as u32;
+            if Self::is_digital_silent_sample(sample) {
+                silent += 1;
+            }
+        }
+        self.push_chunk_stats(now, silent, samples.len() as u32, abs_max)
+    }
+
+    /// Same as [`Self::push_samples`], but callers can compute stats without
+    /// allocating a converted float buffer on the realtime audio thread.
+    pub fn push_chunk_stats(
+        &mut self,
+        now: Instant,
+        silent: u32,
+        total: u32,
+        abs_max: f32,
+    ) -> Option<SilenceTransition> {
+        if total > 0 {
             self.chunks.push_back(ChunkStat {
                 at: now,
                 silent,
@@ -109,6 +120,7 @@ impl DigitalSilenceDetector {
     }
 
     fn prune(&mut self, now: Instant) {
+        let mut removed = false;
         while let Some(front) = self.chunks.front().copied() {
             if now.saturating_duration_since(front.at) <= self.window {
                 break;
@@ -116,16 +128,15 @@ impl DigitalSilenceDetector {
             self.chunks.pop_front();
             self.silent_count = self.silent_count.saturating_sub(u64::from(front.silent));
             self.total_count = self.total_count.saturating_sub(u64::from(front.total));
+            removed = true;
+        }
+        if removed {
             self.recompute_abs_max();
         }
     }
 
     fn recompute_abs_max(&mut self) {
-        self.abs_max = self
-            .chunks
-            .iter()
-            .map(|c| c.abs_max)
-            .fold(0.0f32, f32::max);
+        self.abs_max = self.chunks.iter().map(|c| c.abs_max).fold(0.0f32, f32::max);
     }
 
     fn evaluate(&mut self, now: Instant) -> Option<SilenceTransition> {
@@ -241,10 +252,8 @@ mod tests {
     #[test]
     fn exact_zeros_become_muted_after_debounce() {
         let start = Instant::now();
-        let mut det = DigitalSilenceDetector::new(
-            Duration::from_millis(200),
-            Duration::from_millis(100),
-        );
+        let mut det =
+            DigitalSilenceDetector::new(Duration::from_millis(200), Duration::from_millis(100));
         // Seed with non-silent so the first mute is a real transition.
         assert!(det.push_samples(&noise(512, 0.01), start).is_none());
         assert!(!det.is_muted());
@@ -267,10 +276,8 @@ mod tests {
     #[test]
     fn whisper_quiet_noise_is_not_muted() {
         let start = Instant::now();
-        let mut det = DigitalSilenceDetector::new(
-            Duration::from_millis(200),
-            Duration::from_millis(100),
-        );
+        let mut det =
+            DigitalSilenceDetector::new(Duration::from_millis(200), Duration::from_millis(100));
         // ~0.001 is far above 1/32768 (~3e-5) but still "quiet".
         let quiet = noise(2048, 0.001);
         assert!(det.push_samples(&quiet, start).is_none());
@@ -289,10 +296,8 @@ mod tests {
     #[test]
     fn unmute_requires_sustained_non_silent() {
         let start = Instant::now();
-        let mut det = DigitalSilenceDetector::new(
-            Duration::from_millis(200),
-            Duration::from_millis(100),
-        );
+        let mut det =
+            DigitalSilenceDetector::new(Duration::from_millis(200), Duration::from_millis(100));
         assert!(det.push_samples(&noise(256, 0.01), start).is_none());
         assert!(det
             .push_samples(&zeros(4096), start + Duration::from_millis(50))

--- a/src-tauri/src/media/digital_silence.rs
+++ b/src-tauri/src/media/digital_silence.rs
@@ -1,0 +1,361 @@
+//! Digital-silence detector for microphones that zero PCM when hardware-muted.
+//!
+//! Treats a sample as silent when `|s| <= 1/32768` (one LSB at 16-bit). A window
+//! must be almost entirely silent before "muted"; quiet ambient noise must not
+//! trip that threshold.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+/// One LSB of a full-scale 16-bit sample, expressed as f32 in [-1, 1].
+pub const DIGITAL_SILENCE_EPS: f32 = 1.0 / 32768.0;
+
+const DEFAULT_WINDOW: Duration = Duration::from_millis(250);
+const MUTE_SILENT_FRACTION: f64 = 0.98;
+const UNMUTE_SILENT_FRACTION: f64 = 0.90;
+const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(120);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SilenceTransition {
+    BecameMuted,
+    BecameUnmuted,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ChunkStat {
+    at: Instant,
+    silent: u32,
+    total: u32,
+    abs_max: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct DigitalSilenceDetector {
+    window: Duration,
+    debounce: Duration,
+    muted: bool,
+    chunks: VecDeque<ChunkStat>,
+    silent_count: u64,
+    total_count: u64,
+    abs_max: f32,
+    pending: Option<(bool, Instant)>,
+    seeded: bool,
+}
+
+impl Default for DigitalSilenceDetector {
+    fn default() -> Self {
+        Self::new(DEFAULT_WINDOW, DEFAULT_DEBOUNCE)
+    }
+}
+
+impl DigitalSilenceDetector {
+    pub fn new(window: Duration, debounce: Duration) -> Self {
+        Self {
+            window,
+            debounce,
+            muted: false,
+            chunks: VecDeque::new(),
+            silent_count: 0,
+            total_count: 0,
+            abs_max: 0.0,
+            pending: None,
+            seeded: false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_muted(&self) -> bool {
+        self.muted
+    }
+
+    pub fn is_digital_silent_sample(sample: f32) -> bool {
+        sample.abs() <= DIGITAL_SILENCE_EPS
+    }
+
+    /// Push a block of PCM samples observed at `now`. Returns a debounced
+    /// transition when the mute state has been stable long enough.
+    pub fn push_samples(
+        &mut self,
+        samples: &[f32],
+        now: Instant,
+    ) -> Option<SilenceTransition> {
+        if !samples.is_empty() {
+            let mut silent = 0u32;
+            let mut abs_max = 0.0f32;
+            for &sample in samples {
+                let a = sample.abs();
+                if a > abs_max {
+                    abs_max = a;
+                }
+                if Self::is_digital_silent_sample(sample) {
+                    silent += 1;
+                }
+            }
+            let total = samples.len() as u32;
+            self.chunks.push_back(ChunkStat {
+                at: now,
+                silent,
+                total,
+                abs_max,
+            });
+            self.silent_count += u64::from(silent);
+            self.total_count += u64::from(total);
+            if abs_max > self.abs_max {
+                self.abs_max = abs_max;
+            }
+        }
+        self.prune(now);
+        self.evaluate(now)
+    }
+
+    fn prune(&mut self, now: Instant) {
+        while let Some(front) = self.chunks.front().copied() {
+            if now.saturating_duration_since(front.at) <= self.window {
+                break;
+            }
+            self.chunks.pop_front();
+            self.silent_count = self.silent_count.saturating_sub(u64::from(front.silent));
+            self.total_count = self.total_count.saturating_sub(u64::from(front.total));
+            self.recompute_abs_max();
+        }
+    }
+
+    fn recompute_abs_max(&mut self) {
+        self.abs_max = self
+            .chunks
+            .iter()
+            .map(|c| c.abs_max)
+            .fold(0.0f32, f32::max);
+    }
+
+    fn evaluate(&mut self, now: Instant) -> Option<SilenceTransition> {
+        if self.total_count == 0 {
+            return None;
+        }
+        let silent_fraction = self.silent_count as f64 / self.total_count as f64;
+        let looks_muted = silent_fraction >= MUTE_SILENT_FRACTION;
+        let looks_unmuted =
+            self.abs_max > DIGITAL_SILENCE_EPS && silent_fraction < UNMUTE_SILENT_FRACTION;
+        let want_muted = if self.muted {
+            !looks_unmuted
+        } else {
+            looks_muted
+        };
+
+        if !self.seeded {
+            self.muted = want_muted;
+            self.seeded = true;
+            self.pending = None;
+            return None;
+        }
+
+        if want_muted == self.muted {
+            self.pending = None;
+            return None;
+        }
+
+        match self.pending {
+            Some((target, since)) if target == want_muted => {
+                if now.saturating_duration_since(since) < self.debounce {
+                    return None;
+                }
+                self.pending = None;
+                self.muted = want_muted;
+                Some(if want_muted {
+                    SilenceTransition::BecameMuted
+                } else {
+                    SilenceTransition::BecameUnmuted
+                })
+            }
+            _ => {
+                self.pending = Some((want_muted, now));
+                None
+            }
+        }
+    }
+}
+
+/// Debounces boolean mute transitions so brief glitches do not fire.
+#[derive(Debug, Clone)]
+pub struct MuteDebouncer {
+    debounce: Duration,
+    last_stable: Option<bool>,
+    pending: Option<(bool, Instant)>,
+}
+
+impl MuteDebouncer {
+    pub fn new(debounce: Duration) -> Self {
+        Self {
+            debounce,
+            last_stable: None,
+            pending: None,
+        }
+    }
+
+    /// Seeds the current mute state without emitting a transition.
+    pub fn seed(&mut self, muted: bool) {
+        self.last_stable = Some(muted);
+        self.pending = None;
+    }
+
+    pub fn observe(&mut self, muted: bool, now: Instant) -> Option<bool> {
+        let Some(last) = self.last_stable else {
+            self.last_stable = Some(muted);
+            return None;
+        };
+        if muted == last {
+            self.pending = None;
+            return None;
+        }
+        match self.pending {
+            Some((target, since)) if target == muted => {
+                if now.saturating_duration_since(since) < self.debounce {
+                    return None;
+                }
+                self.pending = None;
+                self.last_stable = Some(muted);
+                Some(muted)
+            }
+            _ => {
+                self.pending = Some((muted, now));
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zeros(n: usize) -> Vec<f32> {
+        vec![0.0; n]
+    }
+
+    fn noise(n: usize, amplitude: f32) -> Vec<f32> {
+        (0..n)
+            .map(|i| if i % 2 == 0 { amplitude } else { -amplitude })
+            .collect()
+    }
+
+    #[test]
+    fn exact_zeros_become_muted_after_debounce() {
+        let start = Instant::now();
+        let mut det = DigitalSilenceDetector::new(
+            Duration::from_millis(200),
+            Duration::from_millis(100),
+        );
+        // Seed with non-silent so the first mute is a real transition.
+        assert!(det.push_samples(&noise(512, 0.01), start).is_none());
+        assert!(!det.is_muted());
+
+        // Fill the window with zeros so the earlier noise ages out.
+        assert!(det
+            .push_samples(&zeros(2048), start + Duration::from_millis(50))
+            .is_none());
+        assert!(det
+            .push_samples(&zeros(2048), start + Duration::from_millis(220))
+            .is_none());
+        // Window is now all zeros; debounce still needs to elapse.
+        assert_eq!(
+            det.push_samples(&zeros(2048), start + Duration::from_millis(330)),
+            Some(SilenceTransition::BecameMuted)
+        );
+        assert!(det.is_muted());
+    }
+
+    #[test]
+    fn whisper_quiet_noise_is_not_muted() {
+        let start = Instant::now();
+        let mut det = DigitalSilenceDetector::new(
+            Duration::from_millis(200),
+            Duration::from_millis(100),
+        );
+        // ~0.001 is far above 1/32768 (~3e-5) but still "quiet".
+        let quiet = noise(2048, 0.001);
+        assert!(det.push_samples(&quiet, start).is_none());
+        assert!(det
+            .push_samples(&quiet, start + Duration::from_millis(50))
+            .is_none());
+        assert!(det
+            .push_samples(&quiet, start + Duration::from_millis(150))
+            .is_none());
+        assert!(det
+            .push_samples(&quiet, start + Duration::from_millis(250))
+            .is_none());
+        assert!(!det.is_muted());
+    }
+
+    #[test]
+    fn unmute_requires_sustained_non_silent() {
+        let start = Instant::now();
+        let mut det = DigitalSilenceDetector::new(
+            Duration::from_millis(200),
+            Duration::from_millis(100),
+        );
+        assert!(det.push_samples(&noise(256, 0.01), start).is_none());
+        assert!(det
+            .push_samples(&zeros(4096), start + Duration::from_millis(50))
+            .is_none());
+        assert!(det
+            .push_samples(&zeros(4096), start + Duration::from_millis(220))
+            .is_none());
+        assert_eq!(
+            det.push_samples(&zeros(4096), start + Duration::from_millis(330)),
+            Some(SilenceTransition::BecameMuted)
+        );
+
+        // A single non-zero sample inside an otherwise silent window must not unmute.
+        let mut mostly_silent = zeros(1000);
+        mostly_silent[0] = 0.05;
+        assert!(det
+            .push_samples(&mostly_silent, start + Duration::from_millis(340))
+            .is_none());
+        assert!(det.is_muted());
+
+        let open = noise(4096, 0.02);
+        assert!(det
+            .push_samples(&open, start + Duration::from_millis(350))
+            .is_none());
+        // Age out silent chunks and complete unmute debounce.
+        assert_eq!(
+            det.push_samples(&open, start + Duration::from_millis(560)),
+            Some(SilenceTransition::BecameUnmuted)
+        );
+        assert!(!det.is_muted());
+    }
+
+    #[test]
+    fn mute_debouncer_ignores_seed_and_short_glitches() {
+        let start = Instant::now();
+        let mut deb = MuteDebouncer::new(Duration::from_millis(120));
+        deb.seed(true);
+        assert!(deb.observe(false, start).is_none());
+        assert!(deb
+            .observe(false, start + Duration::from_millis(50))
+            .is_none());
+        // Bounce back before debounce completes.
+        assert!(deb
+            .observe(true, start + Duration::from_millis(60))
+            .is_none());
+        assert!(deb
+            .observe(false, start + Duration::from_millis(70))
+            .is_none());
+        assert_eq!(
+            deb.observe(false, start + Duration::from_millis(200)),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn digital_silence_eps_matches_16bit_lsb() {
+        assert!(DigitalSilenceDetector::is_digital_silent_sample(0.0));
+        assert!(DigitalSilenceDetector::is_digital_silent_sample(
+            DIGITAL_SILENCE_EPS
+        ));
+        assert!(!DigitalSilenceDetector::is_digital_silent_sample(
+            DIGITAL_SILENCE_EPS * 2.0
+        ));
+        assert!(!DigitalSilenceDetector::is_digital_silent_sample(0.001));
+    }
+}

--- a/src-tauri/src/media/hardware_mute.rs
+++ b/src-tauri/src/media/hardware_mute.rs
@@ -95,6 +95,12 @@ fn collect_capture_path_mutes(device: &IMMDevice) -> Vec<IAudioMute> {
         if let Ok(part) = other.cast::<IPart>() {
             walk_incoming(&part, &mut mutes, &mut visited, 0);
         }
+        // Prefer the mute closest to the capture endpoint. Watching every
+        // subunit and OR-ing them can stick muted on unused mux paths.
+        if !mutes.is_empty() {
+            mutes.truncate(1);
+            break;
+        }
     }
     mutes
 }

--- a/src-tauri/src/media/hardware_mute.rs
+++ b/src-tauri/src/media/hardware_mute.rs
@@ -6,8 +6,8 @@
 
 use std::collections::HashSet;
 use windows::core::Interface;
-use windows::Win32::Media::Audio::{IAudioMute, IDeviceTopology, IPart, IMMDevice};
-use windows::Win32::System::Com::CLSCTX_ALL;
+use windows::Win32::Media::Audio::{IAudioMute, IDeviceTopology, IMMDevice, IPart};
+use windows::Win32::System::Com::{CoTaskMemFree, CLSCTX_ALL};
 
 const MAX_DEPTH: u8 = 16;
 
@@ -21,7 +21,11 @@ impl TopologyMuteWatch {
         let mutes = collect_capture_path_mutes(device);
         let last = mutes
             .iter()
-            .map(|mute| unsafe { mute.GetMute() }.map(|v| v.as_bool()).unwrap_or(false))
+            .map(|mute| {
+                unsafe { mute.GetMute() }
+                    .map(|v| v.as_bool())
+                    .unwrap_or(false)
+            })
             .collect();
         log::info!(
             "mic_mute_trigger: {} hardware mute control(s) on the capture path",
@@ -105,10 +109,12 @@ fn walk_incoming(
         return;
     }
     if let Ok(global_id) = unsafe { part.GetGlobalId() } {
-        if let Ok(id) = unsafe { global_id.to_string() } {
-            if !id.is_empty() && !visited.insert(id) {
-                return;
-            }
+        let id = unsafe { global_id.to_string() }.unwrap_or_default();
+        unsafe {
+            CoTaskMemFree(Some(global_id.0 as *const _));
+        }
+        if !id.is_empty() && !visited.insert(id) {
+            return;
         }
     }
 
@@ -129,10 +135,16 @@ fn try_push_mute(part: &IPart, mutes: &mut Vec<IAudioMute>) {
     let Some(mute) = activate_mute(part) else {
         return;
     };
-    let name = unsafe { part.GetName() }
-        .ok()
-        .and_then(|pwstr| unsafe { pwstr.to_string().ok() })
-        .unwrap_or_else(|| "unnamed".into());
+    let name = match unsafe { part.GetName() } {
+        Ok(pwstr) => {
+            let text = unsafe { pwstr.to_string() }.unwrap_or_else(|_| "unnamed".into());
+            unsafe {
+                CoTaskMemFree(Some(pwstr.0 as *const _));
+            }
+            text
+        }
+        Err(_) => "unnamed".into(),
+    };
     log::info!("mic_mute_trigger: capture-path hardware mute '{name}'");
     mutes.push(mute);
 }
@@ -140,12 +152,8 @@ fn try_push_mute(part: &IPart, mutes: &mut Vec<IAudioMute>) {
 fn activate_mute(part: &IPart) -> Option<IAudioMute> {
     unsafe {
         let mut ppv: *mut std::ffi::c_void = std::ptr::null_mut();
-        part.Activate(
-            CLSCTX_ALL.0,
-            &IAudioMute::IID,
-            Some(&mut ppv),
-        )
-        .ok()?;
+        part.Activate(CLSCTX_ALL.0, &IAudioMute::IID, Some(&mut ppv))
+            .ok()?;
         if ppv.is_null() {
             return None;
         }

--- a/src-tauri/src/media/hardware_mute.rs
+++ b/src-tauri/src/media/hardware_mute.rs
@@ -1,0 +1,154 @@
+//! Capture-path hardware mute controls via the Windows Device Topology API.
+//!
+//! `IAudioEndpointVolume::GetMute` is the endpoint (mixer) mute bit. Many USB
+//! Audio Class microphones and headsets put the physical mute button on an
+//! `IAudioMute` subunit along the capture path instead. Never calls SetMute.
+
+use std::collections::HashSet;
+use windows::core::Interface;
+use windows::Win32::Media::Audio::{IAudioMute, IDeviceTopology, IPart, IMMDevice};
+use windows::Win32::System::Com::CLSCTX_ALL;
+
+const MAX_DEPTH: u8 = 16;
+
+pub struct TopologyMuteWatch {
+    mutes: Vec<IAudioMute>,
+    last: Vec<bool>,
+}
+
+impl TopologyMuteWatch {
+    pub fn from_device(device: &IMMDevice) -> Self {
+        let mutes = collect_capture_path_mutes(device);
+        let last = mutes
+            .iter()
+            .map(|mute| unsafe { mute.GetMute() }.map(|v| v.as_bool()).unwrap_or(false))
+            .collect();
+        log::info!(
+            "mic_mute_trigger: {} hardware mute control(s) on the capture path",
+            mutes.len()
+        );
+        Self { mutes, last }
+    }
+
+    pub fn control_count(&self) -> usize {
+        self.mutes.len()
+    }
+
+    pub fn any_muted(&self) -> Option<bool> {
+        if self.last.is_empty() {
+            None
+        } else {
+            Some(self.last.iter().any(|&muted| muted))
+        }
+    }
+
+    /// Returns a debounced-ready raw mute bit when any path control changes.
+    pub fn poll_edge(&mut self) -> Option<bool> {
+        for (i, mute) in self.mutes.iter().enumerate() {
+            let Ok(flag) = (unsafe { mute.GetMute() }) else {
+                continue;
+            };
+            let muted = flag.as_bool();
+            if self.last.get(i).copied() != Some(muted) {
+                if let Some(slot) = self.last.get_mut(i) {
+                    *slot = muted;
+                }
+                return Some(muted);
+            }
+        }
+        None
+    }
+}
+
+fn collect_capture_path_mutes(device: &IMMDevice) -> Vec<IAudioMute> {
+    let topology: IDeviceTopology = match unsafe { device.Activate(CLSCTX_ALL, None) } {
+        Ok(topo) => topo,
+        Err(err) => {
+            log::debug!("mic_mute_trigger: IDeviceTopology activate failed: {err}");
+            return Vec::new();
+        }
+    };
+
+    let mut mutes = Vec::new();
+    let mut visited = HashSet::new();
+    let connector_count = unsafe { topology.GetConnectorCount() }.unwrap_or(0);
+    for index in 0..connector_count {
+        let Ok(connector) = (unsafe { topology.GetConnector(index) }) else {
+            continue;
+        };
+        if let Ok(part) = connector.cast::<IPart>() {
+            try_push_mute(&part, &mut mutes);
+        }
+        let connected = unsafe { connector.IsConnected() }
+            .ok()
+            .is_some_and(|flag| flag.as_bool());
+        if !connected {
+            continue;
+        }
+        let Ok(other) = (unsafe { connector.GetConnectedTo() }) else {
+            continue;
+        };
+        if let Ok(part) = other.cast::<IPart>() {
+            walk_incoming(&part, &mut mutes, &mut visited, 0);
+        }
+    }
+    mutes
+}
+
+fn walk_incoming(
+    part: &IPart,
+    mutes: &mut Vec<IAudioMute>,
+    visited: &mut HashSet<String>,
+    depth: u8,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    if let Ok(global_id) = unsafe { part.GetGlobalId() } {
+        if let Ok(id) = unsafe { global_id.to_string() } {
+            if !id.is_empty() && !visited.insert(id) {
+                return;
+            }
+        }
+    }
+
+    try_push_mute(part, mutes);
+
+    let Ok(list) = (unsafe { part.EnumPartsIncoming() }) else {
+        return;
+    };
+    let count = unsafe { list.GetCount() }.unwrap_or(0);
+    for index in 0..count {
+        if let Ok(next) = unsafe { list.GetPart(index) } {
+            walk_incoming(&next, mutes, visited, depth + 1);
+        }
+    }
+}
+
+fn try_push_mute(part: &IPart, mutes: &mut Vec<IAudioMute>) {
+    let Some(mute) = activate_mute(part) else {
+        return;
+    };
+    let name = unsafe { part.GetName() }
+        .ok()
+        .and_then(|pwstr| unsafe { pwstr.to_string().ok() })
+        .unwrap_or_else(|| "unnamed".into());
+    log::info!("mic_mute_trigger: capture-path hardware mute '{name}'");
+    mutes.push(mute);
+}
+
+fn activate_mute(part: &IPart) -> Option<IAudioMute> {
+    unsafe {
+        let mut ppv: *mut std::ffi::c_void = std::ptr::null_mut();
+        part.Activate(
+            CLSCTX_ALL.0,
+            &IAudioMute::IID,
+            Some(&mut ppv),
+        )
+        .ok()?;
+        if ppv.is_null() {
+            return None;
+        }
+        Some(IAudioMute::from_raw(ppv))
+    }
+}

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -122,12 +122,15 @@ mod win {
     }
 
     fn install_active_pcm(guard: PcmMonitorGuard) {
-        if let Ok(mut slot) = ACTIVE_PCM.lock() {
-            let previous = slot.take();
+        let previous = if let Ok(mut slot) = ACTIVE_PCM.lock() {
+            let old = slot.take();
             *slot = Some(guard);
-            // Join any finished/failed prior thread before keeping the new guard.
-            drop(previous);
-        }
+            old
+        } else {
+            None
+        };
+        // Join outside the mutex — Drop may block on JoinHandle::join.
+        drop(previous);
     }
 
     fn event_tx_slot(

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -308,11 +308,8 @@ mod win {
                     log::info!("mic_mute_trigger: ignored pulse — could not reserve starting");
                     return;
                 }
-                // Release the idle PCM client before opening the dictation
-                // capture stream. Waiting for the watcher loop is too late —
-                // both clients would briefly share the mic and flatten the
-                // visualizer.
-                release_active_pcm();
+                // Idle PCM was already released on the blocking pool before
+                // this unmute dispatch ran.
                 let target = WindowTarget::capture_foreground();
                 if let Ok(mut st) = state.lock() {
                     st.target = target;

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -147,6 +147,12 @@ mod win {
         let state_hk = shared;
         tauri::async_runtime::spawn(async move {
             while let Some(event) = rx.recv().await {
+                // Joining the idle PCM WASAPI client can take tens of ms.
+                // Do that on a blocking pool thread before unmute dispatch may
+                // open the dictation capture stream on this Tokio worker.
+                if matches!(event, MuteTriggerEvent::BecameUnmuted { .. }) {
+                    let _ = tauri::async_runtime::spawn_blocking(release_active_pcm).await;
+                }
                 dispatch_event(&app_hk, &state_hk, event);
             }
         });

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -440,6 +440,8 @@ mod win {
         }
         let mut level_debouncer = MuteDebouncer::new(DEBOUNCE);
         let mut level_seeded = false;
+        let mut last_pcm_start_at: Option<Instant> = None;
+        const PCM_RETRY: Duration = Duration::from_secs(5);
 
         let mut debouncer = MuteDebouncer::new(DEBOUNCE);
         debouncer.seed(initial_muted);
@@ -515,13 +517,19 @@ mod win {
                     }
                 }
             } else if need_pcm && !pcm_is_running() {
-                log::info!(
-                    "mic_mute_trigger: starting digital-silence PCM monitor (hw_mute={hw_mute})"
-                );
-                install_active_pcm(start_pcm_monitor(
-                    Some(friendly.clone()),
-                    Arc::clone(&last_endpoint_event),
-                ));
+                let can_retry = last_pcm_start_at
+                    .map(|at| at.elapsed() >= PCM_RETRY)
+                    .unwrap_or(true);
+                if can_retry {
+                    log::info!(
+                        "mic_mute_trigger: starting digital-silence PCM monitor (hw_mute={hw_mute})"
+                    );
+                    last_pcm_start_at = Some(Instant::now());
+                    install_active_pcm(start_pcm_monitor(
+                        Some(friendly.clone()),
+                        Arc::clone(&last_endpoint_event),
+                    ));
+                }
             }
 
             let mut method = DetectionMethod::EndpointPoll;

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -1,0 +1,962 @@
+//! Optional Windows dictation trigger driven by the selected microphone's mute
+//! button. Watches, in parallel:
+//! - endpoint (mixer) mute bit
+//! - hardware mute subunits on the capture topology path
+//! - digital-silence PCM when hardware mute never flips a Windows mute bit
+//!
+//! Binds the selected capture device with relaxed name matching so WASAPI and
+//! CPAL labels for the same mic still resolve. Never calls SetMute.
+
+#[cfg(windows)]
+mod win {
+    use crate::data::store;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum DetectionMethod {
+        EndpointNotify,
+        EndpointPoll,
+        HardwareMute,
+        DigitalSilence,
+    }
+
+    impl DetectionMethod {
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::EndpointNotify => "endpoint_notify",
+                Self::EndpointPoll => "endpoint_poll",
+                Self::HardwareMute => "hardware_mute",
+                Self::DigitalSilence => "digital_silence",
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MuteTriggerEvent {
+        BecameMuted { method: DetectionMethod },
+        BecameUnmuted { method: DetectionMethod },
+    }
+    use crate::media::digital_silence::{
+        DigitalSilenceDetector, MuteDebouncer, SilenceTransition,
+    };
+    use crate::pipeline::{self, start_recording_session, SharedState};
+    use crate::core::window_geometry::WindowTarget;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+    use tauri::AppHandle;
+    use windows::core::{implement, GUID};
+    use windows::Win32::Foundation::PROPERTYKEY;
+    use windows::Win32::Media::Audio::Endpoints::{
+        IAudioEndpointVolume, IAudioEndpointVolumeCallback, IAudioEndpointVolumeCallback_Impl,
+    };
+    use windows::Win32::Media::Audio::{
+        eCapture, eConsole, AUDIO_VOLUME_NOTIFICATION_DATA, DEVICE_STATE_ACTIVE,
+        ENDPOINT_HARDWARE_SUPPORT_MUTE, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator,
+    };
+    use windows::Win32::System::Com::StructuredStorage::{PropVariantClear, PROPVARIANT};
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED, STGM_READ,
+    };
+    use windows::Win32::System::Variant::VT_LPWSTR;
+    use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
+
+    const PKEY_DEVICE_FRIENDLY_NAME: PROPERTYKEY = PROPERTYKEY {
+        fmtid: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0),
+        pid: 14,
+    };
+    const PKEY_DEVICE_DEVICE_DESC: PROPERTYKEY = PROPERTYKEY {
+        fmtid: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0),
+        pid: 2,
+    };
+
+    const POLL_INTERVAL: Duration = Duration::from_millis(20);
+    const REBIND_INTERVAL: Duration = Duration::from_secs(2);
+    const DISABLED_IDLE: Duration = Duration::from_secs(2);
+    const DEBOUNCE: Duration = Duration::from_millis(25);
+    /// Ignore PCM unmute/mute if endpoint already reported a matching transition
+    /// within this window — endpoint path wins.
+    const ENDPOINT_PRIORITY_WINDOW: Duration = Duration::from_millis(500);
+    /// A dictation gesture is unmuted → muted → unmuted. The mute→unmute half
+    /// must land inside this window or it is treated as an ordinary unmute.
+    const PULSE_MIN: Duration = Duration::from_millis(10);
+    const PULSE_MAX: Duration = Duration::from_millis(3000);
+    /// PCM mute detection window. 250ms made a physical mute click feel like
+    /// it needed a half-second hold before unmute would count.
+    const PCM_WINDOW: Duration = Duration::from_millis(40);
+    const PCM_DEBOUNCE: Duration = Duration::from_millis(15);
+
+    static GENERATION: AtomicU64 = AtomicU64::new(0);
+    static STARTED: AtomicBool = AtomicBool::new(false);
+    static WATCHER_THREAD: Mutex<Option<std::thread::Thread>> = Mutex::new(None);
+    static EVENT_TX: OnceLock<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>> =
+        OnceLock::new();
+    /// Instant the selected mic last entered the muted bit, used to recognize
+    /// a mute→unmute pulse as a hands-free toggle.
+    static PULSE_MUTED_AT: Mutex<Option<Instant>> = Mutex::new(None);
+    /// Guards against endpoint+PCM both delivering the same unmute edge and
+    /// starting then immediately stopping dictation.
+    static LAST_PULSE_AT: Mutex<Option<Instant>> = Mutex::new(None);
+    /// Idle digital-silence capture client. Taken/dropped before dictation
+    /// opens the same mic so the streams never overlap.
+    static ACTIVE_PCM: Mutex<Option<PcmMonitorGuard>> = Mutex::new(None);
+    const PULSE_COOLDOWN: Duration = Duration::from_millis(180);
+
+    fn release_active_pcm() {
+        let guard = ACTIVE_PCM.lock().ok().and_then(|mut slot| slot.take());
+        if guard.is_some() {
+            log::info!("mic_mute_trigger: PCM monitor released");
+        }
+        // Join happens in Drop outside the mutex.
+        drop(guard);
+    }
+
+    fn pcm_is_running() -> bool {
+        ACTIVE_PCM
+            .lock()
+            .ok()
+            .is_some_and(|slot| slot.is_some())
+    }
+
+    fn install_active_pcm(guard: PcmMonitorGuard) {
+        if let Ok(mut slot) = ACTIVE_PCM.lock() {
+            *slot = Some(guard);
+        }
+    }
+
+    fn event_tx_slot() -> &'static std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>
+    {
+        EVENT_TX.get_or_init(|| std::sync::Mutex::new(None))
+    }
+
+    pub fn setup(app: &mut tauri::App, shared: SharedState) {
+        if STARTED.swap(true, Ordering::SeqCst) {
+            reload(app.handle());
+            return;
+        }
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<MuteTriggerEvent>();
+        if let Ok(mut slot) = event_tx_slot().lock() {
+            *slot = Some(tx);
+        }
+
+        let app_handle = app.handle().clone();
+        let state_watch = shared.clone();
+        std::thread::Builder::new()
+            .name("mic-mute-trigger".into())
+            .spawn(move || watcher_loop(app_handle, state_watch))
+            .expect("spawn mic-mute-trigger thread");
+
+        let app_hk = app.handle().clone();
+        let state_hk = shared;
+        tauri::async_runtime::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                dispatch_event(&app_hk, &state_hk, event);
+            }
+        });
+
+        // Kick an initial bind attempt for the current setting.
+        GENERATION.fetch_add(1, Ordering::SeqCst);
+        log::info!("mic_mute_trigger: watcher started");
+    }
+
+    pub fn reload(app: &AppHandle) {
+        let _ = app;
+        let gen = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+        log::info!("mic_mute_trigger: reload requested (generation={gen})");
+        if let Ok(slot) = WATCHER_THREAD.lock() {
+            if let Some(thread) = slot.as_ref() {
+                thread.unpark();
+            }
+        }
+    }
+
+    fn emit(event: MuteTriggerEvent) {
+        let Ok(slot) = event_tx_slot().lock() else {
+            return;
+        };
+        if let Some(tx) = slot.as_ref() {
+            let _ = tx.send(event);
+        }
+    }
+
+    fn feature_enabled(app: &AppHandle) -> bool {
+        store::settings_handle(app)
+            .ok()
+            .and_then(|s| s.get(store::MIC_MUTE_BUTTON_DICTATION))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    fn selected_device_name(app: &AppHandle) -> Option<String> {
+        store::settings_handle(app)
+            .ok()
+            .and_then(|s| s.get(store::MICROPHONE_DEVICE))
+            .and_then(|v| v.as_str().map(|s| s.to_owned()))
+            .filter(|s| !s.trim().is_empty())
+    }
+
+    fn take_pulse(now: Instant) -> Option<Duration> {
+        let Ok(mut slot) = PULSE_MUTED_AT.lock() else {
+            return None;
+        };
+        let muted_at = slot.take()?;
+        let elapsed = now.saturating_duration_since(muted_at);
+        if elapsed < PULSE_MIN || elapsed > PULSE_MAX {
+            log::info!(
+                "mic_mute_trigger: ignored unmute — not a mute→unmute pulse (held {elapsed:?}, want {PULSE_MIN:?}..{PULSE_MAX:?})"
+            );
+            return None;
+        }
+        Some(elapsed)
+    }
+
+    fn mark_pulse_muted(now: Instant) {
+        if let Ok(mut slot) = PULSE_MUTED_AT.lock() {
+            *slot = Some(now);
+        }
+    }
+
+    fn clear_pulse() {
+        if let Ok(mut slot) = PULSE_MUTED_AT.lock() {
+            *slot = None;
+        }
+    }
+
+    fn dispatch_event(app: &AppHandle, state: &SharedState, event: MuteTriggerEvent) {
+        if !feature_enabled(app) {
+            log::debug!("mic_mute_trigger: ignored event — feature disabled");
+            clear_pulse();
+            return;
+        }
+
+        match event {
+            MuteTriggerEvent::BecameMuted { method } => {
+                // Arm the pulse only. Stopping on mute alone leaves the mic
+                // muted mid-gesture and fires before the unmute half arrives.
+                mark_pulse_muted(Instant::now());
+                log::info!(
+                    "mic_mute_trigger: muted via {} — pulse armed (waiting for unmute)",
+                    method.as_str()
+                );
+            }
+            MuteTriggerEvent::BecameUnmuted { method } => {
+                let now = Instant::now();
+                let Some(held) = take_pulse(now) else {
+                    return;
+                };
+                if let Ok(mut last) = LAST_PULSE_AT.lock() {
+                    if let Some(prev) = *last {
+                        if now.saturating_duration_since(prev) < PULSE_COOLDOWN {
+                            log::info!(
+                                "mic_mute_trigger: ignored pulse via {} — cooldown after prior pulse",
+                                method.as_str()
+                            );
+                            return;
+                        }
+                    }
+                    *last = Some(now);
+                }
+                log::info!(
+                    "mic_mute_trigger: mute→unmute pulse via {} (held {held:?}) — toggling hands-free",
+                    method.as_str()
+                );
+
+                let recording = {
+                    let Ok(st) = state.lock() else {
+                        log::error!("mic_mute_trigger: state lock poisoned");
+                        return;
+                    };
+                    st.lifecycle.is_recording()
+                };
+
+                if recording {
+                    crate::core::hotkey::set_handless_active(false);
+                    tauri::async_runtime::spawn(pipeline::run_pipeline(
+                        app.clone(),
+                        state.clone(),
+                    ));
+                    log::info!("mic_mute_trigger: dictation stop requested");
+                    return;
+                }
+
+                let busy = {
+                    let Ok(st) = state.lock() else {
+                        log::error!("mic_mute_trigger: state lock poisoned");
+                        return;
+                    };
+                    !matches!(st.lifecycle, pipeline::DictationLifecycle::Idle)
+                };
+                if busy {
+                    log::info!("mic_mute_trigger: ignored pulse — lifecycle busy");
+                    return;
+                }
+                if pipeline::reserve_starting(state).is_err() {
+                    log::info!("mic_mute_trigger: ignored pulse — could not reserve starting");
+                    return;
+                }
+                // Release the idle PCM client before opening the dictation
+                // capture stream. Waiting for the watcher loop is too late —
+                // both clients would briefly share the mic and flatten the
+                // visualizer.
+                release_active_pcm();
+                let target = WindowTarget::capture_foreground();
+                if let Ok(mut st) = state.lock() {
+                    st.target = target;
+                    st.pill_placement_stale = true;
+                }
+                // Use the normal recording capsule (waveform), not the
+                // hands-free Cancel/Confirm chrome — mute-pulse dictation
+                // doesn't need those buttons and that UI read as "broken".
+                start_recording_session(app, state, "handsfree", true);
+                crate::core::hotkey::set_handless_active(true);
+                log::info!("mic_mute_trigger: dictation started (handsfree)");
+            }
+        }
+    }
+
+    fn dictation_holds_mic(state: &SharedState) -> bool {
+        let Ok(st) = state.lock() else {
+            return false;
+        };
+        !st.lifecycle.is_idle()
+    }
+
+    fn recording_raw_level(state: &SharedState) -> Option<f32> {
+        let Ok(st) = state.lock() else {
+            return None;
+        };
+        match &st.lifecycle {
+            pipeline::DictationLifecycle::Recording { session, .. } => {
+                Some(f32::from_bits(session.raw_level.load(Ordering::Relaxed)))
+            }
+            _ => None,
+        }
+    }
+
+    fn watcher_loop(app: AppHandle, state: SharedState) {
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+        }
+        if let Ok(mut slot) = WATCHER_THREAD.lock() {
+            *slot = Some(std::thread::current());
+        }
+
+        loop {
+            let gen = GENERATION.load(Ordering::SeqCst);
+            if !feature_enabled(&app) {
+                // No GetMute / PCM work while the setting is off. Park until
+                // save_setting calls reload(), with a long timeout as a backstop.
+                std::thread::park_timeout(DISABLED_IDLE);
+                continue;
+            }
+
+            let desired = selected_device_name(&app);
+            match bind_and_watch(&app, &state, desired.as_deref(), gen) {
+                Ok(()) => {}
+                Err(err) => {
+                    log::warn!("mic_mute_trigger: bind failed: {err}");
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+            }
+        }
+    }
+
+    fn bind_and_watch(
+        app: &AppHandle,
+        state: &SharedState,
+        desired_name: Option<&str>,
+        gen: u64,
+    ) -> Result<(), String> {
+        let enumerator: IMMDeviceEnumerator =
+            unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) }
+                .map_err(|e| format!("MMDeviceEnumerator: {e}"))?;
+
+        let (device, device_id, friendly) = resolve_capture_device(&enumerator, desired_name)?;
+        let volume: IAudioEndpointVolume = unsafe { device.Activate(CLSCTX_ALL, None) }
+            .map_err(|e| format!("Activate IAudioEndpointVolume: {e}"))?;
+
+        let hw_support = unsafe { volume.QueryHardwareSupport() }.unwrap_or(0);
+        let hw_mute = (hw_support & ENDPOINT_HARDWARE_SUPPORT_MUTE) != 0;
+        let mut topology = crate::media::hardware_mute::TopologyMuteWatch::from_device(&device);
+        let mut topo_debouncer = MuteDebouncer::new(DEBOUNCE);
+        topo_debouncer.seed(topology.any_muted().unwrap_or(false));
+        let mut topo_held = topology.any_muted();
+        log::info!(
+            "mic_mute_trigger: watching device '{friendly}' id={device_id} hw_support=0x{hw_support:x} endpoint_hw_mute={hw_mute} topology_mutes={}",
+            topology.control_count()
+        );
+
+        let initial_muted = unsafe { volume.GetMute() }
+            .map(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Shared raw mute bit: notify callback writes, watch loop debounces once.
+        let raw_muted = Arc::new(Mutex::new(EndpointRawMute {
+            muted: initial_muted,
+            source: DetectionMethod::EndpointPoll,
+            changed: false,
+        }));
+        let last_endpoint_event = Arc::new(Mutex::new(None::<(bool, Instant)>));
+
+        let callback = MuteCallback {
+            raw: Arc::clone(&raw_muted),
+        };
+        let callback_iface: IAudioEndpointVolumeCallback = callback.into();
+        unsafe {
+            volume
+                .RegisterControlChangeNotify(&callback_iface)
+                .map_err(|e| format!("RegisterControlChangeNotify: {e}"))?;
+        }
+        log::info!(
+            "mic_mute_trigger: endpoint mute watcher bound (initial_muted={initial_muted}, seeded without firing)"
+        );
+
+        // PCM digital-silence covers mute buttons that never flip GetMute
+        // (common on USB mics even when QueryHardwareSupport advertises mute).
+        // Skip it only when the capture path already exposes IAudioMute.
+        // Always join/drop the stream before dictation so a second WASAPI
+        // client cannot starve the pill visualizer.
+        let need_pcm = topology.control_count() == 0;
+        if need_pcm {
+            log::info!(
+                "mic_mute_trigger: enabling digital-silence PCM fallback (no topology mute; endpoint_hw_mute={hw_mute})"
+            );
+        } else {
+            log::info!(
+                "mic_mute_trigger: skipping idle PCM monitor (topology_mutes={})",
+                topology.control_count()
+            );
+        }
+        let mut level_debouncer = MuteDebouncer::new(DEBOUNCE);
+        let mut level_seeded = false;
+
+        let mut debouncer = MuteDebouncer::new(DEBOUNCE);
+        debouncer.seed(initial_muted);
+        let mut last_rebind_check = Instant::now();
+        let started_gen = gen;
+
+        loop {
+            if GENERATION.load(Ordering::SeqCst) != started_gen {
+                log::info!("mic_mute_trigger: generation changed — rebinding");
+                break;
+            }
+            if !feature_enabled(app) {
+                log::info!("mic_mute_trigger: feature disabled — releasing watch");
+                clear_pulse();
+                break;
+            }
+
+            if last_rebind_check.elapsed() >= REBIND_INTERVAL {
+                last_rebind_check = Instant::now();
+                let current_desired = selected_device_name(app);
+                match resolve_capture_device(&enumerator, current_desired.as_deref()) {
+                    Ok((_, id, name)) if id != device_id || name != friendly => {
+                        log::info!(
+                            "mic_mute_trigger: device changed ('{friendly}' -> '{name}') — rebinding"
+                        );
+                        break;
+                    }
+                    Err(err) => {
+                        log::warn!("mic_mute_trigger: device resolve failed during watch: {err}");
+                        break;
+                    }
+                    Ok(_) => {}
+                }
+            }
+
+            let holding_mic = dictation_holds_mic(state);
+            if holding_mic {
+                if pcm_is_running() {
+                    release_active_pcm();
+                    log::info!("mic_mute_trigger: PCM monitor paused (dictation holds the mic)");
+                    level_seeded = false;
+                }
+                if let Some(level) = recording_raw_level(state) {
+                    let silent = level <= crate::media::digital_silence::DIGITAL_SILENCE_EPS * 4.0;
+                    if !level_seeded {
+                        level_debouncer.seed(silent);
+                        level_seeded = true;
+                    } else if let Some(stable) = level_debouncer.observe(silent, Instant::now()) {
+                        let recent_endpoint = last_endpoint_event
+                            .lock()
+                            .ok()
+                            .and_then(|last| *last)
+                            .is_some_and(|(muted, at)| {
+                                muted == stable
+                                    && Instant::now().saturating_duration_since(at)
+                                        <= ENDPOINT_PRIORITY_WINDOW
+                            });
+                        if !recent_endpoint {
+                            log::info!(
+                                "mic_mute_trigger: {} via recording-level (rms={level:.6})",
+                                if stable { "muted" } else { "unmuted" }
+                            );
+                            emit(if stable {
+                                MuteTriggerEvent::BecameMuted {
+                                    method: DetectionMethod::DigitalSilence,
+                                }
+                            } else {
+                                MuteTriggerEvent::BecameUnmuted {
+                                    method: DetectionMethod::DigitalSilence,
+                                }
+                            });
+                        }
+                    }
+                }
+            } else if need_pcm && !pcm_is_running() {
+                log::info!(
+                    "mic_mute_trigger: starting digital-silence PCM monitor (hw_mute={hw_mute})"
+                );
+                install_active_pcm(start_pcm_monitor(
+                    Some(friendly.clone()),
+                    Arc::clone(&last_endpoint_event),
+                ));
+            }
+
+            let mut method = DetectionMethod::EndpointPoll;
+            let muted = match unsafe { volume.GetMute() } {
+                Ok(flag) => {
+                    let polled = flag.as_bool();
+                    if let Ok(mut raw) = raw_muted.lock() {
+                        if raw.changed {
+                            method = raw.source;
+                            raw.changed = false;
+                            log::info!(
+                                "mic_mute_trigger: endpoint notify edge muted={} (debouncing)",
+                                raw.muted
+                            );
+                            raw.muted
+                        } else {
+                            if polled != raw.muted {
+                                log::info!(
+                                    "mic_mute_trigger: endpoint poll edge muted={polled} (debouncing)"
+                                );
+                            }
+                            raw.muted = polled;
+                            polled
+                        }
+                    } else {
+                        polled
+                    }
+                }
+                Err(err) => {
+                    log::warn!("mic_mute_trigger: GetMute failed: {err}");
+                    break;
+                }
+            };
+
+            let now = Instant::now();
+            if let Some(edge) = topology.poll_edge() {
+                topo_held = Some(edge);
+            }
+            if let Some(raw) = topo_held {
+                if let Some(stable) = topo_debouncer.observe(raw, now) {
+                    if let Ok(mut last) = last_endpoint_event.lock() {
+                        *last = Some((stable, now));
+                    }
+                    log::info!(
+                        "mic_mute_trigger: mute bit {} via {} (device='{friendly}')",
+                        if stable { "muted" } else { "unmuted" },
+                        DetectionMethod::HardwareMute.as_str()
+                    );
+                    emit(if stable {
+                        MuteTriggerEvent::BecameMuted {
+                            method: DetectionMethod::HardwareMute,
+                        }
+                    } else {
+                        MuteTriggerEvent::BecameUnmuted {
+                            method: DetectionMethod::HardwareMute,
+                        }
+                    });
+                }
+            }
+            if let Some(stable) = debouncer.observe(muted, now) {
+                if let Ok(mut last) = last_endpoint_event.lock() {
+                    *last = Some((stable, now));
+                }
+                log::info!(
+                    "mic_mute_trigger: mute bit {} via {} (device='{friendly}')",
+                    if stable { "muted" } else { "unmuted" },
+                    method.as_str()
+                );
+                emit(if stable {
+                    MuteTriggerEvent::BecameMuted { method }
+                } else {
+                    MuteTriggerEvent::BecameUnmuted { method }
+                });
+            }
+
+            std::thread::sleep(POLL_INTERVAL);
+        }
+
+        release_active_pcm();
+        unsafe {
+            let _ = volume.UnregisterControlChangeNotify(&callback_iface);
+        }
+        Ok(())
+    }
+
+    struct EndpointRawMute {
+        muted: bool,
+        source: DetectionMethod,
+        changed: bool,
+    }
+
+    #[implement(IAudioEndpointVolumeCallback)]
+    struct MuteCallback {
+        raw: Arc<Mutex<EndpointRawMute>>,
+    }
+
+    impl IAudioEndpointVolumeCallback_Impl for MuteCallback_Impl {
+        fn OnNotify(
+            &self,
+            pnotify: *mut AUDIO_VOLUME_NOTIFICATION_DATA,
+        ) -> windows_core::Result<()> {
+            if pnotify.is_null() {
+                return Ok(());
+            }
+            let data = unsafe { &*pnotify };
+            // Volume-only notifications share this callback; only mute-bit edges matter.
+            let muted = data.bMuted.as_bool();
+            if let Ok(mut raw) = self.raw.lock() {
+                if muted != raw.muted {
+                    raw.muted = muted;
+                    raw.source = DetectionMethod::EndpointNotify;
+                    raw.changed = true;
+                    log::debug!(
+                        "mic_mute_trigger: notify mute bit {} (queued for debounce)",
+                        muted
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+
+    fn resolve_capture_device(
+        enumerator: &IMMDeviceEnumerator,
+        desired_name: Option<&str>,
+    ) -> Result<(IMMDevice, String, String), String> {
+        if let Some(name) = desired_name {
+            let collection = unsafe {
+                enumerator
+                    .EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE)
+                    .map_err(|e| format!("EnumAudioEndpoints: {e}"))?
+            };
+            let count = unsafe { collection.GetCount() }.unwrap_or(0);
+            let mut best: Option<(u8, IMMDevice, String, String)> = None;
+            for i in 0..count {
+                let device = unsafe { collection.Item(i) }
+                    .map_err(|e| format!("IMMDeviceCollection::Item: {e}"))?;
+                let friendly = device_friendly_name(&device).unwrap_or_default();
+                let desc = device_property(&device, &PKEY_DEVICE_DEVICE_DESC).unwrap_or_default();
+                let score = crate::media::device_match::best_score_against(
+                    name,
+                    &[friendly.as_str(), desc.as_str()],
+                );
+                if score == crate::media::device_match::SCORE_NONE {
+                    continue;
+                }
+                let better = match &best {
+                    None => true,
+                    Some((best_score, _, _, _)) => score > *best_score,
+                };
+                if better {
+                    let id = device_id(&device)?;
+                    if score == crate::media::device_match::SCORE_EXACT {
+                        return Ok((device, id, friendly));
+                    }
+                    best = Some((score, device, id, friendly));
+                }
+            }
+            if let Some((score, device, id, friendly)) = best {
+                log::info!(
+                    "mic_mute_trigger: matched selected mic '{name}' to '{friendly}' (score={score})"
+                );
+                return Ok((device, id, friendly));
+            }
+            log::warn!(
+                "mic_mute_trigger: selected device '{name}' not found — falling back to default input"
+            );
+        }
+
+        let device = unsafe { enumerator.GetDefaultAudioEndpoint(eCapture, eConsole) }
+            .map_err(|e| format!("GetDefaultAudioEndpoint(eCapture): {e}"))?;
+        let friendly = device_friendly_name(&device).unwrap_or_else(|_| "default".into());
+        let id = device_id(&device)?;
+        Ok((device, id, friendly))
+    }
+
+    fn device_id(device: &IMMDevice) -> Result<String, String> {
+        let id = unsafe { device.GetId() }.map_err(|e| format!("GetId: {e}"))?;
+        unsafe { id.to_string() }.map_err(|e| format!("device id utf16: {e}"))
+    }
+
+    fn device_friendly_name(device: &IMMDevice) -> Result<String, String> {
+        device_property(device, &PKEY_DEVICE_FRIENDLY_NAME)
+    }
+
+    fn device_property(device: &IMMDevice, key: &PROPERTYKEY) -> Result<String, String> {
+        let store: IPropertyStore = unsafe { device.OpenPropertyStore(STGM_READ) }
+            .map_err(|e| format!("OpenPropertyStore: {e}"))?;
+        let mut pv: PROPVARIANT =
+            unsafe { store.GetValue(key) }.map_err(|e| format!("GetValue: {e}"))?;
+        let name = propvariant_to_string(&pv);
+        unsafe {
+            let _ = PropVariantClear(&mut pv);
+        }
+        name
+    }
+
+    fn propvariant_to_string(pv: &PROPVARIANT) -> Result<String, String> {
+        let vt = unsafe { pv.Anonymous.Anonymous.vt };
+        if vt != VT_LPWSTR {
+            return Err(format!("unsupported PROPVARIANT vt={vt:?}"));
+        }
+        let ptr = unsafe { pv.Anonymous.Anonymous.Anonymous.pwszVal };
+        if ptr.0.is_null() {
+            return Err("null LPWSTR".into());
+        }
+        unsafe { ptr.to_string() }.map_err(|e| e.to_string())
+    }
+
+    struct PcmMonitorGuard {
+        stop: Arc<AtomicBool>,
+        join: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl Drop for PcmMonitorGuard {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::SeqCst);
+            if let Some(handle) = self.join.take() {
+                // Join so WASAPI releases the capture client before dictation
+                // opens the same mic. Fire-and-forget stop left the stream up
+                // long enough to starve the pill visualizer.
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn start_pcm_monitor(
+        device_name: Option<String>,
+        last_endpoint_event: Arc<Mutex<Option<(bool, Instant)>>>,
+    ) -> PcmMonitorGuard {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let join = std::thread::Builder::new()
+            .name("mic-mute-pcm".into())
+            .spawn(move || {
+                if let Err(err) = run_pcm_monitor(device_name, stop_thread, last_endpoint_event) {
+                    log::warn!("mic_mute_trigger: PCM monitor stopped: {err}");
+                }
+            })
+            .ok();
+        PcmMonitorGuard { stop, join }
+    }
+
+    fn run_pcm_monitor(
+        device_name: Option<String>,
+        stop: Arc<AtomicBool>,
+        last_endpoint_event: Arc<Mutex<Option<(bool, Instant)>>>,
+    ) -> Result<(), String> {
+        use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+        let host = cpal::default_host();
+        let device = if let Some(name) = device_name.as_deref() {
+            let mut best: Option<(u8, cpal::Device)> = None;
+            if let Ok(iter) = host.input_devices() {
+                for device in iter {
+                    let Ok(candidate) = device.name() else {
+                        continue;
+                    };
+                    let score = crate::media::device_match::device_name_match_score(&candidate, name);
+                    if score == crate::media::device_match::SCORE_NONE {
+                        continue;
+                    }
+                    let better = match &best {
+                        None => true,
+                        Some((best_score, _)) => score > *best_score,
+                    };
+                    if better {
+                        if score == crate::media::device_match::SCORE_EXACT {
+                            best = Some((score, device));
+                            break;
+                        }
+                        best = Some((score, device));
+                    }
+                }
+            }
+            best.map(|(_, device)| device)
+                .or_else(|| host.default_input_device())
+                .ok_or_else(|| "no input device for PCM monitor".to_string())?
+        } else {
+            host.default_input_device()
+                .ok_or_else(|| "no default input device for PCM monitor".to_string())?
+        };
+        if stop.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        let name = device.name().unwrap_or_else(|_| "unknown".into());
+        let config = device
+            .default_input_config()
+            .map_err(|e| format!("default_input_config: {e}"))?;
+        log::info!(
+            "mic_mute_trigger: PCM digital-silence monitor on '{name}' ({:?})",
+            config.sample_format()
+        );
+
+        let detector = Arc::new(Mutex::new(DigitalSilenceDetector::new(
+            PCM_WINDOW,
+            PCM_DEBOUNCE,
+        )));
+        let err_fn = |err| log::warn!("mic_mute_trigger: PCM stream error: {err}");
+        let detector_cb = Arc::clone(&detector);
+        let last_ep = Arc::clone(&last_endpoint_event);
+
+        let cfg: cpal::StreamConfig = config.clone().into();
+        let stream = match config.sample_format() {
+            cpal::SampleFormat::F32 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[f32], _| {
+                        handle_pcm_block(data, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::F64 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[f64], _| {
+                        let buf: Vec<f32> = data.iter().map(|s| *s as f32).collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::I16 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[i16], _| {
+                        let buf: Vec<f32> = data.iter().map(|s| *s as f32 / 32768.0).collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::I32 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[i32], _| {
+                        let buf: Vec<f32> = data
+                            .iter()
+                            .map(|s| *s as f32 / 2147483648.0)
+                            .collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::I8 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[i8], _| {
+                        let buf: Vec<f32> = data.iter().map(|s| *s as f32 / 128.0).collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::U16 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[u16], _| {
+                        let buf: Vec<f32> = data
+                            .iter()
+                            .map(|s| (*s as f32 - 32768.0) / 32768.0)
+                            .collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            cpal::SampleFormat::U8 => device
+                .build_input_stream(
+                    &cfg,
+                    move |data: &[u8], _| {
+                        let buf: Vec<f32> = data.iter().map(|s| (*s as f32 - 128.0) / 128.0).collect();
+                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| e.to_string())?,
+            other => {
+                return Err(format!("unsupported PCM sample format: {other:?}"));
+            }
+        };
+        stream.play().map_err(|e| e.to_string())?;
+
+        while !stop.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        drop(stream);
+        Ok(())
+    }
+
+    fn handle_pcm_block(
+        samples: &[f32],
+        detector: &Mutex<DigitalSilenceDetector>,
+        last_endpoint_event: &Mutex<Option<(bool, Instant)>>,
+    ) {
+        let now = Instant::now();
+        let Ok(mut det) = detector.lock() else {
+            return;
+        };
+        let Some(transition) = det.push_samples(samples, now) else {
+            return;
+        };
+        let muted = matches!(transition, SilenceTransition::BecameMuted);
+        if let Ok(last) = last_endpoint_event.lock() {
+            if let Some((ep_muted, at)) = *last {
+                if ep_muted == muted && now.saturating_duration_since(at) <= ENDPOINT_PRIORITY_WINDOW
+                {
+                    log::debug!(
+                        "mic_mute_trigger: PCM {} ignored — endpoint already reported it",
+                        if muted { "mute" } else { "unmute" }
+                    );
+                    return;
+                }
+            }
+        }
+        log::info!(
+            "mic_mute_trigger: {} via {}",
+            if muted { "muted" } else { "unmuted" },
+            DetectionMethod::DigitalSilence.as_str()
+        );
+        emit(if muted {
+            MuteTriggerEvent::BecameMuted {
+                method: DetectionMethod::DigitalSilence,
+            }
+        } else {
+            MuteTriggerEvent::BecameUnmuted {
+                method: DetectionMethod::DigitalSilence,
+            }
+        });
+    }
+}
+
+#[cfg(windows)]
+pub use win::{reload, setup};
+
+#[cfg(not(windows))]
+pub fn setup(_app: &mut tauri::App, _shared: crate::pipeline::SharedState) {}
+
+#[cfg(not(windows))]
+pub fn reload(_app: &tauri::AppHandle) {}

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -110,12 +110,23 @@ mod win {
     }
 
     fn pcm_is_running() -> bool {
-        ACTIVE_PCM.lock().ok().is_some_and(|slot| slot.is_some())
+        let Ok(slot) = ACTIVE_PCM.lock() else {
+            return false;
+        };
+        slot.as_ref().is_some_and(|guard| {
+            guard
+                .join
+                .as_ref()
+                .is_some_and(|handle| !handle.is_finished())
+        })
     }
 
     fn install_active_pcm(guard: PcmMonitorGuard) {
         if let Ok(mut slot) = ACTIVE_PCM.lock() {
+            let previous = slot.take();
             *slot = Some(guard);
+            // Join any finished/failed prior thread before keeping the new guard.
+            drop(previous);
         }
     }
 

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -35,11 +35,9 @@ mod win {
         BecameMuted { method: DetectionMethod },
         BecameUnmuted { method: DetectionMethod },
     }
-    use crate::media::digital_silence::{
-        DigitalSilenceDetector, MuteDebouncer, SilenceTransition,
-    };
-    use crate::pipeline::{self, start_recording_session, SharedState};
     use crate::core::window_geometry::WindowTarget;
+    use crate::media::digital_silence::{DigitalSilenceDetector, MuteDebouncer, SilenceTransition};
+    use crate::pipeline::{self, start_recording_session, SharedState};
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{Duration, Instant};
@@ -50,8 +48,8 @@ mod win {
         IAudioEndpointVolume, IAudioEndpointVolumeCallback, IAudioEndpointVolumeCallback_Impl,
     };
     use windows::Win32::Media::Audio::{
-        eCapture, eConsole, AUDIO_VOLUME_NOTIFICATION_DATA, DEVICE_STATE_ACTIVE,
-        ENDPOINT_HARDWARE_SUPPORT_MUTE, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator,
+        eCapture, eConsole, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator,
+        AUDIO_VOLUME_NOTIFICATION_DATA, DEVICE_STATE_ACTIVE, ENDPOINT_HARDWARE_SUPPORT_MUTE,
     };
     use windows::Win32::System::Com::StructuredStorage::{PropVariantClear, PROPVARIANT};
     use windows::Win32::System::Com::{
@@ -88,8 +86,9 @@ mod win {
     static GENERATION: AtomicU64 = AtomicU64::new(0);
     static STARTED: AtomicBool = AtomicBool::new(false);
     static WATCHER_THREAD: Mutex<Option<std::thread::Thread>> = Mutex::new(None);
-    static EVENT_TX: OnceLock<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>> =
-        OnceLock::new();
+    static EVENT_TX: OnceLock<
+        std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>,
+    > = OnceLock::new();
     /// Instant the selected mic last entered the muted bit, used to recognize
     /// a mute→unmute pulse as a hands-free toggle.
     static PULSE_MUTED_AT: Mutex<Option<Instant>> = Mutex::new(None);
@@ -111,10 +110,7 @@ mod win {
     }
 
     fn pcm_is_running() -> bool {
-        ACTIVE_PCM
-            .lock()
-            .ok()
-            .is_some_and(|slot| slot.is_some())
+        ACTIVE_PCM.lock().ok().is_some_and(|slot| slot.is_some())
     }
 
     fn install_active_pcm(guard: PcmMonitorGuard) {
@@ -123,7 +119,8 @@ mod win {
         }
     }
 
-    fn event_tx_slot() -> &'static std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>
+    fn event_tx_slot(
+    ) -> &'static std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<MuteTriggerEvent>>>
     {
         EVENT_TX.get_or_init(|| std::sync::Mutex::new(None))
     }
@@ -271,10 +268,7 @@ mod win {
 
                 if recording {
                     crate::core::hotkey::set_handless_active(false);
-                    tauri::async_runtime::spawn(pipeline::run_pipeline(
-                        app.clone(),
-                        state.clone(),
-                    ));
+                    tauri::async_runtime::spawn(pipeline::run_pipeline(app.clone(), state.clone()));
                     log::info!("mic_mute_trigger: dictation stop requested");
                     return;
                 }
@@ -769,7 +763,8 @@ mod win {
                     let Ok(candidate) = device.name() else {
                         continue;
                     };
-                    let score = crate::media::device_match::device_name_match_score(&candidate, name);
+                    let score =
+                        crate::media::device_match::device_name_match_score(&candidate, name);
                     if score == crate::media::device_match::SCORE_NONE {
                         continue;
                     }
@@ -829,8 +824,8 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[f64], _| {
-                        let buf: Vec<f32> = data.iter().map(|s| *s as f32).collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) = pcm_stats(data.iter().map(|s| (*s as f32).abs()));
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -840,8 +835,9 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[i16], _| {
-                        let buf: Vec<f32> = data.iter().map(|s| *s as f32 / 32768.0).collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) =
+                            pcm_stats(data.iter().map(|s| (*s as f32 / 32768.0).abs()));
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -851,11 +847,9 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[i32], _| {
-                        let buf: Vec<f32> = data
-                            .iter()
-                            .map(|s| *s as f32 / 2147483648.0)
-                            .collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) =
+                            pcm_stats(data.iter().map(|s| (*s as f32 / 2147483648.0).abs()));
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -865,8 +859,9 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[i8], _| {
-                        let buf: Vec<f32> = data.iter().map(|s| *s as f32 / 128.0).collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) =
+                            pcm_stats(data.iter().map(|s| (*s as f32 / 128.0).abs()));
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -876,11 +871,11 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[u16], _| {
-                        let buf: Vec<f32> = data
-                            .iter()
-                            .map(|s| (*s as f32 - 32768.0) / 32768.0)
-                            .collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) = pcm_stats(
+                            data.iter()
+                                .map(|s| ((*s as f32 - 32768.0) / 32768.0).abs()),
+                        );
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -890,8 +885,9 @@ mod win {
                 .build_input_stream(
                     &cfg,
                     move |data: &[u8], _| {
-                        let buf: Vec<f32> = data.iter().map(|s| (*s as f32 - 128.0) / 128.0).collect();
-                        handle_pcm_block(&buf, &detector_cb, &last_ep);
+                        let (silent, abs_max) =
+                            pcm_stats(data.iter().map(|s| ((*s as f32 - 128.0) / 128.0).abs()));
+                        handle_pcm_stats(data.len(), silent, abs_max, &detector_cb, &last_ep);
                     },
                     err_fn,
                     None,
@@ -910,6 +906,39 @@ mod win {
         Ok(())
     }
 
+    fn pcm_stats(abs_samples: impl Iterator<Item = f32>) -> (u32, f32) {
+        let mut silent = 0u32;
+        let mut abs_max = 0.0f32;
+        for a in abs_samples {
+            if a > abs_max {
+                abs_max = a;
+            }
+            if a <= crate::media::digital_silence::DIGITAL_SILENCE_EPS {
+                silent += 1;
+            }
+        }
+        (silent, abs_max)
+    }
+
+    fn handle_pcm_stats(
+        total: usize,
+        silent: u32,
+        abs_max: f32,
+        detector: &Mutex<DigitalSilenceDetector>,
+        last_endpoint_event: &Mutex<Option<(bool, Instant)>>,
+    ) {
+        let now = Instant::now();
+        let Ok(mut det) = detector.lock() else {
+            return;
+        };
+        let Some(transition) =
+            det.push_chunk_stats(now, silent, total as u32, abs_max)
+        else {
+            return;
+        };
+        finish_pcm_transition(transition, now, last_endpoint_event);
+    }
+
     fn handle_pcm_block(
         samples: &[f32],
         detector: &Mutex<DigitalSilenceDetector>,
@@ -922,10 +951,19 @@ mod win {
         let Some(transition) = det.push_samples(samples, now) else {
             return;
         };
+        finish_pcm_transition(transition, now, last_endpoint_event);
+    }
+
+    fn finish_pcm_transition(
+        transition: SilenceTransition,
+        now: Instant,
+        last_endpoint_event: &Mutex<Option<(bool, Instant)>>,
+    ) {
         let muted = matches!(transition, SilenceTransition::BecameMuted);
         if let Ok(last) = last_endpoint_event.lock() {
             if let Some((ep_muted, at)) = *last {
-                if ep_muted == muted && now.saturating_duration_since(at) <= ENDPOINT_PRIORITY_WINDOW
+                if ep_muted == muted
+                    && now.saturating_duration_since(at) <= ENDPOINT_PRIORITY_WINDOW
                 {
                     log::debug!(
                         "mic_mute_trigger: PCM {} ignored — endpoint already reported it",

--- a/src-tauri/src/media/mic_mute_trigger.rs
+++ b/src-tauri/src/media/mic_mute_trigger.rs
@@ -482,8 +482,9 @@ mod win {
                 if pcm_is_running() {
                     release_active_pcm();
                     log::info!("mic_mute_trigger: PCM monitor paused (dictation holds the mic)");
-                    level_seeded = false;
                 }
+                // Allow idle PCM to restart immediately after this dictation.
+                last_pcm_start_at = None;
                 if let Some(level) = recording_raw_level(state) {
                     let silent = level <= crate::media::digital_silence::DIGITAL_SILENCE_EPS * 4.0;
                     if !level_seeded {
@@ -516,19 +517,22 @@ mod win {
                         }
                     }
                 }
-            } else if need_pcm && !pcm_is_running() {
-                let can_retry = last_pcm_start_at
-                    .map(|at| at.elapsed() >= PCM_RETRY)
-                    .unwrap_or(true);
-                if can_retry {
-                    log::info!(
-                        "mic_mute_trigger: starting digital-silence PCM monitor (hw_mute={hw_mute})"
-                    );
-                    last_pcm_start_at = Some(Instant::now());
-                    install_active_pcm(start_pcm_monitor(
-                        Some(friendly.clone()),
-                        Arc::clone(&last_endpoint_event),
-                    ));
+            } else {
+                level_seeded = false;
+                if need_pcm && !pcm_is_running() {
+                    let can_retry = last_pcm_start_at
+                        .map(|at| at.elapsed() >= PCM_RETRY)
+                        .unwrap_or(true);
+                    if can_retry {
+                        log::info!(
+                            "mic_mute_trigger: starting digital-silence PCM monitor (hw_mute={hw_mute})"
+                        );
+                        last_pcm_start_at = Some(Instant::now());
+                        install_active_pcm(start_pcm_monitor(
+                            Some(friendly.clone()),
+                            Arc::clone(&last_endpoint_event),
+                        ));
+                    }
                 }
             }
 

--- a/src-tauri/src/media/mod.rs
+++ b/src-tauri/src/media/mod.rs
@@ -1,3 +1,10 @@
 pub mod audio;
+#[cfg(any(windows, test))]
+pub mod device_match;
+#[cfg(any(windows, test))]
+pub mod digital_silence;
+#[cfg(windows)]
+pub mod hardware_mute;
+pub mod mic_mute_trigger;
 pub mod sound;
 pub mod vad;

--- a/src/lib/components/settings/AudioSection.svelte
+++ b/src/lib/components/settings/AudioSection.svelte
@@ -25,8 +25,11 @@
   let muteAudio = $state(false);
   let exclusiveMic = $state(false);
   let pauseMediaDuringDictation = $state(false);
+  let micMuteButtonDictation = $state(false);
   let soundEffectsVolume = $state(100);
   let micGain = $state(3.5);
+  let micGainSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastSavedMicGain: number | null = null;
   const audioCopy = $derived(getAudioCalibrationCopy());
 
   // Reset any stale calibrated gain on mount so it cannot override the saved
@@ -42,11 +45,12 @@
 
   async function loadSettings() {
     try {
-      const [nr, mute, exclusive, pauseMedia, legacySounds, savedVolume, savedGain] = await Promise.all([
+      const [nr, mute, exclusive, pauseMedia, micMute, legacySounds, savedVolume, savedGain] = await Promise.all([
         invoke<boolean | null>('get_setting', { key: 'noise_reduction' }),
         invoke<boolean | null>('get_setting', { key: 'mute_audio' }),
         invoke<boolean | null>('get_setting', { key: 'exclusive_mic' }),
         invoke<boolean | null>('get_setting', { key: 'pause_media_during_dictation' }),
+        invoke<boolean | null>('get_setting', { key: 'mic_mute_button_dictation' }),
         invoke<boolean | null>('get_setting', { key: 'play_start_stop_sounds' }),
         invoke<number | null>('get_setting', { key: 'sound_effects_volume' }),
         invoke<number | null>('get_setting', { key: 'mic_gain' }),
@@ -55,12 +59,14 @@
       muteAudio = mute ?? false;
       exclusiveMic = exclusive ?? false;
       pauseMediaDuringDictation = pauseMedia ?? false;
+      micMuteButtonDictation = micMute ?? false;
       soundEffectsVolume = savedVolume !== null && savedVolume !== undefined
         ? Math.max(0, Math.min(100, savedVolume))
         : legacySounds === false ? 0 : 100;
       if (savedGain !== null && savedGain !== undefined) {
         micGain = Math.max(1, Math.min(8, savedGain));
       }
+      lastSavedMicGain = micGain;
     } catch (err) {
       console.error('AudioSection load failed:', err);
     }
@@ -106,6 +112,16 @@
     }
   }
 
+  async function handleMicMuteButtonDictation(value: boolean) {
+    micMuteButtonDictation = value;
+    try {
+      await saveSetting('mic_mute_button_dictation', value);
+    } catch (err) {
+      micMuteButtonDictation = !value;
+      console.error('save mic_mute_button_dictation failed:', err);
+    }
+  }
+
   async function saveSoundEffectsVolume() {
     try {
       await saveSetting('sound_effects_volume', soundEffectsVolume);
@@ -114,15 +130,37 @@
     }
   }
 
-  async function saveMicGain() {
+  async function persistMicGain() {
+    const value = micGain;
+    if (lastSavedMicGain === value) return;
+    lastSavedMicGain = value;
     try {
-      await saveSetting('mic_gain', micGain);
+      await saveSetting('mic_gain', value);
     } catch (err) {
+      lastSavedMicGain = null;
       console.error('saveMicGain failed:', err);
     }
   }
 
+  function scheduleMicGainSave() {
+    if (micGainSaveTimer) clearTimeout(micGainSaveTimer);
+    micGainSaveTimer = setTimeout(() => {
+      micGainSaveTimer = null;
+      void persistMicGain();
+    }, 250);
+  }
+
+  function saveMicGainOnRelease() {
+    if (micGainSaveTimer) {
+      clearTimeout(micGainSaveTimer);
+      micGainSaveTimer = null;
+    }
+    void persistMicGain();
+  }
+
   onDestroy(() => {
+    if (micGainSaveTimer) clearTimeout(micGainSaveTimer);
+    void persistMicGain();
     void cancelCalibration();
     calibrationError.set(null);
   });
@@ -152,7 +190,8 @@
       class="gain-slider"
       min="1" max="8" step="0.1"
       bind:value={micGain}
-      oninput={saveMicGain}
+      oninput={scheduleMicGainSave}
+      onchange={saveMicGainOnRelease}
       style="--pct: {((micGain - 1) / 7 * 100).toFixed(1)}%"
       aria-label="Microphone gain"
     />
@@ -248,6 +287,17 @@
   <div class="setting-row" data-setting-target="audio-pause-media">
     <div><div class="label">Pause media while dictating</div><div class="desc">Pauses active Windows media sessions and resumes them after transcription finishes. Works with apps that expose Windows media controls.</div></div>
     <Toggle checked={pauseMediaDuringDictation} onchange={handlePauseMedia} label="Pause media while dictating" />
+  </div>
+  <div class="setting-row" data-setting-target="audio-mic-mute-button">
+    <div>
+      <div class="label">Use microphone mute button for dictation</div>
+      <div class="desc">Mute then unmute the selected mic (within ~3s) to toggle hands-free dictation. Works with mute buttons Windows can see — mixer mute, USB/headset hardware mute, or a mute that silences the capture stream. Keyboard hotkey is unchanged.</div>
+    </div>
+    <Toggle
+      checked={micMuteButtonDictation}
+      onchange={handleMicMuteButtonDictation}
+      label="Use microphone mute button for dictation"
+    />
   </div>
 {/if}
 <div class="setting-row" data-setting-target="audio-noise">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -43,6 +43,7 @@ type SettingsValueMap = {
   app_mappings: AppMapping[];
   noise_reduction: boolean;
   mute_audio: boolean;
+  mic_mute_button_dictation: boolean;
   exclusive_mic: boolean;
   pause_media_during_dictation: boolean;
   play_start_stop_sounds: boolean;

--- a/src/lib/settingsSearch.svelte.ts
+++ b/src/lib/settingsSearch.svelte.ts
@@ -78,6 +78,7 @@ const BASE_ENTRIES: SettingsSearchEntry[] = [
   { id: 'audio-system-mute', section: 'advanced', label: 'Mute system audio', description: 'Mute computer audio while dictating', target: 'audio-system-mute', keywords: ['windows', 'macos', 'sound'] },
   { id: 'audio-exclusive', section: 'advanced', label: 'Exclusive microphone access', description: 'Reserve the microphone for Verenu while dictating', target: 'audio-exclusive', keywords: ['mic', 'input', 'other apps'] },
   { id: 'audio-pause-media', section: 'advanced', label: 'Pause media while dictating', description: 'Pause and resume active media around dictation', target: 'audio-pause-media', keywords: ['music', 'video', 'windows'] },
+  { id: 'audio-mic-mute-button', section: 'advanced', label: 'Use microphone mute button for dictation', description: 'Mute then unmute the selected mic to toggle hands-free dictation', target: 'audio-mic-mute-button', keywords: ['windows', 'mute', 'microphone', 'handsfree', 'button'] },
   { id: 'audio-noise', section: 'advanced', label: 'Noise reduction', description: 'Suppress background noise before transcription', target: 'audio-noise', keywords: ['rnnoise', 'background', 'mic'] },
   { id: 'audio-sounds', section: 'advanced', label: 'Sound effects volume', description: 'Set the volume of dictation chimes', target: 'audio-sounds', keywords: ['chime', 'sound', 'mute'] },
 

--- a/src/lib/settingsSearch.test.ts
+++ b/src/lib/settingsSearch.test.ts
@@ -29,4 +29,11 @@ describe('settings search', () => {
   it('does not return results from hidden settings sections', () => {
     expect(searchSettings('notification test', visibleSections)).toEqual([]);
   });
+
+  it('routes microphone mute-button dictation to audio settings', () => {
+    expect(searchSettings('mute button dictation', visibleSections)[0]).toMatchObject({
+      section: 'advanced',
+      target: 'audio-mic-mute-button',
+    });
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app — hotkey hold → audio capture → transcription → LLM cleanup → text injection
> - Audio / settings subsystem owns microphone selection and Windows-only input helpers
> - Some users want the selected mic''s mute button as a hands-free dictation toggle without changing the keyboard hotkey
> - Mute buttons expose differently across devices: mixer mute bit, USB/headset topology mute, or digital silence on the capture stream
> - This pull request adds an optional Windows Audio setting that watches those signals with a mute→unmute pulse, matching the selected mic across WASAPI/CPAL name variants
> - The benefit is a device-agnostic mute-button trigger that stays off the hotkey path and does not call SetMute

## What Changed

- Added `mic_mute_button_dictation` Windows Audio setting (moved out of Developer) with settings search coverage
- Watches endpoint mute, capture-path hardware mute (`IAudioMute`), and digital-silence PCM fallback
- Relaxes selected-mic name matching across WASAPI/CPAL labels and instance suffixes
- Releases the idle PCM client before dictation opens the mic so the pill visualizer is not starved
- Never calls SetMute; mute/PCM watching runs only while the setting is on

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml --offline`
- `npm run check`
- `npx vitest run src/lib/settingsSearch.test.ts`
- Manual (Windows): enable Settings → Audio → Use microphone mute button for dictation; mute→unmute within ~3s starts hands-free; same pulse stops; pill bars still move while recording; keyboard hotkey unchanged

## Risks

- Second capture client for PCM fallback can still contend with dictation if release/join races; mitigated by releasing PCM before `start_recording_session`
- Mute buttons that only drive an LED and never mute Windows / silence PCM still will not trigger
- Stacked on `fix/pure-white-native-icons` because the changelog hunk depended on that branch

## Model Used

- xAI Grok 4.5 / Grok 4.6 via T3 Code (tool use)

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791360701&installation_model_id=432577&pr_number=371&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F371&signature=caee5f67709a7e4a18bb776e95ebcadbf580999bcd1fd717bfc3cf6e1bfd7230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->