### PR TITLE
Fix appearance selector indicator alignment

### DIFF
--- a/src/lib/components/settings/GeneralSection.svelte
+++ b/src/lib/components/settings/GeneralSection.svelte
@@ -66,11 +66,13 @@
     const idx = appearanceOptions.findIndex(o => o.id === appStore.appearanceMode);
     if (!segmentEl) return;
 
-    const measure = () => {
-      const btn = segmentEl?.querySelectorAll<HTMLElement>('.appearance-option')[idx];
-      if (!btn) return;
-      indicatorStyle = `left:${btn.offsetLeft}px;width:${btn.offsetWidth}px`;
-    };
+      const measure = () => {
+        const btn = segmentEl?.querySelectorAll<HTMLElement>('.appearance-option')[idx];
+        if (!btn) return;
+        // Horizontal only. Vertical inset stays in CSS so the fill remains
+        // centered regardless of font metrics and option padding.
+        indicatorStyle = `left:${btn.offsetLeft}px;width:${btn.offsetWidth}px`;
+      };
 
     measure();
     // The settings column is fluid now, so a one-shot measurement goes stale as
@@ -835,36 +837,44 @@
     text-transform: uppercase;
   }
   .appearance-segment {
+    /* Keep the indicator clear of the rounded track corners. */
     position: relative;
     display: inline-flex;
     align-items: center;
-    padding: 2px;
+    box-sizing: border-box;
+    padding: 3px;
     background: var(--paper);
     border: 1px solid var(--line);
     border-radius: 7px;
     gap: 2px;
+    overflow: hidden;
   }
   .appearance-indicator {
     position: absolute;
-    top: 2px;
-    height: calc(100% - 4px);
+    top: 3px;
+    bottom: 3px;
     background: var(--bg-elev);
-    border-radius: 5px;
-    box-shadow: 0 0 0 1px var(--line-soft);
+    border-radius: 4px;
     pointer-events: none;
     transition: left 180ms cubic-bezier(0.22, 1, 0.36, 1), width 180ms cubic-bezier(0.22, 1, 0.36, 1);
   }
   .appearance-option {
     position: relative;
     z-index: 1;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 22px;
     border: 0;
-    border-radius: 5px;
+    border-radius: 4px;
     background: transparent;
     color: var(--ink-mute);
     font-family: var(--sans);
     font-size: 12px;
     font-weight: 500;
-    padding: 4px 9px;
+    line-height: 1;
+    padding: 0 9px;
     cursor: pointer;
     transition: color 0.12s;
   }


### PR DESCRIPTION
## Thinking Path\n\n> - Verenu is a Windows and macOS AI dictation app.\n> - This change is in the settings UI, specifically the appearance mode selector.\n> - The selected background indicator used a different inset and radius than the outer selector track.\n> - That made the fill look vertically high and crowded into the rounded corners.\n> - This pull request gives the track and indicator equal geometry and keeps vertical positioning in CSS.\n> - The benefit is a centered selector fill with consistent corner clearance.\n\n## What Changed\n\n- Set the appearance selector track to a 3px inset with border-box sizing and clipped overflow.\n- Set the indicator to equal 3px top and bottom insets, a 4px radius, and no outline ring.\n- Give selector options fixed centered geometry so font metrics do not move the indicator vertically.\n\n## Verification\n\n- 
pm run check\n- git diff --check\n- Manual UI screenshots were not captured in the isolated clone.\n\n## Risks\n\nLow risk. This only changes the appearance selector CSS and its measurement comment. No settings persistence or backend behavior changed.\n\n## Model Used\n\nOpenAI GPT-5.6, tool use.\n\n## Checklist\n\n- [x] This PR targets master directly\n- [x] Thinking path traces from Verenu context down to this specific change\n- [x] Model used is specified\n- [x] 
pm run check passes\n- [x] No API keys, secrets, or personal data in code or logs\n- [ ] UI changes include before/after screenshots\n- [ ] 
pm run lint passes\n- [ ] 
pm run test:rust passes\n- [ ] Smoke tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791619527&installation_model_id=432577&pr_number=388&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F388&signature=48f72c985754f832c8c6075e804d08bb9043b9025eb63e45785154b4299f951e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->