### PR TITLE
Add Context-scoped AutoLearn data model

### DIFF
--- a/src-tauri/src/api/auto_learn.rs
+++ b/src-tauri/src/api/auto_learn.rs
@@ -257,8 +257,9 @@ mod tests {
             0.6,
         ));
 
-        let count = db::count_pending_corrections_recent(
+        let count = db::count_pending_corrections_recent_for_context(
             &db,
+            db::EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
             "Kubernetes",
             PENDING_RETENTION_DAYS,

--- a/src-tauri/src/api/auto_learn/monitor.rs
+++ b/src-tauri/src/api/auto_learn/monitor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::db::EVERYWHERE_CONTEXT_ID;
 
 static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 

--- a/src-tauri/src/api/auto_learn/monitor.rs
+++ b/src-tauri/src/api/auto_learn/monitor.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::db::EVERYWHERE_CONTEXT_ID;
 
 static ACTIVE_MONITORS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -71,13 +70,7 @@ pub(super) fn record_candidate(
     }
 
     let confidence_avg =
-        match db::upsert_auto_learn_candidate_for_context(
-            db,
-            EVERYWHERE_CONTEXT_ID,
-            &mistake,
-            &correction,
-            confidence,
-        ) {
+        match db::upsert_auto_learn_candidate(db, &mistake, &correction, confidence) {
             Ok(confidence_avg) => confidence_avg,
             Err(e) => {
                 log::warn!("auto-learn candidate upsert failed: {e}");
@@ -113,9 +106,8 @@ pub(super) fn record_candidate(
     // "promote" it (double events / inflated correction_count), and a rejection
     // that purges the candidate mid-flight can no longer be undone by an
     // in-flight promotion recreating the rejected row.
-    match db::auto_learn_promote_for_context(
+    match db::auto_learn_promote(
         db,
-        EVERYWHERE_CONTEXT_ID,
         &mistake,
         &correction,
         tier,

--- a/src-tauri/src/api/auto_learn/monitor.rs
+++ b/src-tauri/src/api/auto_learn/monitor.rs
@@ -70,7 +70,13 @@ pub(super) fn record_candidate(
     }
 
     let confidence_avg =
-        match db::upsert_auto_learn_candidate(db, &mistake, &correction, confidence) {
+        match db::upsert_auto_learn_candidate_for_context(
+            db,
+            EVERYWHERE_CONTEXT_ID,
+            &mistake,
+            &correction,
+            confidence,
+        ) {
             Ok(confidence_avg) => confidence_avg,
             Err(e) => {
                 log::warn!("auto-learn candidate upsert failed: {e}");
@@ -106,8 +112,9 @@ pub(super) fn record_candidate(
     // "promote" it (double events / inflated correction_count), and a rejection
     // that purges the candidate mid-flight can no longer be undone by an
     // in-flight promotion recreating the rejected row.
-    match db::auto_learn_promote(
+    match db::auto_learn_promote_for_context(
         db,
+        EVERYWHERE_CONTEXT_ID,
         &mistake,
         &correction,
         tier,

--- a/src-tauri/src/api/prompts/tests.rs
+++ b/src-tauri/src/api/prompts/tests.rs
@@ -100,6 +100,7 @@ fn rendered_prompt_size_is_measured_with_worst_case_selected_vocabulary() {
             confidence_tier: "manual".to_string(),
             last_seen_at: None,
             created_at: "now".to_string(),
+            corrections: Vec::new(),
         })
         .collect();
     let raw = entries

--- a/src-tauri/src/data/db/autolearn_context_tests.rs
+++ b/src-tauri/src/data/db/autolearn_context_tests.rs
@@ -546,12 +546,14 @@ fn context_event_and_backup_helpers_keep_child_mapping_metadata() {
     log_auto_learn_event_for_context(
         &db,
         context.id,
-        "candidate",
-        "test",
-        "Development",
-        "mistake-hash",
-        "correction-hash",
-        0.8,
+        AutoLearnEventFields {
+            event_type: "candidate",
+            reason_code: "test",
+            app_context: "Development",
+            mistake_hash: "mistake-hash",
+            correction_hash: "correction-hash",
+            confidence: 0.8,
+        },
     )
     .expect("context event");
     let event = get_recent_auto_learn_activity(&db, 1)

--- a/src-tauri/src/data/db/autolearn_context_tests.rs
+++ b/src-tauri/src/data/db/autolearn_context_tests.rs
@@ -597,3 +597,36 @@ fn context_event_and_backup_helpers_keep_child_mapping_metadata() {
         .expect("backup legacy projection");
     assert!(legacy_projection.is_none());
 }
+
+#[test]
+fn auto_learn_conflict_returns_blocked_without_claiming_candidate() {
+    let db = open(":memory:").expect("db");
+    let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("context");
+    insert_dictionary_entry_returning(&db, "ExistingTerm", Some("shared typo"), Some(context.id))
+        .expect("manual mapping");
+    upsert_auto_learn_candidate(&db, context.id, "shared typo", "NewTerm", 0.95)
+        .expect("candidate");
+
+    assert_eq!(
+        auto_learn_promote(&db, context.id, "shared typo", "NewTerm", "high", 2, 1)
+            .expect("promotion result"),
+        AutoLearnPromoteResult::Blocked
+    );
+
+    let conn = lock_conn(&db).expect("verification lock");
+    let promoted_at: Option<String> = conn
+        .query_row(
+            "SELECT promoted_at FROM auto_learn_candidates
+              WHERE context_id = ?1 AND wrong_word = 'shared typo' AND correct_word = 'NewTerm'",
+            params![context.id],
+            |row| row.get(0),
+        )
+        .expect("candidate row");
+    assert!(promoted_at.is_none());
+    drop(conn);
+    assert!(!query_dictionary_for_context(&db, context.id)
+        .expect("context dictionary")
+        .iter()
+        .any(|entry| entry.term == "NewTerm"));
+}

--- a/src-tauri/src/data/db/autolearn_context_tests.rs
+++ b/src-tauri/src/data/db/autolearn_context_tests.rs
@@ -273,10 +273,10 @@ fn scoped_promotion_and_rejection_preserve_shared_canonical_identity() {
         insert_context_returning(&db, "Writing", None, None, None, None, false).expect("writing");
 
     for context_id in [development.id, writing.id] {
-        upsert_auto_learn_candidate(&db, context_id, "Kubernetez", "Kubernetes", 0.6)
+        upsert_auto_learn_candidate_for_context(&db, context_id, "Kubernetez", "Kubernetes", 0.6)
             .expect("candidate");
         assert_eq!(
-            auto_learn_promote(&db, context_id, "Kubernetez", "Kubernetes", "medium", 2, 2)
+            auto_learn_promote_for_context(&db, context_id, "Kubernetez", "Kubernetes", "medium", 2, 2)
                 .expect("first observation"),
             AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
         );
@@ -299,10 +299,10 @@ fn scoped_promotion_and_rejection_preserve_shared_canonical_identity() {
         1
     );
 
-    upsert_auto_learn_candidate(&db, development.id, "Kubernetez", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, development.id, "Kubernetez", "Kubernetes", 0.6)
         .expect("development second candidate");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             development.id,
             "Kubernetez",
@@ -325,10 +325,10 @@ fn scoped_promotion_and_rejection_preserve_shared_canonical_identity() {
         .expect("writing remains isolated")
         .is_empty());
 
-    upsert_auto_learn_candidate(&db, writing.id, "Kubernetez", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, writing.id, "Kubernetez", "Kubernetes", 0.6)
         .expect("writing second candidate");
     assert_eq!(
-        auto_learn_promote(&db, writing.id, "Kubernetez", "Kubernetes", "medium", 2, 2,)
+        auto_learn_promote_for_context(&db, writing.id, "Kubernetez", "Kubernetes", "medium", 2, 2,)
             .expect("writing promotion"),
         AutoLearnPromoteResult::Promoted
     );
@@ -605,11 +605,11 @@ fn auto_learn_conflict_returns_blocked_without_claiming_candidate() {
         .expect("context");
     insert_dictionary_entry_returning(&db, "ExistingTerm", Some("shared typo"), Some(context.id))
         .expect("manual mapping");
-    upsert_auto_learn_candidate(&db, context.id, "shared typo", "NewTerm", 0.95)
+    upsert_auto_learn_candidate_for_context(&db, context.id, "shared typo", "NewTerm", 0.95)
         .expect("candidate");
 
     assert_eq!(
-        auto_learn_promote(&db, context.id, "shared typo", "NewTerm", "high", 2, 1)
+        auto_learn_promote_for_context(&db, context.id, "shared typo", "NewTerm", "high", 2, 1)
             .expect("promotion result"),
         AutoLearnPromoteResult::Blocked
     );

--- a/src-tauri/src/data/db/autolearn_context_tests.rs
+++ b/src-tauri/src/data/db/autolearn_context_tests.rs
@@ -1,0 +1,599 @@
+use super::*;
+use rusqlite::params;
+use uuid::Uuid;
+
+fn temp_db_path() -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "verenu_autolearn_v26_{}_{}.db",
+        std::process::id(),
+        nanos
+    ))
+}
+
+fn remove_db_files(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
+#[test]
+fn v25_reopen_runs_schema_before_scoped_autolearn_migration() {
+    let path = temp_db_path();
+    {
+        let db = open(&path).expect("create fixture database");
+        let development =
+            insert_context_returning(&db, "Development", None, None, None, None, false)
+                .expect("development context");
+        insert_dictionary_entry(&db, "SharedTerm", Some("shared typo")).expect("manual term");
+        let shared_id = query_dictionary(&db)
+            .expect("dictionary")
+            .into_iter()
+            .find(|entry| entry.term == "SharedTerm")
+            .expect("shared canonical row")
+            .id;
+        set_dictionary_context_assignment(&db, development.id, shared_id, true)
+            .expect("share manual term");
+        // Keep a malformed legacy collision in the fixture as well: the
+        // manual mapping must win over an old automatic row when v26 creates
+        // the new Context/variant uniqueness constraint.
+        {
+            let conn = lock_conn(&db).expect("collision fixture lock");
+            conn.execute(
+                "INSERT INTO dictionary (term, mistake, auto_learned, confidence_tier)
+                 VALUES ('AutoCollision', 'shared typo', 1, 'high')",
+                [],
+            )
+            .expect("legacy automatic collision");
+            let collision_id = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO dictionary_contexts (context_id, dictionary_id)
+                 VALUES (?1, ?2)",
+                params![EVERYWHERE_CONTEXT_ID, collision_id],
+            )
+            .expect("collision Everywhere assignment");
+        }
+        insert_dictionary_entry_auto_learned(&db, "LegacyLearned", Some("legacy typo"), "high")
+            .expect("historical auto-learned term");
+        let legacy_id = query_dictionary(&db)
+            .expect("dictionary after auto-learn")
+            .into_iter()
+            .find(|entry| entry.term == "LegacyLearned")
+            .expect("legacy canonical row")
+            .id;
+        // A targeted assignment without reliable origin evidence must not
+        // cause the old automatic mapping to be copied into that Context.
+        set_dictionary_context_assignment(&db, development.id, legacy_id, true)
+            .expect("share legacy canonical term");
+
+        let conn = lock_conn(&db).expect("fixture lock");
+        // Make the current database look like a real v25 install: the old
+        // global projection is populated, the child table did not exist, and
+        // transient evidence has no originating Context column.
+        conn.execute("DELETE FROM dictionary_corrections", [])
+            .expect("clear v26 child rows");
+        conn.execute(
+            "UPDATE dictionary
+                SET mistake = CASE term
+                    WHEN 'SharedTerm' THEN 'shared typo'
+                    WHEN 'AutoCollision' THEN 'shared typo'
+                    WHEN 'LegacyLearned' THEN 'legacy typo'
+                    ELSE mistake
+                END
+              WHERE term IN ('SharedTerm', 'AutoCollision', 'LegacyLearned')",
+            [],
+        )
+        .expect("restore legacy correction projection");
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_dictionary_contexts_delete_corrections;
+             DROP TABLE dictionary_corrections;
+             DROP INDEX IF EXISTS idx_pending_words;
+             ALTER TABLE pending_corrections RENAME TO pending_corrections_v26;
+             CREATE TABLE pending_corrections (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             INSERT INTO pending_corrections (wrong_word, correct_word)
+               VALUES ('ambiguous typo', 'TargetTerm');
+             DROP TABLE pending_corrections_v26;
+             DROP INDEX IF EXISTS idx_auto_learn_candidates_seen;
+             ALTER TABLE auto_learn_candidates RENAME TO auto_learn_candidates_v26;
+             CREATE TABLE auto_learn_candidates (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               confidence_sum REAL NOT NULL DEFAULT 0.0,
+               confidence_avg REAL NOT NULL DEFAULT 0.0,
+               seen_count INTEGER NOT NULL DEFAULT 0,
+               last_seen_at DATETIME NOT NULL DEFAULT (datetime('now')),
+               cooldown_until DATETIME,
+               promoted_at DATETIME,
+               UNIQUE(wrong_word, correct_word)
+             );
+             INSERT INTO auto_learn_candidates
+               (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+               VALUES ('ambiguous typo', 'TargetTerm', 0.7, 0.7, 1);
+             DROP TABLE auto_learn_candidates_v26;
+             DROP TABLE auto_learn_events;
+             CREATE TABLE auto_learn_events (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               event_type TEXT NOT NULL,
+               reason_code TEXT NOT NULL DEFAULT '',
+               app_context TEXT NOT NULL DEFAULT '',
+               mistake_hash TEXT NOT NULL DEFAULT '',
+               correction_hash TEXT NOT NULL DEFAULT '',
+               confidence REAL NOT NULL DEFAULT 0.0,
+               created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             INSERT INTO auto_learn_events (event_type, reason_code)
+               VALUES ('candidate', 'legacy_fixture');
+             PRAGMA user_version = 25;",
+        )
+        .expect("downgrade fixture to v25 shapes");
+    }
+
+    let db = open(&path).expect("v25 database must reopen through v26");
+    let conn = lock_conn(&db).expect("repaired lock");
+    let version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .expect("schema version");
+    assert_eq!(version, 26);
+    assert!(table_has_column(&conn, "pending_corrections", "context_id").expect("pending scope"));
+    assert!(
+        table_has_column(&conn, "auto_learn_candidates", "context_id").expect("candidate scope")
+    );
+    assert!(table_has_column(&conn, "auto_learn_events", "context_id").expect("event scope"));
+    let transient_rows: i64 = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM pending_corrections)
+                  + (SELECT COUNT(*) FROM auto_learn_candidates)",
+            [],
+            |row| row.get(0),
+        )
+        .expect("transient row count");
+    assert_eq!(transient_rows, 0, "ambiguous v25 evidence is discarded");
+    let global_projection: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM dictionary WHERE mistake IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("legacy projection count");
+    assert_eq!(global_projection, 0, "global mistake projection is retired");
+    let correction_uuids: Vec<String> = conn
+        .prepare("SELECT uuid FROM dictionary_corrections ORDER BY id")
+        .expect("correction UUID query")
+        .query_map([], |row| row.get(0))
+        .expect("correction UUID rows")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("correction UUID collection");
+    assert_eq!(
+        correction_uuids.len(),
+        3,
+        "one shared row per assigned Context"
+    );
+    assert!(correction_uuids
+        .iter()
+        .all(|uuid| Uuid::parse_str(uuid).is_ok()));
+
+    let shared_id: i64 = conn
+        .query_row(
+            "SELECT id FROM dictionary WHERE term = 'SharedTerm'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("shared id");
+    let shared_contexts: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM dictionary_corrections
+              WHERE dictionary_id = ?1 AND mistake = 'shared typo'",
+            params![shared_id],
+            |row| row.get(0),
+        )
+        .expect("shared mappings");
+    assert_eq!(
+        shared_contexts, 2,
+        "manual sharing is preserved in migration"
+    );
+    let automatic_collision_mapping: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+               FROM dictionary_corrections c
+               JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE d.term = 'AutoCollision' AND c.mistake = 'shared typo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("legacy collision mapping");
+    assert_eq!(
+        automatic_collision_mapping, 0,
+        "manual legacy correction wins a same-Context automatic collision"
+    );
+    let everywhere_mapping: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+               FROM dictionary_corrections c
+               JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE d.term = 'LegacyLearned' AND c.context_id = ?1
+                AND c.mistake = 'legacy typo'",
+            params![EVERYWHERE_CONTEXT_ID],
+            |row| row.get(0),
+        )
+        .expect("Everywhere mapping");
+    assert_eq!(
+        everywhere_mapping, 1,
+        "legacy promoted data stays in Everywhere"
+    );
+    let targeted_legacy_mapping: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+               FROM dictionary_corrections c
+               JOIN dictionary d ON d.id = c.dictionary_id
+               JOIN contexts ctx ON ctx.id = c.context_id
+              WHERE d.term = 'LegacyLearned' AND ctx.name = 'Development'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("targeted legacy mapping");
+    assert_eq!(
+        targeted_legacy_mapping, 0,
+        "ambiguous legacy AutoLearn scope is not copied into Development"
+    );
+    drop(conn);
+    drop(db);
+
+    // Reopening an already-v26 database is idempotent and preserves the
+    // mapping identities and count.
+    let db = open(&path).expect("reopen migrated database");
+    let conn = lock_conn(&db).expect("second repaired lock");
+    let second_uuids: Vec<String> = conn
+        .prepare("SELECT uuid FROM dictionary_corrections ORDER BY id")
+        .expect("second UUID query")
+        .query_map([], |row| row.get(0))
+        .expect("second UUID rows")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("second UUID collection");
+    assert_eq!(second_uuids, correction_uuids);
+    drop(conn);
+    drop(db);
+    remove_db_files(&path);
+}
+
+#[test]
+fn scoped_promotion_and_rejection_preserve_shared_canonical_identity() {
+    let db = open(":memory:").expect("db");
+    let development = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("development");
+    let writing =
+        insert_context_returning(&db, "Writing", None, None, None, None, false).expect("writing");
+
+    for context_id in [development.id, writing.id] {
+        upsert_auto_learn_candidate(&db, context_id, "Kubernetez", "Kubernetes", 0.6)
+            .expect("candidate");
+        assert_eq!(
+            auto_learn_promote(&db, context_id, "Kubernetez", "Kubernetes", "medium", 2, 2)
+                .expect("first observation"),
+            AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
+        );
+    }
+    assert!(query_dictionary_for_context(&db, development.id)
+        .expect("development before threshold")
+        .is_empty());
+    assert!(query_dictionary_for_context(&db, writing.id)
+        .expect("writing before threshold")
+        .is_empty());
+    assert_eq!(
+        count_pending_corrections_recent_for_context(
+            &db,
+            development.id,
+            "Kubernetez",
+            "Kubernetes",
+            2,
+        )
+        .expect("development evidence"),
+        1
+    );
+
+    upsert_auto_learn_candidate(&db, development.id, "Kubernetez", "Kubernetes", 0.6)
+        .expect("development second candidate");
+    assert_eq!(
+        auto_learn_promote(
+            &db,
+            development.id,
+            "Kubernetez",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("development promotion"),
+        AutoLearnPromoteResult::Promoted
+    );
+    let development_entry = query_dictionary_for_context(&db, development.id)
+        .expect("development dictionary")
+        .into_iter()
+        .find(|entry| entry.term == "Kubernetes")
+        .expect("development learned entry");
+    assert_eq!(development_entry.mistake.as_deref(), Some("Kubernetez"));
+    assert!(development_entry.corrections[0].auto_learned);
+    assert!(query_dictionary_for_context(&db, writing.id)
+        .expect("writing remains isolated")
+        .is_empty());
+
+    upsert_auto_learn_candidate(&db, writing.id, "Kubernetez", "Kubernetes", 0.6)
+        .expect("writing second candidate");
+    assert_eq!(
+        auto_learn_promote(&db, writing.id, "Kubernetez", "Kubernetes", "medium", 2, 2,)
+            .expect("writing promotion"),
+        AutoLearnPromoteResult::Promoted
+    );
+
+    let writing_mapping_id = query_dictionary_for_context(&db, writing.id)
+        .expect("writing dictionary")
+        .into_iter()
+        .find(|entry| entry.term == "Kubernetes")
+        .and_then(|entry| entry.corrections.into_iter().next())
+        .expect("writing mapping")
+        .id;
+    assert_eq!(
+        delete_auto_learned_corrections_by_ids(
+            &db,
+            development.id,
+            &[development_entry.corrections[0].id]
+        )
+        .expect("reject development mapping"),
+        1
+    );
+    assert!(query_dictionary_for_context(&db, development.id)
+        .expect("development after rejection")
+        .into_iter()
+        .find(|entry| entry.term == "Kubernetes")
+        .expect("development canonical remains")
+        .corrections
+        .is_empty());
+    let writing_after = query_dictionary_for_context(&db, writing.id)
+        .expect("writing after development rejection")
+        .into_iter()
+        .find(|entry| entry.term == "Kubernetes")
+        .expect("writing mapping remains");
+    assert_eq!(writing_after.corrections[0].id, writing_mapping_id);
+    assert_eq!(
+        count_pending_corrections_recent_for_context(
+            &db,
+            development.id,
+            "Kubernetez",
+            "Kubernetes",
+            2,
+        )
+        .expect("development evidence after rejection"),
+        0
+    );
+}
+
+#[test]
+fn correction_rows_capture_stable_sync_identity_and_delete_events() {
+    let db = open(":memory:").expect("db");
+    let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("context");
+    insert_dictionary_entry_auto_learned_for_context(
+        &db,
+        context.id,
+        "Rust",
+        Some("Russt"),
+        "high",
+    )
+    .expect("mapping");
+
+    let (mapping_id, mapping_uuid): (i64, String) = {
+        let conn = lock_conn(&db).expect("lock");
+        conn.query_row(
+            "SELECT id, uuid FROM dictionary_corrections
+              WHERE context_id = ?1",
+            params![context.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("mapping identity")
+    };
+    assert!(Uuid::parse_str(&mapping_uuid).is_ok());
+    let conn = lock_conn(&db).expect("sync log lock");
+    let insert_log: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sync_log
+              WHERE table_name = 'dictionary_corrections'
+                AND row_uuid = ?1 AND op = 'upsert'",
+            params![mapping_uuid],
+            |row| row.get(0),
+        )
+        .expect("insert sync log");
+    assert!(insert_log >= 1);
+    drop(conn);
+    delete_auto_learned_corrections_by_ids(&db, context.id, &[mapping_id]).expect("delete mapping");
+    let conn = lock_conn(&db).expect("delete log lock");
+    let delete_log: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sync_log
+              WHERE table_name = 'dictionary_corrections'
+                AND row_uuid = ?1 AND op = 'delete'",
+            params![mapping_uuid],
+            |row| row.get(0),
+        )
+        .expect("delete sync log");
+    assert!(delete_log >= 1);
+}
+
+#[test]
+fn context_edit_replaces_only_its_mapping_and_ignores_stale_global_projection() {
+    let db = open(":memory:").expect("db");
+    let development = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("development");
+    let writing =
+        insert_context_returning(&db, "Writing", None, None, None, None, false).expect("writing");
+    let entry = insert_dictionary_entry_returning(&db, "Groq", Some("grock"), Some(development.id))
+        .expect("manual development mapping");
+    set_dictionary_context_assignment(&db, writing.id, entry.id, true)
+        .expect("share canonical term");
+    insert_dictionary_entry_auto_learned_for_context(
+        &db,
+        writing.id,
+        "Groq",
+        Some("grocker"),
+        "high",
+    )
+    .expect("independent writing mapping");
+
+    update_dictionary_entry_for_context(&db, development.id, entry.id, "Groq", Some("grok"))
+        .expect("edit development mapping");
+
+    // Simulate a stale write from a pre-v26/remote legacy consumer. Context
+    // materialization must remain child-table-only even if the compatibility
+    // column is unexpectedly populated after migration.
+    {
+        let conn = lock_conn(&db).expect("stale projection lock");
+        conn.execute(
+            "UPDATE dictionary SET mistake = 'must not leak' WHERE id = ?1",
+            params![entry.id],
+        )
+        .expect("stale projection");
+    }
+
+    let development_entry = query_dictionary_for_context(&db, development.id)
+        .expect("development dictionary")
+        .into_iter()
+        .find(|row| row.id == entry.id)
+        .expect("development entry");
+    assert_eq!(development_entry.mistake.as_deref(), Some("grok"));
+    assert_eq!(development_entry.corrections.len(), 1);
+    assert!(!development_entry.corrections[0].auto_learned);
+
+    let writing_entry = query_dictionary_for_context(&db, writing.id)
+        .expect("writing dictionary")
+        .into_iter()
+        .find(|row| row.id == entry.id)
+        .expect("writing entry");
+    assert_eq!(writing_entry.mistake.as_deref(), Some("grocker"));
+    assert_eq!(writing_entry.corrections.len(), 1);
+    assert!(writing_entry.corrections[0].auto_learned);
+}
+
+#[test]
+fn removing_an_auto_assignment_cleans_orphan_and_scoped_evidence() {
+    let db = open(":memory:").expect("db");
+    let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("context");
+    insert_dictionary_entry_auto_learned_for_context(
+        &db,
+        context.id,
+        "Kubernetes",
+        Some("kubernetez"),
+        "high",
+    )
+    .expect("mapping");
+    let dictionary_id = query_dictionary_for_context(&db, context.id)
+        .expect("context dictionary")
+        .into_iter()
+        .find(|entry| entry.term == "Kubernetes")
+        .expect("entry")
+        .id;
+    {
+        let conn = lock_conn(&db).expect("evidence lock");
+        conn.execute(
+            "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+             VALUES (?1, 'stale typo', 'Kubernetes')",
+            params![context.id],
+        )
+        .expect("pending evidence");
+        conn.execute(
+            "INSERT INTO auto_learn_candidates
+               (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+             VALUES (?1, 'stale typo', 'Kubernetes', 0.8, 0.8, 1)",
+            params![context.id],
+        )
+        .expect("candidate evidence");
+    }
+
+    set_dictionary_context_assignment(&db, context.id, dictionary_id, false)
+        .expect("remove assignment");
+
+    assert!(query_dictionary_for_context(&db, context.id)
+        .expect("context dictionary after removal")
+        .is_empty());
+    assert!(query_dictionary(&db)
+        .expect("global dictionary after removal")
+        .into_iter()
+        .all(|entry| entry.term != "Kubernetes"));
+    let conn = lock_conn(&db).expect("evidence verification lock");
+    let evidence_rows: i64 = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM pending_corrections WHERE context_id = ?1)
+                    + (SELECT COUNT(*) FROM auto_learn_candidates WHERE context_id = ?1)",
+            params![context.id],
+            |row| row.get(0),
+        )
+        .expect("evidence count");
+    assert_eq!(evidence_rows, 0);
+}
+
+#[test]
+fn context_event_and_backup_helpers_keep_child_mapping_metadata() {
+    let db = open(":memory:").expect("db");
+    let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+        .expect("context");
+    log_auto_learn_event_for_context(
+        &db,
+        context.id,
+        "candidate",
+        "test",
+        "Development",
+        "mistake-hash",
+        "correction-hash",
+        0.8,
+    )
+    .expect("context event");
+    let event = get_recent_auto_learn_activity(&db, 1)
+        .expect("recent event")
+        .into_iter()
+        .next()
+        .expect("event row");
+    assert_eq!(event.context_id, Some(context.id));
+
+    {
+        let conn = lock_conn(&db).expect("backup lock");
+        insert_dictionary_entry_from_backup_conn(
+            &conn,
+            "BackupTerm",
+            Some("BackupTypo"),
+            true,
+            "high",
+            4,
+        )
+        .expect("backup entry");
+    }
+    let conn = lock_conn(&db).expect("backup verification lock");
+    let (uuid, auto_learned, correction_count, mapping_context): (String, i64, i64, i64) = conn
+        .query_row(
+            "SELECT c.uuid, c.auto_learned, c.correction_count, c.context_id
+               FROM dictionary_corrections c
+               JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE d.term = 'BackupTerm'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("backup mapping");
+    assert!(Uuid::parse_str(&uuid).is_ok());
+    assert_eq!(auto_learned, 1);
+    assert_eq!(correction_count, 4);
+    assert_eq!(mapping_context, EVERYWHERE_CONTEXT_ID);
+    let legacy_projection: Option<String> = conn
+        .query_row(
+            "SELECT mistake FROM dictionary WHERE term = 'BackupTerm'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("backup legacy projection");
+    assert!(legacy_projection.is_none());
+}

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -928,6 +928,375 @@ mod tests {
     }
 
     #[test]
+    fn removing_a_dictionary_assignment_purges_only_that_context_mapping_and_evidence() {
+        let db = open(":memory:").expect("db");
+        let first = insert_context_returning(&db, "Development", None, None, None, None, false)
+            .expect("first context");
+        let second = insert_context_returning(&db, "Writing", None, None, None, None, false)
+            .expect("second context");
+
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            first.id,
+            "Kubernetes",
+            Some("kubernetez"),
+            "high",
+        )
+        .expect("first mapping");
+        let dictionary_id = query_dictionary(&db)
+            .expect("dictionary")
+            .into_iter()
+            .find(|entry| entry.term == "Kubernetes")
+            .expect("canonical entry")
+            .id;
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            second.id,
+            "Kubernetes",
+            Some("kubernetez"),
+            "high",
+        )
+        .expect("second mapping");
+
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+                 VALUES (?1, 'kubernetez', 'Kubernetes'), (?2, 'kubernetez', 'Kubernetes')",
+                params![first.id, second.id],
+            )
+            .expect("pending evidence");
+            conn.execute(
+                "INSERT INTO auto_learn_candidates
+                   (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+                 VALUES (?1, 'kubernetez', 'Kubernetes', 0.9, 0.9, 1),
+                        (?2, 'kubernetez', 'Kubernetes', 0.9, 0.9, 1)",
+                params![first.id, second.id],
+            )
+            .expect("candidate evidence");
+        }
+
+        set_dictionary_context_assignment(&db, first.id, dictionary_id, false)
+            .expect("remove first assignment");
+
+        assert!(query_dictionary_for_context(&db, first.id)
+            .expect("first dictionary")
+            .is_empty());
+        let second_entry = query_dictionary_for_context(&db, second.id)
+            .expect("second dictionary")
+            .into_iter()
+            .find(|entry| entry.id == dictionary_id)
+            .expect("second mapping remains");
+        assert_eq!(second_entry.corrections.len(), 1);
+
+        let conn = lock_conn(&db).expect("lock");
+        let first_pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pending_corrections WHERE context_id = ?1",
+                params![first.id],
+                |row| row.get(0),
+            )
+            .expect("first pending count");
+        let second_pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pending_corrections WHERE context_id = ?1",
+                params![second.id],
+                |row| row.get(0),
+            )
+            .expect("second pending count");
+        assert_eq!(first_pending, 0);
+        assert_eq!(second_pending, 1);
+    }
+
+    #[test]
+    fn rejecting_a_mapping_is_scoped_to_its_context_and_mapping_id() {
+        let db = open(":memory:").expect("db");
+        let first = insert_context_returning(&db, "Development", None, None, None, None, false)
+            .expect("first context");
+        let second = insert_context_returning(&db, "Writing", None, None, None, None, false)
+            .expect("second context");
+
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            first.id,
+            "Groq",
+            Some("grockx"),
+            "high",
+        )
+        .expect("first mapping");
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            second.id,
+            "Groq",
+            Some("rockz"),
+            "high",
+        )
+        .expect("second mapping");
+        let dictionary_id = query_dictionary(&db)
+            .expect("dictionary")
+            .into_iter()
+            .find(|entry| entry.term == "Groq")
+            .expect("canonical entry")
+            .id;
+        let first_mapping_id = query_dictionary_for_context(&db, first.id)
+            .expect("first dictionary")
+            .into_iter()
+            .find(|entry| entry.id == dictionary_id)
+            .and_then(|entry| entry.corrections.into_iter().next())
+            .expect("first correction")
+            .id;
+        let second_mapping_id = query_dictionary_for_context(&db, second.id)
+            .expect("second dictionary")
+            .into_iter()
+            .find(|entry| entry.id == dictionary_id)
+            .and_then(|entry| entry.corrections.into_iter().next())
+            .expect("second correction")
+            .id;
+
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+                 VALUES (?1, 'grockx', 'Groq'), (?2, 'rockz', 'Groq')",
+                params![first.id, second.id],
+            )
+            .expect("pending evidence");
+            conn.execute(
+                "INSERT INTO auto_learn_candidates
+                   (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+                 VALUES (?1, 'grockx', 'Groq', 0.9, 0.9, 1),
+                        (?2, 'rockz', 'Groq', 0.9, 0.9, 1)",
+                params![first.id, second.id],
+            )
+            .expect("candidate evidence");
+        }
+
+        assert_eq!(
+            delete_auto_learned_corrections_by_ids(&db, first.id, &[first_mapping_id])
+                .expect("reject first mapping"),
+            1
+        );
+        assert_eq!(
+            delete_auto_learned_corrections_by_ids(&db, first.id, &[second_mapping_id])
+                .expect("wrong-context rejection is ignored"),
+            0
+        );
+
+        let first_entry = query_dictionary_for_context(&db, first.id)
+            .expect("first dictionary after rejection")
+            .into_iter()
+            .find(|entry| entry.id == dictionary_id)
+            .expect("canonical row remains assigned");
+        assert!(first_entry.corrections.is_empty());
+        assert!(first_entry.mistake.is_none());
+
+        let second_entry = query_dictionary_for_context(&db, second.id)
+            .expect("second dictionary after rejection")
+            .into_iter()
+            .find(|entry| entry.id == dictionary_id)
+            .expect("second mapping remains");
+        assert_eq!(second_entry.corrections.len(), 1);
+        assert_eq!(second_entry.corrections[0].id, second_mapping_id);
+        assert_eq!(second_entry.corrections[0].mistake, "rockz");
+
+        let conn = lock_conn(&db).expect("lock");
+        let first_candidates: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_learn_candidates WHERE context_id = ?1",
+                params![first.id],
+                |row| row.get(0),
+            )
+            .expect("first candidates");
+        let second_candidates: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_learn_candidates WHERE context_id = ?1",
+                params![second.id],
+                |row| row.get(0),
+            )
+            .expect("second candidates");
+        assert_eq!(first_candidates, 0);
+        assert_eq!(second_candidates, 1);
+    }
+
+    #[test]
+    fn rejecting_the_last_auto_mapping_removes_only_its_orphaned_canonical() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+            .expect("context");
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            context.id,
+            "Kubernetes",
+            Some("kubernetez"),
+            "high",
+        )
+        .expect("auto mapping");
+        let entry = query_dictionary_for_context(&db, context.id)
+            .expect("context dictionary")
+            .into_iter()
+            .next()
+            .expect("entry");
+        let correction_id = entry.corrections[0].id;
+
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+                 VALUES (?1, 'kubernetez', 'Kubernetes')",
+                params![context.id],
+            )
+            .expect("pending evidence");
+            conn.execute(
+                "INSERT INTO auto_learn_candidates
+                   (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+                 VALUES (?1, 'kubernetez', 'Kubernetes', 0.9, 0.9, 1)",
+                params![context.id],
+            )
+            .expect("candidate evidence");
+        }
+
+        assert_eq!(
+            delete_auto_learned_corrections_by_ids(&db, context.id, &[correction_id])
+                .expect("reject mapping"),
+            1
+        );
+        assert!(query_dictionary(&db)
+            .expect("global dictionary")
+            .into_iter()
+            .all(|entry| entry.term != "Kubernetes"));
+
+        let conn = lock_conn(&db).expect("lock");
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pending_corrections WHERE context_id = ?1",
+                params![context.id],
+                |row| row.get(0),
+            )
+            .expect("pending count");
+        let candidates: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_learn_candidates WHERE context_id = ?1",
+                params![context.id],
+                |row| row.get(0),
+            )
+            .expect("candidate count");
+        assert_eq!(pending, 0);
+        assert_eq!(candidates, 0);
+    }
+
+    #[test]
+    fn manual_mapping_is_context_local_and_protected_from_auto_learn() {
+        let db = open(":memory:").expect("db");
+        let manual_context =
+            insert_context_returning(&db, "Writing", None, None, None, None, false)
+                .expect("manual context");
+        let auto_context =
+            insert_context_returning(&db, "Development", None, None, None, None, false)
+                .expect("auto context");
+
+        {
+            let conn = lock_conn(&db).expect("lock");
+            conn.execute(
+                "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+                 VALUES (?1, 'user typo', 'Kubernetes')",
+                params![manual_context.id],
+            )
+            .expect("pending evidence");
+            conn.execute(
+                "INSERT INTO auto_learn_candidates
+                   (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count)
+                 VALUES (?1, 'user typo', 'Kubernetes', 0.9, 0.9, 1)",
+                params![manual_context.id],
+            )
+            .expect("candidate evidence");
+        }
+
+        let manual = insert_dictionary_entry_returning(
+            &db,
+            "Kubernetes",
+            Some("user typo"),
+            Some(manual_context.id),
+        )
+        .expect("manual mapping");
+        let conn = lock_conn(&db).expect("lock");
+        let stale_evidence: i64 = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM pending_corrections WHERE context_id = ?1)
+                        + (SELECT COUNT(*) FROM auto_learn_candidates WHERE context_id = ?1)",
+                params![manual_context.id],
+                |row| row.get(0),
+            )
+            .expect("stale evidence count");
+        assert_eq!(stale_evidence, 0);
+        drop(conn);
+        assert!(!insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            manual_context.id,
+            "Kubernetes",
+            Some("user typo"),
+            "high",
+        )
+        .expect("same-context auto attempt"));
+        insert_dictionary_entry_auto_learned_for_context(
+            &db,
+            auto_context.id,
+            "Kubernetes",
+            Some("koobernetes"),
+            "high",
+        )
+        .expect("other-context auto mapping");
+
+        let manual_entry = query_dictionary_for_context(&db, manual_context.id)
+            .expect("manual dictionary")
+            .into_iter()
+            .find(|entry| entry.id == manual.id)
+            .expect("manual entry");
+        assert_eq!(manual_entry.corrections.len(), 1);
+        assert!(!manual_entry.corrections[0].auto_learned);
+        assert_eq!(manual_entry.corrections[0].mistake, "user typo");
+        assert_eq!(
+            delete_auto_learned_corrections_by_ids(
+                &db,
+                manual_context.id,
+                &[manual_entry.corrections[0].id],
+            )
+            .expect("manual rejection is ignored"),
+            0
+        );
+
+        let auto_entry = query_dictionary_for_context(&db, auto_context.id)
+            .expect("auto dictionary")
+            .into_iter()
+            .find(|entry| entry.id == manual.id)
+            .expect("shared canonical entry");
+        assert_eq!(auto_entry.corrections.len(), 1);
+        assert!(auto_entry.corrections[0].auto_learned);
+        assert_eq!(auto_entry.corrections[0].mistake, "koobernetes");
+    }
+
+    #[test]
+    fn duplicate_comma_variants_materialize_as_one_mapping() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Development", None, None, None, None, false)
+            .expect("context");
+        let entry = insert_dictionary_entry_returning(
+            &db,
+            "Kubernetes",
+            Some("Kubernetez, kubernetez,  Kubernetez "),
+            Some(context.id),
+        )
+        .expect("dictionary");
+
+        let materialized = query_dictionary_for_context(&db, context.id)
+            .expect("context dictionary")
+            .into_iter()
+            .find(|row| row.id == entry.id)
+            .expect("entry");
+        assert_eq!(materialized.corrections.len(), 1);
+        assert_eq!(materialized.corrections[0].mistake, "Kubernetez");
+    }
+
+    #[test]
     fn target_resolution_returns_one_context_and_falls_back_to_everywhere() {
         let db = open(":memory:").expect("db");
         let context = insert_context_returning(&db, "Writing", None, None, None, None, false)

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -1612,6 +1612,16 @@ mod tests {
     }
 
     #[test]
+    fn legacy_edit_reports_missing_dictionary_entry() {
+        let db = open(":memory:").expect("db");
+
+        let error = update_dictionary_entry(&db, 999, "Missing", None)
+            .expect_err("editing a missing entry should fail");
+
+        assert_eq!(error.to_string(), "Dictionary entry 999 was not found");
+    }
+
+    #[test]
     fn assigning_an_existing_entry_shares_only_canonical_identity() {
         let db = open(":memory:").expect("db");
         let source =

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -304,6 +304,21 @@ pub fn delete_context(db: &Db, context_id: i64) -> Result<()> {
 pub fn delete_context_conn(conn: &Connection, context_id: i64) -> Result<()> {
     let tx = conn.unchecked_transaction()?;
     let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+    // Vocabulary assignments move to Everywhere when a Context is deleted;
+    // move the Context-owned correction mappings in the same transaction so
+    // learned substitutions do not disappear or remain orphaned.
+    move_dictionary_corrections_conn(&tx, context_id, everywhere_id)?;
+    // Evidence is transient and its original Context is being removed. Drop
+    // it rather than allowing a later promotion to invent an Everywhere
+    // origin after the source Context no longer exists.
+    tx.execute(
+        "DELETE FROM pending_corrections WHERE context_id = ?1",
+        params![context_id],
+    )?;
+    tx.execute(
+        "DELETE FROM auto_learn_candidates WHERE context_id = ?1",
+        params![context_id],
+    )?;
     tx.execute(
         "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
          SELECT ?1, dictionary_id FROM dictionary_contexts WHERE context_id = ?2",
@@ -650,16 +665,12 @@ pub fn set_dictionary_context_assignment(
         anyhow::bail!("Dictionary entry {dictionary_id} was not found");
     }
     if assigned {
-        let mistake: Option<String> = conn.query_row(
-            "SELECT mistake FROM dictionary WHERE id = ?1",
+        // Sharing a canonical vocabulary item intentionally shares only the
+        // canonical identity. Context-specific correction mappings are not
+        // copied; callers can create an explicit mapping in this Context.
+        conn.execute(
+            "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
             params![dictionary_id],
-            |row| row.get(0),
-        )?;
-        check_dictionary_mistake_conflicts(
-            &conn,
-            context_id,
-            Some(dictionary_id),
-            mistake.as_deref(),
         )?;
         conn.execute(
             "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
@@ -667,10 +678,12 @@ pub fn set_dictionary_context_assignment(
             params![context_id, dictionary_id],
         )?;
     } else {
+        remove_dictionary_corrections_for_context_conn(&conn, context_id, dictionary_id)?;
         conn.execute(
             "DELETE FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2",
             params![context_id, dictionary_id],
         )?;
+        cleanup_orphaned_auto_dictionary_conn(&conn, context_id, dictionary_id)?;
     }
     Ok(())
 }
@@ -877,6 +890,16 @@ mod tests {
             query_dictionary_for_context(&db, context.id).unwrap().len(),
             1
         );
+        let context_entry = query_dictionary_for_context(&db, context.id)
+            .expect("context dictionary")
+            .into_iter()
+            .next()
+            .expect("shared canonical entry");
+        assert!(
+            context_entry.corrections.is_empty(),
+            "sharing a canonical term must not copy another Context's correction mapping"
+        );
+        assert!(context_entry.mistake.is_none());
         assert_eq!(
             query_snippets_for_context(&db, context.id).unwrap().len(),
             1
@@ -1106,25 +1129,27 @@ mod tests {
         insert_dictionary_entry_returning(&db, "Verenu", Some("Vernu"), None).expect("dictionary");
         insert_snippet_returning(&db, "sig", "signature", "", None).expect("snippet");
 
-        assert!(
-            insert_dictionary_entry_returning(&db, "Verenu", Some("Verano"), Some(context.id))
-                .is_err()
-        );
+        insert_dictionary_entry_returning(&db, "Verenu", Some("Verano"), Some(context.id))
+            .expect("assign existing canonical with a Context-specific correction");
         assert!(insert_snippet_returning(&db, "sig", "different", "", Some(context.id)).is_err());
 
         let dictionary = query_dictionary(&db).expect("dictionary");
-        assert_eq!(dictionary[0].mistake.as_deref(), Some("Vernu"));
+        assert_eq!(dictionary[0].mistake.as_deref(), Some("Vernu, Verano"));
         let snippets = query_snippets(&db).expect("snippets");
         assert_eq!(snippets[0].expansion, "signature");
-        assert!(query_dictionary_for_context(&db, context.id)
-            .unwrap()
-            .is_empty());
+        let context_dictionary =
+            query_dictionary_for_context(&db, context.id).expect("context dictionary");
+        assert_eq!(context_dictionary.len(), 1);
+        assert_eq!(context_dictionary[0].mistake.as_deref(), Some("Verano"));
         assert!(query_snippets_for_context(&db, context.id)
             .unwrap()
             .is_empty());
 
-        insert_dictionary_entry_returning(&db, "Verenu", Some("Vernu"), Some(context.id))
-            .expect("assign existing dictionary entry");
+        assert!(
+            insert_dictionary_entry_returning(&db, "Verenu", Some("Verano"), Some(context.id))
+                .is_err(),
+            "the same Context cannot add a duplicate canonical mapping"
+        );
         insert_snippet_returning(&db, "sig", "signature", "", Some(context.id))
             .expect("assign existing snippet");
         assert_eq!(
@@ -1184,7 +1209,7 @@ mod tests {
     }
 
     #[test]
-    fn assigning_an_existing_entry_checks_the_target_context() {
+    fn assigning_an_existing_entry_shares_only_canonical_identity() {
         let db = open(":memory:").expect("db");
         let source =
             insert_context_returning(&db, "Source", None, None, None, None, false).expect("source");
@@ -1196,17 +1221,26 @@ mod tests {
             insert_dictionary_entry_returning(&db, "Boot", Some("grok bot"), Some(source.id))
                 .expect("source dictionary entry");
 
-        let error = set_dictionary_context_assignment(&db, target.id, second.id, true)
-            .expect_err("assignment should reject duplicate variant");
-        assert!(error.to_string().contains("@bot"));
+        // Assignment is explicit sharing of the canonical term. It must not
+        // copy the source Context's private correction into the target, so a
+        // same spelling in the target can remain owned by its existing term.
+        set_dictionary_context_assignment(&db, target.id, second.id, true)
+            .expect("canonical assignment should not copy source mapping");
         assert_eq!(
             query_dictionary_for_context(&db, target.id).unwrap().len(),
-            1
+            2
         );
         assert_eq!(
             query_dictionary_for_context(&db, source.id).unwrap().len(),
             1
         );
+        let target_entry = query_dictionary_for_context(&db, target.id)
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.id == second.id)
+            .expect("shared canonical entry");
+        assert!(target_entry.corrections.is_empty());
+        assert!(target_entry.mistake.is_none());
     }
 }
 

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -1566,6 +1566,18 @@ mod tests {
     }
 
     #[test]
+    fn legacy_insert_reports_duplicate_canonical_term() {
+        let db = open(":memory:").expect("db");
+        insert_dictionary_entry_returning(&db, "Verenu", None, None).expect("dictionary");
+
+        let error = insert_dictionary_entry_returning(&db, "Verenu", None, None)
+            .expect_err("duplicate legacy term should fail cleanly");
+
+        assert_eq!(error.to_string(), "\"Verenu\" is already in the dictionary");
+        assert_eq!(query_dictionary(&db).expect("dictionary").len(), 1);
+    }
+
+    #[test]
     fn context_rejects_duplicate_mistranscription_variants() {
         let db = open(":memory:").expect("db");
         let context = insert_context_returning(&db, "AI tools", None, None, None, None, false)

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -1491,6 +1491,40 @@ mod tests {
     }
 
     #[test]
+    fn deleting_a_context_moves_its_correction_mapping_to_everywhere() {
+        let db = open(":memory:").expect("db");
+        let context = insert_context_returning(&db, "Temporary", None, None, None, None, false)
+            .expect("context");
+        let dictionary = insert_dictionary_entry_returning(
+            &db,
+            "Kubernetes",
+            Some("kubernetez"),
+            Some(context.id),
+        )
+        .expect("dictionary");
+
+        let before = query_dictionary_for_context(&db, context.id)
+            .expect("context dictionary")
+            .into_iter()
+            .find(|entry| entry.id == dictionary.id)
+            .expect("context entry");
+        assert_eq!(before.corrections.len(), 1);
+        assert_eq!(before.corrections[0].context_id, context.id);
+
+        delete_context(&db, context.id).expect("delete context");
+
+        let after = query_dictionary_for_context(&db, EVERYWHERE_CONTEXT_ID)
+            .expect("Everywhere dictionary")
+            .into_iter()
+            .find(|entry| entry.id == dictionary.id)
+            .expect("moved entry");
+        assert_eq!(after.mistake.as_deref(), Some("kubernetez"));
+        assert_eq!(after.corrections.len(), 1);
+        assert_eq!(after.corrections[0].context_id, EVERYWHERE_CONTEXT_ID);
+        assert_eq!(after.corrections[0].mistake, "kubernetez");
+    }
+
+    #[test]
     fn adding_existing_content_to_a_context_does_not_overwrite_everywhere() {
         let db = open(":memory:").expect("db");
         let context = insert_context_returning(&db, "Writing", None, None, None, None, false)

--- a/src-tauri/src/data/db/contexts.rs
+++ b/src-tauri/src/data/db/contexts.rs
@@ -654,9 +654,10 @@ pub fn set_dictionary_context_assignment(
     dictionary_id: i64,
     assigned: bool,
 ) -> Result<()> {
-    let conn = lock_conn(db)?;
-    query_context_conn(&conn, context_id)?;
-    let exists: bool = conn.query_row(
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    query_context_conn(&tx, context_id)?;
+    let exists: bool = tx.query_row(
         "SELECT EXISTS(SELECT 1 FROM dictionary WHERE id = ?1)",
         params![dictionary_id],
         |row| row.get(0),
@@ -668,23 +669,24 @@ pub fn set_dictionary_context_assignment(
         // Sharing a canonical vocabulary item intentionally shares only the
         // canonical identity. Context-specific correction mappings are not
         // copied; callers can create an explicit mapping in this Context.
-        conn.execute(
+        tx.execute(
             "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
             params![dictionary_id],
         )?;
-        conn.execute(
+        tx.execute(
             "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
              VALUES (?1, ?2)",
             params![context_id, dictionary_id],
         )?;
     } else {
-        remove_dictionary_corrections_for_context_conn(&conn, context_id, dictionary_id)?;
-        conn.execute(
+        remove_dictionary_corrections_for_context_conn(&tx, context_id, dictionary_id)?;
+        tx.execute(
             "DELETE FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2",
             params![context_id, dictionary_id],
         )?;
-        cleanup_orphaned_auto_dictionary_conn(&conn, context_id, dictionary_id)?;
+        cleanup_orphaned_auto_dictionary_conn(&tx, context_id, dictionary_id)?;
     }
+    tx.commit()?;
     Ok(())
 }
 

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -1333,6 +1333,27 @@ pub fn auto_learn_promote(
         return Ok(AutoLearnPromoteResult::Blocked);
     }
 
+    // A Context may already use this mistranscription for another canonical
+    // term. Treat that as a normal AutoLearn block, before claiming the
+    // candidate gate, so the candidate remains eligible only if the competing
+    // mapping is later removed. Database failures still propagate normally.
+    let existing_dictionary_id: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM dictionary WHERE term = ?1",
+            params![correct],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if let Err(error) =
+        check_dictionary_mistake_conflicts(&tx, context_id, existing_dictionary_id, Some(wrong))
+    {
+        if error.to_string().starts_with("Often mistranscribed as ") {
+            tx.commit()?;
+            return Ok(AutoLearnPromoteResult::Blocked);
+        }
+        return Err(error);
+    }
+
     // Atomic claim on the candidate. 0 rows means the candidate is already
     // promoted (a concurrent monitor won the race) or was purged by a
     // rejection / manual delete — either way this pair must not promote again.
@@ -1373,7 +1394,6 @@ pub fn auto_learn_promote(
         params![context_id, dictionary_id],
     )?;
 
-    check_dictionary_mistake_conflicts(&tx, context_id, Some(dictionary_id), Some(wrong))?;
     tx.execute(
         "INSERT INTO dictionary_corrections
            (uuid, context_id, dictionary_id, mistake, auto_learned,

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -666,83 +666,84 @@ pub fn insert_dictionary_entry_returning(
     let tx = conn.transaction()?;
     let everywhere_id = ensure_everywhere_context_conn(&tx)?;
     let target_context = context_id.unwrap_or(everywhere_id);
-    if context_id.is_some() {
-        let exists: bool = tx.query_row(
-            "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
-            params![target_context],
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![target_context],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        anyhow::bail!("Context {target_context} was not found");
+    }
+    let existing: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM dictionary WHERE term = ?1",
+            params![normalized_term],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(id) = existing {
+        if context_id.is_none() {
+            anyhow::bail!("\"{normalized_term}\" is already in the dictionary");
+        }
+        let already_in_context: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2)",
+            params![target_context, id],
             |row| row.get(0),
         )?;
-        if !exists {
-            anyhow::bail!("Context {target_context} was not found");
+        if already_in_context {
+            anyhow::bail!("\"{normalized_term}\" is already in this context");
         }
-        let existing: Option<i64> = tx
-            .query_row(
-                "SELECT id FROM dictionary WHERE term = ?1",
-                params![normalized_term],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if let Some(id) = existing {
-            let already_in_context: bool = tx.query_row(
-                "SELECT EXISTS(SELECT 1 FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2)",
-                params![target_context, id],
-                |row| row.get(0),
-            )?;
-            if already_in_context {
-                anyhow::bail!("\"{normalized_term}\" is already in this context");
-            }
-            check_dictionary_mistake_conflicts(
-                &tx,
-                target_context,
-                Some(id),
-                normalized_mistake.as_deref(),
-            )?;
+        check_dictionary_mistake_conflicts(
+            &tx,
+            target_context,
+            Some(id),
+            normalized_mistake.as_deref(),
+        )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+            params![target_context, id],
+        )?;
+        // The legacy projection is no longer authoritative. Clear it
+        // when an existing row is touched so later legacy consumers
+        // cannot observe a stale correction that has no scoped owner.
+        tx.execute(
+            "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
+            params![id],
+        )?;
+        insert_correction_mappings_conn(
+            &tx,
+            target_context,
+            id,
+            CorrectionMappingSeed {
+                mistake: normalized_mistake.as_deref(),
+                auto_learned: false,
+                correction_count: 0,
+                confidence_tier: "manual",
+                last_seen_at: None,
+            },
+        )?;
+        // Keep the legacy global field as a compatibility projection for
+        // the standalone pre-Context sync path. Context-aware consumers
+        // use dictionary_corrections as the source of truth and ignore it.
+        if target_context == everywhere_id {
             tx.execute(
-                "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
-                params![target_context, id],
+                "UPDATE dictionary SET mistake = ?2 WHERE id = ?1",
+                params![id, normalized_mistake],
             )?;
-            // The legacy projection is no longer authoritative. Clear it
-            // when an existing row is touched so later legacy consumers
-            // cannot observe a stale correction that has no scoped owner.
-            tx.execute(
-                "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
-                params![id],
-            )?;
-            insert_correction_mappings_conn(
-                &tx,
-                target_context,
-                id,
-                CorrectionMappingSeed {
-                    mistake: normalized_mistake.as_deref(),
-                    auto_learned: false,
-                    correction_count: 0,
-                    confidence_tier: "manual",
-                    last_seen_at: None,
-                },
-            )?;
-            // Keep the legacy global field as a compatibility projection for
-            // the standalone pre-Context sync path. Context-aware consumers
-            // use dictionary_corrections as the source of truth and ignore it.
-            if target_context == everywhere_id {
-                tx.execute(
-                    "UPDATE dictionary SET mistake = ?2 WHERE id = ?1",
-                    params![id, normalized_mistake],
-                )?;
-            }
-            purge_auto_learn_evidence_for_mistake_list_conn(
-                &tx,
-                target_context,
-                normalized_mistake.as_deref(),
-                &normalized_term,
-            )?;
-            let created_at = tx.query_row(
-                "SELECT created_at FROM dictionary WHERE id=?1",
-                params![id],
-                |r| r.get(0),
-            )?;
-            tx.commit()?;
-            return Ok(CreatedRecordMeta { id, created_at });
         }
+        purge_auto_learn_evidence_for_mistake_list_conn(
+            &tx,
+            target_context,
+            normalized_mistake.as_deref(),
+            &normalized_term,
+        )?;
+        let created_at = tx.query_row(
+            "SELECT created_at FROM dictionary WHERE id=?1",
+            params![id],
+            |r| r.get(0),
+        )?;
+        tx.commit()?;
+        return Ok(CreatedRecordMeta { id, created_at });
     }
 
     check_dictionary_mistake_conflicts(&tx, target_context, None, normalized_mistake.as_deref())?;
@@ -2065,10 +2066,6 @@ pub(crate) fn cleanup_orphaned_auto_dictionary_conn(
 /// immediately re-promote. Manual mappings, other Contexts, and the shared
 /// canonical term remain untouched unless the canonical row is an auto-learned
 /// orphan with no remaining Context assignment.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "Consumed by the rejection monitor in the stacked runtime change")
-)]
 pub fn delete_auto_learned_corrections_by_ids(
     db: &Db,
     context_id: i64,

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -346,21 +346,14 @@ pub fn move_dictionary_corrections_conn(
                     params![target_id, source_count, source_last_seen_at],
                 )?;
             } else if source_auto_learned && target_auto_learned {
-                let target_count: i64 = conn.query_row(
-                    "SELECT correction_count FROM dictionary_corrections WHERE id = ?1",
-                    params![target_id],
-                    |row| row.get(0),
-                )?;
-                let target_tier: String = conn.query_row(
-                    "SELECT confidence_tier FROM dictionary_corrections WHERE id = ?1",
-                    params![target_id],
-                    |row| row.get(0),
-                )?;
-                let target_last_seen_at: Option<String> = conn.query_row(
-                    "SELECT last_seen_at FROM dictionary_corrections WHERE id = ?1",
-                    params![target_id],
-                    |row| row.get(0),
-                )?;
+                let (target_count, target_tier, target_last_seen_at):
+                    (i64, String, Option<String>) = conn.query_row(
+                        "SELECT correction_count, confidence_tier, last_seen_at
+                           FROM dictionary_corrections
+                          WHERE id = ?1",
+                        params![target_id],
+                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    )?;
                 let last_seen_at = match (target_last_seen_at, source_last_seen_at) {
                     (Some(target), Some(source)) => Some(target.max(source)),
                     (target, source) => target.or(source),
@@ -854,14 +847,15 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
 
     match existing {
         Some(id) => {
-            let everywhere_id = ensure_everywhere_context_conn(&conn)?;
-            conn.execute(
+            let tx = conn.transaction()?;
+            let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+            tx.execute(
                 "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
                  VALUES (?1, ?2)",
                 params![everywhere_id, id],
             )?;
             for known in KNOWN_VARIANTS {
-                let already_mapped: bool = conn.query_row(
+                let already_mapped: bool = tx.query_row(
                     "SELECT EXISTS(
                        SELECT 1 FROM dictionary_corrections
                         WHERE context_id = ?1 AND dictionary_id = ?2 AND mistake = ?3
@@ -872,7 +866,7 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
                 if already_mapped {
                     continue;
                 }
-                let conflicting: bool = conn.query_row(
+                let conflicting: bool = tx.query_row(
                     "SELECT EXISTS(
                        SELECT 1 FROM dictionary_corrections
                         WHERE context_id = ?1 AND mistake = ?2 AND dictionary_id != ?3
@@ -881,7 +875,7 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
                     |row| row.get(0),
                 )?;
                 if !conflicting {
-                    conn.execute(
+                    tx.execute(
                         "INSERT INTO dictionary_corrections
                            (uuid, context_id, dictionary_id, mistake, confidence_tier)
                          VALUES (?1, ?2, ?3, ?4, 'manual')",
@@ -889,14 +883,15 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
                     )?;
                 }
             }
-            conn.execute(
+            tx.execute(
                 "UPDATE dictionary SET mistake = NULL WHERE id = ?1",
                 params![id],
             )?;
-            conn.execute(
+            tx.execute(
                 "INSERT OR IGNORE INTO seeded_defaults (key) VALUES (?1)",
                 params![MARKER],
             )?;
+            tx.commit()?;
         }
         None => {
             let already_seeded: i64 = conn.query_row(
@@ -2154,13 +2149,13 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
         // rusqlite does not expose a portable array parameter. The small
         // compatibility path can safely inspect each requested id.
         let mut result = Vec::new();
+        let mut stmt = conn.prepare(
+            "SELECT c.id
+               FROM dictionary_corrections c
+              WHERE c.context_id = ?1 AND c.dictionary_id = ?2 AND c.auto_learned = 1",
+        )?;
         for id in ids {
-            let rows = conn
-                .prepare(
-                    "SELECT c.id
-                       FROM dictionary_corrections c
-                      WHERE c.context_id = ?1 AND c.dictionary_id = ?2 AND c.auto_learned = 1",
-                )?
+            let rows = stmt
                 .query_map(params![everywhere_id, id], |row| row.get::<_, i64>(0))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             result.extend(rows);

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -67,6 +67,36 @@ pub struct AutoLearnStatusSummary {
     pub timeout_finishes: i64,
 }
 
+#[derive(Debug)]
+struct LegacyDictionaryFields {
+    term: String,
+    mistake: Option<String>,
+    auto_learned: bool,
+    correction_count: i64,
+    confidence_tier: String,
+    last_seen_at: Option<String>,
+    created_at: String,
+}
+
+struct CorrectionMappingSeed<'a> {
+    mistake: Option<&'a str>,
+    auto_learned: bool,
+    correction_count: i64,
+    confidence_tier: &'a str,
+    last_seen_at: Option<&'a str>,
+}
+
+pub struct AutoLearnEventFields<'a> {
+    pub event_type: &'a str,
+    pub reason_code: &'a str,
+    pub app_context: &'a str,
+    pub mistake_hash: &'a str,
+    pub correction_hash: &'a str,
+    pub confidence: f64,
+}
+
+type CorrectionTransferRow = (i64, i64, String, bool, i64, String, Option<String>);
+
 pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
     let conn = lock_conn(db)?;
     query_dictionary_conn(&conn, None)
@@ -95,27 +125,20 @@ fn query_dictionary_conn(
           WHERE ?1 IS NULL
           ORDER BY created_at DESC"
     };
-    let canonical_rows: Vec<(
-        i64,
-        String,
-        Option<String>,
-        bool,
-        i64,
-        String,
-        Option<String>,
-        String,
-    )> = conn
+    let canonical_rows: Vec<(i64, LegacyDictionaryFields)> = conn
         .prepare(canonical_sql)?
         .query_map(params![context_id], |row| {
             Ok((
                 row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get::<_, i64>(3)? != 0,
-                row.get(4)?,
-                row.get(5)?,
-                row.get(6)?,
-                row.get(7)?,
+                LegacyDictionaryFields {
+                    term: row.get(1)?,
+                    mistake: row.get(2)?,
+                    auto_learned: row.get::<_, i64>(3)? != 0,
+                    correction_count: row.get(4)?,
+                    confidence_tier: row.get(5)?,
+                    last_seen_at: row.get(6)?,
+                    created_at: row.get(7)?,
+                },
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -159,51 +182,21 @@ fn query_dictionary_conn(
 
     Ok(canonical_rows
         .into_iter()
-        .map(
-            |(
-                id,
-                term,
-                legacy_mistake,
-                legacy_auto_learned,
-                legacy_correction_count,
-                legacy_confidence_tier,
-                legacy_last_seen_at,
-                created_at,
-            )| {
+        .map(|(id, mut legacy)| {
                 let corrections = corrections_by_dictionary.remove(&id).unwrap_or_default();
                 // A scoped query must never fall back to the old global
                 // projection.  v26 migrates it into child rows and clears
                 // `dictionary.mistake`; ignoring the projection here also
                 // keeps a stale value from an interrupted/remote legacy write
                 // from leaking a correction learned in another Context.
-                let (
-                    legacy_mistake,
-                    legacy_auto_learned,
-                    legacy_correction_count,
-                    legacy_confidence_tier,
-                    legacy_last_seen_at,
-                ) = if context_id.is_some() {
-                    (None, false, 0, "manual".to_string(), None)
-                } else {
-                    (
-                        legacy_mistake,
-                        legacy_auto_learned,
-                        legacy_correction_count,
-                        legacy_confidence_tier,
-                        legacy_last_seen_at,
-                    )
-                };
-                materialize_dictionary_entry(
-                    id,
-                    term,
-                    legacy_mistake,
-                    legacy_auto_learned,
-                    legacy_correction_count,
-                    legacy_confidence_tier,
-                    legacy_last_seen_at,
-                    created_at,
-                    corrections,
-                )
+                if context_id.is_some() {
+                    legacy.mistake = None;
+                    legacy.auto_learned = false;
+                    legacy.correction_count = 0;
+                    legacy.confidence_tier = "manual".to_string();
+                    legacy.last_seen_at = None;
+                }
+                materialize_dictionary_entry(id, legacy, corrections)
             },
         )
         .collect())
@@ -211,13 +204,7 @@ fn query_dictionary_conn(
 
 fn materialize_dictionary_entry(
     id: i64,
-    term: String,
-    legacy_mistake: Option<String>,
-    legacy_auto_learned: bool,
-    legacy_correction_count: i64,
-    legacy_confidence_tier: String,
-    legacy_last_seen_at: Option<String>,
-    created_at: String,
+    legacy: LegacyDictionaryFields,
     corrections: Vec<DictionaryCorrection>,
 ) -> DictionaryEntry {
     if corrections.is_empty() {
@@ -226,13 +213,13 @@ fn materialize_dictionary_entry(
         // child table, so a healthy database cannot leak it into a Context.
         return DictionaryEntry {
             id,
-            term,
-            mistake: legacy_mistake,
-            auto_learned: legacy_auto_learned,
-            correction_count: legacy_correction_count,
-            confidence_tier: legacy_confidence_tier,
-            last_seen_at: legacy_last_seen_at,
-            created_at,
+            term: legacy.term,
+            mistake: legacy.mistake,
+            auto_learned: legacy.auto_learned,
+            correction_count: legacy.correction_count,
+            confidence_tier: legacy.confidence_tier,
+            last_seen_at: legacy.last_seen_at,
+            created_at: legacy.created_at,
             corrections,
         };
     }
@@ -262,13 +249,13 @@ fn materialize_dictionary_entry(
 
     DictionaryEntry {
         id,
-        term,
+        term: legacy.term,
         mistake: (!mistake.is_empty()).then_some(mistake),
         auto_learned,
         correction_count,
         confidence_tier,
         last_seen_at,
-        created_at,
+        created_at: legacy.created_at,
         corrections,
     }
 }
@@ -300,7 +287,7 @@ pub fn move_dictionary_corrections_conn(
         return Ok(0);
     }
 
-    let source_rows: Vec<(i64, i64, String, bool, i64, String, Option<String>)> = conn
+    let source_rows: Vec<CorrectionTransferRow> = conn
         .prepare(
             "SELECT id, dictionary_id, mistake, auto_learned, correction_count,
                     confidence_tier, last_seen_at
@@ -604,10 +591,8 @@ fn normalized_mistake_list(mistake: Option<&str>) -> Vec<String> {
     mistake
         .into_iter()
         .flat_map(dictionary_mistake_variants)
-        .filter_map(|variant| {
-            seen.insert(variant.to_lowercase())
-                .then(|| variant.to_owned())
-        })
+        .filter(|variant| seen.insert(variant.to_lowercase()))
+        .map(str::to_owned)
         .collect()
 }
 
@@ -619,13 +604,9 @@ fn insert_correction_mappings_conn(
     conn: &rusqlite::Connection,
     context_id: i64,
     dictionary_id: i64,
-    mistake: Option<&str>,
-    auto_learned: bool,
-    correction_count: i64,
-    confidence_tier: &str,
-    last_seen_at: Option<&str>,
+    seed: CorrectionMappingSeed<'_>,
 ) -> Result<usize> {
-    let variants = normalized_mistake_list(mistake);
+    let variants = normalized_mistake_list(seed.mistake);
     let mut inserted = 0;
     for (index, variant) in variants.iter().enumerate() {
         let changed = conn.execute(
@@ -638,10 +619,10 @@ fn insert_correction_mappings_conn(
                 context_id,
                 dictionary_id,
                 variant,
-                auto_learned as i64,
-                if index == 0 { correction_count } else { 0 },
-                confidence_tier,
-                last_seen_at,
+                seed.auto_learned as i64,
+                if index == 0 { seed.correction_count } else { 0 },
+                seed.confidence_tier,
+                seed.last_seen_at,
             ],
         )?;
         inserted += changed;
@@ -731,11 +712,13 @@ pub fn insert_dictionary_entry_returning(
                 &tx,
                 target_context,
                 id,
-                normalized_mistake.as_deref(),
-                false,
-                0,
-                "manual",
-                None,
+                CorrectionMappingSeed {
+                    mistake: normalized_mistake.as_deref(),
+                    auto_learned: false,
+                    correction_count: 0,
+                    confidence_tier: "manual",
+                    last_seen_at: None,
+                },
             )?;
             purge_auto_learn_evidence_for_mistake_list_conn(
                 &tx,
@@ -767,11 +750,13 @@ pub fn insert_dictionary_entry_returning(
         &tx,
         target_context,
         id,
-        normalized_mistake.as_deref(),
-        false,
-        0,
-        "manual",
-        None,
+        CorrectionMappingSeed {
+            mistake: normalized_mistake.as_deref(),
+            auto_learned: false,
+            correction_count: 0,
+            confidence_tier: "manual",
+            last_seen_at: None,
+        },
     )?;
     purge_auto_learn_evidence_for_mistake_list_conn(
         &tx,
@@ -920,11 +905,13 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
                 &tx,
                 everywhere_id,
                 id,
-                Some(&KNOWN_VARIANTS.join(", ")),
-                false,
-                0,
-                "manual",
-                None,
+                CorrectionMappingSeed {
+                    mistake: Some(&KNOWN_VARIANTS.join(", ")),
+                    auto_learned: false,
+                    correction_count: 0,
+                    confidence_tier: "manual",
+                    last_seen_at: None,
+                },
             )?;
             tx.execute(
                 "INSERT INTO seeded_defaults (key) VALUES (?1)",
@@ -968,11 +955,13 @@ pub fn insert_dictionary_entry_from_backup_conn(
         conn,
         everywhere_id,
         id,
-        normalized_mistake.as_deref(),
-        auto_learned,
-        correction_count,
-        confidence_tier,
-        None,
+        CorrectionMappingSeed {
+            mistake: normalized_mistake.as_deref(),
+            auto_learned,
+            correction_count,
+            confidence_tier,
+            last_seen_at: None,
+        },
     )?;
     Ok(())
 }
@@ -1123,49 +1112,37 @@ pub fn log_auto_learn_event(
     log_auto_learn_event_with_context(
         db,
         None,
-        event_type,
-        reason_code,
-        app_context,
-        mistake_hash,
-        correction_hash,
-        confidence,
+        AutoLearnEventFields {
+            event_type,
+            reason_code,
+            app_context,
+            mistake_hash,
+            correction_hash,
+            confidence,
+        },
     )
 }
 
 /// Context-aware event writer. The legacy wrapper above remains for old
 /// telemetry callers; new monitor paths should always provide the immutable
 /// originating Context id.
+#[expect(dead_code, reason = "Consumed by the Context-aware monitor in the stacked runtime change")]
 pub fn log_auto_learn_event_for_context(
     db: &Db,
     context_id: i64,
-    event_type: &str,
-    reason_code: &str,
-    app_context: &str,
-    mistake_hash: &str,
-    correction_hash: &str,
-    confidence: f64,
+    event: AutoLearnEventFields<'_>,
 ) -> Result<()> {
     log_auto_learn_event_with_context(
         db,
         Some(context_id),
-        event_type,
-        reason_code,
-        app_context,
-        mistake_hash,
-        correction_hash,
-        confidence,
+        event,
     )
 }
 
 fn log_auto_learn_event_with_context(
     db: &Db,
     context_id: Option<i64>,
-    event_type: &str,
-    reason_code: &str,
-    app_context: &str,
-    mistake_hash: &str,
-    correction_hash: &str,
-    confidence: f64,
+    event: AutoLearnEventFields<'_>,
 ) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
@@ -1173,13 +1150,13 @@ fn log_auto_learn_event_with_context(
          (event_type, reason_code, context_id, app_context, mistake_hash, correction_hash, confidence)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
-            event_type,
-            reason_code,
+            event.event_type,
+            event.reason_code,
             context_id,
-            app_context,
-            mistake_hash,
-            correction_hash,
-            confidence
+            event.app_context,
+            event.mistake_hash,
+            event.correction_hash,
+            event.confidence
         ],
     )?;
     Ok(())
@@ -1681,11 +1658,13 @@ fn update_dictionary_entry_for_context_conn(
         conn,
         context_id,
         id,
-        normalized_mistake,
-        false,
-        0,
-        "manual",
-        None,
+        CorrectionMappingSeed {
+            mistake: normalized_mistake,
+            auto_learned: false,
+            correction_count: 0,
+            confidence_tier: "manual",
+            last_seen_at: None,
+        },
     )?;
     purge_auto_learn_evidence_for_mistake_list_conn(
         conn,
@@ -1720,6 +1699,7 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
 /// This is the Contexts-surface counterpart to the legacy global delete. An
 /// automatically-created canonical row is removed only when this was its last
 /// assignment and no correction mapping remains anywhere.
+#[expect(dead_code, reason = "Consumed by the Contexts library command in the stacked runtime change")]
 pub fn remove_dictionary_entry_from_context(
     db: &Db,
     context_id: i64,
@@ -1752,6 +1732,7 @@ pub fn remove_dictionary_entry_from_context(
 /// shared item, moving is an explicit transfer: its Context-owned correction
 /// mappings follow the assignment, while any unpromoted evidence in the source
 /// Context is discarded because it has no safe destination.
+#[expect(dead_code, reason = "Consumed by the Contexts library command in the stacked runtime change")]
 pub fn move_dictionary_entry_to_context(
     db: &Db,
     dictionary_id: i64,
@@ -2031,6 +2012,7 @@ pub(crate) fn cleanup_orphaned_auto_dictionary_conn(
 /// immediately re-promote. Manual mappings, other Contexts, and the shared
 /// canonical term remain untouched unless the canonical row is an auto-learned
 /// orphan with no remaining Context assignment.
+#[expect(dead_code, reason = "Consumed by the rejection monitor in the stacked runtime change")]
 pub fn delete_auto_learned_corrections_by_ids(
     db: &Db,
     context_id: i64,

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -2065,7 +2065,10 @@ pub(crate) fn cleanup_orphaned_auto_dictionary_conn(
 /// immediately re-promote. Manual mappings, other Contexts, and the shared
 /// canonical term remain untouched unless the canonical row is an auto-learned
 /// orphan with no remaining Context assignment.
-#[expect(dead_code, reason = "Consumed by the rejection monitor in the stacked runtime change")]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Consumed by the rejection monitor in the stacked runtime change")
+)]
 pub fn delete_auto_learned_corrections_by_ids(
     db: &Db,
     context_id: i64,

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -1189,7 +1189,7 @@ fn log_auto_learn_event_with_context(
 /// the running average confidence across all observations of that pair in one
 /// Context. Context is part of the natural key; observations from another
 /// Context cannot contribute to this average.
-pub fn upsert_auto_learn_candidate(
+pub fn upsert_auto_learn_candidate_for_context(
     db: &Db,
     context_id: i64,
     wrong: &str,
@@ -1219,6 +1219,19 @@ pub fn upsert_auto_learn_candidate(
         |r| r.get(0),
     )
     .map_err(Into::into)
+}
+
+/// Compatibility wrapper for the legacy monitor API. The Context-aware
+/// runtime uses [`upsert_auto_learn_candidate_for_context`]; callers that do
+/// not yet capture a Context retain the historical Everywhere scope until
+/// they are migrated.
+pub fn upsert_auto_learn_candidate(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    confidence: f64,
+) -> Result<f64> {
+    upsert_auto_learn_candidate_for_context(db, EVERYWHERE_CONTEXT_ID, wrong, correct, confidence)
 }
 
 /// Outcome of an [`auto_learn_promote`] attempt.
@@ -1253,7 +1266,7 @@ pub enum AutoLearnPromoteResult {
 /// rejected entry. `promoted_at` is the single promotion gate: it is claimed
 /// here (atomically, `IS NULL` guard) and only cleared by the rejection /
 /// manual-delete paths, which purge the candidate row entirely.
-pub fn auto_learn_promote(
+pub fn auto_learn_promote_for_context(
     db: &Db,
     context_id: i64,
     wrong: &str,
@@ -1415,6 +1428,28 @@ pub fn auto_learn_promote(
 
     tx.commit()?;
     Ok(AutoLearnPromoteResult::Promoted)
+}
+
+/// Compatibility wrapper for legacy callers that do not carry the resolved
+/// Context. New code must use [`auto_learn_promote_for_context`] so evidence
+/// and persistent mappings retain their originating Context.
+pub fn auto_learn_promote(
+    db: &Db,
+    wrong: &str,
+    correct: &str,
+    confidence_tier: &str,
+    pending_retention_days: i64,
+    threshold: i64,
+) -> Result<AutoLearnPromoteResult> {
+    auto_learn_promote_for_context(
+        db,
+        EVERYWHERE_CONTEXT_ID,
+        wrong,
+        correct,
+        confidence_tier,
+        pending_retention_days,
+        threshold,
+    )
 }
 
 pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> {

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -835,7 +835,7 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
         "Marino", "Zarinu", "Berenu", "Ferenu", "Werenu", "Verinu", "Varineu",
     ];
 
-    let conn = lock_conn(db)?;
+    let mut conn = lock_conn(db)?;
     let existing: Option<i64> = {
         let mut stmt = conn.prepare("SELECT id FROM dictionary WHERE term = 'Verenu' LIMIT 1")?;
         let mut rows = stmt.query([])?;

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -3,9 +3,27 @@
 use anyhow::Result;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
 
 use super::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DictionaryCorrection {
+    /// Persistent identity of the correction mapping. This is deliberately
+    /// separate from `DictionaryEntry::id`: the latter identifies the shared
+    /// canonical term and must never be used as a context-scoped rejection
+    /// target.
+    pub id: i64,
+    pub dictionary_id: i64,
+    pub context_id: i64,
+    pub mistake: String,
+    pub auto_learned: bool,
+    pub correction_count: i64,
+    pub confidence_tier: String,
+    pub last_seen_at: Option<String>,
+    pub created_at: String,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DictionaryEntry {
@@ -17,6 +35,13 @@ pub struct DictionaryEntry {
     pub confidence_tier: String,
     pub last_seen_at: Option<String>,
     pub created_at: String,
+    /// Context-effective correction mappings. The legacy Dictionary view
+    /// leaves this empty and uses `mistake`; context materialization fills it
+    /// with the child mappings effective in that one context. Keeping both
+    /// fields lets old IPC consumers continue to render a flattened row while
+    /// the pipeline/rejection path uses typed mapping identities.
+    #[serde(default)]
+    pub corrections: Vec<DictionaryCorrection>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -24,6 +49,7 @@ pub struct AutoLearnEvent {
     pub id: i64,
     pub event_type: String,
     pub reason_code: String,
+    pub context_id: Option<i64>,
     pub app_context: String,
     pub mistake_hash: String,
     pub correction_hash: String,
@@ -43,52 +69,468 @@ pub struct AutoLearnStatusSummary {
 
 pub fn query_dictionary(db: &Db) -> Result<Vec<DictionaryEntry>> {
     let conn = lock_conn(db)?;
-    let mut stmt = conn.prepare(
-        "SELECT id, term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at, created_at \
-         FROM dictionary ORDER BY created_at DESC",
-    )?;
-    let rows = stmt
-        .query_map([], |r| {
-            Ok(DictionaryEntry {
-                id: r.get(0)?,
-                term: r.get(1)?,
-                mistake: r.get(2)?,
-                auto_learned: r.get::<_, i64>(3)? != 0,
-                correction_count: r.get(4)?,
-                confidence_tier: r.get(5)?,
-                last_seen_at: r.get(6)?,
-                created_at: r.get(7)?,
-            })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(rows)
+    query_dictionary_conn(&conn, None)
 }
 
 pub fn query_dictionary_for_context(db: &Db, context_id: i64) -> Result<Vec<DictionaryEntry>> {
     let conn = lock_conn(db)?;
-    let mut stmt = conn.prepare(
+    query_dictionary_conn(&conn, Some(context_id))
+}
+
+fn query_dictionary_conn(
+    conn: &rusqlite::Connection,
+    context_id: Option<i64>,
+) -> Result<Vec<DictionaryEntry>> {
+    let canonical_sql = if context_id.is_some() {
         "SELECT d.id, d.term, d.mistake, d.auto_learned, d.correction_count,
                 d.confidence_tier, d.last_seen_at, d.created_at
-         FROM dictionary d
-         INNER JOIN dictionary_contexts dc ON dc.dictionary_id = d.id
-         WHERE dc.context_id = ?1
-         ORDER BY d.created_at DESC",
-    )?;
-    let rows = stmt
-        .query_map(params![context_id], |r| {
-            Ok(DictionaryEntry {
-                id: r.get(0)?,
-                term: r.get(1)?,
-                mistake: r.get(2)?,
-                auto_learned: r.get::<_, i64>(3)? != 0,
-                correction_count: r.get(4)?,
-                confidence_tier: r.get(5)?,
-                last_seen_at: r.get(6)?,
-                created_at: r.get(7)?,
+           FROM dictionary d
+           INNER JOIN dictionary_contexts dc ON dc.dictionary_id = d.id
+          WHERE dc.context_id = ?1
+          ORDER BY d.created_at DESC"
+    } else {
+        "SELECT id, term, mistake, auto_learned, correction_count, confidence_tier,
+                last_seen_at, created_at
+           FROM dictionary
+          WHERE ?1 IS NULL
+          ORDER BY created_at DESC"
+    };
+    let canonical_rows: Vec<(
+        i64,
+        String,
+        Option<String>,
+        bool,
+        i64,
+        String,
+        Option<String>,
+        String,
+    )> = conn
+        .prepare(canonical_sql)?
+        .query_map(params![context_id], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get::<_, i64>(3)? != 0,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let correction_sql = if context_id.is_some() {
+        "SELECT id, dictionary_id, context_id, mistake, auto_learned,
+                correction_count, confidence_tier, last_seen_at, created_at
+           FROM dictionary_corrections
+          WHERE context_id = ?1
+          ORDER BY dictionary_id, id"
+    } else {
+        "SELECT id, dictionary_id, context_id, mistake, auto_learned,
+                correction_count, confidence_tier, last_seen_at, created_at
+           FROM dictionary_corrections
+          WHERE ?1 IS NULL
+          ORDER BY dictionary_id, context_id, id"
+    };
+    let correction_rows = conn
+        .prepare(correction_sql)?
+        .query_map(params![context_id], |row| {
+            Ok(DictionaryCorrection {
+                id: row.get(0)?,
+                dictionary_id: row.get(1)?,
+                context_id: row.get(2)?,
+                mistake: row.get(3)?,
+                auto_learned: row.get::<_, i64>(4)? != 0,
+                correction_count: row.get(5)?,
+                confidence_tier: row.get(6)?,
+                last_seen_at: row.get(7)?,
+                created_at: row.get(8)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(rows)
+    let mut corrections_by_dictionary: HashMap<i64, Vec<DictionaryCorrection>> = HashMap::new();
+    for correction in correction_rows {
+        corrections_by_dictionary
+            .entry(correction.dictionary_id)
+            .or_default()
+            .push(correction);
+    }
+
+    Ok(canonical_rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                term,
+                legacy_mistake,
+                legacy_auto_learned,
+                legacy_correction_count,
+                legacy_confidence_tier,
+                legacy_last_seen_at,
+                created_at,
+            )| {
+                let corrections = corrections_by_dictionary.remove(&id).unwrap_or_default();
+                // A scoped query must never fall back to the old global
+                // projection.  v26 migrates it into child rows and clears
+                // `dictionary.mistake`; ignoring the projection here also
+                // keeps a stale value from an interrupted/remote legacy write
+                // from leaking a correction learned in another Context.
+                let (
+                    legacy_mistake,
+                    legacy_auto_learned,
+                    legacy_correction_count,
+                    legacy_confidence_tier,
+                    legacy_last_seen_at,
+                ) = if context_id.is_some() {
+                    (None, false, 0, "manual".to_string(), None)
+                } else {
+                    (
+                        legacy_mistake,
+                        legacy_auto_learned,
+                        legacy_correction_count,
+                        legacy_confidence_tier,
+                        legacy_last_seen_at,
+                    )
+                };
+                materialize_dictionary_entry(
+                    id,
+                    term,
+                    legacy_mistake,
+                    legacy_auto_learned,
+                    legacy_correction_count,
+                    legacy_confidence_tier,
+                    legacy_last_seen_at,
+                    created_at,
+                    corrections,
+                )
+            },
+        )
+        .collect())
+}
+
+fn materialize_dictionary_entry(
+    id: i64,
+    term: String,
+    legacy_mistake: Option<String>,
+    legacy_auto_learned: bool,
+    legacy_correction_count: i64,
+    legacy_confidence_tier: String,
+    legacy_last_seen_at: Option<String>,
+    created_at: String,
+    corrections: Vec<DictionaryCorrection>,
+) -> DictionaryEntry {
+    if corrections.is_empty() {
+        // This fallback is only for a pre-v26/partially repaired row. v26
+        // clears the global projection, and all writes after v26 populate the
+        // child table, so a healthy database cannot leak it into a Context.
+        return DictionaryEntry {
+            id,
+            term,
+            mistake: legacy_mistake,
+            auto_learned: legacy_auto_learned,
+            correction_count: legacy_correction_count,
+            confidence_tier: legacy_confidence_tier,
+            last_seen_at: legacy_last_seen_at,
+            created_at,
+            corrections,
+        };
+    }
+
+    let mut seen = HashSet::new();
+    let mistake = corrections
+        .iter()
+        .filter(|correction| seen.insert(correction.mistake.to_lowercase()))
+        .map(|correction| correction.mistake.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let auto_learned = corrections.iter().any(|correction| correction.auto_learned);
+    let correction_count = corrections
+        .iter()
+        .map(|correction| correction.correction_count)
+        .sum();
+    let confidence_tier = corrections
+        .iter()
+        .filter(|correction| correction.auto_learned)
+        .max_by_key(|correction| confidence_tier_rank(&correction.confidence_tier))
+        .map(|correction| correction.confidence_tier.clone())
+        .unwrap_or_else(|| "manual".to_string());
+    let last_seen_at = corrections
+        .iter()
+        .filter_map(|correction| correction.last_seen_at.clone())
+        .max();
+
+    DictionaryEntry {
+        id,
+        term,
+        mistake: (!mistake.is_empty()).then_some(mistake),
+        auto_learned,
+        correction_count,
+        confidence_tier,
+        last_seen_at,
+        created_at,
+        corrections,
+    }
+}
+
+fn confidence_tier_rank(tier: &str) -> u8 {
+    match tier {
+        "high" => 3,
+        "medium" => 2,
+        "low" => 1,
+        _ => 0,
+    }
+}
+
+/// Move correction mappings along with their canonical dictionary assignment
+/// when a Context is deleted.
+///
+/// Context deletion has always moved vocabulary assignments to Everywhere.
+/// The child mapping must follow that move, but a direct `UPDATE` can collide
+/// with an existing Everywhere mapping. An exact same-term/same-variant row is
+/// merged (manual metadata wins); a different canonical term already using the
+/// same variant wins deterministically and the deleted-Context row is dropped
+/// rather than creating an ambiguous substitution.
+pub fn move_dictionary_corrections_conn(
+    conn: &rusqlite::Connection,
+    from_context_id: i64,
+    to_context_id: i64,
+) -> Result<usize> {
+    if from_context_id == to_context_id {
+        return Ok(0);
+    }
+
+    let source_rows: Vec<(i64, i64, String, bool, i64, String, Option<String>)> = conn
+        .prepare(
+            "SELECT id, dictionary_id, mistake, auto_learned, correction_count,
+                    confidence_tier, last_seen_at
+               FROM dictionary_corrections
+              WHERE context_id = ?1
+              ORDER BY id",
+        )?
+        .query_map(params![from_context_id], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get::<_, i64>(3)? != 0,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut changed = 0;
+    for (
+        id,
+        dictionary_id,
+        mistake,
+        source_auto_learned,
+        source_count,
+        source_tier,
+        source_last_seen_at,
+    ) in source_rows
+    {
+        let exact_target: Option<(i64, bool)> = conn
+            .query_row(
+                "SELECT id, auto_learned
+                   FROM dictionary_corrections
+                  WHERE context_id = ?1 AND dictionary_id = ?2 AND mistake = ?3
+                  LIMIT 1",
+                params![to_context_id, dictionary_id, mistake],
+                |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)),
+            )
+            .optional()?;
+
+        if let Some((target_id, target_auto_learned)) = exact_target {
+            // A manual mapping is authoritative. If the source mapping is
+            // manual and the target was automatic, transfer that authority;
+            // otherwise retain the existing target row and only accumulate
+            // automatic evidence.
+            if !source_auto_learned && target_auto_learned {
+                conn.execute(
+                    "UPDATE dictionary_corrections
+                        SET auto_learned = 0,
+                            correction_count = ?2,
+                            confidence_tier = 'manual',
+                            last_seen_at = ?3
+                      WHERE id = ?1",
+                    params![target_id, source_count, source_last_seen_at],
+                )?;
+            } else if source_auto_learned && target_auto_learned {
+                let target_count: i64 = conn.query_row(
+                    "SELECT correction_count FROM dictionary_corrections WHERE id = ?1",
+                    params![target_id],
+                    |row| row.get(0),
+                )?;
+                let target_tier: String = conn.query_row(
+                    "SELECT confidence_tier FROM dictionary_corrections WHERE id = ?1",
+                    params![target_id],
+                    |row| row.get(0),
+                )?;
+                let target_last_seen_at: Option<String> = conn.query_row(
+                    "SELECT last_seen_at FROM dictionary_corrections WHERE id = ?1",
+                    params![target_id],
+                    |row| row.get(0),
+                )?;
+                let last_seen_at = match (target_last_seen_at, source_last_seen_at) {
+                    (Some(target), Some(source)) => Some(target.max(source)),
+                    (target, source) => target.or(source),
+                };
+                let tier =
+                    if confidence_tier_rank(&source_tier) > confidence_tier_rank(&target_tier) {
+                        source_tier
+                    } else {
+                        target_tier
+                    };
+                conn.execute(
+                    "UPDATE dictionary_corrections
+                        SET correction_count = ?2,
+                            confidence_tier = ?3,
+                            last_seen_at = ?4
+                      WHERE id = ?1",
+                    params![target_id, target_count + source_count, tier, last_seen_at],
+                )?;
+            }
+            conn.execute(
+                "DELETE FROM dictionary_corrections WHERE id = ?1",
+                params![id],
+            )?;
+            changed += 1;
+            continue;
+        }
+
+        // The unique Context/variant index cannot represent two canonical
+        // terms for the same spelling. Keep the pre-existing Everywhere row;
+        // this is the same deterministic conflict policy used during legacy
+        // migration and default seeding.
+        let variant_conflict: bool = conn.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM dictionary_corrections
+                  WHERE context_id = ?1 AND mistake = ?2 AND dictionary_id != ?3
+             )",
+            params![to_context_id, mistake, dictionary_id],
+            |row| row.get(0),
+        )?;
+        if variant_conflict {
+            conn.execute(
+                "DELETE FROM dictionary_corrections WHERE id = ?1",
+                params![id],
+            )?;
+            changed += 1;
+            continue;
+        }
+
+        changed += conn.execute(
+            "UPDATE dictionary_corrections SET context_id = ?2 WHERE id = ?1",
+            params![id, to_context_id],
+        )?;
+    }
+
+    Ok(changed)
+}
+
+/// Remove all correction mappings for one canonical item from one Context.
+///
+/// This is the connection-level operation used by the Context assignment
+/// "remove" path. Removing only `dictionary_contexts` would leave an orphaned
+/// child mapping that could reappear if the canonical item is assigned again,
+/// and would leave stale evidence eligible for promotion.
+pub fn remove_dictionary_corrections_for_context_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    dictionary_id: i64,
+) -> Result<usize> {
+    let term: Option<String> = conn
+        .query_row(
+            "SELECT term FROM dictionary WHERE id = ?1",
+            params![dictionary_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let mappings: Vec<(String, String)> = conn
+        .prepare(
+            "SELECT c.mistake, d.term
+               FROM dictionary_corrections c
+               INNER JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE c.context_id = ?1 AND c.dictionary_id = ?2",
+        )?
+        .query_map(params![context_id, dictionary_id], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    for (mistake, term) in mappings {
+        for variant in dictionary_mistake_variants(&mistake) {
+            purge_auto_learn_evidence_for_pair_conn(conn, context_id, variant, &term)?;
+        }
+    }
+    // Evidence can outlive its promoted child row after a rejection or a
+    // partially completed import. Removing the canonical assignment must
+    // purge that evidence even when no mapping row remains to enumerate it.
+    if let Some(term) = term.as_deref() {
+        purge_auto_learn_evidence_for_term_conn(conn, context_id, term)?;
+    }
+
+    Ok(conn.execute(
+        "DELETE FROM dictionary_corrections
+           WHERE context_id = ?1 AND dictionary_id = ?2",
+        params![context_id, dictionary_id],
+    )?)
+}
+
+fn purge_auto_learn_evidence_for_pair_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    mistake: &str,
+    term: &str,
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM pending_corrections
+           WHERE context_id = ?1
+             AND lower(wrong_word) = lower(?2)
+             AND lower(correct_word) = lower(?3)",
+        params![context_id, mistake, term],
+    )?;
+    conn.execute(
+        "DELETE FROM auto_learn_candidates
+           WHERE context_id = ?1
+             AND lower(wrong_word) = lower(?2)
+             AND lower(correct_word) = lower(?3)",
+        params![context_id, mistake, term],
+    )?;
+    Ok(())
+}
+
+fn purge_auto_learn_evidence_for_term_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    term: &str,
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM pending_corrections
+           WHERE context_id = ?1 AND lower(correct_word) = lower(?2)",
+        params![context_id, term],
+    )?;
+    conn.execute(
+        "DELETE FROM auto_learn_candidates
+           WHERE context_id = ?1 AND lower(correct_word) = lower(?2)",
+        params![context_id, term],
+    )?;
+    Ok(())
+}
+
+fn purge_auto_learn_evidence_for_mistake_list_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    mistake: Option<&str>,
+    term: &str,
+) -> Result<()> {
+    for variant in mistake.into_iter().flat_map(dictionary_mistake_variants) {
+        purge_auto_learn_evidence_for_pair_conn(conn, context_id, variant, term)?;
+    }
+    Ok(())
 }
 
 /// Returns the comma-separated mistranscription variants in a dictionary
@@ -124,12 +566,16 @@ pub fn check_dictionary_mistake_conflicts(
         return Ok(());
     }
 
+    // v26 makes child rows the only Context-aware source of corrections.
+    // Deliberately do not consult `dictionary.mistake`: it is retained only
+    // as a legacy compatibility column and a stale value must not block or
+    // leak a mapping in a different Context.
     let mut stmt = conn.prepare(
-        "SELECT d.id, d.term, d.mistake
-         FROM dictionary d
-         INNER JOIN dictionary_contexts dc ON dc.dictionary_id = d.id
-         WHERE dc.context_id = ?1
-           AND (?2 IS NULL OR d.id != ?2)",
+        "SELECT d.id, d.term, c.mistake
+           FROM dictionary_corrections c
+           INNER JOIN dictionary d ON d.id = c.dictionary_id
+          WHERE c.context_id = ?1
+            AND (?2 IS NULL OR d.id != ?2)",
     )?;
     let rows = stmt.query_map(params![context_id, dictionary_id], |row| {
         Ok((
@@ -151,6 +597,56 @@ pub fn check_dictionary_mistake_conflicts(
     }
 
     Ok(())
+}
+
+fn normalized_mistake_list(mistake: Option<&str>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    mistake
+        .into_iter()
+        .flat_map(dictionary_mistake_variants)
+        .filter_map(|variant| {
+            seen.insert(variant.to_lowercase())
+                .then(|| variant.to_owned())
+        })
+        .collect()
+}
+
+/// Inserts the context-owned child mappings for one canonical term.  The
+/// caller must perform the context conflict check first.  A mapping row is
+/// intentionally one variant, not the legacy comma-separated field, because
+/// the row id is the rejection/sync identity.
+fn insert_correction_mappings_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    dictionary_id: i64,
+    mistake: Option<&str>,
+    auto_learned: bool,
+    correction_count: i64,
+    confidence_tier: &str,
+    last_seen_at: Option<&str>,
+) -> Result<usize> {
+    let variants = normalized_mistake_list(mistake);
+    let mut inserted = 0;
+    for (index, variant) in variants.iter().enumerate() {
+        let changed = conn.execute(
+            "INSERT INTO dictionary_corrections
+               (uuid, context_id, dictionary_id, mistake, auto_learned,
+                correction_count, confidence_tier, last_seen_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                Uuid::new_v4().to_string(),
+                context_id,
+                dictionary_id,
+                variant,
+                auto_learned as i64,
+                if index == 0 { correction_count } else { 0 },
+                confidence_tier,
+                last_seen_at,
+            ],
+        )?;
+        inserted += changed;
+    }
+    Ok(inserted)
 }
 
 #[cfg(test)]
@@ -188,9 +684,16 @@ pub fn insert_dictionary_entry_returning(
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
     let everywhere_id = ensure_everywhere_context_conn(&tx)?;
-    let target_context = context_id.filter(|id| *id != everywhere_id);
-
-    if let Some(target_context) = target_context {
+    let target_context = context_id.unwrap_or(everywhere_id);
+    if context_id.is_some() {
+        let exists: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+            params![target_context],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            anyhow::bail!("Context {target_context} was not found");
+        }
         let existing: Option<i64> = tx
             .query_row(
                 "SELECT id FROM dictionary WHERE term = ?1",
@@ -207,14 +710,6 @@ pub fn insert_dictionary_entry_returning(
             if already_in_context {
                 anyhow::bail!("\"{normalized_term}\" is already in this context");
             }
-            let existing_mistake: Option<String> = tx.query_row(
-                "SELECT mistake FROM dictionary WHERE id = ?1",
-                params![id],
-                |row| row.get(0),
-            )?;
-            if existing_mistake != normalized_mistake {
-                anyhow::bail!("\"{normalized_term}\" already exists with a different correction");
-            }
             check_dictionary_mistake_conflicts(
                 &tx,
                 target_context,
@@ -224,6 +719,29 @@ pub fn insert_dictionary_entry_returning(
             tx.execute(
                 "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
                 params![target_context, id],
+            )?;
+            // The legacy projection is no longer authoritative. Clear it
+            // when an existing row is touched so later legacy consumers
+            // cannot observe a stale correction that has no scoped owner.
+            tx.execute(
+                "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
+                params![id],
+            )?;
+            insert_correction_mappings_conn(
+                &tx,
+                target_context,
+                id,
+                normalized_mistake.as_deref(),
+                false,
+                0,
+                "manual",
+                None,
+            )?;
+            purge_auto_learn_evidence_for_mistake_list_conn(
+                &tx,
+                target_context,
+                normalized_mistake.as_deref(),
+                &normalized_term,
             )?;
             let created_at = tx.query_row(
                 "SELECT created_at FROM dictionary WHERE id=?1",
@@ -235,20 +753,31 @@ pub fn insert_dictionary_entry_returning(
         }
     }
 
-    check_dictionary_mistake_conflicts(
-        &tx,
-        target_context.unwrap_or(everywhere_id),
-        None,
-        normalized_mistake.as_deref(),
-    )?;
+    check_dictionary_mistake_conflicts(&tx, target_context, None, normalized_mistake.as_deref())?;
     tx.execute(
-        "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, ?2, 'manual', datetime('now'))",
-        params![normalized_term, normalized_mistake],
+        "INSERT INTO dictionary (term, mistake, confidence_tier, last_seen_at) VALUES (?1, NULL, 'manual', datetime('now'))",
+        params![normalized_term],
     )?;
     let id = tx.last_insert_rowid();
     tx.execute(
         "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
-        params![target_context.unwrap_or(everywhere_id), id],
+        params![target_context, id],
+    )?;
+    insert_correction_mappings_conn(
+        &tx,
+        target_context,
+        id,
+        normalized_mistake.as_deref(),
+        false,
+        0,
+        "manual",
+        None,
+    )?;
+    purge_auto_learn_evidence_for_mistake_list_conn(
+        &tx,
+        target_context,
+        normalized_mistake.as_deref(),
+        &normalized_term,
     )?;
     let created_at = tx.query_row(
         "SELECT created_at FROM dictionary WHERE id=?1",
@@ -311,38 +840,56 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
     ];
 
     let conn = lock_conn(db)?;
-    let existing: Option<(i64, Option<String>)> = {
-        let mut stmt =
-            conn.prepare("SELECT id, mistake FROM dictionary WHERE term = 'Verenu' LIMIT 1")?;
+    let existing: Option<i64> = {
+        let mut stmt = conn.prepare("SELECT id FROM dictionary WHERE term = 'Verenu' LIMIT 1")?;
         let mut rows = stmt.query([])?;
         match rows.next()? {
-            Some(row) => Some((row.get(0)?, row.get(1)?)),
+            Some(row) => Some(row.get(0)?),
             None => None,
         }
     };
 
     match existing {
-        Some((id, mistake)) => {
-            let mut variants: Vec<String> = mistake
-                .as_deref()
-                .unwrap_or_default()
-                .split(',')
-                .map(|v| v.trim().to_string())
-                .filter(|v| !v.is_empty())
-                .collect();
-            let mut changed = false;
+        Some(id) => {
+            let everywhere_id = ensure_everywhere_context_conn(&conn)?;
+            conn.execute(
+                "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
+                 VALUES (?1, ?2)",
+                params![everywhere_id, id],
+            )?;
             for known in KNOWN_VARIANTS {
-                if !variants.iter().any(|v| v.eq_ignore_ascii_case(known)) {
-                    variants.push(known.to_string());
-                    changed = true;
+                let already_mapped: bool = conn.query_row(
+                    "SELECT EXISTS(
+                       SELECT 1 FROM dictionary_corrections
+                        WHERE context_id = ?1 AND dictionary_id = ?2 AND mistake = ?3
+                     )",
+                    params![everywhere_id, id, known],
+                    |row| row.get(0),
+                )?;
+                if already_mapped {
+                    continue;
+                }
+                let conflicting: bool = conn.query_row(
+                    "SELECT EXISTS(
+                       SELECT 1 FROM dictionary_corrections
+                        WHERE context_id = ?1 AND mistake = ?2 AND dictionary_id != ?3
+                     )",
+                    params![everywhere_id, known, id],
+                    |row| row.get(0),
+                )?;
+                if !conflicting {
+                    conn.execute(
+                        "INSERT INTO dictionary_corrections
+                           (uuid, context_id, dictionary_id, mistake, confidence_tier)
+                         VALUES (?1, ?2, ?3, ?4, 'manual')",
+                        params![Uuid::new_v4().to_string(), everywhere_id, id, known],
+                    )?;
                 }
             }
-            if changed {
-                conn.execute(
-                    "UPDATE dictionary SET mistake = ?1 WHERE id = ?2",
-                    params![variants.join(", "), id],
-                )?;
-            }
+            conn.execute(
+                "UPDATE dictionary SET mistake = NULL WHERE id = ?1",
+                params![id],
+            )?;
             conn.execute(
                 "INSERT OR IGNORE INTO seeded_defaults (key) VALUES (?1)",
                 params![MARKER],
@@ -360,14 +907,24 @@ pub fn seed_default_dictionary_entries(db: &Db) -> Result<()> {
             let mut conn = conn;
             let tx = conn.transaction()?;
             tx.execute(
-                "INSERT INTO dictionary (term, mistake, confidence_tier) VALUES ('Verenu', ?1, 'manual')",
-                params![KNOWN_VARIANTS.join(", ")],
+                "INSERT INTO dictionary (term, mistake, confidence_tier) VALUES ('Verenu', NULL, 'manual')",
+                [],
             )?;
             let id = tx.last_insert_rowid();
             let everywhere_id = ensure_everywhere_context_conn(&tx)?;
             tx.execute(
                 "INSERT INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
                 params![everywhere_id, id],
+            )?;
+            insert_correction_mappings_conn(
+                &tx,
+                everywhere_id,
+                id,
+                Some(&KNOWN_VARIANTS.join(", ")),
+                false,
+                0,
+                "manual",
+                None,
             )?;
             tx.execute(
                 "INSERT INTO seeded_defaults (key) VALUES (?1)",
@@ -398,8 +955,8 @@ pub fn insert_dictionary_entry_from_backup_conn(
     }
     conn.execute(
         "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
-        params![normalized_term, normalized_mistake, auto_learned as i64, correction_count, confidence_tier],
+         VALUES (?1, NULL, ?2, ?3, ?4, datetime('now'))",
+        params![normalized_term, auto_learned as i64, correction_count, confidence_tier],
     )?;
     let id = conn.last_insert_rowid();
     let everywhere_id = ensure_everywhere_context_conn(conn)?;
@@ -407,12 +964,39 @@ pub fn insert_dictionary_entry_from_backup_conn(
         "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
         params![everywhere_id, id],
     )?;
+    insert_correction_mappings_conn(
+        conn,
+        everywhere_id,
+        id,
+        normalized_mistake.as_deref(),
+        auto_learned,
+        correction_count,
+        confidence_tier,
+        None,
+    )?;
     Ok(())
 }
 
 #[cfg(test)]
 pub fn insert_dictionary_entry_auto_learned(
     db: &Db,
+    term: &str,
+    mistake: Option<&str>,
+    confidence_tier: &str,
+) -> Result<bool> {
+    insert_dictionary_entry_auto_learned_for_context(
+        db,
+        EVERYWHERE_CONTEXT_ID,
+        term,
+        mistake,
+        confidence_tier,
+    )
+}
+
+#[cfg(test)]
+pub fn insert_dictionary_entry_auto_learned_for_context(
+    db: &Db,
+    context_id: i64,
     term: &str,
     mistake: Option<&str>,
     confidence_tier: &str,
@@ -428,29 +1012,103 @@ pub fn insert_dictionary_entry_auto_learned(
         )?;
     }
 
-    let conn = lock_conn(db)?;
-    let changed = conn.execute(
-        "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier) \
-         VALUES (?1, ?2, 1, 1, ?3) \
-         ON CONFLICT(term) DO UPDATE SET \
-           correction_count = correction_count + 1, \
-           confidence_tier = ?3, \
-           last_seen_at = datetime('now') \
-         WHERE dictionary.auto_learned = 1 \
-           AND COALESCE(dictionary.mistake, '') = COALESCE(excluded.mistake, '')",
-        params![normalized_term, normalized_mistake, confidence_tier],
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![context_id],
+        |row| row.get(0),
     )?;
-    let id: i64 = conn.query_row(
-        "SELECT id FROM dictionary WHERE term = ?1",
-        params![normalized_term],
-        |r| r.get(0),
+    if !exists {
+        anyhow::bail!("Context {context_id} was not found");
+    }
+    let id: i64 = match tx
+        .query_row(
+            "SELECT id FROM dictionary WHERE term = ?1",
+            params![normalized_term],
+            |r| r.get(0),
+        )
+        .optional()?
+    {
+        Some(id) => id,
+        None => {
+            tx.execute(
+                "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier)
+                 VALUES (?1, NULL, 1, 0, ?2)",
+                params![normalized_term, confidence_tier],
+            )?;
+            tx.last_insert_rowid()
+        }
+    };
+    // Manual correction mappings are authoritative only in their owning
+    // Context. A manual mapping for the same canonical term elsewhere must
+    // not poison this Context, but an automatic mapping must not overwrite a
+    // manual mapping here either.
+    let manual_mapping_exists: bool = tx.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM dictionary_corrections
+            WHERE context_id = ?1 AND dictionary_id = ?2 AND auto_learned = 0
+         )",
+        params![context_id, id],
+        |row| row.get(0),
     )?;
-    let everywhere_id = ensure_everywhere_context_conn(&conn)?;
-    conn.execute(
+    if manual_mapping_exists {
+        tx.commit()?;
+        return Ok(false);
+    }
+    tx.execute(
+        "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
+        params![id],
+    )?;
+    check_dictionary_mistake_conflicts(&tx, context_id, Some(id), normalized_mistake.as_deref())?;
+    tx.execute(
         "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
-        params![everywhere_id, id],
+        params![context_id, id],
     )?;
-    Ok(changed > 0)
+
+    let mut changed = false;
+    for variant in normalized_mistake_list(normalized_mistake.as_deref()) {
+        let existing: Option<(i64, bool)> = tx
+            .query_row(
+                "SELECT id, auto_learned FROM dictionary_corrections
+                  WHERE context_id = ?1 AND dictionary_id = ?2 AND mistake = ?3",
+                params![context_id, id, variant],
+                |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)),
+            )
+            .optional()?;
+        match existing {
+            Some((correction_id, true)) => {
+                tx.execute(
+                    "UPDATE dictionary_corrections
+                        SET correction_count = correction_count + 1,
+                            confidence_tier = ?1,
+                            last_seen_at = datetime('now')
+                      WHERE id = ?2",
+                    params![confidence_tier, correction_id],
+                )?;
+                changed = true;
+            }
+            Some((_correction_id, false)) => {}
+            None => {
+                tx.execute(
+                    "INSERT INTO dictionary_corrections
+                       (uuid, context_id, dictionary_id, mistake, auto_learned,
+                        correction_count, confidence_tier, last_seen_at)
+                     VALUES (?1, ?2, ?3, ?4, 1, 1, ?5, datetime('now'))",
+                    params![
+                        Uuid::new_v4().to_string(),
+                        context_id,
+                        id,
+                        variant,
+                        confidence_tier
+                    ],
+                )?;
+                changed = true;
+            }
+        }
+    }
+    tx.commit()?;
+    Ok(changed)
 }
 
 pub fn log_auto_learn_event(
@@ -462,14 +1120,62 @@ pub fn log_auto_learn_event(
     correction_hash: &str,
     confidence: f64,
 ) -> Result<()> {
+    log_auto_learn_event_with_context(
+        db,
+        None,
+        event_type,
+        reason_code,
+        app_context,
+        mistake_hash,
+        correction_hash,
+        confidence,
+    )
+}
+
+/// Context-aware event writer. The legacy wrapper above remains for old
+/// telemetry callers; new monitor paths should always provide the immutable
+/// originating Context id.
+pub fn log_auto_learn_event_for_context(
+    db: &Db,
+    context_id: i64,
+    event_type: &str,
+    reason_code: &str,
+    app_context: &str,
+    mistake_hash: &str,
+    correction_hash: &str,
+    confidence: f64,
+) -> Result<()> {
+    log_auto_learn_event_with_context(
+        db,
+        Some(context_id),
+        event_type,
+        reason_code,
+        app_context,
+        mistake_hash,
+        correction_hash,
+        confidence,
+    )
+}
+
+fn log_auto_learn_event_with_context(
+    db: &Db,
+    context_id: Option<i64>,
+    event_type: &str,
+    reason_code: &str,
+    app_context: &str,
+    mistake_hash: &str,
+    correction_hash: &str,
+    confidence: f64,
+) -> Result<()> {
     let conn = lock_conn(db)?;
     conn.execute(
         "INSERT INTO auto_learn_events
-         (event_type, reason_code, app_context, mistake_hash, correction_hash, confidence)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+         (event_type, reason_code, context_id, app_context, mistake_hash, correction_hash, confidence)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             event_type,
             reason_code,
+            context_id,
             app_context,
             mistake_hash,
             correction_hash,
@@ -480,25 +1186,36 @@ pub fn log_auto_learn_event(
 }
 
 /// Records a confidence observation for a (wrong, correct) pair and returns
-/// the running average confidence across all observations of that pair.
+/// the running average confidence across all observations of that pair in one
+/// Context. Context is part of the natural key; observations from another
+/// Context cannot contribute to this average.
 pub fn upsert_auto_learn_candidate(
     db: &Db,
+    context_id: i64,
     wrong: &str,
     correct: &str,
     confidence: f64,
 ) -> Result<f64> {
     let conn = lock_conn(db)?;
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![context_id],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        anyhow::bail!("Context {context_id} was not found");
+    }
     conn.query_row(
         "INSERT INTO auto_learn_candidates
-         (wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at)
-         VALUES (?1, ?2, ?3, ?3, 1, datetime('now'))
-         ON CONFLICT(wrong_word, correct_word) DO UPDATE SET
+         (context_id, wrong_word, correct_word, confidence_sum, confidence_avg, seen_count, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?4, 1, datetime('now'))
+         ON CONFLICT(context_id, wrong_word, correct_word) DO UPDATE SET
            confidence_sum = auto_learn_candidates.confidence_sum + excluded.confidence_sum,
            seen_count = auto_learn_candidates.seen_count + 1,
            confidence_avg = (auto_learn_candidates.confidence_sum + excluded.confidence_sum) / (auto_learn_candidates.seen_count + 1),
            last_seen_at = datetime('now')
          RETURNING confidence_avg",
-        params![wrong, correct, confidence],
+        params![context_id, wrong, correct, confidence],
         |r| r.get(0),
     )
     .map_err(Into::into)
@@ -538,6 +1255,7 @@ pub enum AutoLearnPromoteResult {
 /// manual-delete paths, which purge the candidate row entirely.
 pub fn auto_learn_promote(
     db: &Db,
+    context_id: i64,
     wrong: &str,
     correct: &str,
     confidence_tier: &str,
@@ -546,18 +1264,46 @@ pub fn auto_learn_promote(
 ) -> Result<AutoLearnPromoteResult> {
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
-    let everywhere_id = ensure_everywhere_context_conn(&tx)?;
+    let context_exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![context_id],
+        |row| row.get(0),
+    )?;
+    if !context_exists {
+        anyhow::bail!("Context {context_id} was not found");
+    }
+
+    // Rejection and manual-removal paths purge the candidate row. Check that
+    // the still-unclaimed, Context-scoped candidate exists before adding a
+    // pending observation. Without this guard, a promotion that starts after
+    // rejection could recreate fresh pending evidence, then discover that its
+    // candidate was gone and leave stale state that immediately re-promotes.
+    let candidate_available: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM auto_learn_candidates
+              WHERE context_id = ?1 AND wrong_word = ?2 AND correct_word = ?3
+                AND promoted_at IS NULL
+         )",
+        params![context_id, wrong, correct],
+        |r| r.get(0),
+    )?;
+    if !candidate_available {
+        tx.commit()?;
+        return Ok(AutoLearnPromoteResult::AlreadyPromoted);
+    }
 
     tx.execute(
-        "INSERT INTO pending_corrections (wrong_word, correct_word) VALUES (?1, ?2)",
-        params![wrong, correct],
+        "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+         VALUES (?1, ?2, ?3)",
+        params![context_id, wrong, correct],
     )?;
 
     let pending_count: i64 = tx.query_row(
         "SELECT COUNT(*) FROM pending_corrections
-         WHERE wrong_word = ?1 AND correct_word = ?2
-           AND created_at >= datetime('now', ?3)",
+         WHERE context_id = ?1 AND wrong_word = ?2 AND correct_word = ?3
+           AND created_at >= datetime('now', ?4)",
         params![
+            context_id,
             wrong,
             correct,
             format!("-{} days", pending_retention_days.max(1))
@@ -573,8 +1319,13 @@ pub fn auto_learn_promote(
     // A manual entry must block auto-learn WITHOUT claiming the candidate, so
     // that deleting the manual entry later allows the pair to be learned anew.
     let manual_exists: i64 = tx.query_row(
-        "SELECT COUNT(*) FROM dictionary WHERE term = ?1 AND auto_learned = 0",
-        params![correct],
+        "SELECT COUNT(*)
+           FROM dictionary_corrections c
+           INNER JOIN dictionary d ON d.id = c.dictionary_id
+          WHERE c.context_id = ?1
+            AND d.term = ?2
+            AND c.auto_learned = 0",
+        params![context_id, correct],
         |r| r.get(0),
     )?;
     if manual_exists > 0 {
@@ -588,48 +1339,25 @@ pub fn auto_learn_promote(
     let claimed = tx.execute(
         "UPDATE auto_learn_candidates
          SET promoted_at = datetime('now')
-         WHERE wrong_word = ?1 AND correct_word = ?2
+         WHERE context_id = ?1 AND wrong_word = ?2 AND correct_word = ?3
            AND promoted_at IS NULL",
-        params![wrong, correct],
+        params![context_id, wrong, correct],
     )?;
     if claimed == 0 {
         tx.commit()?;
         return Ok(AutoLearnPromoteResult::AlreadyPromoted);
     }
 
-    // Promote into the dictionary. An existing auto-learned entry for the same
-    // pair (a later learning window) increments its lifetime correction count;
-    // a manual entry was already excluded above, and an auto-learned entry for
-    // a DIFFERENT mistake can't be matched (RETURNING yields no row).
-    let promoted: Option<i64> = tx
-        .query_row(
-            "INSERT INTO dictionary (term, mistake, auto_learned, correction_count, confidence_tier)
-             VALUES (?1, ?2, 1, 1, ?3)
-             ON CONFLICT(term) DO UPDATE SET
-               correction_count = correction_count + 1,
-               confidence_tier = ?3,
-               last_seen_at = datetime('now')
-             WHERE dictionary.auto_learned = 1
-               AND COALESCE(dictionary.mistake, '') = COALESCE(?2, '')
-             RETURNING id",
-            params![correct, wrong, confidence_tier],
-            |r| r.get(0),
-        )
-        .optional()?;
-
-    if promoted.is_none() {
-        // An auto-learned entry for a DIFFERENT mistake won the upsert's
-        // conflict clause. Release the claimed gate so this pair can still be
-        // learned once that entry is removed — otherwise the claim would burn
-        // the pair's last chance permanently while reporting Blocked.
-        tx.execute(
-            "UPDATE auto_learn_candidates SET promoted_at = NULL
-             WHERE wrong_word = ?1 AND correct_word = ?2",
-            params![wrong, correct],
-        )?;
-        tx.commit()?;
-        return Ok(AutoLearnPromoteResult::Blocked);
-    }
+    // Ensure the shared canonical identity exists. The actual correction
+    // mapping below is Context-owned, so an existing canonical row from
+    // another Context is not a conflict and a different mistake can coexist.
+    tx.execute(
+        "INSERT INTO dictionary
+           (term, mistake, auto_learned, correction_count, confidence_tier, last_seen_at)
+         VALUES (?1, NULL, 1, 0, ?2, datetime('now'))
+         ON CONFLICT(term) DO NOTHING",
+        params![correct, confidence_tier],
+    )?;
 
     let dictionary_id: i64 = tx.query_row(
         "SELECT id FROM dictionary WHERE term = ?1",
@@ -637,8 +1365,32 @@ pub fn auto_learn_promote(
         |r| r.get(0),
     )?;
     tx.execute(
+        "UPDATE dictionary SET mistake = NULL WHERE id = ?1 AND mistake IS NOT NULL",
+        params![dictionary_id],
+    )?;
+    tx.execute(
         "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
-        params![everywhere_id, dictionary_id],
+        params![context_id, dictionary_id],
+    )?;
+
+    check_dictionary_mistake_conflicts(&tx, context_id, Some(dictionary_id), Some(wrong))?;
+    tx.execute(
+        "INSERT INTO dictionary_corrections
+           (uuid, context_id, dictionary_id, mistake, auto_learned,
+            correction_count, confidence_tier, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, 1, 1, ?5, datetime('now'))
+         ON CONFLICT(context_id, dictionary_id, mistake) DO UPDATE SET
+           auto_learned = 1,
+           correction_count = dictionary_corrections.correction_count + 1,
+           confidence_tier = excluded.confidence_tier,
+           last_seen_at = datetime('now')",
+        params![
+            Uuid::new_v4().to_string(),
+            context_id,
+            dictionary_id,
+            wrong,
+            confidence_tier
+        ],
     )?;
 
     tx.commit()?;
@@ -678,7 +1430,7 @@ pub fn get_auto_learn_status_summary(db: &Db) -> Result<AutoLearnStatusSummary> 
 pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLearnEvent>> {
     let conn = lock_conn(db)?;
     let mut stmt = conn.prepare(
-        "SELECT id, event_type, reason_code, app_context, mistake_hash, correction_hash, confidence, created_at
+        "SELECT id, event_type, reason_code, context_id, app_context, mistake_hash, correction_hash, confidence, created_at
          FROM auto_learn_events
          ORDER BY created_at DESC
          LIMIT ?1",
@@ -689,11 +1441,12 @@ pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLea
                 id: r.get(0)?,
                 event_type: r.get(1)?,
                 reason_code: r.get(2)?,
-                app_context: r.get(3)?,
-                mistake_hash: r.get(4)?,
-                correction_hash: r.get(5)?,
-                confidence: r.get(6)?,
-                created_at: r.get(7)?,
+                context_id: r.get(3)?,
+                app_context: r.get(4)?,
+                mistake_hash: r.get(5)?,
+                correction_hash: r.get(6)?,
+                confidence: r.get(7)?,
+                created_at: r.get(8)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -702,10 +1455,32 @@ pub fn get_recent_auto_learn_activity(db: &Db, limit: i64) -> Result<Vec<AutoLea
 
 #[cfg(test)]
 pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<()> {
+    insert_pending_correction_for_context(db, EVERYWHERE_CONTEXT_ID, wrong, correct)
+}
+
+/// Test helper for inserting evidence into an explicit Context. Production
+/// promotion records pending evidence inside its own transaction; keeping the
+/// scoped helper test-only avoids exposing a write API for transient state.
+#[cfg(test)]
+pub fn insert_pending_correction_for_context(
+    db: &Db,
+    context_id: i64,
+    wrong: &str,
+    correct: &str,
+) -> Result<()> {
     let conn = lock_conn(db)?;
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![context_id],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        anyhow::bail!("Context {context_id} was not found");
+    }
     conn.execute(
-        "INSERT INTO pending_corrections (wrong_word, correct_word) VALUES (?1, ?2)",
-        params![wrong, correct],
+        "INSERT INTO pending_corrections (context_id, wrong_word, correct_word)
+         VALUES (?1, ?2, ?3)",
+        params![context_id, wrong, correct],
     )?;
     Ok(())
 }
@@ -713,6 +1488,18 @@ pub fn insert_pending_correction(db: &Db, wrong: &str, correct: &str) -> Result<
 #[cfg(test)]
 pub fn count_pending_corrections_recent(
     db: &Db,
+    context_id: i64,
+    wrong: &str,
+    correct: &str,
+    max_age_days: i64,
+) -> Result<i64> {
+    count_pending_corrections_recent_for_context(db, context_id, wrong, correct, max_age_days)
+}
+
+#[cfg(test)]
+pub fn count_pending_corrections_recent_for_context(
+    db: &Db,
+    context_id: i64,
     wrong: &str,
     correct: &str,
     max_age_days: i64,
@@ -720,9 +1507,14 @@ pub fn count_pending_corrections_recent(
     let conn = lock_conn(db)?;
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM pending_corrections \
-         WHERE wrong_word=?1 AND correct_word=?2 \
-         AND created_at >= datetime('now', ?3)",
-        params![wrong, correct, format!("-{} days", max_age_days.max(1))],
+         WHERE context_id=?1 AND wrong_word=?2 AND correct_word=?3 \
+         AND created_at >= datetime('now', ?4)",
+        params![
+            context_id,
+            wrong,
+            correct,
+            format!("-{} days", max_age_days.max(1))
+        ],
         |r| r.get(0),
     )?;
     Ok(count)
@@ -760,7 +1552,13 @@ pub fn prune_auto_learn_retention(db: &Db) -> Result<usize> {
     Ok(events + candidates)
 }
 
-pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&str>) -> Result<()> {
+pub fn update_dictionary_entry_for_context(
+    db: &Db,
+    context_id: i64,
+    id: i64,
+    term: &str,
+    mistake: Option<&str>,
+) -> Result<()> {
     let normalized_term = require_nonempty_trimmed("Term", term)?;
     let normalized_mistake = normalize_optional_trimmed(mistake);
     validate_char_limit("Term", &normalized_term, DICTIONARY_ENTRY_CHAR_LIMIT)?;
@@ -772,39 +1570,334 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
         )?;
     }
 
-    let conn = lock_conn(db)?;
-    let context_ids: Vec<i64> = conn
-        .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1")?
-        .query_map(params![id], |row| row.get(0))?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    for context_id in context_ids {
-        check_dictionary_mistake_conflicts(
-            &conn,
-            context_id,
-            Some(id),
-            normalized_mistake.as_deref(),
-        )?;
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    update_dictionary_entry_for_context_conn(
+        &tx,
+        context_id,
+        id,
+        &normalized_term,
+        normalized_mistake.as_deref(),
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+fn update_dictionary_entry_for_context_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    id: i64,
+    normalized_term: &str,
+    normalized_mistake: Option<&str>,
+) -> Result<()> {
+    let context_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+        params![context_id],
+        |row| row.get(0),
+    )?;
+    if !context_exists {
+        anyhow::bail!("Context {context_id} was not found");
     }
+    let assigned: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM dictionary_contexts
+                        WHERE context_id = ?1 AND dictionary_id = ?2)",
+        params![context_id, id],
+        |row| row.get(0),
+    )?;
+    if !assigned {
+        anyhow::bail!("Dictionary entry {id} is not assigned to this context");
+    }
+    check_dictionary_mistake_conflicts(conn, context_id, Some(id), normalized_mistake)?;
+
     let changed = conn.execute(
-        "UPDATE dictionary SET term=?2, mistake=?3 WHERE id=?1",
-        params![id, normalized_term, normalized_mistake],
+        "UPDATE dictionary SET term = ?2, mistake = NULL WHERE id = ?1",
+        params![id, normalized_term],
     )?;
     require_row_changed(changed, "Dictionary entry", id)?;
+
+    // An explicit edit is manual authority for this Context. Remove any
+    // automatic mappings/evidence only in this scope before replacing them.
+    purge_auto_learn_evidence_for_dictionary_conn(conn, context_id, id)?;
+    conn.execute(
+        "DELETE FROM dictionary_corrections WHERE context_id = ?1 AND dictionary_id = ?2",
+        params![context_id, id],
+    )?;
+    insert_correction_mappings_conn(
+        conn,
+        context_id,
+        id,
+        normalized_mistake,
+        false,
+        0,
+        "manual",
+        None,
+    )?;
+    purge_auto_learn_evidence_for_mistake_list_conn(
+        conn,
+        context_id,
+        normalized_mistake,
+        normalized_term,
+    )?;
     Ok(())
+}
+
+/// Legacy Dictionary-page edits have no Context argument. Refuse to apply one
+/// edit across divergent Context mappings rather than silently overwriting
+/// them; the Contexts surface should call `update_dictionary_entry_for_context`.
+pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&str>) -> Result<()> {
+    let conn = lock_conn(db)?;
+    let context_ids: Vec<i64> = conn
+        .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1 ORDER BY context_id")?
+        .query_map(params![id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if context_ids.len() != 1 {
+        anyhow::bail!(
+            "Dictionary entry {id} is shared by multiple contexts; edit it from the active Context"
+        );
+    }
+    drop(conn);
+    update_dictionary_entry_for_context(db, context_ids[0], id, term, mistake)
+}
+
+/// Remove a canonical dictionary assignment from one Context without deleting
+/// the shared canonical row or any of its mappings in other Contexts.
+///
+/// This is the Contexts-surface counterpart to the legacy global delete. An
+/// automatically-created canonical row is removed only when this was its last
+/// assignment and no correction mapping remains anywhere.
+pub fn remove_dictionary_entry_from_context(
+    db: &Db,
+    context_id: i64,
+    dictionary_id: i64,
+) -> Result<()> {
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let assigned: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM dictionary_contexts
+              WHERE context_id = ?1 AND dictionary_id = ?2
+         )",
+        params![context_id, dictionary_id],
+        |row| row.get(0),
+    )?;
+    if !assigned {
+        anyhow::bail!("Dictionary entry {dictionary_id} is not assigned to this context");
+    }
+    remove_dictionary_corrections_for_context_conn(&tx, context_id, dictionary_id)?;
+    tx.execute(
+        "DELETE FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2",
+        params![context_id, dictionary_id],
+    )?;
+    cleanup_orphaned_auto_dictionary_conn(&tx, context_id, dictionary_id)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Move one canonical assignment from one Context to another. Unlike adding a
+/// shared item, moving is an explicit transfer: its Context-owned correction
+/// mappings follow the assignment, while any unpromoted evidence in the source
+/// Context is discarded because it has no safe destination.
+pub fn move_dictionary_entry_to_context(
+    db: &Db,
+    dictionary_id: i64,
+    source_context_id: i64,
+    target_context_id: i64,
+) -> Result<()> {
+    if source_context_id == target_context_id {
+        return Ok(());
+    }
+
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    for context_id in [source_context_id, target_context_id] {
+        let exists: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM contexts WHERE id = ?1)",
+            params![context_id],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            anyhow::bail!("Context {context_id} was not found");
+        }
+    }
+
+    let source_assigned: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM dictionary_contexts
+              WHERE context_id = ?1 AND dictionary_id = ?2
+         )",
+        params![source_context_id, dictionary_id],
+        |row| row.get(0),
+    )?;
+    if !source_assigned {
+        anyhow::bail!("Dictionary entry {dictionary_id} is not assigned to the source context");
+    }
+    let target_assigned: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM dictionary_contexts
+              WHERE context_id = ?1 AND dictionary_id = ?2
+         )",
+        params![target_context_id, dictionary_id],
+        |row| row.get(0),
+    )?;
+    if target_assigned {
+        anyhow::bail!("Dictionary entry {dictionary_id} is already assigned to the target context");
+    }
+
+    // Preflight the target so a move cannot transfer some variants and then
+    // fail on a later collision. A wrong spelling may belong to only one
+    // canonical term in a Context.
+    let source_mistakes: Vec<String> = tx
+        .prepare(
+            "SELECT mistake FROM dictionary_corrections
+              WHERE context_id = ?1 AND dictionary_id = ?2 ORDER BY id",
+        )?
+        .query_map(params![source_context_id, dictionary_id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for mistake in &source_mistakes {
+        let conflict: bool = tx.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM dictionary_corrections
+                  WHERE context_id = ?1 AND mistake = ?2 AND dictionary_id != ?3
+             )",
+            params![target_context_id, mistake, dictionary_id],
+            |row| row.get(0),
+        )?;
+        if conflict {
+            anyhow::bail!(
+                "Often mistranscribed as \"{mistake}\" already belongs to another entry in the target context"
+            );
+        }
+    }
+
+    tx.execute(
+        "INSERT INTO dictionary_contexts (context_id, dictionary_id) VALUES (?1, ?2)",
+        params![target_context_id, dictionary_id],
+    )?;
+    tx.execute(
+        "UPDATE dictionary_corrections
+            SET context_id = ?2
+          WHERE context_id = ?1 AND dictionary_id = ?3",
+        params![source_context_id, target_context_id, dictionary_id],
+    )?;
+    let term: Option<String> = tx
+        .query_row(
+            "SELECT term FROM dictionary WHERE id = ?1",
+            params![dictionary_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(term) = term.as_deref() {
+        purge_auto_learn_evidence_for_term_conn(&tx, source_context_id, term)?;
+    }
+    tx.execute(
+        "DELETE FROM dictionary_contexts WHERE context_id = ?1 AND dictionary_id = ?2",
+        params![source_context_id, dictionary_id],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+fn purge_auto_learn_evidence_for_dictionary_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    dictionary_id: i64,
+) -> Result<usize> {
+    let pairs: Vec<(String, String)> = conn
+        .prepare(
+            "SELECT c.mistake, d.term
+               FROM dictionary_corrections c
+               INNER JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE c.context_id = ?1 AND c.dictionary_id = ?2 AND c.auto_learned = 1",
+        )?
+        .query_map(params![context_id, dictionary_id], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut deleted = 0;
+    for (mistake, term) in pairs {
+        deleted += conn.execute(
+            "DELETE FROM pending_corrections
+              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
+                AND lower(correct_word) = lower(?3)",
+            params![context_id, mistake, term],
+        )?;
+        deleted += conn.execute(
+            "DELETE FROM auto_learn_candidates
+              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
+                AND lower(correct_word) = lower(?3)",
+            params![context_id, mistake, term],
+        )?;
+    }
+    Ok(deleted)
 }
 
 pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
 
-    // Capture metadata before deleting so we can clean up auto-learn history.
+    // Capture the canonical term and every Context-owned correction before
+    // deleting. The old global `dictionary.mistake` projection is NULL after
+    // v26, so looking only at that column would leave stale scoped evidence.
     let info: Option<(String, Option<String>, i64)> = tx
         .query_row(
             "SELECT term, mistake, auto_learned FROM dictionary WHERE id=?1",
             params![id],
             |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
         )
-        .ok();
+        .optional()?;
+    let assigned_contexts: Vec<i64> = tx
+        .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1")?
+        .query_map(params![id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut evidence: Vec<(i64, String, String)> = tx
+        .prepare(
+            "SELECT c.context_id, c.mistake, d.term
+               FROM dictionary_corrections c
+               INNER JOIN dictionary d ON d.id = c.dictionary_id
+              WHERE c.dictionary_id = ?1",
+        )?
+        .query_map(params![id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if let Some((term, Some(mistake), _)) = &info {
+        if evidence.is_empty() {
+            evidence.extend(
+                assigned_contexts
+                    .iter()
+                    .copied()
+                    .map(|context_id| (context_id, mistake.clone(), term.clone())),
+            );
+        }
+    }
+
+    // A v26 canonical row can legitimately have no child mapping after a
+    // context-scoped rejection or partial import. Purge by canonical term as
+    // well, otherwise stale evidence could recreate the row after this delete.
+    if let Some((term, _, _)) = &info {
+        for context_id in &assigned_contexts {
+            purge_auto_learn_evidence_for_term_conn(&tx, *context_id, term)?;
+        }
+    }
+
+    for (context_id, mistake, term) in evidence {
+        for variant in dictionary_mistake_variants(&mistake) {
+            tx.execute(
+                "DELETE FROM pending_corrections
+                   WHERE context_id = ?1
+                     AND lower(wrong_word) = lower(?2)
+                     AND lower(correct_word) = lower(?3)",
+                params![context_id, variant, term],
+            )?;
+            tx.execute(
+                "DELETE FROM auto_learn_candidates
+                   WHERE context_id = ?1
+                     AND lower(wrong_word) = lower(?2)
+                     AND lower(correct_word) = lower(?3)",
+                params![context_id, variant, term],
+            )?;
+        }
+    }
 
     tx.execute(
         "DELETE FROM dictionary_contexts WHERE dictionary_id = ?1",
@@ -813,62 +1906,222 @@ pub fn delete_dictionary_entry(db: &Db, id: i64) -> Result<()> {
     let changed = tx.execute("DELETE FROM dictionary WHERE id=?1", params![id])?;
     require_row_changed(changed, "Dictionary entry", id)?;
 
-    // If this was an auto-learned entry, remove its pending corrections and
-    // candidates so the auto-learn system cannot immediately re-promote it.
-    if let Some((term, Some(mistake), 1)) = info {
-        tx.execute(
-            "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
-            params![mistake, term],
-        )?;
-        tx.execute(
-            "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
-            params![mistake, term],
-        )?;
-    }
-
     tx.commit()?;
     Ok(())
 }
 
-// Conservative batch size well below SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999).
-const SQL_BATCH_SIZE: usize = 500;
+// Remove a canonical row only when rejection has left an automatically
+// created entry with neither a mapping nor another Context assignment.
+pub(crate) fn cleanup_orphaned_auto_dictionary_conn(
+    conn: &rusqlite::Connection,
+    context_id: i64,
+    dictionary_id: i64,
+) -> Result<()> {
+    let orphan: Option<(String, bool)> = conn
+        .query_row(
+            "SELECT term, auto_learned = 1
+               FROM dictionary
+              WHERE id = ?1
+                AND NOT EXISTS (
+                    SELECT 1 FROM dictionary_corrections
+                     WHERE dictionary_id = ?1
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM dictionary_contexts
+                     WHERE dictionary_id = ?1 AND context_id != ?2
+                )",
+            params![dictionary_id, context_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let Some((term, auto_learned)) = orphan else {
+        return Ok(());
+    };
+    if !auto_learned {
+        return Ok(());
+    }
 
+    // There is no remaining mapping that can identify a narrower pair, so
+    // clear every stale evidence row for this canonical term in the rejected
+    // Context before removing its last assignment. This is intentionally
+    // scoped: another Context may still have an independently learned pair.
+    conn.execute(
+        "DELETE FROM pending_corrections
+           WHERE context_id = ?1 AND lower(correct_word) = lower(?2)",
+        params![context_id, term],
+    )?;
+    conn.execute(
+        "DELETE FROM auto_learn_candidates
+           WHERE context_id = ?1 AND lower(correct_word) = lower(?2)",
+        params![context_id, term],
+    )?;
+    conn.execute(
+        "DELETE FROM dictionary_contexts WHERE dictionary_id = ?1",
+        params![dictionary_id],
+    )?;
+    conn.execute(
+        "DELETE FROM dictionary WHERE id = ?1 AND auto_learned = 1",
+        params![dictionary_id],
+    )?;
+    Ok(())
+}
+
+/// Delete only automatic correction mappings identified by their persistent
+/// child-row IDs in one Context.
+///
+/// A rejection monitor receives `dictionary_corrections.id`, never the shared
+/// `dictionary.id`. The transaction verifies both the Context and the
+/// `auto_learned` flag before deleting, then purges the matching pending and
+/// candidate rows in that same Context so a rejected mapping cannot
+/// immediately re-promote. Manual mappings, other Contexts, and the shared
+/// canonical term remain untouched unless the canonical row is an auto-learned
+/// orphan with no remaining Context assignment.
+pub fn delete_auto_learned_corrections_by_ids(
+    db: &Db,
+    context_id: i64,
+    correction_ids: &[i64],
+) -> Result<usize> {
+    if correction_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut conn = lock_conn(db)?;
+    let tx = conn.transaction()?;
+    let mut deleted = 0;
+    let mut dictionary_ids = HashSet::new();
+    for correction_id in correction_ids {
+        let mapping: Option<(i64, String, String)> = tx
+            .query_row(
+                "SELECT c.dictionary_id, c.mistake, d.term
+                   FROM dictionary_corrections c
+                   INNER JOIN dictionary d ON d.id = c.dictionary_id
+                  WHERE c.id = ?1 AND c.context_id = ?2 AND c.auto_learned = 1",
+                params![correction_id, context_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        let Some((dictionary_id, mistake, term)) = mapping else {
+            // This also makes repeated rejection notifications idempotent and
+            // keeps a manual row with a stale/incorrect target ID protected.
+            continue;
+        };
+
+        let changed = tx.execute(
+            "DELETE FROM dictionary_corrections
+               WHERE id = ?1 AND context_id = ?2 AND auto_learned = 1",
+            params![correction_id, context_id],
+        )?;
+        if changed == 0 {
+            continue;
+        }
+        deleted += changed;
+        dictionary_ids.insert(dictionary_id);
+
+        // Child rows normally contain one variant, but accepting the legacy
+        // comma-separated representation here keeps cleanup correct for a
+        // partially migrated database as well.
+        for variant in dictionary_mistake_variants(&mistake) {
+            tx.execute(
+                "DELETE FROM pending_corrections
+                   WHERE context_id = ?1
+                     AND lower(wrong_word) = lower(?2)
+                     AND lower(correct_word) = lower(?3)",
+                params![context_id, variant, term],
+            )?;
+            tx.execute(
+                "DELETE FROM auto_learn_candidates
+                   WHERE context_id = ?1
+                     AND lower(wrong_word) = lower(?2)
+                     AND lower(correct_word) = lower(?3)",
+                params![context_id, variant, term],
+            )?;
+        }
+    }
+    for dictionary_id in dictionary_ids {
+        cleanup_orphaned_auto_dictionary_conn(&tx, context_id, dictionary_id)?;
+    }
+
+    tx.commit()?;
+    Ok(deleted)
+}
+
+/// Compatibility wrapper for the legacy rejection caller, whose IDs are
+/// canonical dictionary ids and whose historical behavior only ever learned
+/// into Everywhere. New callers must use
+/// `delete_auto_learned_corrections_by_ids` with child mapping ids and an
+/// originating Context.
 pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     if ids.is_empty() {
         return Ok(());
     }
     let mut conn = lock_conn(db)?;
     let tx = conn.transaction()?;
-    {
-        let mut del_pending_stmt = tx.prepare(
-            "DELETE FROM pending_corrections WHERE wrong_word = ?1 AND correct_word = ?2",
-        )?;
-        let mut del_candidate_stmt = tx.prepare(
-            "DELETE FROM auto_learn_candidates WHERE wrong_word = ?1 AND correct_word = ?2",
-        )?;
-
-        for chunk in ids.chunks(SQL_BATCH_SIZE) {
-            let placeholders = vec!["?"; chunk.len()].join(", ");
-
-            let select_sql = format!(
-                "SELECT term, mistake FROM dictionary \
-                 WHERE id IN ({placeholders}) AND auto_learned = 1 AND mistake IS NOT NULL"
-            );
-            let pairs: Vec<(String, String)> = tx
-                .prepare(&select_sql)?
-                .query_map(rusqlite::params_from_iter(chunk.iter()), |r| {
-                    Ok((r.get(0)?, r.get(1)?))
+    let everywhere_id: i64 = tx.query_row(
+        "SELECT id FROM contexts WHERE is_everywhere = 1 ORDER BY id LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    let mappings: Vec<(i64, String, String)> = {
+        // rusqlite does not expose a portable array parameter. The small
+        // compatibility path can safely inspect each requested id.
+        let mut result = Vec::new();
+        for id in ids {
+            let rows = tx
+                .prepare(
+                    "SELECT c.dictionary_id, c.mistake, d.term
+                       FROM dictionary_corrections c
+                       INNER JOIN dictionary d ON d.id = c.dictionary_id
+                      WHERE c.context_id = ?1 AND c.dictionary_id = ?2 AND c.auto_learned = 1",
+                )?
+                .query_map(params![everywhere_id, id], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
                 })?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
-
-            let delete_dict_sql =
-                format!("DELETE FROM dictionary WHERE id IN ({placeholders}) AND auto_learned = 1");
-            tx.execute(&delete_dict_sql, rusqlite::params_from_iter(chunk.iter()))?;
-
-            for (term, mistake) in pairs {
-                del_pending_stmt.execute(params![mistake, term])?;
-                del_candidate_stmt.execute(params![mistake, term])?;
-            }
+            result.extend(rows);
+        }
+        result
+    };
+    for (dictionary_id, mistake, term) in mappings {
+        tx.execute(
+            "DELETE FROM dictionary_corrections
+              WHERE context_id = ?1 AND dictionary_id = ?2 AND auto_learned = 1
+                AND mistake = ?3",
+            params![everywhere_id, dictionary_id, mistake],
+        )?;
+        tx.execute(
+            "DELETE FROM pending_corrections
+              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
+                AND lower(correct_word) = lower(?3)",
+            params![everywhere_id, mistake, term],
+        )?;
+        tx.execute(
+            "DELETE FROM auto_learn_candidates
+              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
+                AND lower(correct_word) = lower(?3)",
+            params![everywhere_id, mistake, term],
+        )?;
+    }
+    for id in ids {
+        let orphaned: bool = tx
+            .query_row(
+                "SELECT NOT EXISTS(SELECT 1 FROM dictionary_corrections WHERE dictionary_id = ?1)
+                    AND NOT EXISTS(
+                        SELECT 1 FROM dictionary_contexts WHERE dictionary_id = ?1
+                         AND context_id != ?2
+                    )
+                    AND auto_learned = 1
+               FROM dictionary WHERE id = ?1",
+                params![id, everywhere_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or(false);
+        if orphaned {
+            tx.execute(
+                "DELETE FROM dictionary_contexts WHERE dictionary_id = ?1",
+                params![id],
+            )?;
+            tx.execute("DELETE FROM dictionary WHERE id = ?1", params![id])?;
         }
     }
     tx.commit()?;

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -720,6 +720,15 @@ pub fn insert_dictionary_entry_returning(
                     last_seen_at: None,
                 },
             )?;
+            // Keep the legacy global field as a compatibility projection for
+            // the standalone pre-Context sync path. Context-aware consumers
+            // use dictionary_corrections as the source of truth and ignore it.
+            if target_context == everywhere_id {
+                tx.execute(
+                    "UPDATE dictionary SET mistake = ?2 WHERE id = ?1",
+                    params![id, normalized_mistake],
+                )?;
+            }
             purge_auto_learn_evidence_for_mistake_list_conn(
                 &tx,
                 target_context,
@@ -758,6 +767,14 @@ pub fn insert_dictionary_entry_returning(
             last_seen_at: None,
         },
     )?;
+    // See the compatibility projection note above. This is only populated for
+    // Everywhere, never for a targeted Context.
+    if target_context == everywhere_id {
+        tx.execute(
+            "UPDATE dictionary SET mistake = ?2 WHERE id = ?1",
+            params![id, normalized_mistake],
+        )?;
+    }
     purge_auto_learn_evidence_for_mistake_list_conn(
         &tx,
         target_context,
@@ -1666,6 +1683,17 @@ fn update_dictionary_entry_for_context_conn(
             last_seen_at: None,
         },
     )?;
+    // Lower-stack compatibility: the old dictionary sync payload only knows
+    // about dictionary.mistake. The Context-aware runtime ignores this
+    // projection and reads the child mapping instead.
+    conn.execute(
+        "UPDATE dictionary
+            SET mistake = CASE WHEN EXISTS(
+                SELECT 1 FROM contexts WHERE id = ?2 AND is_everywhere = 1
+            ) THEN ?3 ELSE NULL END
+          WHERE id = ?1",
+        params![id, context_id, normalized_mistake],
+    )?;
     purge_auto_learn_evidence_for_mistake_list_conn(
         conn,
         context_id,
@@ -1684,16 +1712,38 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
         .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1 ORDER BY context_id")?
         .query_map(params![id], |row| row.get(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    if context_ids.is_empty() {
-        anyhow::bail!("Dictionary entry {id} was not found");
-    }
-    if context_ids.len() > 1 {
+    let context_id = if context_ids.is_empty() {
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM dictionary WHERE id = ?1)",
+            params![id],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            anyhow::bail!("Dictionary entry {id} was not found");
+        }
+        // The lower-stack legacy sync path can deliver a canonical dictionary
+        // row before its Context aggregate. Preserve the old Dictionary-page
+        // behavior by treating an unassigned existing row as Everywhere.
+        let everywhere_id: i64 = conn.query_row(
+            "SELECT id FROM contexts WHERE is_everywhere = 1 ORDER BY id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        conn.execute(
+            "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
+             VALUES (?1, ?2)",
+            params![everywhere_id, id],
+        )?;
+        everywhere_id
+    } else if context_ids.len() > 1 {
         anyhow::bail!(
             "Dictionary entry {id} is shared by multiple contexts; edit it from the active Context"
         );
-    }
+    } else {
+        context_ids[0]
+    };
     drop(conn);
-    update_dictionary_entry_for_context(db, context_ids[0], id, term, mistake)
+    update_dictionary_entry_for_context(db, context_id, id, term, mistake)
 }
 
 /// Remove a canonical dictionary assignment from one Context without deleting
@@ -2094,76 +2144,30 @@ pub fn delete_auto_learned_entries_by_ids(db: &Db, ids: &[i64]) -> Result<()> {
     if ids.is_empty() {
         return Ok(());
     }
-    let mut conn = lock_conn(db)?;
-    let tx = conn.transaction()?;
-    let everywhere_id: i64 = tx.query_row(
+    let conn = lock_conn(db)?;
+    let everywhere_id: i64 = conn.query_row(
         "SELECT id FROM contexts WHERE is_everywhere = 1 ORDER BY id LIMIT 1",
         [],
         |row| row.get(0),
     )?;
-    let mappings: Vec<(i64, String, String)> = {
+    let mapping_ids: Vec<i64> = {
         // rusqlite does not expose a portable array parameter. The small
         // compatibility path can safely inspect each requested id.
         let mut result = Vec::new();
         for id in ids {
-            let rows = tx
+            let rows = conn
                 .prepare(
-                    "SELECT c.dictionary_id, c.mistake, d.term
+                    "SELECT c.id
                        FROM dictionary_corrections c
-                       INNER JOIN dictionary d ON d.id = c.dictionary_id
                       WHERE c.context_id = ?1 AND c.dictionary_id = ?2 AND c.auto_learned = 1",
                 )?
-                .query_map(params![everywhere_id, id], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                })?
+                .query_map(params![everywhere_id, id], |row| row.get::<_, i64>(0))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             result.extend(rows);
         }
         result
     };
-    for (dictionary_id, mistake, term) in mappings {
-        tx.execute(
-            "DELETE FROM dictionary_corrections
-              WHERE context_id = ?1 AND dictionary_id = ?2 AND auto_learned = 1
-                AND mistake = ?3",
-            params![everywhere_id, dictionary_id, mistake],
-        )?;
-        tx.execute(
-            "DELETE FROM pending_corrections
-              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
-                AND lower(correct_word) = lower(?3)",
-            params![everywhere_id, mistake, term],
-        )?;
-        tx.execute(
-            "DELETE FROM auto_learn_candidates
-              WHERE context_id = ?1 AND lower(wrong_word) = lower(?2)
-                AND lower(correct_word) = lower(?3)",
-            params![everywhere_id, mistake, term],
-        )?;
-    }
-    for id in ids {
-        let orphaned: bool = tx
-            .query_row(
-                "SELECT NOT EXISTS(SELECT 1 FROM dictionary_corrections WHERE dictionary_id = ?1)
-                    AND NOT EXISTS(
-                        SELECT 1 FROM dictionary_contexts WHERE dictionary_id = ?1
-                         AND context_id != ?2
-                    )
-                    AND auto_learned = 1
-               FROM dictionary WHERE id = ?1",
-                params![id, everywhere_id],
-                |row| row.get(0),
-            )
-            .optional()?
-            .unwrap_or(false);
-        if orphaned {
-            tx.execute(
-                "DELETE FROM dictionary_contexts WHERE dictionary_id = ?1",
-                params![id],
-            )?;
-            tx.execute("DELETE FROM dictionary WHERE id = ?1", params![id])?;
-        }
-    }
-    tx.commit()?;
+    drop(conn);
+    delete_auto_learned_corrections_by_ids(db, everywhere_id, &mapping_ids)?;
     Ok(())
 }

--- a/src-tauri/src/data/db/dictionary.rs
+++ b/src-tauri/src/data/db/dictionary.rs
@@ -1684,7 +1684,10 @@ pub fn update_dictionary_entry(db: &Db, id: i64, term: &str, mistake: Option<&st
         .prepare("SELECT context_id FROM dictionary_contexts WHERE dictionary_id = ?1 ORDER BY context_id")?
         .query_map(params![id], |row| row.get(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    if context_ids.len() != 1 {
+    if context_ids.is_empty() {
+        anyhow::bail!("Dictionary entry {id} was not found");
+    }
+    if context_ids.len() > 1 {
         anyhow::bail!(
             "Dictionary entry {id} is shared by multiple contexts; edit it from the active Context"
         );

--- a/src-tauri/src/data/db/mod.rs
+++ b/src-tauri/src/data/db/mod.rs
@@ -47,4 +47,6 @@ pub struct CreatedRecordMeta {
 }
 
 #[cfg(test)]
+mod autolearn_context_tests;
+#[cfg(test)]
 mod tests;

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -95,6 +95,34 @@ CREATE TABLE IF NOT EXISTS dictionary_contexts (
 );
 CREATE INDEX IF NOT EXISTS idx_dictionary_contexts_dictionary_id
   ON dictionary_contexts(dictionary_id);
+-- A canonical dictionary term may be shared by many contexts, but the
+-- mistranscription that produces it is context-specific.  Keep one row per
+-- effective variant so a rejection can identify exactly the mapping that
+-- fired instead of deleting the shared canonical row.
+CREATE TABLE IF NOT EXISTS dictionary_corrections (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  uuid             TEXT,
+  context_id       INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+  dictionary_id    INTEGER NOT NULL REFERENCES dictionary(id) ON DELETE CASCADE,
+  mistake          TEXT NOT NULL COLLATE NOCASE,
+  auto_learned     INTEGER NOT NULL DEFAULT 0 CHECK (auto_learned IN (0, 1)),
+  correction_count INTEGER NOT NULL DEFAULT 0,
+  confidence_tier  TEXT NOT NULL DEFAULT 'low',
+  last_seen_at     DATETIME,
+  created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(context_id, dictionary_id, mistake)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dictionary_corrections_uuid
+  ON dictionary_corrections(uuid) WHERE uuid IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dictionary_corrections_context_mistake
+  ON dictionary_corrections(context_id, mistake);
+CREATE INDEX IF NOT EXISTS idx_dictionary_corrections_context_dictionary
+  ON dictionary_corrections(context_id, dictionary_id);
+CREATE TRIGGER IF NOT EXISTS trg_dictionary_contexts_delete_corrections
+AFTER DELETE ON dictionary_contexts BEGIN
+  DELETE FROM dictionary_corrections
+   WHERE context_id = OLD.context_id AND dictionary_id = OLD.dictionary_id;
+END;
 CREATE TABLE IF NOT EXISTS snippet_contexts (
   context_id INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
   snippet_id INTEGER NOT NULL REFERENCES snippets(id) ON DELETE CASCADE,
@@ -104,16 +132,19 @@ CREATE INDEX IF NOT EXISTS idx_snippet_contexts_snippet_id
   ON snippet_contexts(snippet_id);
 CREATE TABLE IF NOT EXISTS pending_corrections (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  context_id   INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
   wrong_word   TEXT    NOT NULL,
   correct_word TEXT    NOT NULL,
   created_at   DATETIME NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_pending_words
-  ON pending_corrections(wrong_word, correct_word);
+-- This index is created after the v26 shape migration. Do not create it here:
+-- SCHEMA runs before migrations and an existing pre-v26 table has no
+-- context_id column yet.
 CREATE TABLE IF NOT EXISTS auto_learn_events (
   id             INTEGER PRIMARY KEY AUTOINCREMENT,
   event_type     TEXT    NOT NULL,
   reason_code    TEXT    NOT NULL DEFAULT '',
+  context_id     INTEGER REFERENCES contexts(id) ON DELETE SET NULL,
   app_context    TEXT    NOT NULL DEFAULT '',
   mistake_hash   TEXT    NOT NULL DEFAULT '',
   correction_hash TEXT   NOT NULL DEFAULT '',
@@ -124,6 +155,7 @@ CREATE INDEX IF NOT EXISTS idx_auto_learn_events_event_type
   ON auto_learn_events(event_type, created_at);
 CREATE TABLE IF NOT EXISTS auto_learn_candidates (
   id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  context_id         INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
   wrong_word         TEXT    NOT NULL,
   correct_word       TEXT    NOT NULL,
   confidence_sum     REAL    NOT NULL DEFAULT 0.0,
@@ -132,10 +164,11 @@ CREATE TABLE IF NOT EXISTS auto_learn_candidates (
   last_seen_at       DATETIME NOT NULL DEFAULT (datetime('now')),
   cooldown_until     DATETIME,
   promoted_at        DATETIME,
-  UNIQUE(wrong_word, correct_word)
+  UNIQUE(context_id, wrong_word, correct_word)
 );
-CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
-  ON auto_learn_candidates(last_seen_at);
+-- This index is created after the v26 shape migration. Do not create it here:
+-- SCHEMA runs before migrations and an existing pre-v26 table has no
+-- context_id column yet.
 CREATE TABLE IF NOT EXISTS cleanup_cache (
   key         TEXT PRIMARY KEY,
   clean_text  TEXT NOT NULL,
@@ -265,6 +298,10 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
     // new install) and a pointless db.bak gets created on first launch.
     let db_existed_before_open = db_path.exists();
     let mut conn = Connection::open(db_path)?;
+    // SQLite keeps foreign-key enforcement disabled per connection by
+    // default. Context-owned correction/evidence rows use cascading foreign
+    // keys, so enable enforcement before schema work or application queries.
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
     // user_version lives in the file header, so it's readable before SCHEMA
     // is applied. Read it here (and take the pre-migration backup) before any
     // statement touches the file, so db.bak is a true snapshot of what the
@@ -795,6 +832,26 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
             Ok(())
         })?;
     }
+    if user_version < 26 {
+        log::info!("db: migrating schema {user_version} -> 26");
+        run_migration(&mut conn, |conn| {
+            apply_v26_autolearn_context_migration(conn)?;
+            conn.execute_batch("PRAGMA user_version = 26;")?;
+            Ok(())
+        })?;
+    }
+    // SCHEMA executes before migrations so it can safely create missing
+    // tables, but it cannot create a context-aware index against a legacy
+    // pre-v26 table. The v26 rebuild above installs these indexes for an
+    // upgrade, and this idempotent check keeps fresh and already-v26 files
+    // equally healthy on every reopen.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_pending_words
+           ON pending_corrections(context_id, wrong_word, correct_word, created_at);
+         CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
+           ON auto_learn_candidates(context_id, last_seen_at);",
+    )?;
+    ensure_dictionary_correction_membership_trigger(&conn)?;
     // Early v20 development databases created sync_peers before receive and
     // send cursors were split. Their version marker is already 20, so the
     // migration above will not run again. Repair that partial v20 shape on
@@ -809,6 +866,13 @@ pub fn open(path: impl AsRef<std::path::Path>) -> Result<Db> {
     // keychain identity. Keep a provisional UUID in place so early writes are
     // captured; initialize() replaces it with the durable identity UUID.
     ensure_sync_identity_placeholder(&conn)?;
+    // A partially completed v26 install may have created correction rows but
+    // not reached the trigger bundle before its process stopped. Repair their
+    // stable identities before re-installing the idempotent trigger set. The
+    // UUID backfill intentionally precedes the triggers so repair itself does
+    // not create a user-visible sync edit.
+    backfill_canonical_uuids(&conn, "dictionary_corrections")?;
+    conn.execute_batch(SYNC_TRIGGER_SQL)?;
     ensure_cleanup_cache_schema(&conn)?;
     // Index only needed by existing databases: the SCHEMA above declares it
     // for fresh installs, and the v10 migration block adds it for databases
@@ -989,6 +1053,281 @@ fn apply_v20_sync_migration(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migrate AutoLearn's formerly-global state to the current Context model.
+///
+/// The canonical `dictionary` row remains shared and keeps its stable identity.
+/// Explicit manual mappings are copied to each existing Context assignment;
+/// legacy automatic mappings are retained only in an existing Everywhere
+/// assignment because their originating Context was never persisted. Candidate
+/// and pending rows are deliberately not copied: pre-v26 rows have no
+/// originating Context, so retaining them would let ambiguous history promote a
+/// correction into an arbitrary Context.  They are short-lived learning state,
+/// unlike already-promoted dictionary data, which is migrated to Everywhere
+/// when that is the historical assignment.
+fn apply_v26_autolearn_context_migration(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO contexts (id, name, is_everywhere)
+           VALUES (1, 'Everywhere', 1);
+         CREATE TABLE IF NOT EXISTS dictionary_corrections (
+           id               INTEGER PRIMARY KEY AUTOINCREMENT,
+           uuid             TEXT,
+           context_id       INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+           dictionary_id    INTEGER NOT NULL REFERENCES dictionary(id) ON DELETE CASCADE,
+           mistake          TEXT NOT NULL COLLATE NOCASE,
+           auto_learned     INTEGER NOT NULL DEFAULT 0 CHECK (auto_learned IN (0, 1)),
+           correction_count INTEGER NOT NULL DEFAULT 0,
+           confidence_tier  TEXT NOT NULL DEFAULT 'low',
+           last_seen_at     DATETIME,
+           created_at       DATETIME NOT NULL DEFAULT (datetime('now')),
+           UNIQUE(context_id, dictionary_id, mistake)
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_dictionary_corrections_uuid
+           ON dictionary_corrections(uuid) WHERE uuid IS NOT NULL;
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_dictionary_corrections_context_mistake
+           ON dictionary_corrections(context_id, mistake);
+         CREATE INDEX IF NOT EXISTS idx_dictionary_corrections_context_dictionary
+           ON dictionary_corrections(context_id, dictionary_id);",
+    )?;
+
+    // Existing installs have the old tables, whose rows cannot be attributed to
+    // a Context. Rename-and-recreate is required instead of ALTER TABLE because
+    // both the foreign key and the candidate uniqueness constraint changed.
+    rebuild_scoped_pending_corrections(conn)?;
+    rebuild_scoped_auto_learn_candidates(conn)?;
+    ensure_table_column(
+        conn,
+        "auto_learn_events",
+        "context_id",
+        "ALTER TABLE auto_learn_events ADD COLUMN context_id INTEGER REFERENCES contexts(id) ON DELETE SET NULL;",
+    )?;
+
+    // v12 assigned all pre-Contexts dictionary rows to Everywhere. Heal any
+    // partially migrated database with an unassigned canonical row before
+    // copying its old global correction field, preserving the old behavior.
+    let everywhere_id: i64 = conn.query_row(
+        "SELECT id FROM contexts WHERE is_everywhere = 1 ORDER BY id LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO dictionary_contexts (context_id, dictionary_id)
+         SELECT ?1, d.id
+           FROM dictionary d
+          WHERE NOT EXISTS (
+                SELECT 1 FROM dictionary_contexts dc WHERE dc.dictionary_id = d.id
+          )",
+        params![everywhere_id],
+    )?;
+
+    // `dictionary.mistake` was one comma-separated value for every assignment.
+    // Expand it once per assigned Context. Manual rows are processed before old
+    // automatic rows so a malformed legacy database cannot let an automatic
+    // mapping displace a manual correction when both claim the same variant.
+    // Within one authority tier, the stable dictionary id is the tie-breaker.
+    let legacy_rows: Vec<(
+        i64,
+        Option<String>,
+        i64,
+        i64,
+        String,
+        Option<String>,
+        String,
+    )> = conn
+        .prepare(
+            "SELECT id, mistake, auto_learned, correction_count, confidence_tier,
+                    last_seen_at, created_at
+               FROM dictionary
+              ORDER BY auto_learned ASC, id ASC",
+        )?
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    for (
+        dictionary_id,
+        mistake,
+        auto_learned,
+        correction_count,
+        confidence_tier,
+        last_seen_at,
+        created_at,
+    ) in legacy_rows
+    {
+        let Some(mistake) = mistake else { continue };
+        let variants = mistake
+            .split(',')
+            .map(str::trim)
+            .filter(|variant| !variant.is_empty())
+            .collect::<Vec<_>>();
+        if variants.is_empty() {
+            continue;
+        }
+        let context_sql = if auto_learned != 0 {
+            // A pre-v26 automatic correction has no persisted originating
+            // Context. Historically AutoLearn promoted into Everywhere, so
+            // retain it there when that assignment exists; never guess that
+            // an unrelated targeted assignment was its origin.
+            "SELECT dc.context_id
+               FROM dictionary_contexts dc
+               INNER JOIN contexts c ON c.id = dc.context_id
+              WHERE dc.dictionary_id = ?1 AND c.is_everywhere = 1
+              ORDER BY dc.context_id"
+        } else {
+            // Manual sharing is explicit in dictionary_contexts, so preserve
+            // the old mapping in every Context to which the user assigned it.
+            "SELECT context_id FROM dictionary_contexts
+              WHERE dictionary_id = ?1 ORDER BY context_id"
+        };
+        let context_ids: Vec<i64> = conn
+            .prepare(context_sql)?
+            .query_map(params![dictionary_id], |row| row.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        for context_id in context_ids {
+            for (index, variant) in variants.iter().enumerate() {
+                // The old counter represented the whole comma-separated entry.
+                // Keep it on one deterministic child row rather than multiplying
+                // lifetime counts by the number of variants.
+                let child_count = if index == 0 { correction_count } else { 0 };
+                let inserted = conn.execute(
+                    "INSERT OR IGNORE INTO dictionary_corrections
+                       (context_id, dictionary_id, mistake, auto_learned,
+                        correction_count, confidence_tier, last_seen_at, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    params![
+                        context_id,
+                        dictionary_id,
+                        variant,
+                        auto_learned,
+                        child_count,
+                        confidence_tier,
+                        last_seen_at,
+                        created_at,
+                    ],
+                )?;
+                if inserted == 0 {
+                    log::warn!(
+                        "db: skipped an ambiguous legacy AutoLearn correction while scoping it to Contexts"
+                    );
+                }
+            }
+        }
+    }
+
+    // From v26 onward the child table is the only mutable source of correction
+    // mappings.  Leaving the old global projection populated would allow a
+    // legacy query to leak one Context's correction into another.
+    conn.execute("UPDATE dictionary SET mistake = NULL", [])?;
+    backfill_canonical_uuids(conn, "dictionary_corrections")?;
+    // v20-created databases already have the older trigger set. Re-run the
+    // idempotent bundle so upgrades install the correction-row triggers too.
+    conn.execute_batch(SYNC_TRIGGER_SQL)?;
+    ensure_dictionary_correction_membership_trigger(conn)?;
+    Ok(())
+}
+
+fn ensure_dictionary_correction_membership_trigger(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TRIGGER IF NOT EXISTS trg_dictionary_contexts_delete_corrections
+         AFTER DELETE ON dictionary_contexts BEGIN
+           DELETE FROM dictionary_corrections
+            WHERE context_id = OLD.context_id AND dictionary_id = OLD.dictionary_id;
+         END;",
+    )?;
+    Ok(())
+}
+
+fn rebuild_scoped_pending_corrections(conn: &Connection) -> Result<()> {
+    if table_exists(conn, "pending_corrections")?
+        && !table_has_column(conn, "pending_corrections", "context_id")?
+    {
+        conn.execute_batch(
+            "DROP INDEX IF EXISTS idx_pending_words;
+             ALTER TABLE pending_corrections RENAME TO pending_corrections_legacy_v26;
+             CREATE TABLE pending_corrections (
+               id         INTEGER PRIMARY KEY AUTOINCREMENT,
+               context_id INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             CREATE INDEX idx_pending_words
+               ON pending_corrections(context_id, wrong_word, correct_word, created_at);
+             DROP TABLE pending_corrections_legacy_v26;",
+        )?;
+    } else {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS pending_corrections (
+               id         INTEGER PRIMARY KEY AUTOINCREMENT,
+               context_id INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+             );
+             DROP INDEX IF EXISTS idx_pending_words;
+             CREATE INDEX IF NOT EXISTS idx_pending_words
+               ON pending_corrections(context_id, wrong_word, correct_word, created_at);",
+        )?;
+    }
+    Ok(())
+}
+
+fn rebuild_scoped_auto_learn_candidates(conn: &Connection) -> Result<()> {
+    if table_exists(conn, "auto_learn_candidates")?
+        && !table_has_column(conn, "auto_learn_candidates", "context_id")?
+    {
+        conn.execute_batch(
+            "DROP INDEX IF EXISTS idx_auto_learn_candidates_seen;
+             ALTER TABLE auto_learn_candidates RENAME TO auto_learn_candidates_legacy_v26;
+             CREATE TABLE auto_learn_candidates (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               context_id INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               confidence_sum REAL NOT NULL DEFAULT 0.0,
+               confidence_avg REAL NOT NULL DEFAULT 0.0,
+               seen_count INTEGER NOT NULL DEFAULT 0,
+               last_seen_at DATETIME NOT NULL DEFAULT (datetime('now')),
+               cooldown_until DATETIME,
+               promoted_at DATETIME,
+               UNIQUE(context_id, wrong_word, correct_word)
+             );
+             CREATE INDEX idx_auto_learn_candidates_seen
+               ON auto_learn_candidates(context_id, last_seen_at);
+             DROP TABLE auto_learn_candidates_legacy_v26;",
+        )?;
+    } else {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS auto_learn_candidates (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               context_id INTEGER NOT NULL REFERENCES contexts(id) ON DELETE CASCADE,
+               wrong_word TEXT NOT NULL,
+               correct_word TEXT NOT NULL,
+               confidence_sum REAL NOT NULL DEFAULT 0.0,
+               confidence_avg REAL NOT NULL DEFAULT 0.0,
+               seen_count INTEGER NOT NULL DEFAULT 0,
+               last_seen_at DATETIME NOT NULL DEFAULT (datetime('now')),
+               cooldown_until DATETIME,
+               promoted_at DATETIME,
+               UNIQUE(context_id, wrong_word, correct_word)
+             );
+             DROP INDEX IF EXISTS idx_auto_learn_candidates_seen;
+             CREATE INDEX IF NOT EXISTS idx_auto_learn_candidates_seen
+               ON auto_learn_candidates(context_id, last_seen_at);",
+        )?;
+    }
+    Ok(())
+}
+
 fn ensure_sync_identity_placeholder(conn: &Connection) -> Result<()> {
     conn.execute(
         "INSERT INTO sync_identity (uuid, name)
@@ -1084,6 +1423,51 @@ CREATE TRIGGER IF NOT EXISTS trg_sync_dictionary_del AFTER DELETE ON dictionary 
                    WHERE origin = (SELECT uuid FROM sync_identity)), 0) + 1
   WHERE (SELECT uuid FROM sync_identity) IS NOT NULL
     AND (SELECT COALESCE(applying, 0) FROM sync_state) = 0;
+END;
+-- Correction mappings are independent sync rows. Their payload carries the
+-- stable mapping UUID; the sync engine resolves the local Context and
+-- canonical dictionary UUIDs when it applies the row. The Context aggregate
+-- still captures membership changes through dictionary_contexts.
+CREATE TRIGGER IF NOT EXISTS trg_sync_dictionary_corrections_ins
+AFTER INSERT ON dictionary_corrections BEGIN
+  UPDATE dictionary_corrections
+     SET uuid = lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-' ||
+                lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' ||
+                lower(hex(randomblob(6)))
+   WHERE id = NEW.id AND uuid IS NULL;
+  INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
+  SELECT 'dictionary_corrections',
+         (SELECT uuid FROM dictionary_corrections WHERE id = NEW.id),
+         'upsert',
+         CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+         (SELECT uuid FROM sync_identity),
+         COALESCE((SELECT MAX(origin_seq) FROM sync_log
+                    WHERE origin = (SELECT uuid FROM sync_identity)), 0) + 1
+   WHERE (SELECT uuid FROM sync_identity) IS NOT NULL
+     AND (SELECT COALESCE(applying, 0) FROM sync_state) = 0;
+END;
+CREATE TRIGGER IF NOT EXISTS trg_sync_dictionary_corrections_upd
+AFTER UPDATE ON dictionary_corrections
+  WHEN NEW.uuid IS OLD.uuid BEGIN
+  INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
+  SELECT 'dictionary_corrections', NEW.uuid, 'upsert',
+         CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+         (SELECT uuid FROM sync_identity),
+         COALESCE((SELECT MAX(origin_seq) FROM sync_log
+                    WHERE origin = (SELECT uuid FROM sync_identity)), 0) + 1
+   WHERE (SELECT uuid FROM sync_identity) IS NOT NULL
+     AND (SELECT COALESCE(applying, 0) FROM sync_state) = 0;
+END;
+CREATE TRIGGER IF NOT EXISTS trg_sync_dictionary_corrections_del
+AFTER DELETE ON dictionary_corrections BEGIN
+  INSERT INTO sync_log (table_name, row_uuid, op, ts_ms, origin, origin_seq)
+  SELECT 'dictionary_corrections', OLD.uuid, 'delete',
+         CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+         (SELECT uuid FROM sync_identity),
+         COALESCE((SELECT MAX(origin_seq) FROM sync_log
+                    WHERE origin = (SELECT uuid FROM sync_identity)), 0) + 1
+   WHERE (SELECT uuid FROM sync_identity) IS NOT NULL
+     AND (SELECT COALESCE(applying, 0) FROM sync_state) = 0;
 END;
 CREATE TRIGGER IF NOT EXISTS trg_sync_snippets_ins AFTER INSERT ON snippets BEGIN
   UPDATE snippets SET uuid = lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(6))) WHERE id = NEW.id AND uuid IS NULL;

--- a/src-tauri/src/data/db/schema.rs
+++ b/src-tauri/src/data/db/schema.rs
@@ -1124,15 +1124,17 @@ fn apply_v26_autolearn_context_migration(conn: &Connection) -> Result<()> {
     // automatic rows so a malformed legacy database cannot let an automatic
     // mapping displace a manual correction when both claim the same variant.
     // Within one authority tier, the stable dictionary id is the tie-breaker.
-    let legacy_rows: Vec<(
-        i64,
-        Option<String>,
-        i64,
-        i64,
-        String,
-        Option<String>,
-        String,
-    )> = conn
+    struct LegacyDictionaryMigrationRow {
+        dictionary_id: i64,
+        mistake: Option<String>,
+        auto_learned: i64,
+        correction_count: i64,
+        confidence_tier: String,
+        last_seen_at: Option<String>,
+        created_at: String,
+    }
+
+    let legacy_rows: Vec<LegacyDictionaryMigrationRow> = conn
         .prepare(
             "SELECT id, mistake, auto_learned, correction_count, confidence_tier,
                     last_seen_at, created_at
@@ -1140,28 +1142,28 @@ fn apply_v26_autolearn_context_migration(conn: &Connection) -> Result<()> {
               ORDER BY auto_learned ASC, id ASC",
         )?
         .query_map([], |row| {
-            Ok((
-                row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get(3)?,
-                row.get(4)?,
-                row.get(5)?,
-                row.get(6)?,
-            ))
+            Ok(LegacyDictionaryMigrationRow {
+                dictionary_id: row.get(0)?,
+                mistake: row.get(1)?,
+                auto_learned: row.get(2)?,
+                correction_count: row.get(3)?,
+                confidence_tier: row.get(4)?,
+                last_seen_at: row.get(5)?,
+                created_at: row.get(6)?,
+            })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
-    for (
-        dictionary_id,
-        mistake,
-        auto_learned,
-        correction_count,
-        confidence_tier,
-        last_seen_at,
-        created_at,
-    ) in legacy_rows
-    {
+    for row in legacy_rows {
+        let LegacyDictionaryMigrationRow {
+            dictionary_id,
+            mistake,
+            auto_learned,
+            correction_count,
+            confidence_tier,
+            last_seen_at,
+            created_at,
+        } = row;
         let Some(mistake) = mistake else { continue };
         let variants = mistake
             .split(',')

--- a/src-tauri/src/data/db/tests.rs
+++ b/src-tauri/src/data/db/tests.rs
@@ -365,7 +365,7 @@ fn open_repairs_db_stuck_at_v7_without_spoken_words_column() {
 #[test]
 fn open_alone_does_not_seed_the_dictionary() {
     // seed_default_dictionary_entries is deliberately NOT part of the
-    // generic migration chain (see its doc comment) — open() alone must
+    // generic migration chain (see its doc comment) â€” open() alone must
     // leave test/fixture databases pristine.
     let db = test_db();
     let entries = query_dictionary(&db).expect("query dictionary");
@@ -378,7 +378,7 @@ fn open_self_heals_database_stuck_at_v2_with_legacy_dictionary() {
     // non-transactional v2 migration keep the old `wrong`/`correct`
     // dictionary shape (and may also lack `snippets.instructions` and
     // `pending_corrections`). Without the self-heal, every dictionary
-    // query fails with `no such column: term` — and v7's spoken-words
+    // query fails with `no such column: term` â€” and v7's spoken-words
     // backfill would fail on the missing `instructions` column.
     let path = temp_db_path("v2_legacy_dictionary");
     {
@@ -505,10 +505,10 @@ fn open_with_recovery_quarantines_a_corrupt_database_and_opens_fresh() {
     std::fs::write(&path, b"this is not a sqlite database at all").expect("write garbage");
 
     // Plain open must fail (the corrupt file is a real error, not something
-    // to silently paper over)…
+    // to silently paper over)â€¦
     assert!(open(&path).is_err());
 
-    // …but the startup path must recover: quarantine + fresh database.
+    // â€¦but the startup path must recover: quarantine + fresh database.
     let db = open_with_recovery(&path).expect("recovery opens a fresh database");
     insert_transcription_returning(&db, "fresh", "fresh", 1, 1000, "test", None, None)
         .expect("fresh db is writable");
@@ -645,7 +645,7 @@ fn seed_default_dictionary_entries_does_not_resurrect_a_deleted_entry() {
             .id;
         delete_dictionary_entry(&db, verenu_id).expect("user deletes the default entry");
     }
-    // Reopening and re-seeding must not resurrect it — the marker table
+    // Reopening and re-seeding must not resurrect it â€” the marker table
     // makes this a no-op after the first successful seed, regardless of
     // whether the user has since deleted the row.
     let db = open(path.to_str().expect("path string")).expect("second open");
@@ -664,7 +664,7 @@ fn seed_default_dictionary_entries_merges_into_a_preexisting_manual_verenu_entry
     // The actual observed bug: a user who'd already hand-added a
     // "Verenu" -> "Vernu" correction weeks before this feature existed
     // hit the dictionary's UNIQUE(term) constraint, silently dropping
-    // every known variant from the original INSERT OR IGNORE — leaving
+    // every known variant from the original INSERT OR IGNORE â€” leaving
     // only "Vernu", which doesn't match "Varino"/"Varinu" and so never
     // fired. Merging into the existing row instead must add every known
     // variant while preserving the user's own "Vernu".
@@ -761,9 +761,9 @@ fn auto_learn_promote_promotes_when_pending_reaches_threshold() {
     let db = test_db();
 
     // Session 1: pending count reaches 1, below the default threshold of 2.
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
-    let first = auto_learn_promote(
+    let first = auto_learn_promote_for_context(
         &db,
         EVERYWHERE_CONTEXT_ID,
         "Koobernetes",
@@ -779,8 +779,8 @@ fn auto_learn_promote_promotes_when_pending_reaches_threshold() {
     );
     assert!(query_dictionary(&db).expect("dictionary").is_empty());
 
-    // Session 2: pending count reaches 2 — the pair promotes.
-    let second = auto_learn_promote(
+    // Session 2: pending count reaches 2 â€” the pair promotes.
+    let second = auto_learn_promote_for_context(
         &db,
         EVERYWHERE_CONTEXT_ID,
         "Koobernetes",
@@ -803,15 +803,15 @@ fn auto_learn_promote_promotes_when_pending_reaches_threshold() {
 fn auto_learn_promote_is_atomic_against_double_promotion() {
     // Two concurrent monitors both observe the pair and both believe the
     // pending count has crossed the threshold (two prior sessions already
-    // recorded pending rows). Only ONE may actually promote — the second
+    // recorded pending rows). Only ONE may actually promote â€” the second
     // caller's atomic `promoted_at` claim must be refused.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending 1");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending 2");
 
-    let first = auto_learn_promote(
+    let first = auto_learn_promote_for_context(
         &db,
         EVERYWHERE_CONTEXT_ID,
         "Koobernetes",
@@ -823,7 +823,7 @@ fn auto_learn_promote_is_atomic_against_double_promotion() {
     .expect("first");
     assert_eq!(first, AutoLearnPromoteResult::Promoted);
 
-    let second = auto_learn_promote(
+    let second = auto_learn_promote_for_context(
         &db,
         EVERYWHERE_CONTEXT_ID,
         "Koobernetes",
@@ -853,11 +853,11 @@ fn auto_learn_promote_does_not_resurrect_a_rejected_candidate() {
     // rows. An in-flight promotion for that pair must not re-create it: the
     // `promoted_at` claim no-ops against a purged candidate.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
@@ -884,7 +884,7 @@ fn auto_learn_promote_does_not_resurrect_a_rejected_candidate() {
     // Its count is re-evaluated inside the SAME transaction as the claim
     // and dict insert, against post-rejection state: the pending rows are
     // gone, so it lands BelowThreshold and must NOT re-create the entry.
-    let stale = auto_learn_promote(
+    let stale = auto_learn_promote_for_context(
         &db,
         EVERYWHERE_CONTEXT_ID,
         "Koobernetes",
@@ -912,11 +912,11 @@ fn auto_learn_promote_can_relearn_after_rejection() {
     // After a rejection fully purges the candidate, a genuinely new learning
     // window (a fresh candidate row with promoted_at IS NULL) can promote.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
@@ -937,10 +937,10 @@ fn auto_learn_promote_can_relearn_after_rejection() {
     delete_auto_learned_entries_by_ids(&db, &[id]).expect("reject");
 
     // New learning episode: fresh candidate (promoted_at NULL), two sessions.
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate again");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
@@ -953,7 +953,7 @@ fn auto_learn_promote_can_relearn_after_rejection() {
         AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
     );
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
@@ -974,7 +974,7 @@ fn auto_learn_promote_can_relearn_after_rejection() {
 fn auto_learn_promote_manual_entry_blocks_without_claiming() {
     let db = test_db();
     insert_dictionary_entry(&db, "Kubernetes", Some("Koobernetes")).expect("manual");
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending 1");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending 2");
@@ -983,7 +983,7 @@ fn auto_learn_promote_manual_entry_blocks_without_claiming() {
     // every attempt (and records the pending rows for later sessions).
     for _ in 0..2 {
         assert_eq!(
-            auto_learn_promote(
+            auto_learn_promote_for_context(
                 &db,
                 EVERYWHERE_CONTEXT_ID,
                 "Koobernetes",
@@ -1155,7 +1155,7 @@ fn cache_rejection_delete_removes_entry() {
     // Simulate rejection monitor firing.
     cleanup_cache_delete_by_key(&db, "key1").expect("delete");
 
-    // Entry must be gone — next dictation will hit the LLM.
+    // Entry must be gone â€” next dictation will hit the LLM.
     assert!(cleanup_cache_get_active(&db, "key1")
         .expect("get after")
         .is_none());
@@ -1208,7 +1208,7 @@ fn cache_rejection_after_hit_removes_entry() {
         .expect("exists");
     assert_eq!(hit.hit_count, 2);
 
-    // User deletes output → rejection monitor fires.
+    // User deletes output â†’ rejection monitor fires.
     cleanup_cache_delete_by_key(&db, "k").expect("delete");
 
     assert!(cleanup_cache_get_active(&db, "k")
@@ -1268,9 +1268,9 @@ fn pruning_history_removes_orphaned_api_cost_rows() {
 #[test]
 fn auto_learn_retention_prunes_only_stale_rows() {
     let db = test_db();
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 0.6)
         .expect("candidate");
     log_auto_learn_event(&db, "monitor", "started", "", "", "", 0.0).expect("event");
     {
@@ -1319,12 +1319,12 @@ fn auto_learn_promote_keeps_different_mistakes_independent() {
     let db = test_db();
 
     // Promote a first pair for the term.
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Koobernetes",
@@ -1340,12 +1340,12 @@ fn auto_learn_promote_keeps_different_mistakes_independent() {
     // A second pair for the same canonical term is independently represented
     // by a child mapping in this Context; the old global mistake field could
     // not express this without overwriting the first pair.
-    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Kubernetz", "Kubernetes", 0.6)
+    upsert_auto_learn_candidate_for_context(&db, EVERYWHERE_CONTEXT_ID, "Kubernetz", "Kubernetes", 0.6)
         .expect("candidate");
     insert_pending_correction(&db, "Kubernetz", "Kubernetes").expect("pending");
     insert_pending_correction(&db, "Kubernetz", "Kubernetes").expect("pending");
     assert_eq!(
-        auto_learn_promote(
+        auto_learn_promote_for_context(
             &db,
             EVERYWHERE_CONTEXT_ID,
             "Kubernetz",
@@ -1556,7 +1556,7 @@ fn pruning_old_transcriptions_does_not_reduce_lifetime_word_total() {
 fn dict_rejection_only_removes_auto_learned_entries() {
     let db = test_db();
 
-    // Manual entry — must survive rejection.
+    // Manual entry â€” must survive rejection.
     insert_dictionary_entry(&db, "groq", Some("grog")).expect("manual");
     let manual_id = query_dictionary(&db)
         .expect("query")
@@ -1565,7 +1565,7 @@ fn dict_rejection_only_removes_auto_learned_entries() {
         .expect("find")
         .id;
 
-    // Auto-learned entry — must be removed.
+    // Auto-learned entry â€” must be removed.
     insert_dictionary_entry_auto_learned(&db, "Tauri", Some("Tari"), "high").expect("auto");
     let auto_id = query_dictionary(&db)
         .expect("query")
@@ -1607,7 +1607,7 @@ fn dict_rejection_cleans_up_pending_corrections() {
 
     // Dictionary entry gone.
     assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
-    // Pending corrections also purged — prevents immediate re-promotion.
+    // Pending corrections also purged â€” prevents immediate re-promotion.
     assert_eq!(
         count_pending_corrections_recent(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 7,)
             .expect("count after"),
@@ -1617,7 +1617,7 @@ fn dict_rejection_cleans_up_pending_corrections() {
 
 #[test]
 fn cache_rejection_full_lifecycle() {
-    // End-to-end: insert → hit (cache serves stale) → reject → miss (LLM runs again).
+    // End-to-end: insert â†’ hit (cache serves stale) â†’ reject â†’ miss (LLM runs again).
     let db = test_db();
     let key = "chromium-is-a-web-browser-base";
     let bad_answer = "bad cached answer";
@@ -1642,7 +1642,7 @@ fn cache_rejection_full_lifecycle() {
     )
     .expect("touch");
 
-    // User deletes output within 10s → monitor fires.
+    // User deletes output within 10s â†’ monitor fires.
     cleanup_cache_delete_by_key(&db, key).expect("delete");
 
     // Third dictation: cache miss, LLM runs again with fresh context.

--- a/src-tauri/src/data/db/tests.rs
+++ b/src-tauri/src/data/db/tests.rs
@@ -163,16 +163,20 @@ fn fts_repair_rebuilds_updates_made_while_triggers_were_missing() {
          VALUES ('synthetic', 'beforemarker', 1);
          DROP TRIGGER trg_transcriptions_fts_upd;
          UPDATE transcriptions SET clean_text = 'aftermarker';",
-    ).expect("simulate an interrupted index installation");
+    )
+    .expect("simulate an interrupted index installation");
     assert!(!super::transcriptions::history_fts_available(&conn));
 
     super::schema::ensure_history_fts(&conn);
     assert!(super::transcriptions::history_fts_available(&conn));
     for (term, expected) in [("beforemarker", 0), ("aftermarker", 1)] {
-        let matches: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcriptions_fts WHERE transcriptions_fts MATCH ?1",
-            [term], |row| row.get(0),
-        ).expect("indexed search without LIKE fallback");
+        let matches: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcriptions_fts WHERE transcriptions_fts MATCH ?1",
+                [term],
+                |row| row.get(0),
+            )
+            .expect("indexed search without LIKE fallback");
         assert_eq!(matches, expected);
     }
     // Reopening a healthy index must not duplicate its postings.
@@ -180,7 +184,8 @@ fn fts_repair_rebuilds_updates_made_while_triggers_were_missing() {
     conn.execute(
         "INSERT INTO transcriptions_fts(transcriptions_fts, rank) VALUES ('integrity-check', 1)",
         [],
-    ).expect("index agrees with external content");
+    )
+    .expect("index agrees with external content");
 }
 
 #[test]
@@ -447,7 +452,7 @@ fn open_self_heals_database_stuck_at_v2_with_legacy_dictionary() {
     let version: i64 = conn
         .query_row("PRAGMA user_version", [], |r| r.get(0))
         .expect("version");
-    assert_eq!(version, 25);
+    assert_eq!(version, 26);
     drop(conn);
     drop(db);
     let _ = std::fs::remove_file(&path);
@@ -712,7 +717,7 @@ fn auto_learn_does_not_overwrite_manual_dictionary_entry() {
 
     insert_dictionary_entry(&db, "Kubernetes", Some("manual typo")).expect("manual insert");
     let promoted =
-        insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Koobernetes"), "high")
+        insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("manual typo"), "high")
             .expect("auto insert");
 
     assert!(!promoted);
@@ -725,7 +730,7 @@ fn auto_learn_does_not_overwrite_manual_dictionary_entry() {
 }
 
 #[test]
-fn auto_learn_updates_only_exact_existing_pair() {
+fn auto_learn_updates_and_keeps_context_owned_pairs_independent() {
     let db = test_db();
 
     assert!(
@@ -737,14 +742,18 @@ fn auto_learn_updates_only_exact_existing_pair() {
             .expect("same pair")
     );
     assert!(
-        !insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Kubernetties"), "low",)
+        insert_dictionary_entry_auto_learned(&db, "Kubernetes", Some("Kubernetties"), "low",)
             .expect("different pair")
     );
 
     let entries = query_dictionary(&db).expect("dictionary");
     assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
-    assert_eq!(entries[0].correction_count, 2);
+    assert_eq!(
+        entries[0].mistake.as_deref(),
+        Some("Koobernetes, Kubernetties")
+    );
+    assert_eq!(entries[0].correction_count, 3);
+    assert_eq!(entries[0].corrections.len(), 2);
 }
 
 #[test]
@@ -752,9 +761,18 @@ fn auto_learn_promote_promotes_when_pending_reaches_threshold() {
     let db = test_db();
 
     // Session 1: pending count reaches 1, below the default threshold of 2.
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
-    let first = auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2)
-        .expect("first promote call");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
+    let first = auto_learn_promote(
+        &db,
+        EVERYWHERE_CONTEXT_ID,
+        "Koobernetes",
+        "Kubernetes",
+        "medium",
+        2,
+        2,
+    )
+    .expect("first promote call");
     assert_eq!(
         first,
         AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
@@ -762,8 +780,16 @@ fn auto_learn_promote_promotes_when_pending_reaches_threshold() {
     assert!(query_dictionary(&db).expect("dictionary").is_empty());
 
     // Session 2: pending count reaches 2 — the pair promotes.
-    let second = auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2)
-        .expect("second promote call");
+    let second = auto_learn_promote(
+        &db,
+        EVERYWHERE_CONTEXT_ID,
+        "Koobernetes",
+        "Kubernetes",
+        "medium",
+        2,
+        2,
+    )
+    .expect("second promote call");
     assert_eq!(second, AutoLearnPromoteResult::Promoted);
 
     let entries = query_dictionary(&db).expect("dictionary");
@@ -780,16 +806,33 @@ fn auto_learn_promote_is_atomic_against_double_promotion() {
     // recorded pending rows). Only ONE may actually promote — the second
     // caller's atomic `promoted_at` claim must be refused.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending 1");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending 2");
 
-    let first =
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("first");
+    let first = auto_learn_promote(
+        &db,
+        EVERYWHERE_CONTEXT_ID,
+        "Koobernetes",
+        "Kubernetes",
+        "medium",
+        2,
+        2,
+    )
+    .expect("first");
     assert_eq!(first, AutoLearnPromoteResult::Promoted);
 
-    let second =
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("second");
+    let second = auto_learn_promote(
+        &db,
+        EVERYWHERE_CONTEXT_ID,
+        "Koobernetes",
+        "Kubernetes",
+        "medium",
+        2,
+        2,
+    )
+    .expect("second");
     assert_eq!(
         second,
         AutoLearnPromoteResult::AlreadyPromoted,
@@ -810,10 +853,20 @@ fn auto_learn_promote_does_not_resurrect_a_rejected_candidate() {
     // rows. An in-flight promotion for that pair must not re-create it: the
     // `promoted_at` claim no-ops against a purged candidate.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending");
     assert_eq!(
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("promote"),
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Koobernetes",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("promote"),
         AutoLearnPromoteResult::Promoted
     );
     let id = query_dictionary(&db)
@@ -831,8 +884,16 @@ fn auto_learn_promote_does_not_resurrect_a_rejected_candidate() {
     // Its count is re-evaluated inside the SAME transaction as the claim
     // and dict insert, against post-rejection state: the pending rows are
     // gone, so it lands BelowThreshold and must NOT re-create the entry.
-    let stale =
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("stale");
+    let stale = auto_learn_promote(
+        &db,
+        EVERYWHERE_CONTEXT_ID,
+        "Koobernetes",
+        "Kubernetes",
+        "medium",
+        2,
+        2,
+    )
+    .expect("stale");
     assert_ne!(
         stale,
         AutoLearnPromoteResult::Promoted,
@@ -851,10 +912,20 @@ fn auto_learn_promote_can_relearn_after_rejection() {
     // After a rejection fully purges the candidate, a genuinely new learning
     // window (a fresh candidate row with promoted_at IS NULL) can promote.
     let db = test_db();
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("prior pending");
     assert_eq!(
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("promote"),
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Koobernetes",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("promote"),
         AutoLearnPromoteResult::Promoted
     );
     let id = query_dictionary(&db)
@@ -866,13 +937,32 @@ fn auto_learn_promote_can_relearn_after_rejection() {
     delete_auto_learned_entries_by_ids(&db, &[id]).expect("reject");
 
     // New learning episode: fresh candidate (promoted_at NULL), two sessions.
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate again");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate again");
     assert_eq!(
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("s1"),
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Koobernetes",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("s1"),
         AutoLearnPromoteResult::BelowThreshold { pending_count: 1 }
     );
     assert_eq!(
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("s2"),
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Koobernetes",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("s2"),
         AutoLearnPromoteResult::Promoted
     );
     let entries = query_dictionary(&db).expect("dictionary");
@@ -883,8 +973,9 @@ fn auto_learn_promote_can_relearn_after_rejection() {
 #[test]
 fn auto_learn_promote_manual_entry_blocks_without_claiming() {
     let db = test_db();
-    insert_dictionary_entry(&db, "Kubernetes", Some("user typo")).expect("manual");
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
+    insert_dictionary_entry(&db, "Kubernetes", Some("Koobernetes")).expect("manual");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending 1");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending 2");
 
@@ -892,14 +983,23 @@ fn auto_learn_promote_manual_entry_blocks_without_claiming() {
     // every attempt (and records the pending rows for later sessions).
     for _ in 0..2 {
         assert_eq!(
-            auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("promote"),
+            auto_learn_promote(
+                &db,
+                EVERYWHERE_CONTEXT_ID,
+                "Koobernetes",
+                "Kubernetes",
+                "medium",
+                2,
+                2,
+            )
+            .expect("promote"),
             AutoLearnPromoteResult::Blocked
         );
     }
     let entries = query_dictionary(&db).expect("dictionary");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].term, "Kubernetes");
-    assert_eq!(entries[0].mistake.as_deref(), Some("user typo"));
+    assert_eq!(entries[0].mistake.as_deref(), Some("Koobernetes"));
     assert!(!entries[0].auto_learned);
 
     // The candidate was NOT claimed, so removing the manual entry later
@@ -1168,8 +1268,10 @@ fn pruning_history_removes_orphaned_api_cost_rows() {
 #[test]
 fn auto_learn_retention_prunes_only_stale_rows() {
     let db = test_db();
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
-    upsert_auto_learn_candidate(&db, "Tari", "Tauri", 0.6).expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 0.6)
+        .expect("candidate");
     log_auto_learn_event(&db, "monitor", "started", "", "", "", 0.0).expect("event");
     {
         let conn = lock_conn(&db).expect("lock");
@@ -1213,29 +1315,50 @@ fn auto_learn_retention_prunes_only_stale_rows() {
 }
 
 #[test]
-fn auto_learn_promote_different_mistake_releases_the_gate() {
+fn auto_learn_promote_keeps_different_mistakes_independent() {
     let db = test_db();
 
     // Promote a first pair for the term.
-    upsert_auto_learn_candidate(&db, "Koobernetes", "Kubernetes", 0.6).expect("candidate");
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Koobernetes", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending");
     insert_pending_correction(&db, "Koobernetes", "Kubernetes").expect("pending");
     assert_eq!(
-        auto_learn_promote(&db, "Koobernetes", "Kubernetes", "medium", 2, 2).expect("promote"),
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Koobernetes",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("promote"),
         AutoLearnPromoteResult::Promoted
     );
 
-    // A second pair for the same term with a different mistake is blocked
-    // by the existing auto-learned entry.
-    upsert_auto_learn_candidate(&db, "Kubernetz", "Kubernetes", 0.6).expect("candidate");
+    // A second pair for the same canonical term is independently represented
+    // by a child mapping in this Context; the old global mistake field could
+    // not express this without overwriting the first pair.
+    upsert_auto_learn_candidate(&db, EVERYWHERE_CONTEXT_ID, "Kubernetz", "Kubernetes", 0.6)
+        .expect("candidate");
     insert_pending_correction(&db, "Kubernetz", "Kubernetes").expect("pending");
     insert_pending_correction(&db, "Kubernetz", "Kubernetes").expect("pending");
     assert_eq!(
-        auto_learn_promote(&db, "Kubernetz", "Kubernetes", "medium", 2, 2).expect("blocked"),
-        AutoLearnPromoteResult::Blocked
+        auto_learn_promote(
+            &db,
+            EVERYWHERE_CONTEXT_ID,
+            "Kubernetz",
+            "Kubernetes",
+            "medium",
+            2,
+            2,
+        )
+        .expect("second promote"),
+        AutoLearnPromoteResult::Promoted
     );
 
-    // …but the gate must not be burned: the candidate is still claimable.
+    // The second candidate has its own promotion gate.
     let conn = lock_conn(&db).expect("lock");
     let promoted_at: Option<String> = conn
         .query_row(
@@ -1245,28 +1368,19 @@ fn auto_learn_promote_different_mistake_releases_the_gate() {
         )
         .expect("gate");
     assert!(
-        promoted_at.is_none(),
-        "different-mistake block must release the promoted_at claim"
+        promoted_at.is_some(),
+        "an independently valid mapping must claim its own gate"
     );
     drop(conn);
 
-    // Removing the conflicting entry lets the pair be learned after all.
-    let entries = query_dictionary(&db).expect("dictionary");
-    let id = entries
-        .iter()
-        .find(|e| e.term == "Kubernetes")
-        .expect("entry")
-        .id;
-    delete_dictionary_entry(&db, id).expect("delete conflicting entry");
-
-    assert_eq!(
-        auto_learn_promote(&db, "Kubernetz", "Kubernetes", "medium", 2, 2).expect("relearn"),
-        AutoLearnPromoteResult::Promoted
-    );
     let entries = query_dictionary(&db).expect("dictionary");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].term, "Kubernetes");
-    assert_eq!(entries[0].mistake.as_deref(), Some("Kubernetz"));
+    assert_eq!(
+        entries[0].mistake.as_deref(),
+        Some("Koobernetes, Kubernetz")
+    );
+    assert_eq!(entries[0].corrections.len(), 2);
 }
 
 #[test]
@@ -1483,7 +1597,8 @@ fn dict_rejection_cleans_up_pending_corrections() {
     insert_pending_correction(&db, "Tari", "Tauri").expect("pending 1");
     insert_pending_correction(&db, "Tari", "Tauri").expect("pending 2");
     assert_eq!(
-        count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count"),
+        count_pending_corrections_recent(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 7)
+            .expect("count"),
         2
     );
 
@@ -1494,7 +1609,8 @@ fn dict_rejection_cleans_up_pending_corrections() {
     assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
     // Pending corrections also purged — prevents immediate re-promotion.
     assert_eq!(
-        count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
+        count_pending_corrections_recent(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 7,)
+            .expect("count after"),
         0
     );
 }
@@ -1641,7 +1757,8 @@ fn manual_delete_of_auto_learned_entry_purges_pending_corrections() {
 
     insert_pending_correction(&db, "Tari", "Tauri").expect("pending");
     assert_eq!(
-        count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count before"),
+        count_pending_corrections_recent(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 7)
+            .expect("count before"),
         1
     );
 
@@ -1649,7 +1766,8 @@ fn manual_delete_of_auto_learned_entry_purges_pending_corrections() {
 
     assert_eq!(query_dictionary(&db).expect("query after").len(), 0);
     assert_eq!(
-        count_pending_corrections_recent(&db, "Tari", "Tauri", 7).expect("count after"),
+        count_pending_corrections_recent(&db, EVERYWHERE_CONTEXT_ID, "Tari", "Tauri", 7,)
+            .expect("count after"),
         0,
         "pending corrections must be purged when the auto-learned entry is manually deleted"
     );

--- a/src-tauri/src/data/dictionary.rs
+++ b/src-tauri/src/data/dictionary.rs
@@ -395,6 +395,7 @@ mod tests {
             confidence_tier: "manual".to_string(),
             last_seen_at: None,
             created_at: "now".to_string(),
+            corrections: Vec::new(),
         }
     }
 

--- a/src-tauri/src/pipeline/finalize.rs
+++ b/src-tauri/src/pipeline/finalize.rs
@@ -403,6 +403,7 @@ mod tests {
             confidence_tier: "confirmed".to_string(),
             last_seen_at: None,
             created_at: String::new(),
+            corrections: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Adds the transactional schema migration and database lifecycle foundation for context-specific AutoLearn correction mappings. Manual vocabulary and existing Context assignments are preserved; ambiguous legacy candidate and pending evidence is discarded safely.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #384
- <kbd>&nbsp;1&nbsp;</kbd> #383 👈 
<!-- GitButler Footer Boundary Bottom -->