### PR TITLE
Preserve dictations when recovery storage fails

### DIFF
--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -171,6 +171,8 @@ impl EnvelopeTap {
 /// Optional crash-recovery sink for a dictation. The audio worker pushes
 /// gain-adjusted, optionally denoised 16 kHz samples here; implementations
 /// must keep disk work off this worker and must not run on the CPAL callback.
+/// A sink failure only disables crash recovery for the current take. It must
+/// never make the in-memory recording unavailable to transcription.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DurableSinkError {
     Disk,
@@ -181,8 +183,8 @@ pub type DurableSinkResult = std::result::Result<(), DurableSinkError>;
 
 pub trait DurableSink: Send {
     /// Returns an error when the sink cannot accept more data. The processing
-    /// worker then ends the take instead of silently producing an incomplete
-    /// recovery spool.
+    /// worker keeps capturing in memory after this error, but will not promise
+    /// that the take can be recovered after a crash.
     fn extend(&mut self, samples_16k: &[f32]) -> DurableSinkResult;
     fn finish(&mut self) -> DurableSinkResult;
 }
@@ -210,6 +212,7 @@ pub enum RecordingTermination {
     Complete,
     DurationLimit,
     DroppedSamples,
+    /// The optional recovery spool failed, but the in-memory take is intact.
     RecoveryWriteFailed,
 }
 
@@ -416,6 +419,7 @@ impl RecordingSession {
                 let mut raw_sum_sq = 0.0f64;
                 let mut raw_sample_count = 0u64;
                 let mut termination = RecordingTermination::Complete;
+                let mut recovery_write_failed = false;
                 let mut resampler = StreamingResampler::new(sample_rate);
                 let mut denoiser = if noise_reduction {
                     Some(FrameDenoiser::new())
@@ -457,7 +461,7 @@ impl RecordingSession {
                         }
                         if let Some(sink) = durable.as_mut() {
                             if sink.extend(&samples_16k[before_len..]).is_err() {
-                                termination = RecordingTermination::RecoveryWriteFailed;
+                                recovery_write_failed = true;
                             }
                         }
                         if termination == RecordingTermination::Complete
@@ -509,14 +513,17 @@ impl RecordingSession {
                     }
                     if let Some(sink) = durable.as_mut() {
                         if sink.extend(&samples_16k[before_len..]).is_err() {
-                            termination = RecordingTermination::RecoveryWriteFailed;
+                            recovery_write_failed = true;
                         }
                     }
                 }
                 if let Some(mut sink) = durable.take() {
                     if sink.finish().is_err() {
-                        termination = RecordingTermination::RecoveryWriteFailed;
+                        recovery_write_failed = true;
                     }
+                }
+                if recovery_write_failed && termination == RecordingTermination::Complete {
+                    termination = RecordingTermination::RecoveryWriteFailed;
                 }
 
                 let raw_rms = if raw_sample_count == 0 {

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -940,14 +940,14 @@ pub fn open_live_writer(
                         WriterMessage::Finish => break,
                     }
                 }
-                if writer.failed || failed_thread.load(Ordering::Acquire) {
-                    writer.invalidate_recovery();
-                }
                 let _ = writer.finish();
                 if writer.storage_full {
                     if let Some(app) = &writer.app {
                         app.emit("verenu:storage-full", ()).ok();
                     }
+                }
+                if writer.failed || failed_thread.load(Ordering::Acquire) {
+                    writer.invalidate_recovery();
                 }
                 if writer.failed {
                     failed_thread.store(true, Ordering::Release);

--- a/src-tauri/src/pipeline/failover.rs
+++ b/src-tauri/src/pipeline/failover.rs
@@ -11,6 +11,7 @@ use super::state::{
 };
 use super::{state, CapturedAudio};
 use crate::core::window_geometry::WindowTarget;
+use crate::data::store;
 use crate::media::audio::{self, DurableSink, DurableSinkError, DurableSinkResult};
 use chrono::{SecondsFormat, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -594,6 +595,7 @@ pub struct LiveWriter {
     pending: Vec<f32>,
     rms_sum_sq: f64,
     failed: bool,
+    storage_full: bool,
     last_checkpoint: Instant,
     superseded: bool,
     app: Option<AppHandle>,
@@ -645,6 +647,7 @@ impl LiveWriter {
                         state,
                         meta,
                         failed: false,
+                        storage_full: false,
                     });
                 }
             }
@@ -694,7 +697,12 @@ impl LiveWriter {
             superseded: false,
             app,
             state,
+            storage_full: false,
         })
+    }
+
+    fn mark_storage_full(&mut self, error: &impl std::fmt::Display) {
+        self.storage_full |= store::is_storage_full_error(&error.to_string());
     }
 
     fn checkpoint(&mut self, finish: bool) {
@@ -705,11 +713,13 @@ impl LiveWriter {
             let pcm = samples_to_pcm(&self.pending);
             if let Err(e) = self.file.write_all(&pcm).and_then(|_| self.file.flush()) {
                 log::warn!("failover: live pcm write failed: {e}");
+                self.mark_storage_full(&e);
                 self.failed = true;
                 return;
             }
             if let Err(e) = self.file.sync_data() {
                 log::warn!("failover: live pcm sync failed: {e}");
+                self.mark_storage_full(&e);
                 self.failed = true;
                 return;
             }
@@ -724,6 +734,7 @@ impl LiveWriter {
             let session_path = slot_dir(&self.root, true).join(SESSION_FILE);
             if let Err(e) = write_session_atomic(&session_path, &self.meta) {
                 log::warn!("failover: live sidecar write failed: {e}");
+                self.mark_storage_full(&e);
                 self.failed = true;
             }
             self.pending.clear();
@@ -758,6 +769,17 @@ impl LiveWriter {
             id_prefix(&self.meta.id),
             self.meta.duration_ms
         );
+    }
+
+    fn invalidate_recovery(&self) {
+        delete_live(&self.root);
+        if let Some(state) = &self.state {
+            if let Ok(mut st) = lock_state(state) {
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
+            }
+        }
     }
 }
 
@@ -803,6 +825,7 @@ impl DurableSink for LiveWriter {
         self.checkpoint(true);
         if let Err(e) = self.file.flush().and_then(|_| self.file.sync_all()) {
             log::warn!("failover: final live pcm sync failed: {e}");
+            self.mark_storage_full(&e);
             self.failed = true;
         }
         if self.failed {
@@ -909,11 +932,23 @@ pub fn open_live_writer(
                                 failed_thread.store(true, Ordering::Release);
                                 break;
                             }
+                            if failed_thread.load(Ordering::Acquire) {
+                                writer.invalidate_recovery();
+                                break;
+                            }
                         }
                         WriterMessage::Finish => break,
                     }
                 }
