### PR TITLE
Add persistent dev mode startup setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Added a Developer setting to automatically enable Developer mode on startup.
 - Removed the microphone calibration step and Audio-page calibration controls; manual microphone gain remains available. Rejected quiet or speech-free captures now make a quick follow-up dictation more sensitive for a bounded number of attempts, including explicit retries.
 - Fixed Windows dictation appearing to freeze after CPAL reported that the
   microphone stream was no longer available; the dead recording now shuts down

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -175,6 +175,7 @@ const SETTING_SPECS: &[SettingSpec] = &[
     setting_spec(store::ACCENT_COLOR, SettingKind::AccentColor, true, true),
     setting_spec(store::FORCE_SETUP_ON_LAUNCH, SettingKind::Bool, true, false),
     setting_spec(store::RUIN_ACCESSIBILITY, SettingKind::Bool, true, false),
+    setting_spec(store::DEV_MODE_ON_STARTUP, SettingKind::Bool, true, true),
     setting_spec(store::ADVANCED_MODEL_UI, SettingKind::Bool, true, true),
     setting_spec(
         store::CLEANUP_PROMPT_OVERRIDE,
@@ -614,6 +615,7 @@ pub struct AllSettings {
     pub legacy_features_enabled: Option<bool>,
     pub sync_enabled: Option<bool>,
     pub ruin_accessibility: Option<bool>,
+    pub dev_mode_on_startup: Option<bool>,
     pub transcription_provider: Option<String>,
     pub transcription_model: Option<String>,
     pub transcription_language: Option<String>,
@@ -686,6 +688,7 @@ pub async fn get_all_settings(app: AppHandle) -> Result<AllSettings, String> {
         legacy_features_enabled: bool_val(store::LEGACY_FEATURES_ENABLED),
         sync_enabled: bool_val(store::SYNC_ENABLED),
         ruin_accessibility: bool_val(store::RUIN_ACCESSIBILITY),
+        dev_mode_on_startup: bool_val(store::DEV_MODE_ON_STARTUP),
         transcription_provider: str_val(store::TRANSCRIPTION_PROVIDER),
         transcription_model: str_val(store::TRANSCRIPTION_MODEL),
         transcription_language: str_val(store::TRANSCRIPTION_LANGUAGE),

--- a/src-tauri/src/data/store/mod.rs
+++ b/src-tauri/src/data/store/mod.rs
@@ -363,6 +363,7 @@ pub const APPEARANCE_MODE: &str = "appearance_mode";
 pub const ACCENT_COLOR: &str = "accent_color";
 pub const FORCE_SETUP_ON_LAUNCH: &str = "force_setup_on_launch";
 pub const RUIN_ACCESSIBILITY: &str = "ruin_accessibility";
+pub const DEV_MODE_ON_STARTUP: &str = "dev_mode_on_startup";
 pub const ADVANCED_MODEL_UI: &str = "advanced_model_ui";
 /// One cleanup prompt for every model. Fallback chains made per-model prompts
 /// a trap: edit the prompt on your default, fall back to another model, and the

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -226,7 +226,7 @@
     // stores disagreeing with what import_data actually wrote to disk.
     async function reloadGlobalSettings() {
       try {
-        const [done, appearance, accentColor, forceSetupOnLaunch, cleanupEnabled, betaUpdatesEnabled, legacyFeaturesEnabled, syncEnabled, ruinAccessibility] = await Promise.all([
+        const [done, appearance, accentColor, forceSetupOnLaunch, cleanupEnabled, betaUpdatesEnabled, legacyFeaturesEnabled, syncEnabled, ruinAccessibility, devModeOnStartup] = await Promise.all([
           invoke<boolean | null>('get_setting', { key: 'setup_complete' }),
           invoke<'system' | 'light' | 'dark' | null>('get_setting', { key: 'appearance_mode' }),
           invoke<string | null>('get_setting', { key: 'accent_color' }),
@@ -236,6 +236,7 @@
           invoke<boolean | null>('get_setting', { key: 'legacy_features_enabled' }),
           invoke<boolean | null>('get_setting', { key: 'sync_enabled' }),
           invoke<boolean | null>('get_setting', { key: 'ruin_accessibility' }),
+          invoke<boolean | null>('get_setting', { key: 'dev_mode_on_startup' }),
         ]);
         appStore.setupComplete = forceSetupOnLaunch ? false : done === true;
         if (appearance === 'light' || appearance === 'dark' || appearance === 'system') {
@@ -247,7 +248,8 @@
         appStore.legacyFeaturesEnabled = legacyFeaturesEnabled ?? false;
         appStore.syncEnabled = syncEnabled ?? false;
         appStore.ruinAccessibility = ruinAccessibility ?? false;
-        if (appStore.ruinAccessibility) appStore.devModeEnabled = true;
+        appStore.devModeOnStartup = devModeOnStartup ?? false;
+        if (appStore.ruinAccessibility || appStore.devModeOnStartup) appStore.devModeEnabled = true;
       } catch {
         appStore.setupComplete = false;
       }

--- a/src/lib/components/settings/DiagnosticsConsole.svelte
+++ b/src/lib/components/settings/DiagnosticsConsole.svelte
@@ -67,6 +67,7 @@
   let providerStatusRaw = $state('');
   let verboseEnabled = $state(false);
   let ruinAccessibility = $state(false);
+  let devModeOnStartup = $state(false);
   let forceSetupOnLaunch = $state(false);
   let storageFullSimulation = $state(false);
   let syncEnabled = $state(false);
@@ -230,6 +231,16 @@
     await saveSetting('ruin_accessibility', value).catch(() => { ruinAccessibility = !value; appStore.ruinAccessibility = !value; });
   }
 
+  async function setDevModeOnStartup(value: boolean) {
+    const previous = devModeOnStartup;
+    devModeOnStartup = value;
+    appStore.devModeOnStartup = value;
+    await saveSetting('dev_mode_on_startup', value).catch(() => {
+      devModeOnStartup = previous;
+      appStore.devModeOnStartup = previous;
+    });
+  }
+
   async function setForceSetup(value: boolean) {
     forceSetupOnLaunch = value;
     await saveSetting('force_setup_on_launch', value).catch(() => { forceSetupOnLaunch = !value; });
@@ -303,9 +314,10 @@
     }).then((unlisten) => { if (active) unlistenDiagnostics = unlisten; else unlisten(); }).catch(() => {});
     Promise.all([
       invoke<boolean>('get_dev_logging_enabled'), invoke<boolean | null>('get_setting', { key: 'ruin_accessibility' }),
+      invoke<boolean | null>('get_setting', { key: 'dev_mode_on_startup' }),
       invoke<boolean | null>('get_setting', { key: 'force_setup_on_launch' }), invoke<boolean | null>('get_setting', { key: 'sync_enabled' }),
       invoke<boolean>('get_storage_full_simulation'),
-    ]).then(([verbose, ruin, force, sync, storage]) => { verboseEnabled = verbose; ruinAccessibility = ruin ?? false; forceSetupOnLaunch = force ?? false; syncEnabled = sync ?? false; storageFullSimulation = storage; }).catch(() => {});
+    ]).then(([verbose, ruin, devStartup, force, sync, storage]) => { verboseEnabled = verbose; ruinAccessibility = ruin ?? false; devModeOnStartup = devStartup ?? false; forceSetupOnLaunch = force ?? false; syncEnabled = sync ?? false; storageFullSimulation = storage; }).catch(() => {});
     return () => { active = false; if (pollTimer) clearTimeout(pollTimer); document.removeEventListener('visibilitychange', onVisibility!); if (unlistenDiagnostics) unlistenDiagnostics(); void invoke('unsubscribe_log_stream').catch(() => {}); if (!recording) void invoke('set_diagnostics_monitoring', { enabled: false }).catch(() => {}); };
   });
 </script>
@@ -410,7 +422,7 @@
       </Dropdown>
     </div><span data-setting-target="developer-storage-simulation"><Toggle checked={storageFullSimulation} onchange={toggleStorageFault} label="Full Storage Failure" /></span></div>{#if providerStatusRaw}<pre class="status-output">{providerStatusRaw}</pre>{/if}<div class="toolbar"><button class="btn-danger btn-compact" onclick={() => void clearFaults()}>Clear</button>{#if faultMessage}<span class="muted">{faultMessage}</span>{/if}</div></section>
   {:else}
-    <section class="diag-panel" data-setting-target="developer-settings"><div class="panel-title"><h3>Developer settings</h3><span class="muted">explicit opt-in controls</span></div><div class="setting-row" data-setting-target="developer-ruin-accessibility"><div><div class="label">Ruin accessibility</div><div class="desc">Expose a compact, privacy-filtered state dump for T3 Code SnapShots. It never includes logs, transcripts, prompts, or keys.</div></div><Toggle checked={ruinAccessibility} onchange={setRuin} label="Ruin accessibility" /></div><div class="setting-row" data-setting-target="developer-logs"><div><div class="label">Verbose logging</div><div class="desc">{verboseEnabled ? 'Debug logging enabled.' : 'Metadata diagnostics remain useful with verbose logging off.'} <button class="link-btn privacy-link" onclick={() => privacyModalOpen = true}>Privacy details</button></div></div><Toggle checked={verboseEnabled} onchange={setVerbose} label={`Verbose: ${verboseEnabled ? 'On' : 'Off'}`} /></div><div class="setting-row" data-setting-target="developer-setup"><div><div class="label">Force setup on launch</div><div class="desc">Show onboarding without erasing saved settings.</div></div><Toggle checked={forceSetupOnLaunch} onchange={setForceSetup} label="Force setup" /></div><div class="setting-row" data-setting-target="developer-sync"><div><div class="label">LAN Device Sync</div><div class="desc">Experimental encrypted device-to-device sync. Off by default.</div></div><Toggle checked={syncEnabled} onchange={setSync} label="Enable LAN sync" /></div></section>
+    <section class="diag-panel" data-setting-target="developer-settings"><div class="panel-title"><h3>Developer settings</h3><span class="muted">explicit opt-in controls</span></div><div class="setting-row" data-setting-target="developer-dev-mode-startup"><div><div class="label">Enable dev mode on startup</div><div class="desc">Keep Developer visible automatically whenever Verenu starts.</div></div><Toggle checked={devModeOnStartup} onchange={setDevModeOnStartup} label="Enable dev mode on startup" /></div><div class="setting-row" data-setting-target="developer-ruin-accessibility"><div><div class="label">Ruin accessibility</div><div class="desc">Expose a compact, privacy-filtered state dump for T3 Code SnapShots. It never includes logs, transcripts, prompts, or keys.</div></div><Toggle checked={ruinAccessibility} onchange={setRuin} label="Ruin accessibility" /></div><div class="setting-row" data-setting-target="developer-logs"><div><div class="label">Verbose logging</div><div class="desc">{verboseEnabled ? 'Debug logging enabled.' : 'Metadata diagnostics remain useful with verbose logging off.'} <button class="link-btn privacy-link" onclick={() => privacyModalOpen = true}>Privacy details</button></div></div><Toggle checked={verboseEnabled} onchange={setVerbose} label={`Verbose: ${verboseEnabled ? 'On' : 'Off'}`} /></div><div class="setting-row" data-setting-target="developer-setup"><div><div class="label">Force setup on launch</div><div class="desc">Show onboarding without erasing saved settings.</div></div><Toggle checked={forceSetupOnLaunch} onchange={setForceSetup} label="Force setup" /></div><div class="setting-row" data-setting-target="developer-sync"><div><div class="label">LAN Device Sync</div><div class="desc">Experimental encrypted device-to-device sync. Off by default.</div></div><Toggle checked={syncEnabled} onchange={setSync} label="Enable LAN sync" /></div></section>
   {/if}
   </div>
   {/key}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -52,6 +52,7 @@ type SettingsValueMap = {
   setup_complete: boolean;
   force_setup_on_launch: boolean;
   ruin_accessibility: boolean;
+  dev_mode_on_startup: boolean;
   app_context_hint: boolean;
   auto_learn_enabled: boolean;
   contextual_formatting_enabled: boolean;

--- a/src/lib/stores.svelte.ts
+++ b/src/lib/stores.svelte.ts
@@ -114,6 +114,7 @@ export const appStore = $state({
   settingsAnimDir: 1 as 1 | -1,
   appVersion: '',
   devModeEnabled: false,
+  devModeOnStartup: false,
   // Developer-only: dump diagnostics into the OS accessibility tree for agent
   // SnapShots. Off by default. Real screen-reader use is unusable while on.
   ruinAccessibility: false,

--- a/src/lib/tauri.dev.ts
+++ b/src/lib/tauri.dev.ts
@@ -121,6 +121,7 @@ const defaultSettings: Record<string, unknown> = {
   setup_complete: true,
   force_setup_on_launch: false,
   ruin_accessibility: false,
+  dev_mode_on_startup: false,
   appearance_mode: 'system',
   transcription_provider: 'groq',
   transcription_language: 'en',

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -241,6 +241,7 @@ const defaultSettings: Record<string, unknown> = {
   setup_complete: true,
   force_setup_on_launch: false,
   ruin_accessibility: false,
+  dev_mode_on_startup: false,
   appearance_mode: 'system',
   transcription_provider: 'groq',
   transcription_language: 'en',


### PR DESCRIPTION
## Summary\n- Add a Developer setting to enable dev mode automatically on startup.\n- Persist the preference through the existing settings store and include it in settings export/import.\n- Keep browser-dev defaults aligned with the native app.\n\n## Verification\n- 
pm run check passed in the original workspace.\n- Rust settings tests passed: 20/20 in the original workspace.\n- Clean worktree validation was blocked by missing frontend dependencies and a Windows linker PDB filesystem error during a fresh Rust build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791712628&installation_model_id=432577&pr_number=393&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F393&signature=286ae755687b0d3ab088593eb772848efceee13ac7f378b00ec31284f8a1f171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->