### PR TITLE
Prevent duplicate mistranscription mappings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 - Switched the default accent from terracotta to theme-neutral black in light mode and white in dark mode. Custom accents still override the full accent scale; the Home hotkey tile keeps colored accents exact and only lifts near-black neutrals to white for contrast.
 
 - Context group app targets now survive versioned/nightly app updates by matching a close replacement name with publisher/developer evidence on Windows and macOS.
+- Prevented the same "Often mistranscribed as" variant from mapping to multiple terms in one context group, with prompt filtering for older conflicting data.
 - Reworked cleanup prompting around one default shared by every model, with explicit rule priority, conservative ambiguity handling, multilingual preservation, self-corrections and repair commands, spoken symbols and spelling, technical-token reconstruction, restrained formatting, safer number treatment, and context-assisted disambiguation.
 - **The cleanup prompt is now a single template used by every model**, edited from Clean-up → Edit prompt. It used to be stored per model, so an edit made on your default was silently ignored the moment a fallback model took over. An existing per-model edit is carried over.
 - Fixed Gemini 3 requests failing with `Thinking level MINIMAL is not supported for this model` — affected both cleanup and transcription on newer Gemini 3 flash models, which accept `low` but not `minimal`.

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -650,6 +650,17 @@ pub fn set_dictionary_context_assignment(
         anyhow::bail!("Dictionary entry {dictionary_id} was not found");
     }
     if assigned {
+        let mistake: Option<String> = conn.query_row(
+            "SELECT mistake FROM dictionary WHERE id = ?1",
+            params![dictionary_id],
+            |row| row.get(0),
+        )?;
+        check_dictionary_mistake_conflicts(
+            &conn,
+            context_id,
+            Some(dictionary_id),
+            mistake.as_deref(),
+        )?;
         conn.execute(
             "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
              VALUES (?1, ?2)",
@@ -1122,6 +1133,78 @@ mod tests {
         );
         assert_eq!(
             query_snippets_for_context(&db, context.id).unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn context_rejects_duplicate_mistranscription_variants() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "AI tools", None, None, None, None, false)
+            .expect("context");
+
+        insert_dictionary_entry_returning(&db, "@bot", Some("grok bot"), Some(context.id))
+            .expect("first dictionary entry");
+        let error =
+            insert_dictionary_entry_returning(&db, "Boot", Some("Grok Bot, bot"), Some(context.id))
+                .expect_err("duplicate variant should be rejected");
+
+        let message = error.to_string();
+        assert!(message.contains("Often mistranscribed as"));
+        assert!(message.contains("@bot"));
+        assert_eq!(
+            query_dictionary_for_context(&db, context.id).unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn editing_an_entry_checks_all_contexts_for_duplicate_variants() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "AI tools", None, None, None, None, false)
+            .expect("context");
+        let first =
+            insert_dictionary_entry_returning(&db, "@bot", Some("grok bot"), Some(context.id))
+                .expect("first dictionary entry");
+        let second =
+            insert_dictionary_entry_returning(&db, "Boot", Some("boot bot"), Some(context.id))
+                .expect("second dictionary entry");
+
+        let error = update_dictionary_entry(&db, second.id, "Boot", Some("GROK BOT"))
+            .expect_err("edit should reject duplicate variant");
+        assert!(error.to_string().contains("@bot"));
+        assert_eq!(
+            query_dictionary(&db)
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.id == first.id)
+                .and_then(|entry| entry.mistake),
+            Some("grok bot".to_string())
+        );
+    }
+
+    #[test]
+    fn assigning_an_existing_entry_checks_the_target_context() {
+        let db = open(":memory:").expect("db");
+        let source =
+            insert_context_returning(&db, "Source", None, None, None, None, false).expect("source");
+        let target =
+            insert_context_returning(&db, "Target", None, None, None, None, false).expect("target");
+        insert_dictionary_entry_returning(&db, "@bot", Some("grok bot"), Some(target.id))
+            .expect("target dictionary entry");
+        let second =
+            insert_dictionary_entry_returning(&db, "Boot", Some("grok bot"), Some(source.id))
+                .expect("source dictionary entry");
+
+        let error = set_dictionary_context_assignment(&db, target.id, second.id, true)
+            .expect_err("assignment should reject duplicate variant");
+        assert!(error.to_string().contains("@bot"));
+        assert_eq!(
+            query_dictionary_for_context(&db, target.id).unwrap().len(),
+            1
+        );
+        assert_eq!(
+            query_dictionary_for_context(&db, source.id).unwrap().len(),
             1
         );
     }

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 use super::*;
 