+                if writer.failed || failed_thread.load(Ordering::Acquire) {
+                    writer.invalidate_recovery();
+                }
                 let _ = writer.finish();
+                if writer.storage_full {
+                    if let Some(app) = &writer.app {
+                        app.emit("verenu:storage-full", ()).ok();
+                    }
+                }
                 if writer.failed {
                     failed_thread.store(true, Ordering::Release);
                 }
@@ -926,6 +961,15 @@ pub fn open_live_writer(
         }
         Err(e) => {
             log::warn!("failover: live writer open failed: {e}");
+            abandon_live();
+            if let Ok(mut st) = lock_state(state) {
+                st.failover_session_id = None;
+                st.failover_reuse_id = false;
+                st.failover_started_at_unix = 0;
+            }
+            if store::is_storage_full_error(&e.to_string()) {
+                app.emit("verenu:storage-full", ()).ok();
+            }
             None
         }
     }
@@ -939,22 +983,22 @@ pub fn flush_on_exit(app: &AppHandle) {
     let Some(state) = app.try_state::<SharedState>() else {
         return;
     };
-    let (id, started) = match lock_state(state.inner()) {
-        Ok(st) => (
-            st.failover_session_id.clone(),
-            if st.failover_started_at_unix != 0 {
-                st.failover_started_at_unix
-            } else {
-                now_unix()
-            },
-        ),
-        Err(_) => return,
-    };
     let Some((session, mic_id)) = state::take_recording_plain(state.inner()) else {
         return;
     };
     match session.stop() {
         Ok(result) => {
+            let (id, started) = match lock_state(state.inner()) {
+                Ok(st) => (
+                    st.failover_session_id.clone(),
+                    if st.failover_started_at_unix != 0 {
+                        st.failover_started_at_unix
+                    } else {
+                        now_unix()
+                    },
+                ),
+                Err(_) => (None, now_unix()),
+            };
             if let Some(id) = id {
                 if result.duration_ms >= MIN_RECORDING_MS {
                     let audio = CapturedAudio::from_samples(

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -181,11 +181,17 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
     let min_rms = recording_gate_rms(active_gain);
     log::debug!("pipeline: input gate active_gain={active_gain:.2} min_rms={min_rms:.6}");
 
-    let Some((captured_audio, rms, raw_rms)) =
+    let Some(stopped_capture) =
         stop_and_capture_audio(&app, session, exclusive_mic_session_id).await
     else {
         return Err(anyhow::anyhow!("Failed to stop recording"));
     };
+    let StoppedCapture {
+        audio: captured_audio,
+        rms,
+        raw_rms,
+        ..
+    } = stopped_capture;
     let gate_rms = effective_recording_rms(rms, raw_rms, active_gain);
     if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
         hide_pill(&app);
@@ -409,7 +415,7 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
     // Capture first, gate second: a resumed/prepended recording needs to be
     // merged with the previous session's audio before the quality gate runs,
     // so a short-but-valid continuation isn't rejected on its own merits.
-    let Some((mut captured_audio, mut rms, mut raw_rms)) =
+    let Some(stopped_capture) =
         stop_and_capture_audio(&app, session, exclusive_mic_session_id).await
     else {
         // Stop/capture failures retain any durable prefix for crash recovery;
@@ -417,6 +423,12 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         state::leave_stopping_if_owned(&state, generation);
         return;
     };
+    let StoppedCapture {
+        audio: mut captured_audio,
+        mut rms,
+        mut raw_rms,
+        ..
+    } = stopped_capture;
     if let Some(prev) = prepend_audio {
         let (merged, merged_rms, merged_raw_rms) =
             match merge_prepend_audio(prev, captured_audio, active_gain) {

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -347,12 +347,27 @@ pub async fn cancel_recording_with_resume(
     crate::media::sound::coordinated_unmute();
     crate::system::media_control::end_dictation_media_pause();
 
-    let Some((mut captured_audio, mut rms, mut raw_rms)) =
+    let Some(stopped_capture) =
         stop_and_capture_audio(app, session, exclusive_mic_session_id).await
     else {
         // stop_and_capture_audio already hid the pill on failure.
         return;
     };
+    if stopped_capture.recovery_write_failed {
+        // The take is still valid in memory, but a cancelled capture cannot
+        // be resumed safely once its recovery spool has failed.
+        log::warn!("recording: cancelled capture not offered for resume after recovery failure");
+        if state_is_idle(state) {
+            hide_pill(app);
+        }
+        return;
+    }
+    let StoppedCapture {
+        audio: mut captured_audio,
+        mut rms,
+        mut raw_rms,
+        ..
+    } = stopped_capture;
 
     let active_gain = store::settings_snapshot(app)
         .map(|s| store::load_audio_config(&s).mic_gain)

--- a/src-tauri/src/pipeline/stages_transcription.rs
+++ b/src-tauri/src/pipeline/stages_transcription.rs
@@ -18,11 +18,29 @@ impl Drop for ExclusiveMicReleaseGuard {
     }
 }
 
+pub(crate) struct StoppedCapture {
+    pub(crate) audio: CapturedAudio,
+    pub(crate) rms: f32,
+    pub(crate) raw_rms: f32,
+    pub(crate) recovery_write_failed: bool,
+}
+
+fn disable_recovery_after_write_failure(app: &AppHandle) {
+    super::failover::abandon_live();
+    if let Some(state) = app.try_state::<SharedState>() {
+        if let Ok(mut st) = lock_state(state.inner()) {
+            st.failover_session_id = None;
+            st.failover_reuse_id = false;
+            st.failover_started_at_unix = 0;
+        }
+    }
+}
+
 pub(super) async fn stop_and_capture_audio(
     app: &AppHandle,
     session: audio::RecordingSession,
     exclusive_mic_session_id: Option<u64>,
-) -> Option<(CapturedAudio, f32, f32)> {
+) -> Option<StoppedCapture> {
     let stop_result = tokio::task::spawn_blocking(move || {
         let _mic_release = ExclusiveMicReleaseGuard(exclusive_mic_session_id);
         session.stop()
@@ -82,21 +100,18 @@ pub(super) async fn stop_and_capture_audio(
         }
         audio::RecordingTermination::RecoveryWriteFailed => {
             log::warn!("pipeline: recovery recording could not be kept durable");
-            show_error_pill(
-                app,
-                "Recording could not be saved for recovery. Check available disk space and try again.",
-            )
-            .await;
-            // The live spool contains the last known durable prefix. Do not
-            // delete it just because the current take hit a disk/queue error.
-            return None;
+            // Recovery is optional. Keep the complete in-memory take for the
+            // normal transcription path, but discard the incomplete spool so
+            // it cannot later appear as a misleading continuation prompt.
+            disable_recovery_after_write_failure(app);
         }
     }
-    Some((
-        CapturedAudio::from_samples(samples_16k, sample_rate, duration_ms),
+    Some(StoppedCapture {
+        audio: CapturedAudio::from_samples(samples_16k, sample_rate, duration_ms),
         rms,
         raw_rms,
-    ))
+        recovery_write_failed: termination == audio::RecordingTermination::RecoveryWriteFailed,
+    })
 }
 
 /// Quality gate (min duration / near-silence RMS) against already-captured

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -180,6 +180,7 @@
     let cleanupFn: (() => void) | undefined;
     let stopNotificationClickListener: (() => void) | undefined;
     let stopConnectivityRecheckListener: (() => void) | undefined;
+    let stopRecoveryWriteListener: (() => void) | undefined;
     let stopSettingsImportedListener: (() => void) | undefined;
     let stopAutomaticUpdateChecks: (() => void) | undefined;
     let stopLocalSttListeners: (() => void) | undefined;
@@ -287,6 +288,18 @@
       })
       .catch((error) => { console.warn('Failed to listen for connectivity rechecks:', error); });
 
+    listen('verenu:storage-full', () => {
+      appStore.recoveryStorageWarning = true;
+    })
+      .then((unlisten) => {
+        if (!mounted) {
+          unlisten();
+          return;
+        }
+        stopRecoveryWriteListener = unlisten;
+      })
+      .catch((error) => { console.warn('Failed to listen for storage-full events:', error); });
+
     // Synchronous: startAutomaticUpdateChecks fires its first check in the
     // background and returns the cleanup immediately, so there's no unmount
     // race to guard and the interval is always registered before we return.
@@ -327,6 +340,7 @@
       if (cleanupFn) cleanupFn();
       if (stopNotificationClickListener) stopNotificationClickListener();
       if (stopConnectivityRecheckListener) stopConnectivityRecheckListener();
+      if (stopRecoveryWriteListener) stopRecoveryWriteListener();
       if (stopSettingsImportedListener) stopSettingsImportedListener();
       if (stopAutomaticUpdateChecks) stopAutomaticUpdateChecks();
       if (stopLocalSttListeners) stopLocalSttListeners();

--- a/src/lib/components/settings/DeveloperSection.svelte
+++ b/src/lib/components/settings/DeveloperSection.svelte
@@ -261,6 +261,11 @@
     simulationMessage = 'Offline state previewed.';
   }
 
+  function simulateStorageFullNotice() {
+    appStore.recoveryStorageWarning = true;
+    simulationMessage = 'Drive-full notice previewed.';
+  }
+
   async function toggleStorageFullSimulation(enabled: boolean) {
     const previous = storageFullSimulation;
     storageFullSimulation = enabled;
@@ -292,6 +297,7 @@
     appStore.providerStatusSimulation = false;
     appStore.globalMessage = null;
     appStore.globalMessageSimulation = false;
+    appStore.recoveryStorageWarning = false;
     appStore.isOnline = true;
     try {
       await invoke('set_storage_full_simulation', { enabled: false });
@@ -524,6 +530,7 @@
     <button class="btn-ghost" onclick={simulateProviderDown}>Provider Down</button>
     <button class="btn-ghost" onclick={simulateWifiOffline}>Wi-Fi Offline</button>
     <button class="btn-ghost" onclick={simulateGlobalMessage}>Global Message</button>
+    <button class="btn-ghost" onclick={simulateStorageFullNotice}>Drive Full</button>
     <button class="btn-ghost" onclick={clearSimulations}>Clear</button>
   </div>
 </div>

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -123,6 +123,7 @@ export const appStore = $state({
   providerStatusSimulation: false,
   globalMessage: null as GlobalMessage | null,
   globalMessageSimulation: false,
+  recoveryStorageWarning: false,
   apiHealthy: null as boolean | null,
   isOnline: true,
 });

--- a/src/lib/views/Home.svelte
+++ b/src/lib/views/Home.svelte
@@ -319,6 +319,10 @@
         <GlobalMessageBanner message={appStore.globalMessage.message} />
       {/if}
 
+      {#if appStore.recoveryStorageWarning}
+        <GlobalMessageBanner message="Your drive is full. Some features won't work properly." />
+      {/if}
+
       {#if appStore.providerStatusAlerts.length > 0}
         <ProviderStatusBanner alerts={appStore.providerStatusAlerts} />
       {:else if appStore.updateInfo}


### PR DESCRIPTION
> - Verenu is a Windows and macOS AI dictation app whose audio pipeline keeps an in-progress take recoverable on disk.
> - A recovery write failure used to reject the take and surface a misleading drive-full warning.
> - This pull request keeps the in-memory recording flowing to transcription, discards incomplete recovery state, and shows a home notice only for an actual storage-full OS error.
> - It also adds a developer-only Drive Full preview button.
> - The benefit is that transient recovery failures do not destroy dictation output or misidentify the drive.

## What Changed

- Preserve transcription when optional recovery writes fail.
- Prevent stale continuation prompts after a failed recovery spool.
- Emit the storage warning only for recognized storage-full errors.
- Add and reset the Drive Full developer simulation.

## Verification

- cargo check --manifest-path src-tauri/Cargo.toml --lib --target-dir C:\Users\noah7\AppData\Local\Temp\\verenu-codex-target
- Focused failover tests: 19 passed.
- Frontend unit tests: 135 passed.
- npm run check was run, but the shared workspace reports unrelated diagnostics in PillApp.svelte and agentAccessibilityDump.test.ts.

## Risks

- Low risk. Recovery remains best-effort; normal in-memory transcription and history are unchanged.

## Model Used

- OpenAI GPT-5.6-Luna

## Checklist

- [x] This PR targets master directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] No API keys, secrets, or personal data in code or logs
- [x] Focused Rust and frontend tests pass
- [ ] npm run check passes due unrelated shared-workspace diagnostics
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447755&installation_model_id=432577&pr_number=378&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F378&signature=ea841fd68caa0a9e4d61b1589d6afe85baf991c14623ba5a030fc008346b4734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->