### PR TITLE
Fix Windows single-instance handoff

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable project changes are recorded here. GitHub Release pages remain the sourc
 
 ## Unreleased
 
+- Fixed multiple Verenu sessions running at once on Windows: a newer launch
+  now asks the older session to shut down cleanly and takes over after it has
+  released its instance lock, including when dev and packaged builds overlap.
 - Added a Developer setting to automatically enable Developer mode on startup.
 - Removed the microphone calibration step and Audio-page calibration controls; manual microphone gain remains available. Rejected quiet or speech-free captures now make a quick follow-up dictation more sensitive for a bounded number of attempts, including explicit retries.
 - Fixed Windows dictation appearing to freeze after CPAL reported that the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,8 @@ mod local_llm;
 mod local_stt;
 mod media;
 mod pipeline;
+#[cfg(target_os = "windows")]
+mod single_instance;
 mod sync;
 mod system;
 #[cfg(any(test, debug_assertions))]
@@ -124,6 +126,9 @@ pub fn run() {
     #[cfg(target_os = "windows")]
     wait_for_relaunch_parent_exit();
 
+    #[cfg(target_os = "windows")]
+    let single_instance = crate::single_instance::acquire();
+
     let shared: SharedState = Arc::new(Mutex::new(AppState {
         lifecycle: pipeline::DictationLifecycle::Idle,
         target: WindowTarget::default(),
@@ -155,6 +160,7 @@ pub fn run() {
     let local_transcription_manager = crate::local_stt::LocalTranscriptionManager::new();
     let frontend_readiness = FrontendReadiness::default();
 
+    #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init());
@@ -176,12 +182,21 @@ pub fn run() {
         }));
     }
 
-    builder
+    builder = builder
         .manage(shared.clone())
         .manage(local_cleanup_manager.clone())
         .manage(local_transcription_manager.clone())
-        .manage(frontend_readiness.clone())
+        .manage(frontend_readiness.clone());
+
+    #[cfg(target_os = "windows")]
+    {
+        builder = builder.manage(single_instance);
+    }
+
+    builder
         .setup(move |app| {
+            #[cfg(target_os = "windows")]
+            crate::single_instance::listen_for_takeover(app.handle());
             #[cfg(target_os = "android")]
             {
                 // CPAL's Android/Oboe backend uses ndk-context from its audio

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,8 @@ mod local_llm;
 mod local_stt;
 mod media;
 mod pipeline;
+#[cfg(target_os = "windows")]
+mod single_instance;
 mod sync;
 mod system;
 #[cfg(any(test, debug_assertions))]
@@ -108,6 +110,9 @@ fn main() {
     #[cfg(target_os = "windows")]
     wait_for_relaunch_parent_exit();
 
+    #[cfg(target_os = "windows")]
+    let single_instance = crate::single_instance::acquire();
+
     let shared: SharedState = Arc::new(Mutex::new(AppState {
         lifecycle: pipeline::DictationLifecycle::Idle,
         target: WindowTarget::default(),
@@ -148,7 +153,8 @@ fn main() {
     let local_transcription_manager = crate::local_stt::LocalTranscriptionManager::new();
     let frontend_readiness = FrontendReadiness::default();
 
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
@@ -158,8 +164,17 @@ fn main() {
         .manage(db_handle.clone())
         .manage(local_cleanup_manager.clone())
         .manage(local_transcription_manager.clone())
-        .manage(frontend_readiness.clone())
+        .manage(frontend_readiness.clone());
+
+    #[cfg(target_os = "windows")]
+    {
+        builder = builder.manage(single_instance);
+    }
+
+    builder
         .setup(move |app| {
+            #[cfg(target_os = "windows")]
+            crate::single_instance::listen_for_takeover(app.handle());
             crate::system::logger::attach_app(app.handle());
             let build_mode = if cfg!(debug_assertions) {
                 "debug"

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -1,0 +1,106 @@
+//! Cross-build single-instance handoff for Windows.
+//!
+//! Tauri's single-instance plugin intentionally keeps the first process and
+//! exits the second one. That is the wrong direction for an updater relaunch,
+//! and its identifier-based namespace also lets dev and packaged builds run
+//! side by side. This small mutex/event pair gives the newest process the
+//! ownership instead.
+
+use std::time::Duration;
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, GetLastError, ERROR_ALREADY_EXISTS};
+use windows::Win32::Foundation::{HANDLE, WAIT_ABANDONED_0, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{
+    CreateEventW, CreateMutexW, SetEvent, WaitForSingleObject,
+};
+
+const MUTEX_NAME: &str = "Local\\Verenu.SingleInstance.v1";
+const EVENT_NAME: &str = "Local\\Verenu.SingleInstance.Takeover.v1";
+
+pub(crate) struct Guard {
+    mutex: HANDLE,
+    event: HANDLE,
+}
+
+// Win32 HANDLE values are process-owned opaque references. The guard is only
+// moved into Tauri's synchronized state and each handle is closed exactly once
+// by Drop; no handle is accessed concurrently through the Rust fields.
+unsafe impl Send for Guard {}
+unsafe impl Sync for Guard {}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = windows::Win32::System::Threading::ReleaseMutex(self.mutex);
+            let _ = CloseHandle(self.mutex);
+            let _ = CloseHandle(self.event);
+        }
+    }
+}
+
+pub(crate) fn acquire() -> Guard {
+    let mutex_name = wide(MUTEX_NAME);
+    let event_name = wide(EVENT_NAME);
+
+    loop {
+        let event = unsafe {
+            CreateEventW(None, false, false, PCWSTR(event_name.as_ptr()))
+                .expect("failed to create Verenu takeover event")
+        };
+        let mutex = unsafe {
+            CreateMutexW(None, true, PCWSTR(mutex_name.as_ptr()))
+                .expect("failed to create Verenu single-instance mutex")
+        };
+
+        if unsafe { GetLastError() } != ERROR_ALREADY_EXISTS {
+            return Guard { mutex, event };
+        }
+
+        // Ask the current owner to perform its normal Tauri shutdown. The
+        // mutex handle is also a wait handle, so this process can acquire it
+        // as soon as the old process has completely torn down.
+        unsafe {
+            let _ = SetEvent(event);
+        }
+        let result = unsafe { WaitForSingleObject(mutex, 15_000) };
+        if result == WAIT_OBJECT_0 || result == WAIT_ABANDONED_0 {
+            return Guard { mutex, event };
+        }
+
+        unsafe {
+            let _ = CloseHandle(mutex);
+            let _ = CloseHandle(event);
+        }
+        if result != WAIT_TIMEOUT {
+            panic!("failed waiting for the previous Verenu instance to exit");
+        }
+        // Retry after a bounded wait. This also handles a brief startup race
+        // where the previous owner has not installed its event listener yet.
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(crate) fn listen_for_takeover(app: &tauri::AppHandle) {
+    let event_name = wide(EVENT_NAME);
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let event = unsafe {
+            match CreateEventW(None, false, false, PCWSTR(event_name.as_ptr())) {
+                Ok(event) => event,
+                Err(_) => return,
+            }
+        };
+        let result = unsafe { WaitForSingleObject(event, u32::MAX) };
+        unsafe {
+            let _ = CloseHandle(event);
+        }
+        if result == WAIT_OBJECT_0 {
+            app.exit(0);
+        }
+    });
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}


### PR DESCRIPTION
## Thinking Path

> - Verenu is a Windows and macOS AI dictation app with a native Tauri lifecycle.
> - The startup and process-lifecycle subsystem owns database initialization and app shutdown.
> - The existing Tauri single-instance plugin keeps the first process and exits the second, and dev/package identifiers can differ.
> - That can leave duplicate Verenu tray sessions running and makes updater handoff unreliable.
> - This pull request gives the newest Windows process ownership through a shared mutex and graceful takeover event.
> - The benefit is one active session with clean updater handoff and no duplicate tray icons.

## What Changed

- Added a Windows cross-build mutex and takeover event.
- New launches ask the older process to exit, wait for lock release, and then continue startup.
- Registered the guard in both desktop entry points and documented the fix.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml --bin verenu`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`

## Risks

- Low risk: Windows-only startup coordination; normal Tauri shutdown and existing single-instance behavior remain in place.

## Model Used

- OpenAI, GPT-5.6-Luna, tool-assisted coding session.

## Checklist

- [x] This PR targets `master` directly
- [x] Thinking path traces from Verenu context down to this specific change
- [x] Model used is specified
- [x] No API keys, secrets, or personal data in code or logs
- [x] Relevant documentation updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Verenu/codesmith/Verenu/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791765682&installation_model_id=432577&pr_number=400&repository=Verenu%2FVerenu&return_to=https%3A%2F%2Fgithub.com%2FVerenu%2FVerenu%2Fpull%2F400&signature=6b272864121a39fbeb989a9ad15522ec18ee31d1598c82b85602b0b746ded15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->