### PR TITLE
Add live audio confidence HUD to dictation pill

### DIFF
--- a/src-tauri/src/media/audio.rs
+++ b/src-tauri/src/media/audio.rs
@@ -196,6 +196,9 @@ pub struct RecordingSession {
     pub raw_level: Arc<AtomicU32>,
     pub envelope: Arc<EnvelopeTap>,
     pub active: Arc<AtomicBool>,
+    /// Latched by the audio worker when live VAD or its RMS fallback hears
+    /// speech in the current recording.
+    pub speech_detected: Arc<AtomicBool>,
     /// Set by CPAL's stream-error callback. The callback must not block or
     /// touch lifecycle state; the pill/session watcher consumes this flag on
     /// the async side and ends the recording cleanly.
@@ -390,6 +393,7 @@ impl RecordingSession {
         let raw_level = Arc::new(AtomicU32::new(0f32.to_bits()));
         let envelope = Arc::new(EnvelopeTap::new());
         let active = Arc::new(AtomicBool::new(true));
+        let speech_detected = Arc::new(AtomicBool::new(false));
         let stream_error = Arc::new(AtomicBool::new(false));
         let display_gain = (DISPLAY_GAIN * gain).max(0.0);
 
@@ -397,6 +401,7 @@ impl RecordingSession {
         let raw_level_w = Arc::clone(&raw_level);
         let envelope_w = Arc::clone(&envelope);
         let active_w = Arc::clone(&active);
+        let speech_detected_w = Arc::clone(&speech_detected);
         let stream_error_w = Arc::clone(&stream_error);
         envelope_w.set_sample_rate(sample_rate);
         // `processed` already contains the configured microphone gain. Keep
@@ -435,6 +440,13 @@ impl RecordingSession {
                 } else {
                     None
                 };
+                let mut live_vad = crate::media::vad::LiveSpeechDetector::new(gain);
+                let speech_detected_worker = Arc::clone(&speech_detected_w);
+                let mut update_live_speech = |samples: &[f32]| {
+                    if !speech_detected_worker.load(Ordering::Acquire) && live_vad.push(samples) {
+                        speech_detected_worker.store(true, Ordering::Release);
+                    }
+                };
 
                 let mut observed_wake = worker_wake.sequence.load(Ordering::Acquire);
                 loop {
@@ -465,6 +477,7 @@ impl RecordingSession {
                         let before_len = samples_16k.len();
                         let duration_limit =
                             resampler.push(&processed_batch, &mut samples_16k, max_output_samples);
+                        update_live_speech(&samples_16k[before_len..]);
                         if duration_limit {
                             termination = RecordingTermination::DurationLimit;
                         }
@@ -515,10 +528,13 @@ impl RecordingSession {
                     {
                         termination = RecordingTermination::DurationLimit;
                     }
-                    if termination == RecordingTermination::Complete
-                        && resampler.finish(&mut samples_16k, max_output_samples)
-                    {
-                        termination = RecordingTermination::DurationLimit;
+                    update_live_speech(&samples_16k[before_len..]);
+                    if termination == RecordingTermination::Complete {
+                        let before_len = samples_16k.len();
+                        if resampler.finish(&mut samples_16k, max_output_samples) {
+                            termination = RecordingTermination::DurationLimit;
+                        }
+                        update_live_speech(&samples_16k[before_len..]);
                     }
                     if let Some(sink) = durable.as_mut() {
                         if sink.extend(&samples_16k[before_len..]).is_err() {
@@ -685,6 +701,7 @@ impl RecordingSession {
             raw_level,
             envelope,
             active,
+            speech_detected,
             stream_error,
         })
     }

--- a/src-tauri/src/media/vad.rs
+++ b/src-tauri/src/media/vad.rs
@@ -36,6 +36,23 @@ const MIN_SPEECH_MS_BASE: u64 = 300;
 const MIN_SPEECH_RATIO_BASE: f32 = 0.12;
 const MIN_LONGEST_RUN_MS_BASE: u64 = 250;
 
+fn speech_evidence_passes(
+    speech_ms: u64,
+    total_ms: u64,
+    longest_run_ms: u64,
+    min_speech_ms: u64,
+    min_speech_ratio: f32,
+    min_longest_run_ms: u64,
+) -> bool {
+    if total_ms == 0 {
+        return false;
+    }
+
+    let speech_ratio = speech_ms as f32 / total_ms as f32;
+    speech_ms >= min_speech_ms
+        && (speech_ratio >= min_speech_ratio || longest_run_ms >= min_longest_run_ms)
+}
+
 /// The Silero v4 ONNX model, bundled directly into the binary. At ~1.8MB
 /// this is small enough that shipping it as a Tauri bundle resource (with
 /// its own resource-path resolution at runtime) isn't worth the extra
@@ -127,6 +144,128 @@ fn staged_model_matches(path: &std::path::Path) -> bool {
     bytes.as_slice() == MODEL_BYTES
 }
 
+/// Streaming speech detector for the active recording. It shares the same
+/// Silero model, frame size, and evidence thresholds as the final
+/// recording-wide VAD, but evaluates them incrementally so the pill can
+/// acknowledge speech without waiting for the recording to stop. Requiring
+/// the aggregate gate here is intentional: a monitor bump or a hard breath
+/// can look speech-like for one frame, but should not earn a checkmark.
+pub struct LiveSpeechDetector {
+    #[cfg(not(target_os = "android"))]
+    vad: Option<transcribe_rs::vad::SileroVad>,
+    frame: Vec<f32>,
+    fallback_rms: f32,
+    total_ms: u64,
+    speech_ms: u64,
+    current_run_ms: u64,
+    longest_run_ms: u64,
+    min_speech_ms: u64,
+    min_speech_ratio: f32,
+    min_longest_run_ms: u64,
+}
+
+impl LiveSpeechDetector {
+    pub fn new(active_gain: f32) -> Self {
+        #[cfg(not(target_os = "android"))]
+        let vad = match staged_model_path() {
+            Ok(path) => {
+                match transcribe_rs::vad::SileroVad::new(&path, SPEECH_PROBABILITY_THRESHOLD) {
+                    Ok(vad) => Some(vad),
+                    Err(error) => {
+                        log::warn!("live VAD unavailable, using the RMS fallback: {error}");
+                        None
+                    }
+                }
+            }
+            Err(error) => {
+                log::warn!("live VAD model unavailable, using the RMS fallback: {error}");
+                None
+            }
+        };
+
+        let scale = gain_leniency_scale(active_gain);
+
+        Self {
+            #[cfg(not(target_os = "android"))]
+            vad,
+            frame: Vec::with_capacity(FRAME_SAMPLES * 2),
+            fallback_rms: live_fallback_rms(active_gain),
+            total_ms: 0,
+            speech_ms: 0,
+            current_run_ms: 0,
+            longest_run_ms: 0,
+            min_speech_ms: (MIN_SPEECH_MS_BASE as f32 * scale) as u64,
+            min_speech_ratio: MIN_SPEECH_RATIO_BASE * scale,
+            min_longest_run_ms: (MIN_LONGEST_RUN_MS_BASE as f32 * scale) as u64,
+        }
+    }
+
+    /// Feeds processed 16 kHz samples and returns true once the same evidence
+    /// gate used after recording has passed. The caller can keep the result
+    /// latched for the rest of the recording.
+    pub fn push(&mut self, samples_16k: &[f32]) -> bool {
+        self.frame.extend_from_slice(samples_16k);
+        while self.frame.len() >= FRAME_SAMPLES {
+            let frame = &self.frame[..FRAME_SAMPLES];
+            let fallback_detected = crate::media::audio::rms_f32(frame) >= self.fallback_rms;
+
+            #[cfg(not(target_os = "android"))]
+            let detected = {
+                let probability = self.vad.as_mut().map(|vad| vad.speech_probability(frame));
+                match probability {
+                    Some(Ok(probability)) => probability >= SPEECH_PROBABILITY_THRESHOLD,
+                    Some(Err(error)) => {
+                        log::warn!(
+                            "live VAD inference failed, switching to the RMS fallback: {error}"
+                        );
+                        self.vad = None;
+                        fallback_detected
+                    }
+                    None => fallback_detected,
+                }
+            };
+
+            #[cfg(target_os = "android")]
+            let detected = fallback_detected;
+
+            self.frame.drain(..FRAME_SAMPLES);
+            self.total_ms += FRAME_MS;
+            if detected {
+                self.speech_ms += FRAME_MS;
+                self.current_run_ms += FRAME_MS;
+                self.longest_run_ms = self.longest_run_ms.max(self.current_run_ms);
+            } else {
+                self.current_run_ms = 0;
+            }
+
+            if speech_evidence_passes(
+                self.speech_ms,
+                self.total_ms,
+                self.longest_run_ms,
+                self.min_speech_ms,
+                self.min_speech_ratio,
+                self.min_longest_run_ms,
+            ) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Mirrors the recording gate's gain normalization for the live fallback.
+/// The processed samples already include the configured gain, so the fallback
+/// threshold must move with that gain to avoid penalizing a quiet microphone.
+fn live_fallback_rms(active_gain: f32) -> f32 {
+    const BASE_RMS: f32 = 0.005;
+    let gain = active_gain.clamp(store::MIN_MIC_GAIN, store::MAX_MIC_GAIN);
+    if gain <= store::DEFAULT_MIC_GAIN {
+        BASE_RMS * gain / store::DEFAULT_MIC_GAIN
+    } else {
+        BASE_RMS * store::DEFAULT_MIC_GAIN / gain
+    }
+}
+
 /// Scales how lenient the speech thresholds are with the active mic gain,
 /// mirroring `pipeline::gates::recording_gate_rms`'s normalization: a user
 /// who raised gain for a quiet voice or a distant mic already told the app
@@ -180,23 +319,21 @@ pub fn analyze_speech_with_sensitivity(
     }
 
     let total_ms = frame_count * FRAME_MS;
-    let speech_ratio = if total_ms > 0 {
-        speech_ms as f32 / total_ms as f32
-    } else {
-        0.0
-    };
-
     let scale = gain_leniency_scale(active_gain) * adaptive_scale;
     let min_speech_ms = (MIN_SPEECH_MS_BASE as f32 * scale) as u64;
     let min_ratio = MIN_SPEECH_RATIO_BASE * scale;
     let min_longest_run_ms = (MIN_LONGEST_RUN_MS_BASE as f32 * scale) as u64;
 
-    let contains_speech = speech_ms >= min_speech_ms
-        && (speech_ratio >= min_ratio || longest_run_ms >= min_longest_run_ms);
+    let contains_speech = speech_evidence_passes(
+        speech_ms,
+        total_ms,
+        longest_run_ms,
+        min_speech_ms,
+        min_ratio,
+        min_longest_run_ms,
+    );
 
-    Ok(SpeechDetectionResult {
-        contains_speech,
-    })
+    Ok(SpeechDetectionResult { contains_speech })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/pipeline/pill.rs
+++ b/src-tauri/src/pipeline/pill.rs
@@ -102,9 +102,10 @@ fn harden_pill_window<R: Runtime>(pill: &WebviewWindow<R>) {
             DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
         },
         UI::WindowsAndMessaging::{
-            GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, HWND_TOPMOST,
-            SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, WS_EX_APPWINDOW,
-            WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+            GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, GWL_EXSTYLE, GWL_STYLE,
+            HWND_TOPMOST, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, WS_CAPTION,
+            WS_EX_APPWINDOW, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
+            WS_SYSMENU, WS_THICKFRAME,
         },
     };
 
@@ -139,6 +140,29 @@ fn harden_pill_window<R: Runtime>(pill: &WebviewWindow<R>) {
 
         if desired != current {
             let _ = SetWindowLongPtrW(hwnd, GWL_EXSTYLE, desired);
+        }
+
+        // Tauri creates this window borderless, but a later WebView2 hit-test
+        // transition can make tao reapply caption styles. Remove every native
+        // frame bit defensively so clicking the transparent area can never
+        // expose a title bar, close button, or resize border around the pill.
+        SetLastError(WIN32_ERROR(0));
+        let current_style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        if current_style == 0 {
+            let err = GetLastError();
+            if err != WIN32_ERROR(0) {
+                log::warn!("Failed to read pill window styles: {err:?}");
+            }
+        } else {
+            let frame_bits = WS_CAPTION.0 as isize
+                | WS_THICKFRAME.0 as isize
+                | WS_SYSMENU.0 as isize
+                | WS_MINIMIZEBOX.0 as isize
+                | WS_MAXIMIZEBOX.0 as isize;
+            let desired_style = current_style & !frame_bits;
+            if desired_style != current_style {
+                let _ = SetWindowLongPtrW(hwnd, GWL_STYLE, desired_style);
+            }
         }
 
         let _ = SetWindowPos(
@@ -276,6 +300,8 @@ fn reveal_pill(app: &AppHandle, pill: &WebviewWindow, state: &str, message: Opti
     // Keep this list limited to states that actually render a live control.
     let has_clickable_buttons = pill_state_has_clickable_buttons(state);
     pill.set_ignore_cursor_events(!has_clickable_buttons).ok();
+    pill.set_decorations(false).ok();
+    harden_pill_window(pill);
     // Re-assert every reveal, not just once at window creation: WebView2 has
     // been observed repainting its surface opaque again when the window
     // flips between click-through and interactive (exactly what toggling
@@ -425,6 +451,8 @@ pub(crate) fn hide_pill(app: &AppHandle) {
         // before WebView2 wakes up, causing only "processing" to appear.
         // The pill window is transparent + click-through in idle state, so
         // leaving it visible has no user-visible effect.
+        pill.set_decorations(false).ok();
+        harden_pill_window(&pill);
     }
 }
 

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -642,7 +642,6 @@ pub fn spawn_level_emitter(
             }
         };
 
-        let _speech_emitted = false;
         loop {
             if !active.load(Ordering::Relaxed) {
                 break;

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -206,6 +206,7 @@ pub fn start_recording_session_ex(
             let raw_level_arc = session.raw_level.clone();
             let envelope_arc = session.envelope.clone();
             let active_arc = session.active.clone();
+            let speech_detected_arc = session.speech_detected.clone();
             let stream_error_arc = session.stream_error.clone();
             let start_cue_active = session.active.clone();
             {
@@ -294,6 +295,7 @@ pub fn start_recording_session_ex(
                 raw_level_arc,
                 envelope_arc,
                 active_arc,
+                speech_detected_arc,
                 options.emit_globally,
             );
             if let Some(session_id) = exclusive_mic_session_id {
@@ -589,6 +591,7 @@ pub fn spawn_level_emitter(
     raw_level: Arc<std::sync::atomic::AtomicU32>,
     envelope: Arc<crate::media::audio::EnvelopeTap>,
     active: Arc<std::sync::atomic::AtomicBool>,
+    speech_detected: Arc<std::sync::atomic::AtomicBool>,
     emit_globally: bool,
 ) {
     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -601,10 +601,10 @@ pub fn spawn_level_emitter(
 
         let emit_raw_level = || {
             let raw_level_val = f32::from_bits(raw_level.load(Ordering::Relaxed));
-            if emit_globally {
-                let _ = app.emit("audio-level-raw", raw_level_val);
-            } else if let Some(pill) = app.get_webview_window("pill") {
-                pill.emit("audio-level-raw", raw_level_val).ok();
+            if !emit_globally {
+                if let Some(pill) = app.get_webview_window("pill") {
+                    pill.emit("audio-level-raw", raw_level_val).ok();
+                }
             }
         };
 

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -604,6 +604,22 @@ pub fn spawn_level_emitter(
             }
         };
 
+        let emit_raw_level = |raw_level_val: f32| {
+            if emit_globally {
+                let _ = app.emit("audio-level-raw", raw_level_val);
+            } else if let Some(pill) = app.get_webview_window("pill") {
+                pill.emit("audio-level-raw", raw_level_val).ok();
+            }
+        };
+
+        let emit_speech_detected = || {
+            if emit_globally {
+                let _ = app.emit("pill-speech-detected", ());
+            } else if let Some(pill) = app.get_webview_window("pill") {
+                pill.emit("pill-speech-detected", ()).ok();
+            }
+        };
+
         // The pill is the only consumer of the envelope, so this never goes out
         // globally even when the level does -- no other window needs 100
         // floats a second.

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -635,6 +635,7 @@ pub fn spawn_level_emitter(
             }
         };
 
+        let mut speech_emitted = false;
         loop {
             if !active.load(Ordering::Relaxed) {
                 break;

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -599,15 +599,8 @@ pub fn spawn_level_emitter(
         // "recording" state event before we flood the IPC with 16ms updates.
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
 
-        let emit_level = |level_val: f32| {
-            if emit_globally {
-                let _ = app.emit("audio-level", level_val);
-            } else if let Some(pill) = app.get_webview_window("pill") {
-                pill.emit("audio-level", level_val).ok();
-            }
-        };
-
-        let emit_raw_level = |raw_level_val: f32| {
+        let emit_raw_level = || {
+            let raw_level_val = f32::from_bits(raw_level.load(Ordering::Relaxed));
             if emit_globally {
                 let _ = app.emit("audio-level-raw", raw_level_val);
             } else if let Some(pill) = app.get_webview_window("pill") {
@@ -621,6 +614,20 @@ pub fn spawn_level_emitter(
             } else if let Some(pill) = app.get_webview_window("pill") {
                 pill.emit("pill-speech-detected", ()).ok();
             }
+        };
+
+        let mut speech_emitted = false;
+        let mut emit_level = |level_val: f32| {
+            if !speech_emitted && speech_detected.load(Ordering::Acquire) {
+                emit_speech_detected();
+                speech_emitted = true;
+            }
+            if emit_globally {
+                let _ = app.emit("audio-level", level_val);
+            } else if let Some(pill) = app.get_webview_window("pill") {
+                pill.emit("audio-level", level_val).ok();
+            }
+            emit_raw_level();
         };
 
         // The pill is the only consumer of the envelope, so this never goes out

--- a/src-tauri/src/pipeline/session.rs
+++ b/src-tauri/src/pipeline/session.rs
@@ -642,7 +642,7 @@ pub fn spawn_level_emitter(
             }
         };
 
-        let mut speech_emitted = false;
+        let _speech_emitted = false;
         loop {
             if !active.load(Ordering::Relaxed) {
                 break;

--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { fly } from 'svelte/transition';
   import { BARS, createPillVisualizer } from './lib/pillVisualizer';
   import AgentAccessibilityDump from './lib/components/AgentAccessibilityDump.svelte';
 
@@ -35,12 +36,241 @@
   // Delayed notification controls enable cursor events when they mount.
   async function setPillInteractive(interactive: boolean) {
     const { getCurrentWindow } = await import('@tauri-apps/api/window');
-    await getCurrentWindow().setIgnoreCursorEvents(!interactive).catch(() => {});
+    const pillWindow = getCurrentWindow();
+    await pillWindow.setIgnoreCursorEvents(!interactive).catch(() => {});
+    // The pill is always a borderless overlay. Reassert this after changing
+    // hit-testing because WebView2/tao can restore the native frame while the
+    // window is being switched back to an interactive surface.
+    await pillWindow.setDecorations(false).catch(() => {});
   }
 
   // Resolved context for the current dictation (e.g. "Slack", "Everywhere") —
   // where the text is headed, emitted by the backend's own resolution.
   let contextLabel: string | null = null;
+
+  type AudioStatus = 'starting' | 'healthy' | 'weak' | 'unheard' | 'muted';
+  const AUDIO_START_GRACE_MS = 800;
+  const AUDIO_ZERO_DEBOUNCE_MS = 600;
+  // A candidate status (weak/unheard, mainly) must stay the desired value for
+  // this whole window before it's shown — not just "500ms since the last
+  // switch". The old cooldown only rate-limited commits, so a level hovering
+  // near the weak/unheard threshold still flipped the icon every time the
+  // cooldown expired. Requiring the SAME candidate to persist the full
+  // duration kills that chatter outright. Healthy (via `immediate`) and muted
+  // exit still bypass this — see requestAudioStatus.
+  const AUDIO_STATUS_STABLE_MS = 900;
+  const AUDIO_ZERO_RMS = 0.00001;
+  const AUDIO_MIN_SIGNAL_RMS = 0.0008;
+  const AUDIO_NOISE_SEED_RMS = 0.0002;
+  const AUDIO_NOISE_MULTIPLIER = 2.5;
+
+  let audioStatus: AudioStatus = 'starting';
+  let speechDetected = false;
+  let audioIconEverShown = false;
+  let rawAudioLevel = 0;
+  let zeroInputConfirmed = false;
+  let audioNoiseFloor = AUDIO_NOISE_SEED_RMS;
+  let audioSessionStartedAt = 0;
+  let audioGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  let audioZeroTimer: ReturnType<typeof setTimeout> | null = null;
+  let audioStatusCooldownTimer: ReturnType<typeof setTimeout> | null = null;
+  // The status a non-immediate switch is waiting to confirm, and when it
+  // first became the desired value — reset whenever the desired value
+  // changes, so only a value that holds steady for AUDIO_STATUS_STABLE_MS
+  // straight ever gets shown.
+  let audioStatusCandidate: AudioStatus | null = null;
+  let audioStatusCandidateAt = 0;
+
+  const isAudioState = (value: PillState) => value === 'recording' || value === 'handsfree';
+
+  // Checked fresh per-transition (Svelte re-evaluates a `duration` function at
+  // the moment a transition starts), not cached — the user can flip the OS
+  // setting while the pill is open.
+  const reducedMotion = () =>
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  // Matches the rest of the pill's motion language (see pillIn/audioStatusRoll)
+  // rather than fly's default linear ease, so the icon roll doesn't feel like
+  // a different animation system from everything around it.
+  const rollEase = (t: number) => 1 - Math.pow(1 - t, 3);
+
+  function clearAudioStatusTimers() {
+    if (audioGraceTimer) {
+      clearTimeout(audioGraceTimer);
+      audioGraceTimer = null;
+    }
+    if (audioZeroTimer) {
+      clearTimeout(audioZeroTimer);
+      audioZeroTimer = null;
+    }
+    if (audioStatusCooldownTimer) {
+      clearTimeout(audioStatusCooldownTimer);
+      audioStatusCooldownTimer = null;
+    }
+  }
+
+  function resetAudioStatus() {
+    clearAudioStatusTimers();
+    audioStatus = 'starting';
+    speechDetected = false;
+    rawAudioLevel = 0;
+    zeroInputConfirmed = false;
+    audioNoiseFloor = AUDIO_NOISE_SEED_RMS;
+    audioSessionStartedAt = performance.now();
+    audioStatusCandidate = null;
+    audioGraceTimer = setTimeout(() => {
+      audioGraceTimer = null;
+      refreshAudioStatus();
+    }, AUDIO_START_GRACE_MS);
+  }
+
+  function clearAudioStatus() {
+    clearAudioStatusTimers();
+    audioStatus = 'starting';
+    speechDetected = false;
+    rawAudioLevel = 0;
+    zeroInputConfirmed = false;
+    audioNoiseFloor = AUDIO_NOISE_SEED_RMS;
+    audioSessionStartedAt = 0;
+    audioStatusCandidate = null;
+  }
+
+  function updateNoiseFloor(level: number) {
+    const followRate = level < audioNoiseFloor ? 0.25 : 0.03;
+    audioNoiseFloor += (level - audioNoiseFloor) * followRate;
+  }
+
+  function meaningfulAudioLevel(level: number) {
+    return level >= Math.max(AUDIO_MIN_SIGNAL_RMS, audioNoiseFloor * AUDIO_NOISE_MULTIPLIER);
+  }
+
+  function desiredAudioStatus(now = performance.now()): AudioStatus {
+    if (!speechDetected && audioSessionStartedAt > 0 && now - audioSessionStartedAt < AUDIO_START_GRACE_MS) {
+      return 'starting';
+    }
+    if (zeroInputConfirmed) return 'muted';
+    if (speechDetected) return 'healthy';
+    return meaningfulAudioLevel(rawAudioLevel) ? 'weak' : 'unheard';
+  }
+
+  function commitAudioStatus(next: AudioStatus) {
+    audioStatusCandidate = null;
+    if (audioStatusCooldownTimer) {
+      clearTimeout(audioStatusCooldownTimer);
+      audioStatusCooldownTimer = null;
+    }
+    if (audioStatus === next) return;
+    audioStatus = next;
+  }
+
+  function requestAudioStatus(next: AudioStatus, immediate = false) {
+    if (!isAudioState(state) || next === audioStatus) {
+      audioStatusCandidate = null;
+      if (audioStatusCooldownTimer) {
+        clearTimeout(audioStatusCooldownTimer);
+        audioStatusCooldownTimer = null;
+      }
+      return;
+    }
+
+    if (immediate) {
+      commitAudioStatus(next);
+      return;
+    }
+
+    const now = performance.now();
+    if (audioStatusCandidate !== next) {
+      // The desired value just changed — restart the stability window rather
+      // than crediting time the PREVIOUS candidate accrued.
+      audioStatusCandidate = next;
+      audioStatusCandidateAt = now;
+    }
+    const elapsed = now - audioStatusCandidateAt;
+    if (elapsed >= AUDIO_STATUS_STABLE_MS) {
+      commitAudioStatus(next);
+      return;
+    }
+
+    if (audioStatusCooldownTimer) return;
+    audioStatusCooldownTimer = setTimeout(() => {
+      audioStatusCooldownTimer = null;
+      refreshAudioStatus();
+    }, AUDIO_STATUS_STABLE_MS - elapsed);
+  }
+
+  function refreshAudioStatus(immediate = false) {
+    if (!isAudioState(state)) return;
+    requestAudioStatus(desiredAudioStatus(), immediate);
+  }
+
+  function onRawAudioLevel(level: number) {
+    if (!isAudioState(state)) return;
+    const nextLevel = Number.isFinite(level) ? Math.max(0, level) : 0;
+    rawAudioLevel = nextLevel;
+
+    if (nextLevel <= AUDIO_ZERO_RMS) {
+      if (!audioZeroTimer) {
+        audioZeroTimer = setTimeout(() => {
+          audioZeroTimer = null;
+          if (isAudioState(state) && rawAudioLevel <= AUDIO_ZERO_RMS) {
+            zeroInputConfirmed = true;
+            // AUDIO_ZERO_DEBOUNCE_MS already confirmed this is a real mute,
+            // not a dip — showing it promptly (rather than queueing behind
+            // the weak/unheard stability window too) is the point of a mute
+            // indicator: the user needs to know their mic went silent now.
+            refreshAudioStatus(true);
+          }
+        }, AUDIO_ZERO_DEBOUNCE_MS);
+      }
+      return;
+    }
+
+    if (audioZeroTimer) {
+      clearTimeout(audioZeroTimer);
+      audioZeroTimer = null;
+    }
+    zeroInputConfirmed = false;
+    if (!speechDetected) updateNoiseFloor(nextLevel);
+
+    // A confirmed utterance remains healthy through normal pauses, but a
+    // previously muted microphone should recover immediately when signal
+    // returns. The general status cooldown still protects the other states
+    // from rapid level/VAD chatter.
+    refreshAudioStatus(speechDetected && audioStatus === 'muted');
+  }
+
+  function onSpeechDetected() {
+    if (!isAudioState(state)) return;
+    if (audioZeroTimer) {
+      clearTimeout(audioZeroTimer);
+      audioZeroTimer = null;
+    }
+    zeroInputConfirmed = false;
+    speechDetected = true;
+    refreshAudioStatus(true);
+  }
+
+  function audioStatusDescription(status: AudioStatus) {
+    switch (status) {
+      case 'healthy': return 'Speech detected';
+      case 'weak': return 'Audio is present, but speech detection is marginal';
+      case 'unheard': return 'Speech has not been detected';
+      case 'muted': return 'No microphone input';
+      default: return 'Listening for speech';
+    }
+  }
+
+  $: recordingAudioActive = isAudioState(state);
+  // Sticky once true for the rest of this dictation, so the audio-status
+  // track stays mounted (and can play its width-collapse transition) through
+  // recording -> processing/loading, instead of the `{#if recordingAudioActive}`
+  // block simply unmounting it the instant recording ends. Never explicitly
+  // reset — the next dictation sets it again the moment it starts recording,
+  // and a stale `true` between dictations is harmless (the track only
+  // renders inside the context chip, which needs its own condition to show).
+  $: if (recordingAudioActive) audioIconEverShown = true;
+  $: pillContextTitle = recordingAudioActive
+    ? `${contextLabel ? `${contextLabel}. ` : ''}${audioStatusDescription(audioStatus)}`
+    : contextLabel ?? '';
 
   // Processing sub-stage ("Transcribing…" / "Cleaning…" / "Pasting…"), driven
   // by real `pill-stage` events from the pipeline. Rows for the stages that
@@ -414,6 +644,7 @@
       state = 'idle';
       clearStage();
       contextLabel = null;
+      clearAudioStatus();
       resetVisualizer();
       errOpen = false;
       errWidth = 0;
@@ -587,6 +818,9 @@
         }
         if (incoming === 'recording') {
           contextLabel = null;
+          if (!isAudioState(state)) resetAudioStatus();
+        } else if (incoming === 'handsfree') {
+          if (!isAudioState(state)) resetAudioStatus();
         } else if (
           incoming === 'error' ||
           incoming === 'cancelled' ||
@@ -596,6 +830,9 @@
         ) {
           clearStage();
           contextLabel = null;
+        }
+        if (incoming !== 'recording' && incoming !== 'handsfree' && incoming !== 'idle') {
+          clearAudioStatus();
         }
 
         if (incoming === 'idle' && state !== 'idle') {
@@ -767,6 +1004,18 @@
       if (!mounted) { l3(); return; }
       unlisteners.push(l3);
 
+      const l7 = await listen<number>('audio-level-raw', (ev) => {
+        onRawAudioLevel(ev.payload ?? 0);
+      });
+      if (!mounted) { l7(); return; }
+      unlisteners.push(l7);
+
+      const l8 = await listen('pill-speech-detected', () => {
+        onSpeechDetected();
+      });
+      if (!mounted) { l8(); return; }
+      unlisteners.push(l8);
+
       const l5 = await listen<string>('pill-context', (ev) => {
         const name = ev.payload?.trim();
         contextLabel = name ? name : null;
@@ -811,6 +1060,7 @@
       if (pasteFailedDismissTimer) clearTimeout(pasteFailedDismissTimer);
       if (copiedTimer) clearTimeout(copiedTimer);
       if (copiedPillTimer) clearTimeout(copiedPillTimer);
+      clearAudioStatusTimers();
       unlisteners.forEach(u => u());
     };
   });
@@ -905,6 +1155,8 @@
     prevState,
     errorMsg,
     contextLabel,
+    audioStatus,
+    speechDetected,
     stageIndex,
     seenStages,
     errOpen,
@@ -923,8 +1175,70 @@
        class:steady-width-hf={state === 'handsfree'}
        class:steady-width-cancel={isCancelLike(state)}
        bind:this={clusterEl}>
-  {#if contextLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model')}
-      <span class="pill-context" title={contextLabel}>{contextLabel}</span>
+  {#if recordingAudioActive || (contextLabel && (state === 'recording' || state === 'processing' || state === 'handsfree' || state === 'loading_local_model'))}
+      <span
+        class="pill-context"
+        class:status-only={recordingAudioActive && !contextLabel}
+        class:audio-healthy={recordingAudioActive && audioStatus === 'healthy'}
+        class:audio-weak={recordingAudioActive && audioStatus === 'weak'}
+        class:audio-unheard={recordingAudioActive && audioStatus === 'unheard'}
+        class:audio-muted={recordingAudioActive && audioStatus === 'muted'}
+        title={pillContextTitle}
+        aria-label={pillContextTitle}
+        out:fly={{ y: -4, duration: reducedMotion() ? 0 : 160 }}
+      >
+        <!-- Always mounted (once the icon has appeared once) instead of
+             gated by `{#if recordingAudioActive}` — leaving recording for
+             processing while a context label is still showing (the common
+             case) doesn't destroy this chip at all, only this condition
+             flips, so an enter/leave transition on the icon's own element
+             never got a chance to play; the icon just vanished the instant
+             the block unmounted. Collapsing its WIDTH via a class instead
+             keeps it in the DOM through the whole animation, sliding the
+             icon out to the left as its track shrinks to nothing — which
+             also reflows the label leftward over the same transition,
+             instead of the chip snapping to its new width the instant the
+             icon disappears. -->
+        {#if recordingAudioActive || audioIconEverShown}
+          <span class="pill-audio-status-track" class:audio-collapsed={!recordingAudioActive} aria-hidden="true">
+            {#key audioStatus}
+              <span
+                class="pill-audio-status"
+                in:fly={{ y: -7, duration: reducedMotion() ? 0 : 190, easing: rollEase }}
+                out:fly={{ y: 7, duration: reducedMotion() ? 0 : 150, easing: rollEase }}
+              >
+                {#if audioStatus === 'healthy'}
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"/>
+                  </svg>
+                {:else if audioStatus === 'weak'}
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <path d="M12 8v4M12 16h.01"/>
+                  </svg>
+                {:else if audioStatus === 'muted'}
+                  <!-- Compacted into the same y4-20 band the other three icons
+                       occupy (rather than the old y3-22 with a gap before a
+                       dangling foot): that gap put most of the glyph's ink
+                       above center, so it read as off-center even though its
+                       bounding box was technically balanced. -->
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="4" width="6" height="9" rx="3"/>
+                    <path d="M5 11a7 7 0 0 0 14 0M12 18v2M9 20h6M4 4l16 16"/>
+                  </svg>
+                {:else if audioStatus === 'unheard'}
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round">
+                    <path d="M18 6 6 18M6 6l12 12"/>
+                  </svg>
+                {:else}
+                  <span class="pill-audio-dot"></span>
+                {/if}
+              </span>
+            {/key}
+          </span>
+        {/if}
+        {#if contextLabel}<span class="pill-context-label">{contextLabel}</span>{/if}
+      </span>
     {/if}
 
   {#if state === 'recording'}
@@ -1221,23 +1535,121 @@
      dictation's destination stays legible without crowding or offsetting
      the pill capsule itself. Fades in softly so its appearance
      reads as the pill growing, not a new element popping in. */
-  .pill-context {
-    font-size: 10.5px;
-    font-weight: 500;
+   .pill-context {
+     display: inline-flex;
+     align-items: center;
+     justify-content: center;
+     /* No `gap` — the space between the icon track and the label is the
+        track's own margin-right instead (see .pill-audio-status-track), so
+        that space can collapse to zero in step with the track's width when
+        the icon leaves. A flex `gap` can't be transitioned per-item. */
+     font-size: 10.5px;
+     font-weight: 500;
+     /* Default (~1.4) line-height pads the text's line box with descender
+        room the icon doesn't have, so flex-centering the two against their
+        own box heights put the icon visibly higher than the text's inked
+        glyphs. A tight line-height shrinks the text box down near its actual
+        ink, so both land on the same optical center. */
+     line-height: 1;
     letter-spacing: 0.02em;
     color: var(--pill-context-fg);
     background: var(--pill-context-bg);
     box-shadow: 0 0 0 1px var(--pill-context-line) inset;
     border-radius: 999px;
-    padding: 2px 8px;
+    padding: 3px 7px;
     white-space: nowrap;
     /* Context names are user-authored and can run long — cap the chip so it
        never widens the native window (which is sized to .pill-cluster). */
     max-width: 180px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    animation: chipIn 0.18s ease-out both;
-  }
+     overflow: hidden;
+     text-overflow: ellipsis;
+     animation: chipIn 0.18s ease-out both;
+     transition: color var(--ui-duration-fast, 150ms), background-color var(--ui-duration-fast, 150ms), box-shadow var(--ui-duration-fast, 150ms);
+   }
+   .pill-context.status-only {
+     min-width: 10px;
+     padding-inline: 5px;
+   }
+   .pill-context-label {
+     min-width: 0;
+     overflow: hidden;
+     text-overflow: ellipsis;
+   }
+   /* Fixed-size clipped viewport the icon rolls through. Sized and centered
+      once here so every icon variant (healthy/weak/muted/unheard, each a
+      differently-shaped SVG) sits in exactly the same box instead of each
+      contributing its own width/height to the flex row — that per-icon size
+      drift is what read as the chip being "uneven" as it changed status. */
+   .pill-audio-status-track {
+     position: relative;
+     width: 10px;
+     height: 10px;
+     margin-right: 2px;
+     overflow: hidden;
+     /* Width (not the {#if recordingAudioActive} block it used to live
+        behind) is what now drives the icon leaving: collapsing it to 0
+        reflows the label leftward over the same transition instead of the
+        chip snapping to its new width the instant the icon's block
+        unmounts. margin-right collapses in step so no gap is left behind. */
+     transition: width 0.24s cubic-bezier(0.22, 1, 0.36, 1), margin-right 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+   }
+   .pill-audio-status-track.audio-collapsed {
+     width: 0;
+     margin-right: 0;
+   }
+   /* Absolutely positioned so the outgoing and incoming icon can overlap
+      in-place during the roll (see in:fly/out:fly on the template) instead
+      of the incoming one shifting the row's layout as it enters. */
+   .pill-audio-status {
+     position: absolute;
+     inset: 0;
+     display: flex;
+     align-items: center;
+     justify-content: center;
+     color: var(--accent);
+     transition: transform 0.24s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.2s ease;
+   }
+   /* Slides left as its track collapses around it, instead of just fading —
+      reads as the icon sliding under the label taking its place, matching
+      the direction the whole chip is shrinking in. */
+   .pill-audio-status-track.audio-collapsed .pill-audio-status {
+     transform: translateX(-100%);
+     opacity: 0;
+   }
+   .pill-audio-status svg {
+     display: block;
+   }
+   .pill-audio-dot {
+     width: 4px;
+     height: 4px;
+     border-radius: 50%;
+     background: currentColor;
+   }
+   .pill-context.audio-healthy .pill-audio-status {
+     color: var(--accent);
+   }
+   .pill-context.audio-weak .pill-audio-status {
+     color: var(--warning);
+   }
+   .pill-context.audio-unheard .pill-audio-status {
+     color: var(--danger);
+   }
+   .pill-context.audio-muted {
+     color: var(--danger);
+     background: var(--danger-bg);
+     box-shadow: 0 0 0 1px var(--danger-line) inset;
+   }
+   .pill-context.audio-muted .pill-audio-status {
+     color: currentColor;
+   }
+   @media (prefers-reduced-motion: reduce) {
+     .pill-context,
+     .pill-audio-status-track,
+     .pill-audio-status {
+       animation: none !important;
+       transition: none !important;
+     }
+   }
   @keyframes chipIn {
     from { opacity: 0; transform: translateY(-3px); }
     to   { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that captures audio, transcribes it, cleans the result, and injects text.
> - The audio and pill pipeline already has live microphone levels and local voice activity detection.
> - Users had no immediate way to tell whether speech was reaching those checks, especially when speaking quietly or after an accidental mute.
> - The mini context pill should communicate that state without blocking dictation or changing whether audio is sent.
> - This pull request connects live speech evidence to the pill and adds a small themed confidence HUD with stable state transitions.
> - The benefit is a quick visual explanation when speech is heard, marginal, missing, or muted.

## What Changed

- Added live speech evidence from the audio worker and aligned it with the final speech gate so loud non-speech noise does not produce a false confirmation.
- Added the mini-pill confidence HUD with neutral startup, the existing themed check icon, amber warning, red X, and a red-tinted muted microphone state.
- Added cooldowns and motion handling so status changes do not flicker while the microphone signal moves around a threshold.
- Kept the HUD informational only. It does not block recording, transcription, or audio submission.
- Hardened the native pill window decoration so browser or viewer chrome does not appear around the mini pill.

## Verification

- `npm run check` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --bin verenu --message-format=short` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml` passed: 744 passed, 4 ignored.
- Focused VAD tests passed: 8 passed.
- `npm run lint` was attempted, but the shared workspace includes unrelated Android changes that currently fail `-D warnings` for five dead-code items outside this PR.
- Smoke tests were not run. Manual pill testing covered quiet speech, false loud noise, and mid-dictation mute/unmute behavior.

## Risks

Low runtime risk. The change adds status reporting and reuses the existing speech decision path. It does not gate audio capture or transcription. The main risk is threshold tuning across different microphones, which is why the HUD uses cooldowns and the existing gain-aware logic.

## Model Used

OpenAI GPT-5.6-Luna, max reasoning effort, tool use.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] Checked `docs/ROADMAP.md`; this PR does not duplicate planned work
- [x] `npm run check` passes
- [ ] `npm run lint` passes; blocked locally by unrelated Android branch warnings described above
- [x] `npm run test:rust` passes
- [ ] Smoke tests were not run
- [ ] Tests added or updated where applicable; shared VAD test lines overlap another agent's branch
- [ ] UI screenshots attached
- [x] No API keys, secrets, or personal data in code or logs
- [x] Version bump not needed
- [ ] Documentation update not needed for this internal HUD
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791515661&installation_model_id=432577&pr_number=381&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F381&signature=11242beb900c86fbbd833b7c669eb0541e4c77791b63d6ca496be2be8d6ad8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->