### PR TITLE
Animate Insights rolling numbers and chart hover

### DIFF
--- a/src/lib/views/insights/DailyChart.svelte
+++ b/src/lib/views/insights/DailyChart.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { Spring } from 'svelte/motion';
   import { fmtDayLong, fmtNumber, niceCeiling } from './helpers';
-  import AnimatedNumber from './AnimatedNumber.svelte';
+  import { reducedMotionEnabled } from '../../motion';
+  import { buildSegments, pointOnSegments, segmentsToPath } from './chartCurve';
+  import RollingNumber from './RollingNumber.svelte';
   import ChartTooltip from './ChartTooltip.svelte';
   import type { InsightsDay } from './types';
 
@@ -37,32 +40,21 @@
     return PAD_TOP + plotH * (1 - words / max);
   }
 
-  function clampY(value: number): number {
-    return Math.max(PAD_TOP, Math.min(H - PAD_BOTTOM, value));
-  }
-
   /* Catmull-Rom control points → cubic bezier, so the area reads as a curve
-     without pulling above the data the way a naive spline does. */
+     without pulling above the data the way a naive spline does. The hover
+     indicator reads these same segments, which is what keeps it on the line. */
+  const segments = $derived(
+    buildSegments(
+      daily.map((d, i) => ({ x: x(i), y: y(d.words) })),
+      PAD_TOP,
+      H - PAD_BOTTOM
+    )
+  );
+
   const linePath = $derived.by(() => {
     if (daily.length === 0) return '';
     if (daily.length === 1) return `M 0 ${y(daily[0].words)} L ${W} ${y(daily[0].words)}`;
-    const pts = daily.map((d, i) => [x(i), y(d.words)] as const);
-    let path = `M ${pts[0][0]} ${pts[0][1]}`;
-    for (let i = 0; i < pts.length - 1; i++) {
-      const p0 = pts[i - 1] ?? pts[i];
-      const p1 = pts[i];
-      const p2 = pts[i + 1];
-      const p3 = pts[i + 2] ?? p2;
-      const c1x = p1[0] + (p2[0] - p0[0]) / 6;
-      // Catmull-Rom handles gentle curves well, but its control points can
-      // overshoot between a large spike and a zero-value day. Keeping them in
-      // the plot bounds preserves the curve without inventing negative data.
-      const c1y = clampY(p1[1] + (p2[1] - p0[1]) / 6);
-      const c2x = p2[0] - (p3[0] - p1[0]) / 6;
-      const c2y = clampY(p2[1] - (p3[1] - p1[1]) / 6);
-      path += ` C ${c1x} ${c1y}, ${c2x} ${c2y}, ${p2[0]} ${p2[1]}`;
-    }
-    return path;
+    return segmentsToPath(segments);
   });
 
   const areaPath = $derived(
@@ -72,12 +64,41 @@
   const barWidth = $derived(daily.length > 0 ? Math.min(28, (W / daily.length) * 0.55) : 0);
 
   let hover = $state<number | null>(null);
-  let hoverPos = $state<{ x: number; y: number } | null>(null);
+  let plotWidth = $state(0);
   const active = $derived(hover !== null ? daily[hover] : null);
+  /* Held through the fade-out so the tooltip keeps its text on the way out
+     instead of blanking the instant the pointer leaves. */
+  let lastActive = $state<InsightsDay | null>(null);
+  $effect(() => {
+    if (active) lastActive = active;
+  });
+
+  /* The pointer snaps to whole days, so without this the indicator teleports
+     between them. Springing a fractional index — rather than the co-ordinates —
+     is what lets the dot ride the curve instead of cutting across it. */
+  const cursor = new Spring(0, { stiffness: 0.19, damping: 0.82 });
+
+  const cursorPoint = $derived.by(() => {
+    if (daily.length === 0) return { x: 0, y: H - PAD_BOTTOM };
+    const at = Math.max(0, Math.min(daily.length - 1, cursor.current));
+    // Bars have no curve to ride, so the indicator slides straight across.
+    if (asBars || segments.length === 0) {
+      const i = Math.floor(at);
+      const next = daily[Math.min(daily.length - 1, i + 1)];
+      const y0 = y(daily[i].words);
+      return { x: x(at), y: y0 + (y(next.words) - y0) * (at - i) };
+    }
+    return pointOnSegments(segments, at);
+  });
+
+  // The svg's CSS height matches the viewBox height 1:1 and only its width is
+  // fluid, so x scales by the rendered width and y needs no conversion.
+  const cursorLeft = $derived((cursorPoint.x / W) * plotWidth);
 
   function onMove(event: PointerEvent) {
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
     if (rect.width === 0 || daily.length === 0) return;
+    plotWidth = rect.width;
     const ratio = (event.clientX - rect.left) / rect.width;
     // Bars fill equal-width slots spanning [i/n, (i+1)/n), so floor maps the
     // pointer into its slot; line charts align points at i/(n-1), so round
@@ -85,12 +106,12 @@
     const idx = asBars
       ? Math.min(daily.length - 1, Math.max(0, Math.floor(ratio * daily.length)))
       : Math.min(daily.length - 1, Math.max(0, Math.round(ratio * (daily.length - 1))));
+    // Arriving from outside, place the indicator under the pointer rather than
+    // sliding it in from wherever it was last left — otherwise entering the
+    // card drags a line across the whole chart to meet you.
+    const entering = hover === null;
     hover = idx;
-    // The svg's CSS height matches the viewBox height 1:1, only width is
-    // fluid, so x scales by the rendered width and y needs no conversion.
-    const px = (x(idx) / W) * rect.width;
-    const py = daily[idx].words > 0 ? y(daily[idx].words) : H - PAD_BOTTOM;
-    hoverPos = { x: px, y: py };
+    cursor.set(idx, { instant: entering || reducedMotionEnabled() });
   }
 
   const total = $derived(daily.reduce((sum, d) => sum + d.words, 0));
@@ -110,10 +131,10 @@
     </div>
     <div class="readout" aria-live="polite">
       {#if active}
-        <span class="readout-num">{fmtNumber(active.words)}</span>
+        <span class="readout-num"><RollingNumber value={active.words} format={fmtNumber} /></span>
         <span class="readout-day">{fmtDayLong(active.day)}</span>
       {:else}
-        <span class="readout-num"><AnimatedNumber value={total} /></span>
+        <span class="readout-num"><RollingNumber value={total} format={fmtNumber} /></span>
         <span class="readout-day">total</span>
       {/if}
     </div>
@@ -125,7 +146,7 @@
     role="img"
     aria-label={summary}
     onpointermove={onMove}
-    onpointerleave={() => { hover = null; hoverPos = null; }}
+    onpointerleave={() => (hover = null)}
   >
     <svg viewBox="0 0 {W} {H}" preserveAspectRatio="none">
       <defs>
@@ -166,25 +187,35 @@
           class="line-path"
         />
       {/if}
-      {#if hover !== null && daily[hover]}
+      {#if daily.length > 0}
         <line
-          x1={x(hover)} y1={PAD_TOP - 6} x2={x(hover)} y2={H - PAD_BOTTOM}
-          stroke="var(--accent)" stroke-width="1" stroke-dasharray="3 3" opacity="0.55"
+          class="cursor-line"
+          class:on={hover !== null}
+          x1={cursorPoint.x} y1={PAD_TOP - 6} x2={cursorPoint.x} y2={H - PAD_BOTTOM}
+          stroke="var(--accent)" stroke-width="1" stroke-dasharray="3 3"
           vector-effect="non-scaling-stroke"
         />
       {/if}
     </svg>
-    {#if hoverPos && !asBars}
-      <span class="hover-dot" style:left="{hoverPos.x}px" style:top="{hoverPos.y}px" aria-hidden="true"></span>
+    {#if !asBars && daily.length > 0}
+      <!-- Positioned as a percentage so it tracks a resize without remeasuring;
+           only the tooltip needs the plot's pixel width. -->
+      <span
+        class="hover-dot"
+        class:on={hover !== null}
+        style:left="{(cursorPoint.x / W) * 100}%"
+        style:top="{cursorPoint.y}px"
+        aria-hidden="true"
+      ></span>
     {/if}
     <div class="axis">
       <span>{daily.length ? fmtDayLong(daily[0].day) : ''}</span>
       <span>{daily.length > 1 ? fmtDayLong(daily[daily.length - 1].day) : ''}</span>
     </div>
-    {#if hoverPos && active}
-      <ChartTooltip x={hoverPos.x} y={hoverPos.y} visible={true}>
-        <strong>{fmtNumber(active.words)}</strong> words
-        <div class="tooltip-dim">{fmtDayLong(active.day)}</div>
+    {#if lastActive}
+      <ChartTooltip x={cursorLeft} y={cursorPoint.y} visible={hover !== null}>
+        <strong>{fmtNumber(lastActive.words)}</strong> words
+        <div class="tooltip-dim">{fmtDayLong(lastActive.day)}</div>
       </ChartTooltip>
     {/if}
   </div>
@@ -201,7 +232,7 @@
   }
   .readout-num {
     display: block;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 20px;
     font-weight: 500;
     color: var(--ink);
@@ -263,6 +294,17 @@
     .line-path { animation: none; }
   }
 
+  /* Only opacity and scale are transitioned. Position is driven by the spring
+     every frame, so a transition on left/top would fight it and lag behind. */
+  .cursor-line {
+    opacity: 0;
+    transition: opacity var(--ui-duration-fast) var(--ui-ease-out);
+  }
+
+  .cursor-line.on {
+    opacity: 0.55;
+  }
+
   .hover-dot {
     position: absolute;
     width: 9px;
@@ -271,8 +313,17 @@
     background: var(--accent);
     border: 2.5px solid var(--bg-elev);
     box-sizing: border-box;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(0.5);
+    opacity: 0;
     pointer-events: none;
     filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--accent) 55%, transparent));
+    transition:
+      opacity var(--ui-duration-fast) var(--ui-ease-out),
+      transform var(--ui-duration-base) var(--ui-ease-out);
+  }
+
+  .hover-dot.on {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
   }
 </style>

--- a/src/lib/views/insights/RollingNumber.svelte
+++ b/src/lib/views/insights/RollingNumber.svelte
@@ -1,127 +1,210 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
-  import { tweened } from 'svelte/motion';
-  import { cubicOut } from 'svelte/easing';
-  import { motionMs, reducedMotionEnabled } from '../../motion';
+  import { onDestroy, tick, untrack } from 'svelte';
+  import { reducedMotionEnabled } from '../../motion';
+  import { ROLL_TRAVEL, RollSpring } from './rollingSpring';
 
-  let { value }: { value: number } = $props();
+  let {
+    value,
+    format = (n: number) => Math.round(n).toLocaleString(),
+  }: { value: number; format?: (n: number) => string } = $props();
 
-  const DIGITS = Array.from({ length: 10 }, (_, index) => index);
-  const duration = motionMs(500);
-  const normalize = (next: number) => Math.max(0, Math.round(Number.isFinite(next) ? next : 0));
-  const initialValue = reducedMotionEnabled() ? normalize(untrack(() => value)) : 0;
-  const display = tweened(initialValue, { duration, easing: cubicOut });
-  let previousValue = initialValue;
-  let animating = $state(false);
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const uid = `rn-${Math.random().toString(36).slice(2)}`;
+  const text = $derived(format(value));
+
+  /* Real motion blur is velocity x exposure, and a frame is the exposure. The
+     blur is vertical-only (stdDeviation "0 n"): an isotropic blur smears a
+     digit sideways into its neighbours and reads as glow rather than movement,
+     which is the whole reason this is an SVG filter and not filter: blur(). */
+  const BLUR_PER_PX_PER_S = 0.022;
+  const MAX_BLUR = 7;
+
+  let view = $state<string[]>([]);
+
+  let cellEls: (HTMLSpanElement | null)[] = [];
+  let liveEls: (HTMLSpanElement | null)[] = [];
+  let ghostEls: (HTMLSpanElement | null)[] = [];
+  let blurEls: (SVGFEGaussianBlurElement | null)[] = [];
+
+  // Deliberately not $state: these change every frame and drive the DOM
+  // directly, so routing them through reactivity would only add churn.
+  let chars: string[] = [];
+  // Seeded from the mount value only; every later value arrives via the
+  // effect below, which is the point — silence the reactivity lint.
+  let prevValue = untrack(() => value);
+  let fontPx = 16;
+  const springs: RollSpring[] = [];
+
+  let raf = 0;
+  let lastFrame = 0;
+
+  const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+
+  function paint(i: number) {
+    const live = liveEls[i];
+    const ghost = ghostEls[i];
+    if (!live || !ghost) return;
+    const spring = springs[i];
+    if (!spring) return;
+    const t = spring.pos;
+    const travel = ROLL_TRAVEL * spring.dir;
+    live.style.transform = `translateY(${(t * travel).toFixed(4)}em)`;
+    live.style.opacity = `${clamp(1 - Math.abs(t) * 1.35, 0, 1)}`;
+    ghost.style.transform = `translateY(${((t - 1) * travel).toFixed(4)}em)`;
+    ghost.style.opacity = `${clamp(Math.abs(t) * 1.5 - 0.15, 0, 1)}`;
+    const blur = blurEls[i];
+    if (blur) {
+      const speedPx = Math.abs(spring.vel) * ROLL_TRAVEL * fontPx;
+      blur.setAttribute(
+        'stdDeviation',
+        `0 ${Math.min(MAX_BLUR, speedPx * BLUR_PER_PX_PER_S).toFixed(2)}`
+      );
+    }
+  }
+
+  function settle(i: number) {
+    springs[i]?.reset();
+    const live = liveEls[i];
+    const ghost = ghostEls[i];
+    const cell = cellEls[i];
+    if (live) live.removeAttribute('style');
+    if (ghost) {
+      ghost.textContent = '';
+      ghost.removeAttribute('style');
+    }
+    // Dropping the filter when idle keeps settled text on normal subpixel
+    // antialiasing; a live filter forces every digit onto its own layer.
+    if (cell) cell.style.filter = '';
+  }
+
+  function frame(now: number) {
+    const dt = lastFrame ? Math.min(0.032, (now - lastFrame) / 1000) : 1 / 60;
+    lastFrame = now;
+    let active = false;
+    for (let i = 0; i < springs.length; i++) {
+      const spring = springs[i];
+      if (!spring?.active) continue;
+      if (!spring.step(dt)) {
+        settle(i);
+        continue;
+      }
+      paint(i);
+      active = true;
+    }
+    raf = active ? requestAnimationFrame(frame) : 0;
+    if (!active) lastFrame = 0;
+  }
+
+  function applyChange(next: string[]) {
+    const reduced = reducedMotionEnabled();
+    // Compare by place value, not by string index, so 842 -> 1,749 rolls the
+    // ones digit into the ones digit rather than shifting every column along.
+    const shift = next.length - chars.length;
+    const rollDir: 1 | -1 = value >= prevValue ? 1 : -1;
+    prevValue = value;
+    if (shift !== 0) {
+      for (let i = 0; i < springs.length; i++) settle(i);
+      springs.length = 0;
+    }
+    const firstCell = cellEls[0];
+    if (firstCell) fontPx = parseFloat(getComputedStyle(firstCell).fontSize) || 16;
+
+    let started = false;
+    for (let i = 0; i < next.length; i++) {
+      const was = chars[i - shift];
+      if (reduced || was === undefined || was === next[i]) continue;
+      const live = liveEls[i];
+      const ghost = ghostEls[i];
+      const cell = cellEls[i];
+      if (!live || !ghost || !cell) continue;
+      ghost.textContent = was;
+      (springs[i] ??= new RollSpring()).start(rollDir);
+      cell.style.filter = `url(#${uid}-${i})`;
+      paint(i);
+      started = true;
+    }
+    chars = next;
+    if (started && raf === 0) {
+      lastFrame = 0;
+      raf = requestAnimationFrame(frame);
+    }
+  }
 
   $effect(() => {
-    const next = normalize(value);
-    if (next === previousValue) return;
-    previousValue = next;
-    animating = true;
-    if (timer) clearTimeout(timer);
-    display.set(next);
-    timer = setTimeout(() => {
-      animating = false;
-      timer = undefined;
-    }, duration);
-    return () => {
-      if (timer) clearTimeout(timer);
-      timer = undefined;
-    };
+    const next = text.split('');
+    view = next;
+    // tick() lands after Svelte has written the new digits but before the
+    // browser paints, so a roll's opening frame is applied in the same paint as
+    // the character swap — otherwise the new digit flashes in place first.
+    tick().then(() => applyChange(next));
   });
 
-  const formatted = $derived(normalize($display).toLocaleString());
-  const accessibleValue = $derived(normalize(value).toLocaleString());
+  onDestroy(() => {
+    if (raf) cancelAnimationFrame(raf);
+  });
 </script>
 
-<span class="rolling-number" class:animating aria-hidden="true">
-  {#each formatted.split('') as character, index (index)}
-    {#if /\d/.test(character)}
-      <span class="digit-window">
-        <span class="digit-track" style:transform={`translateY(-${Number(character) * 10}%)`}>
-          {#each DIGITS as digit}
-            <span class="digit-face" data-digit={digit}></span>
-          {/each}
-        </span>
-      </span>
-    {:else}
-      <span class="separator">{character}</span>
-    {/if}
-  {/each}
-</span>
-<span class="sr-only">{accessibleValue}</span>
+<!-- The filter defs are a sibling, and the cells sit on one line with no gaps
+     between them: any whitespace in here becomes a text node, which would make
+     the readout copy and read aloud as "1 , 7 4 9" instead of "1,749". -->
+<svg class="rn-defs" aria-hidden="true" focusable="false">
+  <defs>
+    {#each view as _, i (i)}
+      <!-- The region must be generous: anything the blur or the travel pushes
+           outside it is clipped, which is what draws a hard box round it. -->
+      <filter
+        id="{uid}-{i}"
+        x="-80%"
+        y="-200%"
+        width="260%"
+        height="500%"
+        color-interpolation-filters="sRGB"
+      >
+        <feGaussianBlur bind:this={blurEls[i]} in="SourceGraphic" stdDeviation="0 0" />
+      </filter>
+    {/each}
+  </defs>
+</svg>
+<span class="rolling-number"
+  >{#each view as ch, i (i)}<span class="cell" bind:this={cellEls[i]}><span
+      class="live"
+      bind:this={liveEls[i]}>{ch}</span><span
+      class="ghost"
+      bind:this={ghostEls[i]}
+      aria-hidden="true"
+    ></span></span>{/each}</span
+>
 
 <style>
   .rolling-number {
     display: inline-flex;
     align-items: baseline;
     font-variant-numeric: tabular-nums;
-    white-space: nowrap;
   }
 
-  .digit-window {
-    display: inline-block;
-    height: 1em;
-    overflow: hidden;
+  /* Nothing clips and nothing forces a line-height: the settled digit is plain
+     in-flow text, so a digit that just rolled sits on exactly the same baseline
+     as one that never moved. (inline-block + overflow:hidden does not — it
+     aligns by its bottom margin edge, which is what made them settle uneven.) */
+  .cell {
     position: relative;
-    vertical-align: bottom;
-    width: 0.62em;
-    mask-image: linear-gradient(to bottom, transparent 0%, black 14%, black 86%, transparent 100%);
-    -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 14%, black 86%, transparent 100%);
-  }
-
-  .digit-track {
-    display: block;
-    height: 1000%;
-    will-change: transform, filter;
-  }
-
-  .digit-face {
-    align-items: center;
-    display: flex;
-    height: 10%;
-    justify-content: center;
-  }
-
-  .digit-face::before {
-    content: attr(data-digit);
-  }
-
-  .separator {
     display: inline-block;
-    width: 0.25em;
   }
 
-  .rolling-number.animating .digit-track {
-    filter: blur(0.8px);
+  .live {
+    display: inline-block;
   }
 
-  .rolling-number.animating .digit-window {
-    filter: blur(0.18px);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .digit-track {
-      will-change: auto;
-    }
-
-    .rolling-number.animating .digit-track {
-      filter: none;
-    }
-
-    .rolling-number.animating .digit-window {
-      filter: none;
-    }
-  }
-
-  .sr-only {
+  .ghost {
     position: absolute;
-    width: 1px;
-    height: 1px;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .rn-defs {
+    position: absolute;
+    width: 0;
+    height: 0;
     overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
   }
 </style>

--- a/src/lib/views/insights/RollingNumber.svelte
+++ b/src/lib/views/insights/RollingNumber.svelte
@@ -36,6 +36,7 @@
 
   let raf = 0;
   let lastFrame = 0;
+  let destroyed = false;
 
   const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
 
@@ -135,10 +136,13 @@
     // tick() lands after Svelte has written the new digits but before the
     // browser paints, so a roll's opening frame is applied in the same paint as
     // the character swap — otherwise the new digit flashes in place first.
-    tick().then(() => applyChange(next));
+    tick().then(() => {
+      if (!destroyed) applyChange(next);
+    });
   });
 
   onDestroy(() => {
+    destroyed = true;
     if (raf) cancelAnimationFrame(raf);
   });
 </script>

--- a/src/lib/views/insights/chartCurve.test.ts
+++ b/src/lib/views/insights/chartCurve.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { buildSegments, pointOnSegments, segmentsToPath, type Point } from './chartCurve';
+
+const MIN_Y = 12;
+const MAX_Y = 148;
+
+function points(ys: number[]): Point[] {
+  return ys.map((y, i) => ({ x: i * 50, y }));
+}
+
+describe('chartCurve', () => {
+  it('builds one segment per gap, anchored on the data points', () => {
+    const pts = points([100, 40, 90, 20]);
+    const segments = buildSegments(pts, MIN_Y, MAX_Y);
+    expect(segments).toHaveLength(3);
+    segments.forEach((s, i) => {
+      expect(s.p1).toEqual(pts[i]);
+      expect(s.p2).toEqual(pts[i + 1]);
+    });
+  });
+
+  // The invariant the hover indicator depends on: at a whole index the dot must
+  // sit exactly on that day's point, or it visibly floats off the line.
+  it('lands exactly on the data point at every whole index', () => {
+    const pts = points([100, 40, 90, 20, 75]);
+    const segments = buildSegments(pts, MIN_Y, MAX_Y);
+    pts.forEach((p, i) => {
+      const at = pointOnSegments(segments, i);
+      expect(at.x).toBeCloseTo(p.x, 6);
+      expect(at.y).toBeCloseTo(p.y, 6);
+    });
+  });
+
+  it('advances monotonically in x between points', () => {
+    const segments = buildSegments(points([100, 40, 90, 20]), MIN_Y, MAX_Y);
+    let prev = -Infinity;
+    for (let at = 0; at <= 3; at += 0.05) {
+      const { x } = pointOnSegments(segments, at);
+      expect(x).toBeGreaterThan(prev);
+      prev = x;
+    }
+  });
+
+  it('clamps past either end instead of running off the plot', () => {
+    const pts = points([100, 40, 90]);
+    const segments = buildSegments(pts, MIN_Y, MAX_Y);
+    expect(pointOnSegments(segments, -3).x).toBeCloseTo(pts[0].x, 6);
+    expect(pointOnSegments(segments, 99).x).toBeCloseTo(pts[2].x, 6);
+  });
+
+  it('keeps the curve inside the plot bounds over a spike next to a zero day', () => {
+    const segments = buildSegments(points([MAX_Y, MIN_Y, MAX_Y, MIN_Y]), MIN_Y, MAX_Y);
+    for (let at = 0; at <= 3; at += 0.02) {
+      const { y } = pointOnSegments(segments, at);
+      expect(y).toBeGreaterThanOrEqual(MIN_Y);
+      expect(y).toBeLessThanOrEqual(MAX_Y);
+    }
+  });
+
+  it('emits an empty path when there is nothing to draw', () => {
+    expect(segmentsToPath([])).toBe('');
+    expect(segmentsToPath(buildSegments(points([50]), MIN_Y, MAX_Y))).toBe('');
+  });
+});

--- a/src/lib/views/insights/chartCurve.ts
+++ b/src/lib/views/insights/chartCurve.ts
@@ -1,0 +1,73 @@
+/*
+ * Catmull-Rom → cubic bezier for the daily chart's curve.
+ *
+ * The drawn line and the hover indicator have to agree exactly: the indicator
+ * rides the curve rather than cutting between data points, so if it derived its
+ * own control points any difference would float the dot off the line. Both read
+ * the segments built here.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Segment {
+  p1: Point;
+  c1: Point;
+  c2: Point;
+  p2: Point;
+}
+
+export function buildSegments(points: Point[], minY: number, maxY: number): Segment[] {
+  const clampY = (value: number) => Math.max(minY, Math.min(maxY, value));
+  const segments: Segment[] = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = points[i - 1] ?? points[i];
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const p3 = points[i + 2] ?? p2;
+    segments.push({
+      p1,
+      p2,
+      // Catmull-Rom handles gentle curves well, but its control points can
+      // overshoot between a large spike and a zero-value day. Keeping them in
+      // the plot bounds preserves the curve without inventing negative data.
+      c1: { x: p1.x + (p2.x - p0.x) / 6, y: clampY(p1.y + (p2.y - p0.y) / 6) },
+      c2: { x: p2.x - (p3.x - p1.x) / 6, y: clampY(p2.y - (p3.y - p1.y) / 6) },
+    });
+  }
+  return segments;
+}
+
+export function segmentsToPath(segments: Segment[]): string {
+  if (segments.length === 0) return '';
+  let path = `M ${segments[0].p1.x} ${segments[0].p1.y}`;
+  for (const s of segments) {
+    path += ` C ${s.c1.x} ${s.c1.y}, ${s.c2.x} ${s.c2.y}, ${s.p2.x} ${s.p2.y}`;
+  }
+  return path;
+}
+
+/**
+ * The point on the curve at a fractional data index, clamped to the ends so an
+ * overshooting spring parks the indicator on the last day rather than off the
+ * side of the plot.
+ */
+export function pointOnSegments(segments: Segment[], at: number): Point {
+  if (segments.length === 0) return { x: 0, y: 0 };
+  const last = segments.length - 1;
+  const clamped = Math.max(0, Math.min(segments.length, at));
+  const i = Math.max(0, Math.min(last, Math.floor(clamped)));
+  const t = clamped - i;
+  const s = segments[i];
+  const u = 1 - t;
+  const w1 = u * u * u;
+  const w2 = 3 * u * u * t;
+  const w3 = 3 * u * t * t;
+  const w4 = t * t * t;
+  return {
+    x: w1 * s.p1.x + w2 * s.c1.x + w3 * s.c2.x + w4 * s.p2.x,
+    y: w1 * s.p1.y + w2 * s.c1.y + w3 * s.c2.y + w4 * s.p2.y,
+  };
+}

--- a/src/lib/views/insights/rollingSpring.test.ts
+++ b/src/lib/views/insights/rollingSpring.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { RollSpring } from './rollingSpring';
+
+/** Runs a roll to completion and reports how long it took, in ms. */
+function settleMs(frameMs: number, carriedVelocity = 0): number {
+  const spring = new RollSpring();
+  spring.vel = carriedVelocity;
+  spring.start(1);
+  let elapsed = 0;
+  for (let i = 0; i < 2000; i++) {
+    elapsed += frameMs;
+    if (!spring.step(frameMs / 1000)) return elapsed;
+  }
+  return Infinity;
+}
+
+describe('RollSpring', () => {
+  // The budget is a product requirement, not a detail: a digit roll that
+  // outlasts it stops reading as feedback and starts reading as lag.
+  it('settles inside the 500ms budget at any frame rate', () => {
+    for (const frameMs of [8.33, 16.67, 32]) {
+      expect(settleMs(frameMs)).toBeLessThan(500);
+    }
+  });
+
+  it('still settles when restarted mid-flight at full speed', () => {
+    expect(settleMs(16.67, -26)).toBeLessThan(500);
+    expect(settleMs(16.67, 26)).toBeLessThan(500);
+  });
+
+  it('does not overshoot far enough to read as a bounce', () => {
+    const spring = new RollSpring();
+    spring.start(1);
+    let furthestPast = 0;
+    while (spring.step(1 / 60)) furthestPast = Math.min(furthestPast, spring.pos);
+    expect(furthestPast).toBeGreaterThan(-0.05);
+  });
+
+  it('reaches a speed worth blurring on the way', () => {
+    const spring = new RollSpring();
+    spring.start(1);
+    let peak = 0;
+    while (spring.step(1 / 60)) peak = Math.max(peak, Math.abs(spring.vel));
+    expect(peak).toBeGreaterThan(5);
+  });
+});

--- a/src/lib/views/insights/rollingSpring.ts
+++ b/src/lib/views/insights/rollingSpring.ts
@@ -1,0 +1,54 @@
+/*
+ * The spring behind RollingNumber's digit roll.
+ *
+ * A spring rather than an easing curve for two reasons: it whips into place and
+ * settles without a bounce in a way a fixed curve can't, and it exposes a
+ * per-frame velocity — which is what the motion blur is scaled by. Lives in its
+ * own module so the settle budget stays checkable while the feel is tuned.
+ */
+
+const STIFFNESS = 600;
+// Just under critical damping (2*sqrt(STIFFNESS) ~= 49): sharp, no bounce.
+const DAMPING = 43;
+const MAX_SPEED = 26;
+
+/** How far a digit travels per roll, in em — one slot of the wheel. */
+export const ROLL_TRAVEL = 0.85;
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+
+export class RollSpring {
+  /** 1 = a full slot away from home, 0 = settled. */
+  pos = 0;
+  vel = 0;
+  /** 1 rolls the new digit up from below, -1 brings it down from above. */
+  dir: 1 | -1 = 1;
+  active = false;
+
+  /**
+   * (Re)start the roll. Any speed left over from a roll still in flight is
+   * carried rather than zeroed: scrubbing a chart restarts a digit mid-flight,
+   * and keeping the momentum is both what makes a fast sweep blur harder and
+   * what stops it stuttering back to a standstill between steps.
+   */
+  start(dir: 1 | -1) {
+    this.dir = dir;
+    this.vel = clamp(this.vel, -MAX_SPEED, MAX_SPEED);
+    this.pos = 1;
+    this.active = true;
+  }
+
+  /** Advance by dt seconds. Returns false once the roll has settled. */
+  step(dt: number): boolean {
+    this.vel = clamp(this.vel + (-STIFFNESS * this.pos - DAMPING * this.vel) * dt, -MAX_SPEED, MAX_SPEED);
+    this.pos += this.vel * dt;
+    if (Math.abs(this.pos) < 0.004 && Math.abs(this.vel) < 0.08) this.reset();
+    return this.active;
+  }
+
+  reset() {
+    this.pos = 0;
+    this.vel = 0;
+    this.active = false;
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app whose frontend presents transcription insights and feedback.
> - The Insights UI contains the daily chart and rolling numeric readouts.
> - The readout and chart hover indicator currently change too abruptly, making the interaction feel disconnected from the data.
> - This needs addressing as part of the ongoing Insights polish work.
> - This pull request adds spring-driven digit rolls with directional SVG blur and spring-driven chart hover motion along the rendered curve.
> - The benefit is a more tactile, legible, and coherent Insights interaction without changing backend behavior.

## What Changed

- Added `RollingNumber` with place-value digit rolls, velocity-scaled vertical-only SVG blur, crossfade, reduced-motion handling, and settle cleanup.
- Extracted chart curve construction and fractional point interpolation into tested helpers.
- Animated the chart hover line, dot, and tooltip from one spring-driven fractional index; bars interpolate linearly and hover text persists through fade-out.
- Added curve and spring unit tests.

## Verification

- `npm run check` ✅
- `npm run test:unit` ✅ (157 tests)
- Rust lint was not run: the already-running Verenu app holds a Windows native DLL lock; no Rust files are changed by this PR.
- Manual live-app visual verification remains pending.

## Risks

Low risk. Frontend-only Insights changes; no IPC, persistence, credential, injection, or native pipeline behavior changes. Reduced-motion continues to snap motion instantly.

## Model Used

- OpenAI GPT-5.6 Luna, medium reasoning, tool use

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (Rust half blocked by existing DLL lock; frontend check passes)
- [ ] `npm run test:rust` passes (not run; frontend-only)
- [ ] Smoke tests pass (not run; no smoke contracts touch this chart)
- [x] Tests added or updated where applicable
- [ ] UI changes include before/after screenshots (not captured in this environment)
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791710163&installation_model_id=432577&pr_number=391&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F391&signature=2718e56679d70facc10b581e410d45adc8380434ca7153163d7c275c1d1ad065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->