@@ -90,6 +91,68 @@ pub fn query_dictionary_for_context(db: &Db, context_id: i64) -> Result<Vec<Dict
     Ok(rows)
 }
 
+/// Returns the comma-separated mistranscription variants in a dictionary
+/// field. Variants are compared after trimming and case-folding, but their
+/// stored spelling is preserved for display and prompt evidence.
+pub fn dictionary_mistake_variants(mistake: &str) -> impl Iterator<Item = &str> {
+    mistake
+        .split(',')
+        .map(str::trim)
+        .filter(|variant| !variant.is_empty())
+}
+
+fn normalized_mistake_variants(mistake: Option<&str>) -> HashSet<String> {
+    mistake
+        .into_iter()
+        .flat_map(dictionary_mistake_variants)
+        .map(|variant| variant.to_lowercase())
+        .collect()
+}
+
+/// Rejects a dictionary entry when one of its mistranscription variants is
+/// already mapped to a different term in the same context group. This is
+/// intentionally checked at the database boundary because entries can enter a
+/// context through create, edit, or assignment paths.
+pub fn check_dictionary_mistake_conflicts(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    dictionary_id: Option<i64>,
+    mistake: Option<&str>,
+) -> Result<()> {
+    let candidate_variants = normalized_mistake_variants(mistake);
+    if candidate_variants.is_empty() {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT d.id, d.term, d.mistake
+         FROM dictionary d
+         INNER JOIN dictionary_contexts dc ON dc.dictionary_id = d.id
+         WHERE dc.context_id = ?1
+           AND (?2 IS NULL OR d.id != ?2)",
+    )?;
+    let rows = stmt.query_map(params![context_id, dictionary_id], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<String>>(2)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (_id, term, existing_mistake) = row?;
+        for variant in dictionary_mistake_variants(existing_mistake.as_deref().unwrap_or("")) {
+            if candidate_variants.contains(&variant.to_lowercase()) {
+                anyhow::bail!(
+                    "Often mistranscribed as \"{variant}\" already belongs to \"{term}\" in this context"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 pub fn insert_dictionary_entry(db: &Db, term: &str, mistake: Option<&str>) -> Result<()> {
     insert_dictionary_entry_returning(db, term, mistake, None)?;
@@ -152,6 +215,12 @@ pub fn insert_dictionary_entry_returning(
             if existing_mistake != normalized_mistake {
                 anyhow::bail!("\"{normalized_term}\" already exists with a different correction");
             }
+            check_dictionary_mistake_conflicts(
+                &tx,
+                target_context,
+                Some(id),
+                normalized_mistake.as_deref(),
+            )?;
             tx.execute(
                 "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
                 params![target_context, id],
@@ -166,6 +235,12 @@ pub fn insert_dictionary_entry_returning(
         }
     }
 
+    check_dictionary_mistake_conflicts(
+        &tx,
+        target_context.unwrap_or(everywhere_id),
+        None,
+        normalized_mistake.as_deref(),
+    )?;
     tx.execute(
         "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
         params![normalized_term, normalized_mistake],
@@ -698,6 +773,18 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
     }
 
     let conn = lock_conn(db)?;
+    let context_ids: Vec<i64> = conn
+        .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1")?
+        .query_map(params![id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for context_id in context_ids {
+        check_dictionary_mistake_conflicts(
+            &conn,
+            context_id,
+            Some(id),
+            normalized_mistake.as_deref(),
+        )?;
+    }
     let changed = conn.execute(
         "UPDATE dictionary SET term=?2, mistake=?3 WHERE id=?1",
         params![id, normalized_term, normalized_mistake],

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -1,5 +1,6 @@
 use crate::data::db;
 use crate::system::text::{has_distinctive_features, tokenize_lower_alnum};
+use std::collections::HashSet;
 
 const MAX_PROMPT_ENTRIES: usize = 24;
 const MAX_PROMPT_CHARS: usize = 3_000;
@@ -108,10 +109,7 @@ pub fn build_relevant_dictionary_prompt_from_sources(
 /// transcription model in more than one way, and users need to be able to
 /// list all of them against a single correct spelling.
 fn parse_dictionary_mistakes(mistake: &str) -> impl Iterator<Item = &str> {
-    mistake
-        .split(',')
-        .map(|m| m.trim())
-        .filter(|m| !m.is_empty())
+    db::dictionary_mistake_variants(mistake)
 }
 
 fn entry_match_score(
@@ -246,9 +244,10 @@ fn build_dictionary_prompt_limited<'a>(
 ) -> String {
     let header = "Vocabulary evidence (not a replacement list):";
     let mut rendered = header.to_string();
+    let mut seen_mistakes = HashSet::new();
 
     for entry in entries.take(MAX_PROMPT_ENTRIES) {
-        let line = format_dictionary_entry(entry);
+        let line = format_dictionary_entry(entry, &mut seen_mistakes);
         let candidate = format!("{rendered}\n{line}");
         if candidate.chars().count() > MAX_PROMPT_CHARS {
             break;
@@ -263,10 +262,15 @@ fn build_dictionary_prompt_limited<'a>(
     rendered
 }
 
-fn format_dictionary_entry(entry: &db::DictionaryEntry) -> String {
+fn format_dictionary_entry(
+    entry: &db::DictionaryEntry,
+    seen_mistakes: &mut HashSet<String>,
+) -> String {
     match &entry.mistake {
         Some(mistake) => {
-            let variants: Vec<&str> = parse_dictionary_mistakes(mistake).collect();
+            let variants: Vec<&str> = parse_dictionary_mistakes(mistake)
+                .filter(|variant| seen_mistakes.insert(variant.to_lowercase()))
+                .collect();
             if variants.is_empty() {
                 return format!("- known term: \"{}\"", entry.term);
             }
@@ -572,6 +576,20 @@ mod tests {
         let prompt = build_dictionary_prompt_limited(entries.iter());
         assert!(prompt.contains("\"Varinu\""));
         assert!(prompt.contains("\"Verena\""));
+    }
+
+    #[test]
+    fn prompt_keeps_only_one_term_for_a_duplicate_mistranscription_variant() {
+        let entries = [
+            entry(1, "@bot", Some("grok bot")),
+            entry(2, "Boot", Some("Grok Bot, boot bot")),
+        ];
+        let prompt = build_dictionary_prompt_limited(entries.iter());
+
+        assert_eq!(prompt.matches("\"grok bot\"").count(), 1);
+        assert!(prompt.contains("\"boot bot\""));
+        assert!(prompt.contains("@bot"));
+        assert!(prompt.contains("Boot"));
     }
 
     #[test]


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app that captures audio, transcribes it, cleans the text, and injects the result.
> - Context groups own the vocabulary sent to cleanup for the active app or website.
> - Each dictionary entry can list multiple Often mistranscribed as variants.
> - Two entries in one group could claim the same variant for different preferred terms.
> - The cleanup model would then receive contradictory evidence for the same spoken text.
> - This pull request validates variants at the database boundary and filters legacy conflicts before prompt rendering.
> - The benefit is one deterministic mapping per variant within each active context group.

## What Changed

- Added case-insensitive, comma-aware conflict validation for dictionary creation, editing, and context assignment.
- Added prompt-side filtering so older or synced conflicts do not emit the same variant for multiple terms.
- Added database and prompt regression tests.
- Documented the fix in the Unreleased changelog.

## Verification

- 
pm run check passed with zero Svelte diagnostics.
- 
pm run test:rust passed: 745 passed, 4 ignored.
- Focused duplicate-variant tests passed.
- 
pm run lint reached Clippy but is blocked by five pre-existing unused Android/logger functions in the shared workspace.
- Smoke tests were not run because this change does not alter the UI or smoke-test selectors.

## Risks

- Low risk. New entries and assignments with conflicting variants are rejected without changing existing data.
- Existing conflicts are filtered only from cleanup evidence; no user data is deleted or rewritten.

## Model Used

- OpenAI GPT-5.6-luna, high reasoning, with repository tool use.

## Checklist

- [x] This PR targets master directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked docs/ROADMAP.md - this PR does not duplicate planned work
- [x] 
pm run check passes (TypeScript)
- [ ] 
pm run lint passes (ESLint + Clippy), blocked by pre-existing unrelated warnings noted above
- [x] 
pm run test:rust passes
- [ ] Smoke tests pass (not run; no UI contract changes)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (not applicable)
- [x] No API keys, secrets, or personal data in code or logs
- [ ] If version bumped: all three files updated together (not applicable)
- [x] Relevant documentation updated to reflect changes
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791537438&installation_model_id=432577&pr_number=382&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F382&signature=3169e94ea99d77d2faf5e4ed5d30160f31ad4fae5a48f8f0c393b02f9f2eab7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->