### PR TITLE
Stop dictation cleanly when the microphone stream fails

### DIFF
--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -196,6 +196,10 @@ pub struct RecordingSession {
     pub raw_level: Arc<AtomicU32>,
     pub envelope: Arc<EnvelopeTap>,
     pub active: Arc<AtomicBool>,
+    /// Set by CPAL's stream-error callback. The callback must not block or
+    /// touch lifecycle state; the pill/session watcher consumes this flag on
+    /// the async side and ends the recording cleanly.
+    pub stream_error: Arc<AtomicBool>,
 }
 
 pub struct RecordingResult {
@@ -212,6 +216,9 @@ pub enum RecordingTermination {
     Complete,
     DurationLimit,
     DroppedSamples,
+    /// The input stream stopped unexpectedly. The captured prefix may be
+    /// usable, but must not be misreported as a normal short recording.
+    StreamError,
     /// The optional recovery spool failed, but the in-memory take is intact.
     RecoveryWriteFailed,
 }
@@ -383,12 +390,14 @@ impl RecordingSession {
         let raw_level = Arc::new(AtomicU32::new(0f32.to_bits()));
         let envelope = Arc::new(EnvelopeTap::new());
         let active = Arc::new(AtomicBool::new(true));
+        let stream_error = Arc::new(AtomicBool::new(false));
         let display_gain = (DISPLAY_GAIN * gain).max(0.0);
 
         let level_w = Arc::clone(&level);
         let raw_level_w = Arc::clone(&raw_level);
         let envelope_w = Arc::clone(&envelope);
         let active_w = Arc::clone(&active);
+        let stream_error_w = Arc::clone(&stream_error);
         envelope_w.set_sample_rate(sample_rate);
         // `processed` already contains the configured microphone gain. Keep
         // the remaining display multiplier explicit so the envelope and the
@@ -543,7 +552,16 @@ impl RecordingSession {
             let queue_cb = Arc::clone(&queue);
             let dropped_cb = Arc::clone(&dropped_samples);
             let raw_level_cb = Arc::clone(&raw_level_w);
-            let err_fn = |e| log::error!("Audio stream error: {e}");
+            let stream_error_cb = Arc::clone(&stream_error_w);
+            let active_cb = Arc::clone(&active_w);
+            let err_fn = move |e| {
+                // CPAL may invoke this from an audio-related thread. Keep the
+                // callback allocation-free and nonblocking: a failed stream
+                // must be observed by the session owner, not handled here.
+                log::error!("Audio stream error: {e}");
+                stream_error_cb.store(true, Ordering::Release);
+                active_cb.store(false, Ordering::Release);
+            };
 
             let stream = match config.sample_format() {
                 cpal::SampleFormat::F32 => device.build_input_stream(
@@ -632,18 +650,26 @@ impl RecordingSession {
 
             let dur_ms = samples_16k.len() as u64 * 1000 / TARGET_SAMPLE_RATE as u64;
             let overall_rms = rms_f32(&samples_16k);
-            let result = if samples_16k.is_empty() {
-                Err(anyhow::anyhow!("No audio captured"))
+            let termination = if stream_error_w.load(Ordering::Acquire)
+                && termination == RecordingTermination::Complete
+            {
+                RecordingTermination::StreamError
             } else {
-                Ok(RecordingResult {
-                    samples_16k,
-                    sample_rate: TARGET_SAMPLE_RATE,
-                    duration_ms: dur_ms,
-                    rms: overall_rms,
-                    raw_rms,
-                    termination,
-                })
+                termination
             };
+            let result =
+                if samples_16k.is_empty() && termination != RecordingTermination::StreamError {
+                    Err(anyhow::anyhow!("No audio captured"))
+                } else {
+                    Ok(RecordingResult {
+                        samples_16k,
+                        sample_rate: TARGET_SAMPLE_RATE,
+                        duration_ms: dur_ms,
+                        rms: overall_rms,
+                        raw_rms,
+                        termination,
+                    })
+                };
 
             let _ = result_tx.send(result);
         });
@@ -659,6 +685,7 @@ impl RecordingSession {
             raw_level,
             envelope,
             active,
+            stream_error,
         })
     }
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -190,10 +190,16 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
         audio: captured_audio,
         rms,
         raw_rms,
+        stream_error,
         ..
     } = stopped_capture;
+    if stream_error {
+        show_error_pill(&app, AUDIO_STREAM_ERROR_MESSAGE).await;
+        return Err(anyhow::anyhow!(AUDIO_STREAM_ERROR_MESSAGE));
+    }
     let gate_rms = effective_recording_rms(rms, raw_rms, active_gain);
     if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
+        state::note_sensitivity_rejection(&state);
         hide_pill(&app);
         if captured_audio.duration_ms < MIN_RECORDING_MS {
             anyhow::bail!("Recording too short");
@@ -427,8 +433,15 @@ async fn run_pipeline_with_delivery(app: AppHandle, state: SharedState, event_on
         audio: mut captured_audio,
         mut rms,
         mut raw_rms,
+        stream_error,
         ..
     } = stopped_capture;
+    if stream_error {
+        failover::abandon_live();
+        show_error_pill(&app, AUDIO_STREAM_ERROR_MESSAGE).await;
+        state::leave_stopping_if_owned(&state, generation);
+        return;
+    }
     if let Some(prev) = prepend_audio {
         let (merged, merged_rms, merged_raw_rms) =
             match merge_prepend_audio(prev, captured_audio, active_gain) {

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -199,7 +199,6 @@ pub async fn transcribe_input_only(app: AppHandle, state: SharedState) -> anyhow
     }
     let gate_rms = effective_recording_rms(rms, raw_rms, active_gain);
     if captured_audio.duration_ms < MIN_RECORDING_MS || gate_rms < min_rms {
-        state::note_sensitivity_rejection(&state);
         hide_pill(&app);
         if captured_audio.duration_ms < MIN_RECORDING_MS {
             anyhow::bail!("Recording too short");

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -209,6 +209,7 @@ pub fn start_recording_session_ex(
             let raw_level_arc = session.raw_level.clone();
             let envelope_arc = session.envelope.clone();
             let active_arc = session.active.clone();
+            let stream_error_arc = session.stream_error.clone();
             let start_cue_active = session.active.clone();
             {
                 let mut st = match lock_state(state) {
@@ -283,6 +284,12 @@ pub fn start_recording_session_ex(
                 emit_context_for_window(app, target_hwnd);
                 show_pill(app, pill_state);
             }
+            spawn_stream_error_watcher(
+                app.clone(),
+                state.clone(),
+                stream_error_arc,
+                active_arc.clone(),
+            );
             spawn_level_emitter(
                 app.clone(),
                 level_arc,
@@ -366,8 +373,17 @@ pub async fn cancel_recording_with_resume(
         audio: mut captured_audio,
         mut rms,
         mut raw_rms,
+        stream_error,
         ..
     } = stopped_capture;
+    if stream_error {
+        super::failover::abandon_live();
+        if state_is_idle(state) {
+            super::show_error_pill(app, super::stages_transcription::AUDIO_STREAM_ERROR_MESSAGE)
+                .await;
+        }
+        return;
+    }
 
     let active_gain = store::settings_snapshot(app)
         .map(|s| store::load_audio_config(&s).mic_gain)
@@ -535,6 +551,28 @@ pub(crate) fn release_starting_reservation(state: &SharedState) {
     if matches!(st.lifecycle, DictationLifecycle::Starting { .. }) {
         st.lifecycle = DictationLifecycle::Idle;
     }
+}
+
+fn spawn_stream_error_watcher(
+    app: AppHandle,
+    state: SharedState,
+    stream_error: Arc<std::sync::atomic::AtomicBool>,
+    active: Arc<std::sync::atomic::AtomicBool>,
+) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            if stream_error.load(Ordering::Acquire) {
+                log::warn!("pipeline: input stream ended unexpectedly; stopping the active dictation");
+                crate::core::hotkey::set_handless_active(false);
+                super::run_pipeline(app, state).await;
+                break;
+            }
+            if !active.load(Ordering::Acquire) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    });
 }
 
 /// Spawns a Tokio task that emits `audio-level` events to the pill every 50ms

--- a/src-tauri/src/pipeline/stages_transcription.rs
+++ b/src-tauri/src/pipeline/stages_transcription.rs
@@ -23,7 +23,11 @@ pub(crate) struct StoppedCapture {
     pub(crate) rms: f32,
     pub(crate) raw_rms: f32,
     pub(crate) recovery_write_failed: bool,
+    pub(crate) stream_error: bool,
 }
+
+pub(crate) const AUDIO_STREAM_ERROR_MESSAGE: &str =
+    "Microphone input stopped unexpectedly. Check that your microphone is connected, then try again.";
 
 fn disable_recovery_after_write_failure(app: &AppHandle) {
     super::failover::abandon_live();
@@ -71,6 +75,9 @@ pub(super) async fn stop_and_capture_audio(
     };
     match termination {
         audio::RecordingTermination::Complete => {}
+        audio::RecordingTermination::StreamError => {
+            log::warn!("pipeline: microphone input stream stopped unexpectedly");
+        }
         audio::RecordingTermination::DurationLimit => {
             log::warn!(
                 "pipeline: rejected recording that exceeded max duration limit max_seconds={}",
@@ -111,6 +118,7 @@ pub(super) async fn stop_and_capture_audio(
         rms,
         raw_rms,
         recovery_write_failed: termination == audio::RecordingTermination::RecoveryWriteFailed,
+        stream_error: termination == audio::RecordingTermination::StreamError,
     })
 }
 


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app: hotkey hold -> audio capture -> transcription -> cleanup -> injection
> - The affected subsystem is native audio capture and the recording pipeline that drives the floating pill
> - CPAL can report that the selected input device disappeared while the session remains in the recording lifecycle
> - The stale lifecycle leaves the pill looking frozen and later misclassifies the captured prefix as a normal too-short recording
> - This pull request latches stream failure on the audio side and lets an async watcher terminate the session and surface the real microphone error
> - The benefit is prompt recovery with an actionable error instead of a stuck hands-free recording

## What Changed

- Latch CPAL input-stream errors without blocking the audio callback, stop accepting the dead stream, and classify the resulting capture as StreamError.
- Watch the latched error asynchronously, stop hands-free mode, finish the pipeline cleanup, abandon recovery state, and show a microphone-specific error pill.
- Preserve the error classification through transcription and cancellation paths so it cannot fall through to the normal too-short rejection.

## Verification

- npm run check
- cargo check --manifest-path src-tauri/Cargo.toml --lib
- cargo test --manifest-path src-tauri/Cargo.toml --lib pipeline::tests:: --no-fail-fast (69 passed)
- cargo test --manifest-path src-tauri/Cargo.toml --lib media::audio::tests --no-fail-fast (7 passed)
- Physical microphone unplug/reconnect test was not available in this environment.
- Full cargo check was not clean because the unrelated dirty workspace still has an existing missing start_storage_maintenance symbol in src-tauri/src/main.rs.

## Risks

Low risk. The change only adds an atomic error signal and asynchronous cleanup around the existing capture lifecycle. A real device removal now shows an error instead of attempting to transcribe a partial recording.

## Model Used

OpenAI, GPT-5.6-luna, high reasoning effort, tool use.

## Checklist

- [x] This PR targets master directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked docs/ROADMAP.md; this PR does not duplicate planned work
- [x] npm run check passes
- [ ] npm run lint passes (not run; unrelated workspace state is noisy)
- [x] Focused Rust tests pass
- [ ] Smoke tests pass (not run; no UI contract changed)
- [ ] Tests added or updated where applicable (existing focused coverage used)
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated in the PR description
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791504618&installation_model_id=432577&pr_number=379&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F379&signature=792ce3395bff08ba7ebfbd7a3f257198a457ee2f296c80f85884ebbfc04233bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->