### PR TITLE
Add compact SnapShot dump behind Ruin accessibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Added a developer-only **Ruin accessibility** toggle that dumps a compact diagnostics block into the OS accessibility tree for agent SnapShots: git SHA/branch/dirty, pipeline events, providers, mic, and stable `data-debug-id`s. Off by default. It does not include API keys, clipboard phrase, cleanup prompt text, logs, or dictated history.
 - Added an optional Windows Audio setting to toggle hands-free dictation with a mute→unmute pulse on the selected microphone. Matches the selected mic across WASAPI/CPAL name variants, watches the endpoint mute bit plus USB/headset hardware mute controls on the capture path, and uses a digital-silence PCM fallback when those controls are absent — releasing that idle capture client before dictation opens the mic so the pill visualizer is not starved. Mute watching runs only while the setting is on.
 - Removed orange from the native and packaged app icons. Runtime icons now use a pure black-and-white pair that follows light and dark appearance modes instead of the selected accent color.
 - Fixed hands-free conversion from an active hold-to-talk dictation ending when

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -179,6 +179,7 @@ mod tests {
             crate::data::store::AUTO_SPACING,
             crate::data::store::CONTEXTUAL_FORMATTING,
             crate::data::store::DUAL_TRANSCRIPTION_ENABLED,
+            crate::data::store::RUIN_ACCESSIBILITY,
         ] {
             assert!(
                 validate_setting(key, &json!("yes")).is_err(),

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -174,6 +174,7 @@ const SETTING_SPECS: &[SettingSpec] = &[
     ),
     setting_spec(store::ACCENT_COLOR, SettingKind::AccentColor, true, true),
     setting_spec(store::FORCE_SETUP_ON_LAUNCH, SettingKind::Bool, true, false),
+    setting_spec(store::RUIN_ACCESSIBILITY, SettingKind::Bool, true, false),
     setting_spec(store::ADVANCED_MODEL_UI, SettingKind::Bool, true, true),
     setting_spec(
         store::CLEANUP_PROMPT_OVERRIDE,
@@ -507,6 +508,11 @@ pub async fn save_setting(
     } else {
         None
     };
+    let ruin_accessibility = if key == store::RUIN_ACCESSIBILITY {
+        value.as_bool()
+    } else {
+        None
+    };
     let settings = store::settings_handle(&app)?;
     let key_clone = key.clone();
     let save_result = run_blocking("save_setting", move || {
@@ -574,6 +580,10 @@ pub async fn save_setting(
         crate::media::mic_mute_trigger::reload(&app);
     }
 
+    if let Some(enabled) = ruin_accessibility {
+        let _ = app.emit("verenu:ruin-accessibility-changed", enabled);
+    }
+
     if let Some(days) = history_prune_days {
         let db = app.state::<DbHandle>().inner().clone();
         let deleted =
@@ -603,6 +613,7 @@ pub struct AllSettings {
     pub clipboard_phrase_enabled: Option<bool>,
     pub legacy_features_enabled: Option<bool>,
     pub sync_enabled: Option<bool>,
+    pub ruin_accessibility: Option<bool>,
     pub transcription_provider: Option<String>,
     pub transcription_model: Option<String>,
     pub transcription_language: Option<String>,
@@ -674,6 +685,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         clipboard_phrase_enabled: bool_val(store::CLIPBOARD_PHRASE_ENABLED),
         legacy_features_enabled: bool_val(store::LEGACY_FEATURES_ENABLED),
         sync_enabled: bool_val(store::SYNC_ENABLED),
+        ruin_accessibility: bool_val(store::RUIN_ACCESSIBILITY),
         transcription_provider: str_val(store::TRANSCRIPTION_PROVIDER),
         transcription_model: str_val(store::TRANSCRIPTION_MODEL),
         transcription_language: str_val(store::TRANSCRIPTION_LANGUAGE),

--- a/src-tauri/src/data/store/mod.rs
+++ b/src-tauri/src/data/store/mod.rs
@@ -284,6 +284,9 @@ pub const AUTO_SPACING: &str = "auto_spacing_enabled";
 pub const APPEARANCE_MODE: &str = "appearance_mode";
 pub const ACCENT_COLOR: &str = "accent_color";
 pub const FORCE_SETUP_ON_LAUNCH: &str = "force_setup_on_launch";
+/// Developer-only: stuff a diagnostics dump into the OS accessibility tree
+/// so agent SnapShots can read it. Off by default. Not for real AT users.
+pub const RUIN_ACCESSIBILITY: &str = "ruin_accessibility";
 pub const ADVANCED_MODEL_UI: &str = "advanced_model_ui";
 /// One cleanup prompt for every model. Fallback chains made per-model prompts
 /// a trap: edit the prompt on your default, fall back to another model, and the

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -764,6 +764,7 @@ fn syncable_settings_exclude_device_local_keys() {
         crate::data::store::AUTOSTART_ENABLED,
         crate::data::store::SETUP_COMPLETE,
         crate::data::store::FORCE_SETUP_ON_LAUNCH,
+        crate::data::store::RUIN_ACCESSIBILITY,
         crate::data::store::NOISE_REDUCTION,
         crate::data::store::MUTE_AUDIO,
         crate::data::store::EXCLUSIVE_MIC,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
   import { isWindows } from './lib/platform';
   import Sidebar from './lib/components/layout/Sidebar.svelte';
   import Home from './lib/views/Home.svelte';
+  import AgentAccessibilityDump from './lib/components/AgentAccessibilityDump.svelte';
   import Insights from './lib/views/Insights.svelte';
   import Contexts from './lib/views/Contexts.svelte';
   import Dictionary from './lib/views/Dictionary.svelte';
@@ -207,7 +208,7 @@
     // stores disagreeing with what import_data actually wrote to disk.
     async function reloadGlobalSettings() {
       try {
-        const [done, appearance, accentColor, forceSetupOnLaunch, cleanupEnabled, betaUpdatesEnabled, legacyFeaturesEnabled, syncEnabled] = await Promise.all([
+        const [done, appearance, accentColor, forceSetupOnLaunch, cleanupEnabled, betaUpdatesEnabled, legacyFeaturesEnabled, syncEnabled, ruinAccessibility] = await Promise.all([
           invoke<boolean | null>('get_setting', { key: 'setup_complete' }),
           invoke<'system' | 'light' | 'dark' | null>('get_setting', { key: 'appearance_mode' }),
           invoke<string | null>('get_setting', { key: 'accent_color' }),
@@ -216,6 +217,7 @@
           invoke<boolean | null>('get_setting', { key: 'beta_updates_enabled' }),
           invoke<boolean | null>('get_setting', { key: 'legacy_features_enabled' }),
           invoke<boolean | null>('get_setting', { key: 'sync_enabled' }),
+          invoke<boolean | null>('get_setting', { key: 'ruin_accessibility' }),
         ]);
         appStore.setupComplete = forceSetupOnLaunch ? false : done === true;
         if (appearance === 'light' || appearance === 'dark' || appearance === 'system') {
@@ -226,6 +228,8 @@
         appStore.betaUpdatesEnabled = betaUpdatesEnabled ?? false;
         appStore.legacyFeaturesEnabled = legacyFeaturesEnabled ?? false;
         appStore.syncEnabled = syncEnabled ?? false;
+        appStore.ruinAccessibility = ruinAccessibility ?? false;
+        if (appStore.ruinAccessibility) appStore.devModeEnabled = true;
       } catch {
         appStore.setupComplete = false;
       }
@@ -384,6 +388,7 @@
     <SyncPairModal />
   {/if}
   <DictationPill />
+  <AgentAccessibilityDump windowKind="main" />
 
   {#if errorToast}
     <div

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
   import { BARS, createPillVisualizer } from './lib/pillVisualizer';
+  import AgentAccessibilityDump from './lib/components/AgentAccessibilityDump.svelte';
 
   type PillState = 'idle' | 'recording' | 'processing' | 'loading_local_model' | 'handsfree' | 'error' | 'cancelled' | 'interrupted' | 'paste_failed' | 'copied' | 'clipboard_warning';
   const isCancelLike = (s: PillState) => s === 'cancelled' || s === 'interrupted';
@@ -899,6 +900,19 @@
     goIdle();
   }
 
+  $: dumpExtras = {
+    pillState: state,
+    prevState,
+    errorMsg,
+    contextLabel,
+    stageIndex,
+    seenStages,
+    errOpen,
+    errLines,
+    showHfButtons,
+    cancelOpen,
+  };
+
 </script>
 
 <!-- --bar-w/--bar-gap live on .wrap so every pill state (incl. processing, which
@@ -1090,6 +1104,7 @@
   </div>
 
 </div>
+<AgentAccessibilityDump windowKind="pill" extras={dumpExtras} />
 
 <style>
   :global(*, *::before, *::after) { box-sizing: border-box; }

--- a/src/lib/agentAccessibilityDump.test.ts
+++ b/src/lib/agentAccessibilityDump.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_DUMP_CHARS,
+  buildAgentDump,
+  compactDumpTitle,
+  describeDumpElement,
+  pushDumpEvent,
+  redactSettings,
+  redactValue,
+  shouldRedactSettingKey,
+} from './agentAccessibilityDump';
+
+const baseSnapshot = {
+  windowKind: 'main' as const,
+  version: '0.18.1',
+  extras: { page: 'home', pillState: 'idle', isOnline: true, settingsOpen: false },
+  settings: {
+    transcription_provider: 'groq',
+    transcription_model: 'whisper-large-v3-turbo',
+    cleanup_provider: 'groq',
+    cleanup_model: 'qwen/qwen3.8-27b',
+    microphone_device: 'Yeti Nano',
+    clipboard_phrase: 'do not leak this',
+  },
+  errors: [] as string[],
+  inventory: [] as string[],
+  build: {
+    commit: 'a83f92c',
+    branch: 'gitbutler/workspace',
+    dirty: true,
+    timestamp: '2026-09-07T22:51:03Z',
+  },
+};
+
+describe('agent accessibility dump', () => {
+  it('redacts secrets and clipboard/prompt bodies, keeps ordinary settings', () => {
+    expect(shouldRedactSettingKey('clipboard_phrase')).toBe(true);
+    expect(shouldRedactSettingKey('cleanup_prompt_override')).toBe(true);
+    expect(shouldRedactSettingKey('api_key_groq')).toBe(true);
+    expect(shouldRedactSettingKey('transcription_provider')).toBe(false);
+    expect(redactValue('paste clipboard here')).toBe('[redacted len=20]');
+    expect(
+      redactSettings({
+        transcription_provider: 'groq',
+        clipboard_phrase: 'secret phrase',
+        api_key_openai: 'sk-test',
+      }),
+    ).toEqual({
+      transcription_provider: 'groq',
+      clipboard_phrase: '[redacted len=13]',
+      api_key_openai: '[redacted len=7]',
+    });
+  });
+
+  it('puts build identity, pipeline, and providers before bulky data', () => {
+    const text = buildAgentDump({
+      ...baseSnapshot,
+      extras: {
+        ...baseSnapshot.extras,
+        page: 'settings',
+        settingsSection: 'audio',
+        contexts: {
+          count: 6,
+          selectedId: 12,
+          names: Array.from({ length: 40 }, (_, index) => ({
+            id: index,
+            name: `context-${index}`,
+            instructions: 'x'.repeat(200),
+          })),
+        },
+      },
+      errors: ['auth-401: key rejected'],
+      recent: [{ at: Date.parse('2026-09-07T22:54:12Z'), name: 'pill-state', detail: 'recording' }],
+    });
+
+    expect(text).toContain('VERENU_AX_DUMP');
+    expect(text.indexOf('build.commit=a83f92c')).toBeGreaterThan(-1);
+    expect(text.indexOf('build.commit=')).toBeLessThan(text.indexOf('recent:'));
+    expect(text.indexOf('pipeline=idle')).toBeLessThan(text.indexOf('recent:'));
+    expect(text).toContain('last_error=auth-401: key rejected');
+    expect(text).toContain('providers.stt=groq/whisper-large-v3-turbo');
+    expect(text).toContain('22:54:12 pill-state recording');
+    expect(text).toContain('transcription_provider=groq');
+    expect(text).not.toContain('clipboard_phrase');
+    expect(text).not.toContain('do not leak this');
+    expect(text).not.toContain('context-12');
+    expect(text).not.toContain('"windowKind"');
+  });
+
+  it('caps dump size so the accessibility tree stays queryable', () => {
+    const inventory = Array.from({ length: 4000 }, (_, index) => `row-${index}-${'x'.repeat(20)}`);
+    const text = buildAgentDump({
+      ...baseSnapshot,
+      windowKind: 'pill',
+      inventory,
+    });
+    expect(text.length).toBeLessThanOrEqual(MAX_DUMP_CHARS + 80);
+  });
+
+  it('names the window title with version, commit, and page', () => {
+    const title = compactDumpTitle(baseSnapshot);
+    expect(title).toContain('Verenu DUMP');
+    expect(title).toContain('v0.18.1');
+    expect(title).toContain('a83f92c');
+    expect(title).toContain('home');
+  });
+
+  it('describes a control with stable ids instead of hashed svelte classes', () => {
+    const nav = {
+      tagName: 'BUTTON',
+      className: 'nav-item svelte-6dohdz active',
+      getAttribute: (name: string) => {
+        if (name === 'data-debug-id') return 'nav.home';
+        return null;
+      },
+    } as unknown as Element;
+    expect(describeDumpElement(nav)).toBe('id=nav.home component=nav-item state=active');
+    expect(describeDumpElement(nav)).not.toContain('svelte-');
+
+    const toggle = {
+      tagName: 'BUTTON',
+      className: 'toggle on',
+      getAttribute: (name: string) => {
+        if (name === 'role') return 'switch';
+        if (name === 'aria-checked') return 'true';
+        if (name === 'aria-label') return 'Ruin accessibility';
+        return null;
+      },
+      closest: (selector: string) => {
+        if (selector !== '[data-setting-target]') return null;
+        return {
+          getAttribute: () => 'developer-ruin-accessibility',
+        };
+      },
+    } as unknown as Element;
+    expect(describeDumpElement(toggle)).toContain('setting=developer-ruin-accessibility');
+    expect(describeDumpElement(toggle)).toContain('value=true');
+    expect(describeDumpElement(toggle)).toContain('component=toggle');
+  });
+
+  it('records recent events with deltas', () => {
+    const first = pushDumpEvent('pill-state', 'recording');
+    expect(first[first.length - 1]?.name).toBe('pill-state');
+    const second = pushDumpEvent('pill-stage', 'transcribing');
+    expect(second[second.length - 1]?.detail).toMatch(/transcribing \+\d+ms/);
+  });
+});

--- a/src/lib/agentAccessibilityDump.ts
+++ b/src/lib/agentAccessibilityDump.ts
@@ -1,0 +1,335 @@
+/** Compact developer-only accessibility dump for T3 Code SnapShots. */
+
+export const RUIN_ACCESSIBILITY_EVENT = 'verenu:ruin-accessibility-changed';
+export const DUMP_REGION_ATTR = 'data-verenu-ax-dump-region';
+export const DUMP_ANNOTATION_ATTR = 'data-verenu-ax-dump';
+export const DEFAULT_WINDOW_TITLE = 'Verenu';
+/** T3 truncates the tree. Keep the dump small enough to survive. */
+export const MAX_DUMP_CHARS = 3_200;
+export const RECENT_EVENT_CAP = 12;
+
+const STARTED_AT_MS = Date.now();
+
+const REDACT_KEY = /api_key_|password|secret|token|credential/i;
+const REDACT_EXACT = new Set([
+  'clipboard_phrase',
+  'cleanup_prompt_override',
+  'key_groq',
+  'key_openai',
+  'key_google',
+  'key_assemblyai',
+]);
+
+const PRIORITY_SETTINGS = [
+  'transcription_provider',
+  'transcription_model',
+  'transcription_language',
+  'cleanup_provider',
+  'cleanup_model',
+  'cleanup_enabled',
+  'dual_transcription_enabled',
+  'microphone_device',
+  'hotkey',
+  'noise_reduction',
+  'mic_gain',
+  'exclusive_mic',
+  'pause_media_during_dictation',
+  'mic_mute_button_dictation',
+  'local_model_memory_policy',
+  'appearance_mode',
+  'setup_complete',
+  'advanced_model_ui',
+  'auto_learn_enabled',
+  'app_context_hint',
+  'ruin_accessibility',
+] as const;
+
+export type DumpWindowKind = 'main' | 'pill';
+
+export type BuildIdentity = {
+  commit: string;
+  branch: string;
+  dirty: boolean;
+  timestamp: string;
+};
+
+export type DumpEvent = {
+  at: number;
+  name: string;
+  detail?: string;
+};
+
+export type AgentDumpSnapshot = {
+  windowKind: DumpWindowKind;
+  version: string;
+  extras: Record<string, unknown>;
+  settings: Record<string, unknown>;
+  errors: string[];
+  inventory: string[];
+  recent?: DumpEvent[];
+  build?: BuildIdentity;
+};
+
+let recentEvents: DumpEvent[] = [];
+
+export function readBuildIdentity(): BuildIdentity {
+  const sha = typeof __VERENU_GIT_SHA__ === 'string' ? __VERENU_GIT_SHA__ : 'unknown';
+  const branch = typeof __VERENU_GIT_BRANCH__ === 'string' ? __VERENU_GIT_BRANCH__ : 'unknown';
+  const dirty = typeof __VERENU_GIT_DIRTY__ === 'boolean' ? __VERENU_GIT_DIRTY__ : false;
+  const timestamp = typeof __VERENU_BUILD_TIME__ === 'string' ? __VERENU_BUILD_TIME__ : 'unknown';
+  return { commit: sha, branch, dirty, timestamp };
+}
+
+export function pushDumpEvent(name: string, detail?: string): DumpEvent[] {
+  const at = Date.now();
+  const last = recentEvents[recentEvents.length - 1];
+  const wait = last ? `+${at - last.at}ms` : undefined;
+  const parts = [detail, wait].filter(Boolean).join(' ');
+  recentEvents = [...recentEvents.slice(-(RECENT_EVENT_CAP - 1)), {
+    at,
+    name,
+    detail: parts || undefined,
+  }];
+  return recentEvents;
+}
+
+export function getDumpEvents(): DumpEvent[] {
+  return recentEvents;
+}
+
+export function formatUptime(nowMs = Date.now(), startedAtMs = STARTED_AT_MS): string {
+  const elapsed = Math.max(0, nowMs - startedAtMs);
+  const seconds = Math.floor(elapsed / 1000);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const rest = seconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${rest}s`;
+  if (minutes > 0) return `${minutes}m ${rest}s`;
+  return `${rest}s`;
+}
+
+export function redactValue(value: unknown): string {
+  if (value == null || value === '') return '[redacted empty]';
+  if (typeof value === 'string') return `[redacted len=${value.length}]`;
+  if (Array.isArray(value)) return `[redacted items=${value.length}]`;
+  return '[redacted]';
+}
+
+export function shouldRedactSettingKey(key: string): boolean {
+  return REDACT_EXACT.has(key) || REDACT_KEY.test(key);
+}
+
+export function redactSettings(raw: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    out[key] = shouldRedactSettingKey(key) ? redactValue(value) : value;
+  }
+  return out;
+}
+
+function compactValue(value: unknown): string {
+  if (value == null) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.every((item) => typeof item === 'string' || typeof item === 'number')) {
+      return value.join('+');
+    }
+    return `[${value.length}]`;
+  }
+  return '{…}';
+}
+
+function clock(at: number): string {
+  return new Date(at).toISOString().slice(11, 19);
+}
+
+export function compactDumpTitle(snapshot: AgentDumpSnapshot): string {
+  const page = String(snapshot.extras.page ?? snapshot.windowKind);
+  const build = snapshot.build ?? readBuildIdentity();
+  const sha = build.commit !== 'unknown' ? build.commit : '';
+  return `Verenu DUMP v${snapshot.version || '?'} ${sha} ${snapshot.windowKind} ${page} up ${formatUptime()}`.replace(/\s+/g, ' ').trim();
+}
+
+function pickSettings(settings: Record<string, unknown>): string[] {
+  const redacted = redactSettings(settings);
+  const lines: string[] = [];
+  for (const key of PRIORITY_SETTINGS) {
+    if (!(key in redacted)) continue;
+    lines.push(`${key}=${compactValue(redacted[key])}`);
+  }
+  return lines;
+}
+
+export function buildAgentDump(snapshot: AgentDumpSnapshot): string {
+  const build = snapshot.build ?? readBuildIdentity();
+  const extras = snapshot.extras;
+  const lastError = snapshot.errors[snapshot.errors.length - 1] ?? 'none';
+  const recent = snapshot.recent ?? recentEvents;
+  const lines: string[] = [
+    'VERENU_AX_DUMP',
+    `build.commit=${build.commit} branch=${build.branch} dirty=${build.dirty} time=${build.timestamp}`,
+    `runtime.window=${snapshot.windowKind} version=${snapshot.version || 'unknown'} up=${formatUptime()} page=${compactValue(extras.page ?? snapshot.windowKind)} settingsOpen=${compactValue(extras.settingsOpen)} section=${compactValue(extras.settingsSection)}`,
+    `state.online=${compactValue(extras.isOnline)} apiHealthy=${compactValue(extras.apiHealthy)} pill=${compactValue(extras.pillState)} setup=${compactValue(extras.setupComplete)}`,
+    `pipeline=${compactValue(extras.pillState ?? 'idle')} last_error=${lastError}`,
+  ];
+
+  const stt = extras.localStt && typeof extras.localStt === 'object' ? extras.localStt as Record<string, unknown> : {};
+  const llm = extras.localLlm && typeof extras.localLlm === 'object' ? extras.localLlm as Record<string, unknown> : {};
+  const sync = extras.sync && typeof extras.sync === 'object' ? extras.sync as Record<string, unknown> : {};
+  const platform = extras.platform && typeof extras.platform === 'object' ? extras.platform as Record<string, unknown> : {};
+
+  lines.push(
+    `providers.stt=${compactValue(snapshot.settings.transcription_provider)}/${compactValue(snapshot.settings.transcription_model)} cleanup=${compactValue(snapshot.settings.cleanup_provider)}/${compactValue(snapshot.settings.cleanup_model)} mic=${compactValue(snapshot.settings.microphone_device)} hotkey=${compactValue(snapshot.settings.hotkey)}`,
+  );
+  lines.push(
+    `local.stt=${compactValue(stt.current)} loaded=${compactValue(stt.loaded)} llm=${compactValue(llm.current)} loaded=${compactValue(llm.loaded)} runtime=${compactValue(llm.runtimeInstalled)}`,
+  );
+  lines.push(
+    `sync.enabled=${compactValue(extras.syncEnabled)} listener=${compactValue(sync.listenerActive)} peers=${compactValue(sync.peerCount)} pairing=${compactValue(sync.pairingPhase)} online=${compactValue(extras.isOnline)}`,
+  );
+  lines.push(
+    `platform.win=${compactValue(platform.isWindows)} mac=${compactValue(platform.isMac)} android=${compactValue(platform.isAndroid)} reducedMotion=${compactValue(extras.reducedMotion)}`,
+  );
+
+  const contextCount = extras.contextCount ?? (extras.contexts && typeof extras.contexts === 'object' ? (extras.contexts as { count?: unknown }).count : undefined);
+  const selected = extras.contextSelected ?? (extras.contexts && typeof extras.contexts === 'object' ? (extras.contexts as { selectedId?: unknown }).selectedId : undefined);
+  lines.push(`contexts.count=${compactValue(contextCount)} selected=${compactValue(selected)} snippets=${compactValue(extras.snippetCount)} dictionary=${compactValue(extras.dictionaryCount)}`);
+
+  lines.push('recent:');
+  if (recent.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const event of recent) {
+      lines.push(`  ${clock(event.at)} ${event.name}${event.detail ? ` ${event.detail}` : ''}`);
+    }
+  }
+
+  if (snapshot.errors.length > 0) {
+    lines.push('errors:');
+    for (const error of snapshot.errors.slice(-4)) {
+      lines.push(`  ${error}`);
+    }
+  }
+
+  lines.push('settings:');
+  const settingLines = pickSettings(snapshot.settings);
+  if (settingLines.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const line of settingLines) lines.push(`  ${line}`);
+  }
+
+  if (snapshot.inventory.length > 0) {
+    lines.push('ui:');
+    for (const line of snapshot.inventory.slice(0, 12)) lines.push(`  ${line}`);
+  }
+
+  const text = lines.join('\n');
+  if (text.length <= MAX_DUMP_CHARS) return text;
+  return `${text.slice(0, MAX_DUMP_CHARS)}\n…truncated ${text.length - MAX_DUMP_CHARS} chars`;
+}
+
+function semanticClasses(className: string): string[] {
+  return className
+    .split(/\s+/)
+    .filter((token) => token && !token.startsWith('svelte-') && !/^[A-Z][A-Za-z0-9_-]{6,}$/.test(token));
+}
+
+export function describeDumpElement(el: Element): string {
+  const parts: string[] = [];
+  const debugId = el.getAttribute('data-debug-id');
+  const setting = el.getAttribute('data-setting-target')
+    ?? el.closest?.('[data-setting-target]')?.getAttribute('data-setting-target');
+  if (debugId) parts.push(`id=${debugId}`);
+  if (setting) parts.push(`setting=${setting}`);
+  const className = typeof el.className === 'string' ? el.className.trim() : '';
+  const classes = semanticClasses(className);
+  const component = classes.find((token) => !['on', 'active', 'open', 'disabled'].includes(token));
+  if (component) parts.push(`component=${component}`);
+  if (classes.includes('active')) parts.push('state=active');
+  const checked = el.getAttribute('aria-checked');
+  if (checked != null) parts.push(`value=${checked}`);
+  for (const name of ['aria-expanded', 'aria-selected', 'aria-current', 'aria-pressed'] as const) {
+    const value = el.getAttribute(name);
+    if (value != null) parts.push(`${name.replace('aria-', '')}=${value}`);
+  }
+  if ('disabled' in el && (el as HTMLButtonElement).disabled) parts.push('disabled');
+  if (parts.length === 0) {
+    const tag = el.tagName.toLowerCase();
+    parts.push(`tag=${tag}`);
+  }
+  return parts.join(' ');
+}
+
+export function collectDomInventory(root: ParentNode = document): string[] {
+  const lines: string[] = [];
+  const switches = root.querySelectorAll('[role="switch"]');
+  switches.forEach((el) => {
+    const setting = el.closest('[data-setting-target]')?.getAttribute('data-setting-target')
+      ?? el.getAttribute('data-debug-id')
+      ?? el.getAttribute('aria-label')
+      ?? '';
+    lines.push(`switch ${setting} value=${el.getAttribute('aria-checked')}`);
+  });
+  const current = root.querySelector('[data-debug-id].active, .nav-item.active, .settings-nav-item.active, .ctx-row.active');
+  if (current instanceof Element) {
+    lines.push(`active ${describeDumpElement(current)}`);
+  }
+  return lines.slice(0, 16);
+}
+
+const ANNOTATE_SELECTOR = [
+  'button',
+  'a',
+  'input',
+  'select',
+  'textarea',
+  'h1',
+  'h2',
+  '[role="switch"]',
+  '[data-setting-target]',
+  '[data-debug-id]',
+  '[aria-current]',
+].join(',');
+
+export function annotateAccessibilityDump(root: ParentNode = document): void {
+  const nodes = root.querySelectorAll(ANNOTATE_SELECTOR);
+  for (const el of nodes) {
+    if (el.closest(`[${DUMP_REGION_ATTR}]`)) continue;
+    const extra = describeDumpElement(el);
+    if (!extra) continue;
+    if (!el.hasAttribute(DUMP_ANNOTATION_ATTR)) {
+      el.setAttribute(DUMP_ANNOTATION_ATTR, el.getAttribute('aria-description') ?? '');
+    }
+    const original = el.getAttribute(DUMP_ANNOTATION_ATTR) ?? '';
+    const next = original ? `${original}. ${extra}` : extra;
+    if (el.getAttribute('aria-description') !== next) {
+      el.setAttribute('aria-description', next);
+    }
+  }
+}
+
+export function restoreAccessibilityDump(root: ParentNode = document): void {
+  const nodes = root.querySelectorAll(`[${DUMP_ANNOTATION_ATTR}]`);
+  for (const el of nodes) {
+    const original = el.getAttribute(DUMP_ANNOTATION_ATTR);
+    if (original) el.setAttribute('aria-description', original);
+    else el.removeAttribute('aria-description');
+    el.removeAttribute(DUMP_ANNOTATION_ATTR);
+  }
+}
+
+export function applyDumpWindowTitle(title: string): string {
+  if (typeof document === 'undefined') return title;
+  document.title = title;
+  document.documentElement.setAttribute('aria-label', title);
+  return title;
+}
+
+export function restoreDumpWindowTitle(): void {
+  if (typeof document === 'undefined') return;
+  document.title = DEFAULT_WINDOW_TITLE;
+  document.documentElement.removeAttribute('aria-label');
+}

--- a/src/lib/components/AgentAccessibilityDump.svelte
+++ b/src/lib/components/AgentAccessibilityDump.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { appStore } from '../stores';
+  import { getVersion, invoke, listen } from '../tauri';
+  import { classifyIpcError } from '../errors';
+  import { isMac, isWindows } from '../platform';
+  import { reducedMotionEnabled } from '../motion';
+  import { localSttStore } from '../localSttStore.svelte';
+  import { localLlmStore } from '../localLlmStore.svelte';
+  import { syncStore } from '../syncStore.svelte';
+  import { contextsStore } from '../contextsStore.svelte';
+  import {
+    DUMP_REGION_ATTR,
+    RUIN_ACCESSIBILITY_EVENT,
+    annotateAccessibilityDump,
+    applyDumpWindowTitle,
+    buildAgentDump,
+    collectDomInventory,
+    compactDumpTitle,
+    getDumpEvents,
+    pushDumpEvent,
+    restoreAccessibilityDump,
+    restoreDumpWindowTitle,
+    type DumpWindowKind,
+  } from '../agentAccessibilityDump';
+
+  let {
+    windowKind,
+    extras = {},
+  }: {
+    windowKind: DumpWindowKind;
+    extras?: Record<string, unknown>;
+  } = $props();
+
+  let enabled = $state(false);
+  let dumpText = $state('');
+  let dumpTitle = $state('');
+  let settings = $state<Record<string, unknown>>({});
+  let errors = $state<string[]>([]);
+  let inventory = $state<string[]>([]);
+  let version = $state('');
+
+  const ERRORS_CAP = 8;
+
+  function pushError(raw: string) {
+    const classified = classifyIpcError(raw);
+    const line = `${classified.kind}: ${classified.message}`;
+    errors = [...errors.slice(-(ERRORS_CAP - 1)), line];
+  }
+
+  function mainExtras(): Record<string, unknown> {
+    return {
+      page: appStore.currentPage,
+      settingsOpen: appStore.settingsOpen,
+      settingsSection: appStore.settingsSection,
+      appearanceMode: appStore.appearanceMode,
+      accentColor: appStore.accentColor,
+      cleanupEnabled: appStore.cleanupEnabled,
+      legacyFeaturesEnabled: appStore.legacyFeaturesEnabled,
+      syncEnabled: appStore.syncEnabled,
+      pillState: appStore.pillState,
+      setupComplete: appStore.setupComplete,
+      snippetCount: appStore.snippets.length,
+      dictionaryCount: appStore.dictionary.length,
+      updateInfo: appStore.updateInfo,
+      betaUpdatesEnabled: appStore.betaUpdatesEnabled,
+      providerStatusAlerts: appStore.providerStatusAlerts,
+      apiHealthy: appStore.apiHealthy,
+      isOnline: appStore.isOnline,
+      devModeEnabled: appStore.devModeEnabled,
+      platform: { isWindows, isMac },
+      reducedMotion: reducedMotionEnabled(),
+      localStt: {
+        current: localSttStore.state.current_model_id,
+        loaded: localSttStore.state.is_loaded,
+        loading: localSttStore.state.is_loading,
+        downloading: localSttStore.state.is_downloading,
+        downloadingModel: localSttStore.state.downloading_model_id,
+        modelCount: localSttStore.models.length,
+      },
+      localLlm: {
+        current: localLlmStore.state.current_model_id,
+        loaded: localLlmStore.state.is_loaded,
+        loading: localLlmStore.state.is_loading,
+        downloading: localLlmStore.state.is_downloading,
+        endpoint: localLlmStore.state.endpoint,
+        runtimeInstalled: localLlmStore.runtime.installed,
+        runtimeBackend: localLlmStore.runtime.backend,
+        modelCount: localLlmStore.models.length,
+      },
+      sync: syncStore.status
+        ? {
+            listenerActive: syncStore.status.listener_active,
+            device: syncStore.status.this_device.name,
+            peerCount: syncStore.status.peers.length,
+            discoveredCount: syncStore.status.discovered.length,
+            pairingPhase: syncStore.status.pairing?.phase ?? null,
+            lastErrorHint: syncStore.status.last_error_hint,
+          }
+        : { loaded: syncStore.loaded },
+      contextCount: contextsStore.contexts.length,
+      contextSelected: contextsStore.selectedId,
+      ...extras,
+    };
+  }
+
+  function rebuild() {
+    if (!enabled) return;
+    // Keep the freshly collected inventory local while building the snapshot.
+    // Reading the stateful `inventory` value inside this function and then
+    // assigning it below makes the `$effect` that calls `rebuild()` depend on
+    // a value it also writes, which trips Svelte's effect update-depth guard.
+    const nextInventory = collectDomInventory();
+    const snapshot = {
+      windowKind,
+      version: version || appStore.appVersion,
+      extras: windowKind === 'main' ? mainExtras() : extras,
+      settings,
+      errors,
+      inventory: nextInventory,
+      recent: getDumpEvents(),
+    };
+    const nextTitle = compactDumpTitle(snapshot);
+    const nextText = buildAgentDump(snapshot);
+    inventory = nextInventory;
+    dumpTitle = nextTitle;
+    dumpText = nextText;
+    applyDumpWindowTitle(nextTitle);
+    annotateAccessibilityDump();
+  }
+
+  async function loadSettings() {
+    try {
+      settings = (await invoke<Record<string, unknown>>('get_all_settings')) ?? {};
+    } catch (error) {
+      settings = { loadError: String(error) };
+    }
+  }
+
+  async function setEnabled(next: boolean) {
+    enabled = next;
+    if (windowKind === 'main') {
+      appStore.ruinAccessibility = next;
+      if (next) appStore.devModeEnabled = true;
+    }
+    if (!next) {
+      dumpText = '';
+      dumpTitle = '';
+      restoreAccessibilityDump();
+      restoreDumpWindowTitle();
+      return;
+    }
+    await loadSettings();
+    rebuild();
+  }
+
+  onMount(() => {
+    let active = true;
+    let unlistenFlag: (() => void) | null = null;
+    let unlistenError: (() => void) | null = null;
+    let unlistenPillState: (() => void) | null = null;
+    let unlistenPillStage: (() => void) | null = null;
+    let observer: MutationObserver | null = null;
+    let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleRebuild = () => {
+      if (!enabled) return;
+      if (rebuildTimer) return;
+      rebuildTimer = setTimeout(() => {
+        rebuildTimer = null;
+        if (active && enabled) rebuild();
+      }, 250);
+    };
+
+    getVersion()
+      .then((value) => {
+        if (active) version = value;
+      })
+      .catch((error) => console.error('Failed to read app version for accessibility dump:', error));
+
+    invoke<boolean | null>('get_setting', { key: 'ruin_accessibility' })
+      .then((value) => {
+        if (!active) return;
+        return setEnabled(value === true);
+      })
+      .catch((error) => console.error('Failed to load ruin_accessibility:', error));
+
+    listen<boolean>(RUIN_ACCESSIBILITY_EVENT, (event) => {
+      void setEnabled(Boolean(event.payload));
+    })
+      .then((unlisten) => {
+        if (!active) {
+          unlisten();
+          return;
+        }
+        unlistenFlag = unlisten;
+      })
+      .catch((error) => console.error('Failed to listen for ruin-accessibility changes:', error));
+
+    listen<string>('pill-state', (event) => {
+      pushDumpEvent('pill-state', String(event.payload ?? ''));
+      scheduleRebuild();
+    })
+      .then((unlisten) => {
+        if (!active) {
+          unlisten();
+          return;
+        }
+        unlistenPillState = unlisten;
+      })
+      .catch(() => {});
+
+    listen<string>('pill-stage', (event) => {
+      pushDumpEvent('pill-stage', String(event.payload ?? ''));
+      scheduleRebuild();
+    })
+      .then((unlisten) => {
+        if (!active) {
+          unlisten();
+          return;
+        }
+        unlistenPillStage = unlisten;
+      })
+      .catch(() => {});
+
+    listen<string>('verenu:error', (event) => {
+      pushError(event.payload ?? '');
+      pushDumpEvent('error', classifyIpcError(event.payload ?? '').kind);
+      scheduleRebuild();
+    })
+      .then((unlisten) => {
+        if (!active) {
+          unlisten();
+          return;
+        }
+        unlistenError = unlisten;
+      })
+      .catch((error) => console.error('Failed to listen for errors in accessibility dump:', error));
+
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver((records) => {
+        const relevant = records.some((record) => {
+          const target = record.target;
+          if (!(target instanceof Element)) return true;
+          return !target.closest(`[${DUMP_REGION_ATTR}]`);
+        });
+        if (relevant) scheduleRebuild();
+      });
+      observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['aria-checked', 'aria-expanded', 'aria-selected', 'aria-current', 'class', 'data-setting-target', 'data-debug-id'],
+      });
+    }
+
+    const interval = setInterval(() => {
+      if (!active || !enabled) return;
+      void loadSettings().then(() => {
+        if (active && enabled) rebuild();
+      });
+    }, 4000);
+
+    return () => {
+      active = false;
+      if (rebuildTimer) clearTimeout(rebuildTimer);
+      clearInterval(interval);
+      observer?.disconnect();
+      unlistenFlag?.();
+      unlistenError?.();
+      unlistenPillState?.();
+      unlistenPillStage?.();
+      restoreAccessibilityDump();
+      restoreDumpWindowTitle();
+    };
+  });
+
+  $effect(() => {
+    if (!enabled) return;
+    void appStore.currentPage;
+    void appStore.settingsOpen;
+    void appStore.settingsSection;
+    void appStore.pillState;
+    void appStore.isOnline;
+    void extras;
+    rebuild();
+  });
+</script>
+
+{#if enabled}
+  <section
+    class="agent-ax-dump"
+    data-verenu-ax-dump-region="true"
+    aria-label={dumpTitle}
+  >
+    <h1>Verenu agent accessibility dump</h1>
+    <p>
+      Ruin accessibility is on. This text is in the OS accessibility tree for T3 Code SnapShots.
+      Turn the flag off in Settings → Developer before using a screen reader.
+    </p>
+    <pre>{dumpText}</pre>
+  </section>
+{/if}
+
+<style>
+  .agent-ax-dump {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/components/AgentAccessibilityDump.svelte
+++ b/src/lib/components/AgentAccessibilityDump.svelte
@@ -125,7 +125,9 @@
     inventory = nextInventory;
     dumpTitle = nextTitle;
     dumpText = nextText;
-    applyDumpWindowTitle(nextTitle);
+    // The pill window is content-fit and uses an empty title. Rewriting
+    // document.title here has no SnapShot value and can disturb native sizing.
+    if (windowKind === 'main') applyDumpWindowTitle(nextTitle);
     annotateAccessibilityDump();
   }
 
@@ -147,7 +149,7 @@
       dumpText = '';
       dumpTitle = '';
       restoreAccessibilityDump();
-      restoreDumpWindowTitle();
+      if (windowKind === 'main') restoreDumpWindowTitle();
       return;
     }
     await loadSettings();
@@ -271,7 +273,7 @@
       unlistenPillState?.();
       unlistenPillStage?.();
       restoreAccessibilityDump();
-      restoreDumpWindowTitle();
+      if (windowKind === 'main') restoreDumpWindowTitle();
     };
   });
 
@@ -304,11 +306,15 @@
 
 <style>
   .agent-ax-dump {
-    position: absolute;
+    position: fixed;
+    left: 0;
+    top: 0;
     width: 1px;
     height: 1px;
+    margin: 0;
     overflow: hidden;
     clip-path: inset(50%);
+    contain: strict;
     white-space: nowrap;
     pointer-events: none;
   }

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -562,6 +562,7 @@
                   type="button"
                   class="settings-nav-item"
                   class:active={appStore.settingsSection === entry.id}
+                  data-debug-id={`settings.${entry.id}`}
                   onclick={() => goToSection(entry.id)}
                   in:fly|global={{ x: -motionPx(RAIL_TRAVEL_PX), duration: motionMs(RAIL_IN_MS), delay: 0, easing: cubicOut }}
                   out:fly|global={{ x: -motionPx(RAIL_TRAVEL_PX), duration: motionMs(RAIL_OUT_MS), delay: 0, easing: cubicOut }}
@@ -584,6 +585,7 @@
             type="button"
             class="nav-item"
             class:active={appStore.currentPage === entry.id}
+            data-debug-id={`nav.${entry.id}`}
             disabled={entry.locked}
             onclick={() => nav(entry.id)}
             in:fly|global={{ x: -motionPx(RAIL_TRAVEL_PX), duration: motionMs(RAIL_IN_MS), delay: railDelay(i, RAIL_IN_DELAY_MS), easing: cubicOut }}
@@ -635,6 +637,7 @@
               class="ctx-row"
               class:has-stack={stack.length > 0}
               class:active={appStore.currentPage === 'contexts' && contextsStore.selectedId === context.id}
+              data-debug-id={`context.${context.id}`}
               onclick={() => openContext(context.id)}
             >
               <span class="ctx-icon" style={context.color ? `color: ${context.color}` : ''} aria-hidden="true">
@@ -788,6 +791,7 @@
     <button
       type="button"
       class={appStore.settingsOpen ? 'settings-back' : 'nav-item'}
+      data-debug-id={appStore.settingsOpen ? 'nav.back' : 'nav.settings'}
       onclick={appStore.settingsOpen ? backToApp : openSettings}
     >
       {#if appStore.settingsOpen}

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -20,6 +20,7 @@
   let logViewport: HTMLDivElement | null = null;
   let verboseEnabled = $state(false);
   let forceSetupOnLaunch = $state(false);
+  let ruinAccessibility = $state(false);
   let copied = $state(false);
   let copiedTimer: ReturnType<typeof setTimeout> | null = null;
   let providerStatusRaw = $state('');
@@ -147,17 +148,21 @@
 
   async function loadDevFlags() {
     try {
-      const [force, verbose, betaUpdates, sync] = await Promise.all([
+      const [force, verbose, betaUpdates, sync, ruin] = await Promise.all([
         invoke<boolean | null>('get_setting', { key: 'force_setup_on_launch' }),
         invoke<boolean>('get_dev_logging_enabled'),
         invoke<boolean | null>('get_setting', { key: 'beta_updates_enabled' }),
         invoke<boolean | null>('get_setting', { key: 'sync_enabled' }),
+        invoke<boolean | null>('get_setting', { key: 'ruin_accessibility' }),
       ]);
       forceSetupOnLaunch = force ?? false;
       verboseEnabled = verbose ?? false;
       appStore.betaUpdatesEnabled = betaUpdates ?? false;
       syncEnabled = sync ?? false;
       appStore.syncEnabled = sync ?? false;
+      ruinAccessibility = ruin ?? false;
+      appStore.ruinAccessibility = ruinAccessibility;
+      if (ruinAccessibility) appStore.devModeEnabled = true;
       storageFullSimulation = await invoke<boolean>('get_storage_full_simulation');
     } catch (err) {
       console.error('Failed to load dev flags:', err);
@@ -221,6 +226,19 @@
     } catch (err) {
       forceSetupOnLaunch = !value;
       console.error('Failed to save force_setup_on_launch:', err);
+    }
+  }
+
+  async function handleRuinAccessibility(value: boolean) {
+    ruinAccessibility = value;
+    appStore.ruinAccessibility = value;
+    if (value) appStore.devModeEnabled = true;
+    try {
+      await saveSetting('ruin_accessibility', value);
+    } catch (err) {
+      ruinAccessibility = !value;
+      appStore.ruinAccessibility = !value;
+      console.error('Failed to save ruin_accessibility:', err);
     }
   }
 
@@ -332,7 +350,21 @@
 <svelte:window onkeydown={handleSyncApprovalKeydown} />
 
 <h2 class="settings-h">Developer</h2>
-<p class="panel-note">Session log stream from backend runtime. Dev mode resets after app restart.</p>
+<p class="panel-note">Session log stream from backend runtime. Dev mode resets after app restart. Ruin accessibility is the first toggle on this page.</p>
+<div class="setting-row" data-setting-target="developer-ruin-accessibility">
+  <div>
+    <div class="label">Ruin accessibility</div>
+    <div class="desc">
+      Stuff a diagnostics dump into the OS accessibility tree so T3 Code SnapShots can read version, settings, pipeline state, and page structure. Screen readers will speak this dump. Persists across restarts. Off by default.
+    </div>
+  </div>
+  <Toggle checked={ruinAccessibility} onchange={handleRuinAccessibility} label="Ruin accessibility" />
+</div>
+<div class="privacy-warn" role="note">
+  <strong>Agent dump:</strong> while this is on, any process with accessibility permission can read the dump.
+  API keys, clipboard phrase, cleanup prompt text, logs, and dictated history stay out of it.
+  Turn it off before using Verenu with a screen reader.
+</div>
 <div class="setting-row beta-setting-row" data-setting-target="developer-sync">
   <div>
     <div class="label">LAN Device Sync</div>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -51,6 +51,7 @@ type SettingsValueMap = {
   mic_gain: number;
   setup_complete: boolean;
   force_setup_on_launch: boolean;
+  ruin_accessibility: boolean;
   app_context_hint: boolean;
   auto_learn_enabled: boolean;
   contextual_formatting_enabled: boolean;

--- a/src/lib/settingsSearch.svelte.ts
+++ b/src/lib/settingsSearch.svelte.ts
@@ -99,6 +99,7 @@ const BASE_ENTRIES: SettingsSearchEntry[] = [
 
   { id: 'developer-sync', section: 'developer', label: 'LAN device sync', description: 'Enable experimental device-to-device sync', target: 'developer-sync', keywords: ['network', 'pairing'] },
   { id: 'developer-setup', section: 'developer', label: 'Force setup on launch', description: 'Show onboarding every time Verenu starts', target: 'developer-setup', keywords: ['onboarding', 'startup'] },
+  { id: 'developer-ruin-accessibility', section: 'developer', label: 'Ruin accessibility', description: 'Dump diagnostics into the accessibility tree for agent SnapShots', target: 'developer-ruin-accessibility', keywords: ['a11y', 'snapshot', 'debug', 'agent', 't3'] },
   { id: 'developer-logs', section: 'developer', label: 'Real-time logs', description: 'View the current diagnostic log stream', target: 'developer-logs', keywords: ['debug', 'logging'] },
   { id: 'developer-download-logs', section: 'developer', label: 'Download logs', description: 'Save session logs to the Downloads folder', target: 'developer-download-logs', keywords: ['debug', 'export'] },
   { id: 'developer-status', section: 'developer', label: 'Provider status check', description: 'Fetch and inspect the provider status response', target: 'developer-status', keywords: ['api', 'health'] },

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -92,6 +92,9 @@ export const appStore = $state({
   settingsAnimDir: 1 as 1 | -1,
   appVersion: '',
   devModeEnabled: false,
+  // Developer-only: dump diagnostics into the OS accessibility tree for agent
+  // SnapShots. Off by default. Real screen-reader use is unusable while on.
+  ruinAccessibility: false,
   appearanceMode: 'system' as AppearanceMode,
   accentColor: null as string | null,
   // Mirrors the `cleanup_enabled` setting. Shared here (rather than owned

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -3,6 +3,10 @@ import { emit as tauriEmit, listen as tauriListen } from '@tauri-apps/api/event'
 import { defaultHotkey } from './platform';
 
 declare const __APP_VERSION__: string;
+declare const __VERENU_GIT_SHA__: string;
+declare const __VERENU_GIT_BRANCH__: string;
+declare const __VERENU_GIT_DIRTY__: boolean;
+declare const __VERENU_BUILD_TIME__: string;
 
 type CommandArgs = Record<string, unknown>;
 type EventEnvelope<T> = {
@@ -223,6 +227,7 @@ const defaultCleanupModels = {
 const defaultSettings: Record<string, unknown> = {
   setup_complete: true,
   force_setup_on_launch: false,
+  ruin_accessibility: false,
   appearance_mode: 'system',
   transcription_provider: 'groq',
   transcription_language: 'en',
@@ -1169,6 +1174,9 @@ async function devInvoke<T>(command: string, args?: CommandArgs): Promise<T> {
         throw new Error('STORAGE_FULL: simulated settings write failure');
       }
       writeDevSetting(args.key, args?.value);
+      if (args.key === 'ruin_accessibility') {
+        emitDevTauriEvent('verenu:ruin-accessibility-changed', Boolean(args.value));
+      }
       return undefined as T;
     case 'get_all_settings':
       return { ...defaultSettings, ...readDevSettings() } as T;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+declare const __VERENU_GIT_SHA__: string;
+declare const __VERENU_GIT_BRANCH__: string;
+declare const __VERENU_BUILD_TIME__: string;
+declare const __VERENU_GIT_DIRTY__: boolean;
+
 declare module '*.css' {
   const content: Record<string, any>;
   export default content;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,43 @@
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import pkg from './package.json';
+
+function git(command: string): string {
+  try {
+    return execSync(command, { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+const gitSha = git('git rev-parse --short HEAD') || 'unknown';
+const gitBranch = git('git rev-parse --abbrev-ref HEAD') || 'unknown';
+const gitDirty = git('git status --porcelain') !== '';
+const buildTime = new Date().toISOString();
 
 export default defineConfig({
   plugins: [svelte()],
   clearScreen: false,
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __VERENU_GIT_SHA__: JSON.stringify(gitSha),
+    __VERENU_GIT_BRANCH__: JSON.stringify(gitBranch),
+    __VERENU_GIT_DIRTY__: JSON.stringify(gitDirty),
+    __VERENU_BUILD_TIME__: JSON.stringify(buildTime),
   },
   server: {
     port: 1420,
     strictPort: true,
     host: '127.0.0.1',
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+    watch: {
+      ignored: ['**/src-tauri/**', '**/installers/**', '**/dist/**', '**/.git/**'],
+    },
   },
   build: {
     target: ['es2020', 'chrome100'],


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold, audio capture, transcription, LLM cleanup, text injection
> - Subsystem: settings / UI, plus the OS accessibility tree that T3 Code SnapShots read
> - SnapShots currently see the same tree as VoiceOver/NVDA, so agents get almost no runtime identity, pipeline state, or settings
> - Agents debugging Verenu need that context without turning the default UI into garbage for real assistive tech
> - This pull request adds an off-by-default Developer toggle named Ruin accessibility that stuffs a compact dump into the tree
> - The benefit is a SnapShot that includes git identity, pipeline events, providers, mic, and stable debug ids, capped so T3 truncation still leaves the useful prefix

## What Changed

- Added a persisted `ruin_accessibility` setting (readable, not exportable, not LAN-syncable) and a Developer toggle that also turns on session dev mode while the flag is on
- Injected a clipped accessibility dump region in the main window and pill, plus `data-debug-id`s on sidebar nav, settings, and context rows
- Vite now embeds git SHA/branch/dirty and build time into the dump
- Secrets stay out: API keys, clipboard phrase, cleanup prompt text, logs, and dictated history are redacted

## Verification

- `npx vitest run src/lib/agentAccessibilityDump.test.ts` (6 passing)
- `npm run check`
- `cargo test --manifest-path src-tauri/Cargo.toml validate_setting_rejects_non_boolean_bools`
- Manual: enable Developer mode, turn on Ruin accessibility, SnapShot the main window; dump includes commit/branch and is truncated by T3 rather than empty
- Skipped: `npm run lint`, full `npm run test:rust`, smoke tests, macOS VoiceOver pass

## Risks

- While the flag is on, any process with accessibility permission can read the dump. That is the point of the toggle, and the UI says so. Default remains off.
- Window title is rewritten while the dump is active; turning the flag off restores it.
- Hashed Svelte classes are stripped from the dump so it stays under the 3,200-character cap; T3 still truncates the tree.

> Check [`docs/ROADMAP.md`](../docs/ROADMAP.md) before opening feature PRs - work that overlaps with planned core changes may need to be redirected. See [`CLAUDE.md`](../CLAUDE.md) for architecture and contribution guidance.

## Model Used

- xAI Grok 4.6 (tool use)

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (ESLint + Clippy)
- [ ] `npm run test:rust` passes
- [ ] Smoke tests pass (see `Agent-Skills/SmokeTest.md` for commands)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] If version bumped: all three files updated together (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791443328&installation_model_id=432577&pr_number=373&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F373&signature=2d1e96f4f4d126017dd5299f12bdaaca239f8786b1b9eb29f1ed2a3c54232f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->