### PR TITLE
Fix nightly releases to use the current master version

### DIFF
--- a/.github/workflows/morning-release.yml
+++ b/.github/workflows/morning-release.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Find changes since the previous nightly release
         id: changes
         shell: bash
-        env:
-          NIGHTLY_START_VERSION: '0.16.0'
         run: |
           set -euo pipefail
 
@@ -68,23 +66,37 @@ jobs:
             fi
           done < <(git tag --list 'Verenu-*-nightly.*')
 
-          # Nightlies keep the latest stable release as their numeric version
-          # base. The fallback is used only before the first reachable stable
-          # tag exists in the master history.
-          nightly_base_version="$NIGHTLY_START_VERSION"
-          nightly_base_tag="$(git tag --merged "$master_sha" --list 'Verenu-*' | grep -E '^Verenu-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
-          if [[ -n "$nightly_base_tag" ]]; then
-            nightly_base_version="${nightly_base_tag#Verenu-}"
-          fi
+          # Nightlies use the version currently declared by master. Stable
+          # release tags are not a reliable source here: a release may be
+          # published without a matching stable tag, while an older tag can
+          # still be reachable from the branch.
+          nightly_base_version="$(node <<'NODE'
+          const fs = require('node:fs');
+
+          const packageVersion = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+          const tauriVersion = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8')).version;
+          const cargo = fs.readFileSync('src-tauri/Cargo.toml', 'utf8');
+          const cargoVersion = cargo.match(/^\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m)?.[1];
+          const versions = { packageVersion, tauriVersion, cargoVersion };
+
+          if (!packageVersion || !tauriVersion || !cargoVersion || new Set(Object.values(versions)).size !== 1) {
+            console.error(`Master version files disagree: ${JSON.stringify(versions)}`);
+            process.exit(1);
+          }
+          if (!/^\d+\.\d+\.\d+$/.test(packageVersion)) {
+            console.error(`Master package.json version is not a stable numeric version: ${packageVersion}`);
+            process.exit(1);
+          }
+
+          process.stdout.write(packageVersion);
+          NODE
+          )"
 
           # Before the first nightly, use the newest release tag reachable
           # from master. Tags are branch-agnostic, so reachability is the branch
           # association we can verify safely.
           if [[ -z "$baseline_sha" ]]; then
-            baseline_tag="$nightly_base_tag"
-            if [[ -z "$baseline_tag" ]]; then
-              baseline_tag="$(git tag --merged "$master_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
-            fi
+            baseline_tag="$(git tag --merged "$master_sha" --list 'Verenu-*' | sort -V | tail -n 1 || true)"
             if [[ -z "$baseline_tag" ]]; then
               echo 'No release tag reachable from master; refusing to guess a baseline.' >&2
               exit 1
@@ -106,7 +118,7 @@ jobs:
 
           echo "Baseline: $baseline_tag ($baseline_sha)"
           echo "Master:   $master_sha"
-          echo "Nightly base: $nightly_base_version"
+          echo "Nightly base: $nightly_base_version (from master version files)"
           echo "Changed lines: $changed_lines"
           git diff --stat "$baseline_sha..$master_sha" -- . ':(exclude)package-lock.json'
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a scheduled nightly release pipeline.
> - The affected subsystem is `.github/workflows/morning-release.yml`, which calculates nightly tags and builds installers.
> - The workflow used the newest reachable stable tag instead of the current version declared by master.
> - Master is already on 0.18.1, but the workflow selected the older 0.17.0 tag and published 0.17.0-nightly releases.
> - This pull request makes the version source explicit and validates the three synchronized version files.
> - The benefit is correctly named nightly releases without changing the release-only version rollback behavior.

## What Changed

- Read the nightly base version from the version files on master instead of stable release tags.
- Fail early when package.json, Tauri, and Cargo versions disagree or are not stable numeric versions.
- Keep the existing release-only tag mutation and rollback assertion intact.

## Verification

- Parsed `.github/workflows/morning-release.yml` with PyYAML.
- Ran the focused Bash and Node fragment, which produced `0.18.1-nightly.20260907`.
- Ran `git diff --check` on the workflow.

## Risks

Low risk. This changes nightly naming and adds validation before release preparation. Installer version mutation and rollback are unchanged.

## Model Used

OpenAI GPT-5.6, Codex tool use.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447028&installation_model_id=432577&pr_number=377&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F377&signature=655b2d4f42aef967ff280c96c21bc87d041a4886970a5abdefcfb5ffc9ab8115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->