### PR TITLE
Fix pale frame flash on pill button clicks

### DIFF
--- a/src/PillApp.svelte
+++ b/src/PillApp.svelte
@@ -38,10 +38,10 @@
     const { getCurrentWindow } = await import('@tauri-apps/api/window');
     const pillWindow = getCurrentWindow();
     await pillWindow.setIgnoreCursorEvents(!interactive).catch(() => {});
-    // The pill is always a borderless overlay. Reassert this after changing
-    // hit-testing because WebView2/tao can restore the native frame while the
-    // window is being switched back to an interactive surface.
-    await pillWindow.setDecorations(false).catch(() => {});
+    // Native frame removal is owned by the backend. Calling setDecorations here
+    // after the backend has hardened the window can make WebView2/tao restore a
+    // caption-sized frame on Windows, which flashes as a pale bar above the
+    // pill after a button is clicked.
   }
 
   // Resolved context for the current dictation (e.g. "Slack", "Everywhere") —


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a native Tauri overlay for dictation feedback.
> - This PR targets the pill UI and its Windows/WebView2 native-window interaction.
> - Clicking error-pill buttons could leave a caption-sized pale bar above the pill.
> - The frontend was redundantly mutating native decorations after the backend hardened the borderless overlay.
> - This pull request keeps native frame removal in the backend and removes the late frontend decoration mutation.
> - The benefit is that error controls remain clickable without exposing a transient native frame.

## What Changed

- Removed the frontend `setDecorations(false)` call from pill hit-testing changes so WebView2/tao cannot restore a caption-sized frame after button clicks.

## Verification

- `npm run check` passes with 0 Svelte errors and 0 warnings.
- macOS identity contract passes.
- Windows native visual verification is not available in this environment.

## Risks

Low risk. This only removes a redundant native decoration mutation; backend pill-window hardening remains authoritative.

## Model Used

- OpenAI Codex, GPT-5.6 Luna, medium reasoning effort.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified (provider + version)
- [x] Checked `docs/ROADMAP.md` - this PR does not duplicate planned work
- [x] `npm run check` passes (TypeScript)
- [ ] `npm run lint` passes (not run; focused UI check completed)
- [ ] `npm run test:rust` passes (not run; no Rust changes)
- [ ] Smoke tests pass (not run; native Windows-only interaction)
- [ ] UI changes include before/after screenshots (native Tauri surface unavailable in this environment)
- [x] No API keys, secrets, or personal data in code or logs
- [x] Risks documented above

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791716423&installation_model_id=432577&pr_number=396&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F396&signature=c1393f80fae1f5a54a5a6e65c090d170541e728e9c344bc96a9f7a1d6d85b2cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->