### PR TITLE
Restore original banner geometry with dark theme colors

### DIFF
--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,17 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 150">
-  <rect width="800" height="150" rx="16" fill="#0d1117"/>
+  <!-- dark background -->
+  <rect width="800" height="150" rx="16" fill="#161514"/>
 
-  <!-- The mark geometry is shared with src-tauri/icons/verenu-mark.svg. -->
-  <use href="../src-tauri/icons/verenu-mark.svg#mark" transform="translate(232 31) scale(0.3346456693)" style="color:#ffffff"/>
 
+  <!--
+    Brand mark — 5 bars bottom-aligned, scaled to 88px tall
+    heights: 35%=31  70%=62  100%=88  55%=48  25%=22
+    bar width: 13px  radius: 6.5px  gap: 5px
+    mark total width: 5×13 + 4×5 = 85px
+    mark x-start: (800 - 85 - 16 - textblock) / 2
+    textblock estimate ~235px → total content ~336 → start ~232
+  -->
+  <g transform="translate(232, 31)">
+    <!-- bar 1 -->
+    <rect x="0"  y="57" width="13" height="31" rx="6.5" fill="#ffffff"/>
+    <!-- bar 2 -->
+    <rect x="18" y="26" width="13" height="62" rx="6.5" fill="#ffffff"/>
+    <!-- bar 3 -->
+    <rect x="36" y="0"  width="13" height="88" rx="6.5" fill="#ffffff"/>
+    <!-- bar 4 -->
+    <rect x="54" y="40" width="13" height="48" rx="6.5" fill="#ffffff"/>
+    <!-- bar 5 -->
+    <rect x="72" y="66" width="13" height="22" rx="6.5" fill="#ffffff"/>
+  </g>
+
+  <!-- wordmark — "Verenu" -->
   <text
     x="333"
     y="90"
-    font-family="'Fraunces', Georgia, 'Times New Roman', serif"
+    font-family="Georgia, 'Times New Roman', serif"
     font-size="46"
     font-weight="500"
     fill="#ffffff"
     letter-spacing="-0.5"
   >Verenu</text>
 
+  <!-- tagline -->
+  <text
+    x="335"
+    y="116"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-size="16"
+    fill="#9c9993"
+    letter-spacing="0.01em"
+  >open-source AI dictation for Windows</text>
 </svg>


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app - hotkey hold -> audio capture -> transcription -> LLM cleanup -> text injection
> - The affected subsystem is the documentation/branding asset used to present the application.
> - The banner needed to match the current dark visual theme and remain correct when rendered as a standalone SVG image.
> - The approved design keeps the original banner composition and five-bar mark, with the mark rendered in pure white.
> - This pull request updates only the banner asset's colors, standalone mark rendering, wordmark font fallback, and muted tagline.
> - The benefit is a consistent, dark-theme banner that renders without relying on an external SVG fragment.

## What Changed

- Updated `docs/banner.svg` to the approved `#161514` background.
- Kept the existing banner composition and five-bar mark layout, rendering the mark and wordmark in pure white.
- Restored the muted gray tagline and made the banner standalone-safe by inlining the mark geometry.

## Verification

- Parsed `docs/banner.svg` with .NET's XML parser successfully.
- Confirmed `docs/ROADMAP.md` contains no banner/logo/branding item that overlaps this change.

## Risks

Low risk: documentation-only SVG asset change. No application runtime, IPC, data, or credential behavior is affected.

## Model Used

- OpenAI Codex — GPT-5.6 (PR preparation/review); the banner edit was authored in a prior Claude session, but its exact model ID was not recorded.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [ ] `npm run check` passes (not run; documentation-only SVG change)
- [ ] `npm run lint` passes (not run; documentation-only SVG change)
- [ ] `npm run test:rust` passes (not run; documentation-only SVG change)
- [ ] Smoke tests pass (not run; documentation-only SVG change)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated to reflect this asset change
- [x] Risks documented above