### PR TITLE
Fix rounded corners on small API cost slices

### DIFF
--- a/src/lib/views/insights/DonutChart.svelte
+++ b/src/lib/views/insights/DonutChart.svelte
@@ -124,7 +124,33 @@
     return p;
   }
 
-  /** Exact annular sector, no fillet — the fallback for slices too thin for the corner treatment. */
+  /**
+   * Keep the rounded treatment on slices that are too narrow for the full
+   * corner radius. The gap and radius are scaled together so a tiny slice
+   * still gets soft corners without the two ends folding back over each
+   * other.
+   */
+  function adaptiveDonutSegmentPath(
+    cx: number, cy: number, startBoundary: number, endBoundary: number,
+    radius: number, width: number, gap: number, corner: number,
+  ): Path2D | null {
+    const sweep = endBoundary - startBoundary;
+    const innerRadius = Math.max(1, radius - width / 2);
+    const adaptiveGap = Math.min(gap, innerRadius * sweep * 0.1);
+    const adaptiveCorner = Math.min(corner, innerRadius * sweep * 0.42);
+    return donutSegmentPath(
+      cx,
+      cy,
+      startBoundary,
+      endBoundary,
+      radius,
+      width,
+      Math.max(0, adaptiveGap),
+      Math.max(0, adaptiveCorner),
+    );
+  }
+
+  /** Exact annular sector, no fillet — only a last-resort geometry fallback. */
   function sectorPath(cx: number, cy: number, startBoundary: number, endBoundary: number, radius: number, width: number): Path2D {
     const outerRadius = radius + width / 2;
     const innerRadius = radius - width / 2;
@@ -311,17 +337,15 @@
         const segRadius = radius + HOVER_POP * widenT;
 
         const sweep = end - start;
-        const minSweepForFillet = ((GAP + CORNER * 2) / radius) * 1.4;
-        // For sub-fillet sweeps, shrink the arc bounds by a tiny amount so
-        // the exact-annulus fallback never draws over its own boundary — but
-        // never so much that start passes end (that would invert the arc and
-        // sweep nearly 360 degrees).
-        const inset = Math.min(0.01, sweep / 3);
+        const minSweepForFillet = ((GAP + CORNER * 2) / segRadius) * 1.4;
+        // Narrow slices use a proportionally smaller fillet instead of
+        // dropping to square-ended annular sectors. This is especially
+        // important for the small model-cost slices in the Insights ring.
         const filletPath =
           sweep > minSweepForFillet
             ? donutSegmentPath(cx, cy, start, end, segRadius, width, GAP, CORNER)
-            : null;
-        const path = filletPath ?? sectorPath(cx, cy, start + inset, end - inset, segRadius, width);
+            : adaptiveDonutSegmentPath(cx, cy, start, end, segRadius, width, GAP, CORNER);
+        const path = filletPath ?? sectorPath(cx, cy, start, end, segRadius, width);
 
         ctx!.globalAlpha = dimmed ? dimAlpha : 1;
         ctx!.fillStyle = resolvedColors.get(seg.id) ?? seg.color;


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app whose Insights UI summarizes usage and provider costs
> - The affected subsystem is the Svelte Insights visualization layer
> - Small cost slices fell back to sharp annular-sector geometry while larger slices used rounded fillets
> - That inconsistency made the low-cost model segments visibly harsher than the rest of the donut
> - This pull request keeps the fillet treatment for narrow slices by scaling the gap and corner radius to the available sweep
> - The benefit is a consistent, softer donut ring at every segment size

## What Changed

- Added adaptive rounded geometry for narrow Estimated API cost donut slices.
- Kept the exact-sector path only as a last-resort geometry fallback.

## Verification

- `npm run check` passes with 0 errors and 0 warnings.
- `npm run test:unit` passes: 19 files, 146 tests.
- `npm run build` passes.
- Manually verified the Insights donut in the user-facing Chrome browser, including synthetic narrow-slice rendering.

## Risks

Low risk. This is isolated canvas path geometry in the Insights UI. No backend, data, credential, or IPC behavior changes.

## Model Used

- OpenAI Codex, GPT-5.6 Luna, medium reasoning, tool use

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (not run for this frontend-only geometry change)
- [ ] `npm run test:rust` passes (not run; no Rust changes)
- [ ] Smoke tests pass (not run; no smoke contract changes)
- [ ] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791607074&installation_model_id=432577&pr_number=386&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F386&signature=325a680ef181f07fc4342d1491359e216050d4d87f5e1b35521dc5cc31a2f10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->